### PR TITLE
Update collector core

### DIFF
--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -623,11 +623,11 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -649,8 +649,8 @@ require (
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/mod v0.16.0
 	golang.org/x/text v0.14.0
@@ -170,8 +170,8 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.96.0 // indirect
 	github.com/samber/lo v1.38.1 // indirect
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 )
 
 require (
@@ -621,41 +621,41 @@ require (
 	go.mongodb.org/atlas v0.36.0 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector/forwardconnector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector/forwardconnector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter/loggingexporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/cmd/githubgen/go.mod
+++ b/cmd/githubgen/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/google/go-github/v59 v59.0.0
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/cmd/opampsupervisor/go.mod
+++ b/cmd/opampsupervisor/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.12.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )

--- a/cmd/opampsupervisor/go.mod
+++ b/cmd/opampsupervisor/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sys v0.16.0 // indirect

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -192,29 +192,29 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.96.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector/forwardconnector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector/forwardconnector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 	golang.org/x/sys v0.18.0
 )
 
@@ -653,23 +653,23 @@ require (
 	go.mongodb.org/atlas v0.36.0 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -195,7 +195,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
@@ -209,7 +209,7 @@ require (
 	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6
@@ -655,7 +655,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -667,7 +667,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -217,11 +217,11 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -235,8 +235,8 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -32,21 +32,21 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/udplogreceiver v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/sys v0.18.0
 )
@@ -215,30 +215,30 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.etcd.io/bbolt v1.3.9 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/cmd/telemetrygen/go.mod
+++ b/cmd/telemetrygen/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.24.0

--- a/cmd/telemetrygen/go.mod
+++ b/cmd/telemetrygen/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.24.0
@@ -44,8 +44,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.1.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/cmd/telemetrygen/internal/e2etest/go.mod
+++ b/cmd/telemetrygen/internal/e2etest/go.mod
@@ -48,19 +48,19 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/cmd/telemetrygen/internal/e2etest/go.mod
+++ b/cmd/telemetrygen/internal/e2etest/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 )
 
 require (
@@ -46,19 +46,19 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect

--- a/confmap/provider/s3provider/go.mod
+++ b/confmap/provider/s3provider/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.4
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.51.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/confmap/provider/secretsmanagerprovider/go.mod
+++ b/confmap/provider/secretsmanagerprovider/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.28.1
 	github.com/aws/smithy-go v1.20.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
 )
 
 require (

--- a/connector/countconnector/go.mod
+++ b/connector/countconnector/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/connector/countconnector/go.mod
+++ b/connector/countconnector/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -48,8 +48,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -12,17 +12,17 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -137,29 +137,29 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -18,7 +18,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
@@ -139,11 +139,11 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -157,7 +157,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/connector/exceptionsconnector/go.mod
+++ b/connector/exceptionsconnector/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/connector/exceptionsconnector/go.mod
+++ b/connector/exceptionsconnector/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,8 +43,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/connector/failoverconnector/go.mod
+++ b/connector/failoverconnector/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/connector/failoverconnector/go.mod
+++ b/connector/failoverconnector/go.mod
@@ -4,10 +4,10 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -37,8 +37,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/connector/routingconnector/go.mod
+++ b/connector/routingconnector/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/connector/routingconnector/go.mod
+++ b/connector/routingconnector/go.mod
@@ -5,10 +5,10 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -43,8 +43,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/connector/servicegraphconnector/go.mod
+++ b/connector/servicegraphconnector/go.mod
@@ -4,17 +4,17 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/sdk/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -61,16 +61,16 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/connector/servicegraphconnector/go.mod
+++ b/connector/servicegraphconnector/go.mod
@@ -10,9 +10,9 @@ require (
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/connector/spanmetricsconnector/go.mod
+++ b/connector/spanmetricsconnector/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tilinna/clock v1.1.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -44,8 +44,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/connector/spanmetricsconnector/go.mod
+++ b/connector/spanmetricsconnector/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/alertmanagerexporter/go.mod
+++ b/exporter/alertmanagerexporter/go.mod
@@ -7,16 +7,16 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/prometheus/common v0.48.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -50,15 +50,15 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/alertmanagerexporter/go.mod
+++ b/exporter/alertmanagerexporter/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -52,12 +52,12 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/alibabacloudlogserviceexporter/go.mod
+++ b/exporter/alibabacloudlogserviceexporter/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/gogo/protobuf v1.3.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -45,12 +45,12 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/alibabacloudlogserviceexporter/go.mod
+++ b/exporter/alibabacloudlogserviceexporter/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/awscloudwatchlogsexporter/go.mod
+++ b/exporter/awscloudwatchlogsexporter/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/cwlogs v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -45,10 +45,10 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/awscloudwatchlogsexporter/go.mod
+++ b/exporter/awscloudwatchlogsexporter/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0

--- a/exporter/awsemfexporter/go.mod
+++ b/exporter/awsemfexporter/go.mod
@@ -11,13 +11,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0
@@ -51,11 +51,11 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/awsemfexporter/go.mod
+++ b/exporter/awsemfexporter/go.mod
@@ -15,8 +15,8 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -20,7 +20,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/exporter/awskinesisexporter/go.mod
+++ b/exporter/awskinesisexporter/go.mod
@@ -15,11 +15,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -63,11 +63,11 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/awss3exporter/go.mod
+++ b/exporter/awss3exporter/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/aws/aws-sdk-go v1.50.27
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0
@@ -69,7 +69,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/exporter/awss3exporter/go.mod
+++ b/exporter/awss3exporter/go.mod
@@ -5,12 +5,12 @@ go 1.21
 require (
 	github.com/aws/aws-sdk-go v1.50.27
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -58,22 +58,22 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/awsxrayexporter/go.mod
+++ b/exporter/awsxrayexporter/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -46,11 +46,11 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/awsxrayexporter/go.mod
+++ b/exporter/awsxrayexporter/go.mod
@@ -12,8 +12,8 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/azuredataexplorerexporter/go.mod
+++ b/exporter/azuredataexplorerexporter/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/exporter/azuredataexplorerexporter/go.mod
+++ b/exporter/azuredataexplorerexporter/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -64,11 +64,11 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/samber/lo v1.38.1 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/azuremonitorexporter/go.mod
+++ b/exporter/azuremonitorexporter/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/azuremonitorexporter/go.mod
+++ b/exporter/azuremonitorexporter/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/microsoft/ApplicationInsights-Go v0.4.4
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -45,11 +45,11 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/carbonexporter/go.mod
+++ b/exporter/carbonexporter/go.mod
@@ -6,13 +6,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,12 +43,12 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/carbonexporter/go.mod
+++ b/exporter/carbonexporter/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -47,7 +47,7 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/cassandraexporter/go.mod
+++ b/exporter/cassandraexporter/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/gocql/gocql v1.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -42,12 +42,12 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/cassandraexporter/go.mod
+++ b/exporter/cassandraexporter/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/exporter/clickhouseexporter/go.mod
+++ b/exporter/clickhouseexporter/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/clickhouseexporter/go.mod
+++ b/exporter/clickhouseexporter/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -53,11 +53,11 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/coralogixexporter/go.mod
+++ b/exporter/coralogixexporter/go.mod
@@ -5,15 +5,15 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -50,15 +50,15 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/coralogixexporter/go.mod
+++ b/exporter/coralogixexporter/go.mod
@@ -6,15 +6,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -57,7 +57,7 @@ require (
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -37,19 +37,19 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -35,27 +35,27 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -235,19 +235,19 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	github.com/zorkian/go-datadog-api v2.30.0+incompatible // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -9,17 +9,17 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tinylib/msgp v1.1.9
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0
@@ -140,29 +140,29 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -142,11 +142,11 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -159,8 +159,8 @@ require (
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/exporter/datasetexporter/go.mod
+++ b/exporter/datasetexporter/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/scalyr/dataset-go v0.18.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/zap v1.27.0
 
@@ -19,7 +19,7 @@ require (
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 )
@@ -47,11 +47,11 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/datasetexporter/go.mod
+++ b/exporter/datasetexporter/go.mod
@@ -11,14 +11,14 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/zap v1.27.0
 
 )
 
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/dynatraceexporter/go.mod
+++ b/exporter/dynatraceexporter/go.mod
@@ -8,14 +8,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -52,15 +52,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/dynatraceexporter/go.mod
+++ b/exporter/dynatraceexporter/go.mod
@@ -10,13 +10,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -54,12 +54,12 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -10,13 +10,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -47,12 +47,12 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -43,11 +43,11 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/fileexporter/go.mod
+++ b/exporter/fileexporter/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -64,7 +64,7 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1 // indirect

--- a/exporter/googlecloudexporter/go.mod
+++ b/exporter/googlecloudexporter/go.mod
@@ -5,9 +5,9 @@ go 1.21
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.45.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -59,14 +59,14 @@ require (
 	github.com/tidwall/tinylru v1.1.0 // indirect
 	github.com/tidwall/wal v1.1.7 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/googlecloudpubsubexporter/go.mod
+++ b/exporter/googlecloudpubsubexporter/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0

--- a/exporter/googlecloudpubsubexporter/go.mod
+++ b/exporter/googlecloudpubsubexporter/go.mod
@@ -6,11 +6,11 @@ require (
 	cloud.google.com/go/pubsub v1.36.2
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -54,10 +54,10 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.einride.tech/aip v0.66.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector v0.45.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/collector/googlemanagedprometheus v0.45.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -73,25 +73,25 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.46.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.46.1 // indirect

--- a/exporter/googlemanagedprometheusexporter/go.mod
+++ b/exporter/googlemanagedprometheusexporter/go.mod
@@ -86,8 +86,8 @@ require (
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/exporter/honeycombmarkerexporter/go.mod
+++ b/exporter/honeycombmarkerexporter/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -56,14 +56,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/honeycombmarkerexporter/go.mod
+++ b/exporter/honeycombmarkerexporter/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -54,17 +54,17 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/influxdbexporter/go.mod
+++ b/exporter/influxdbexporter/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -54,13 +54,13 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/exporter/influxdbexporter/go.mod
+++ b/exporter/influxdbexporter/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/influxdata/influxdb-observability/otel2influx v0.5.8
 	github.com/influxdata/line-protocol/v2 v2.2.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -52,17 +52,17 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/instanaexporter/go.mod
+++ b/exporter/instanaexporter/go.mod
@@ -5,16 +5,16 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -50,15 +50,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/instanaexporter/go.mod
+++ b/exporter/instanaexporter/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -52,12 +52,12 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -14,14 +14,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.96.0
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -72,11 +72,11 @@ require (
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/kafkaexporter/go.mod
+++ b/exporter/kafkaexporter/go.mod
@@ -20,7 +20,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -73,7 +73,7 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/exporter/kineticaexporter/go.mod
+++ b/exporter/kineticaexporter/go.mod
@@ -9,10 +9,10 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0

--- a/exporter/kineticaexporter/go.mod
+++ b/exporter/kineticaexporter/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/samber/lo v1.39.0
 	github.com/stretchr/testify v1.9.0
 	github.com/wk8/go-ordered-map/v2 v2.1.8
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -53,12 +53,12 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/ztrue/tracerr v0.3.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -97,29 +97,29 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -15,7 +15,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -99,10 +99,10 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -116,7 +116,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/exporter/logicmonitorexporter/go.mod
+++ b/exporter/logicmonitorexporter/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -51,16 +51,16 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/logicmonitorexporter/go.mod
+++ b/exporter/logicmonitorexporter/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -53,13 +53,13 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/logzioexporter/go.mod
+++ b/exporter/logzioexporter/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -66,7 +66,7 @@ require (
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/logzioexporter/go.mod
+++ b/exporter/logzioexporter/go.mod
@@ -8,16 +8,16 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -59,15 +59,15 @@ require (
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/lokiexporter/go.mod
+++ b/exporter/lokiexporter/go.mod
@@ -13,13 +13,13 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -61,12 +61,12 @@ require (
 	github.com/prometheus/prometheus v0.48.1 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/exporter/lokiexporter/go.mod
+++ b/exporter/lokiexporter/go.mod
@@ -10,15 +10,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.96.0
 	github.com/prometheus/common v0.48.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -60,15 +60,15 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prometheus/prometheus v0.48.1 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/mezmoexporter/go.mod
+++ b/exporter/mezmoexporter/go.mod
@@ -5,14 +5,14 @@ go 1.21
 require (
 	github.com/cenkalti/backoff/v4 v4.2.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -47,17 +47,17 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/mezmoexporter/go.mod
+++ b/exporter/mezmoexporter/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -49,14 +49,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/opencensusexporter/go.mod
+++ b/exporter/opencensusexporter/go.mod
@@ -9,16 +9,16 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/opencensus v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -59,16 +59,16 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/opencensusexporter/go.mod
+++ b/exporter/opencensusexporter/go.mod
@@ -11,13 +11,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -61,13 +61,13 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/opensearchexporter/go.mod
+++ b/exporter/opensearchexporter/go.mod
@@ -9,12 +9,12 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -58,13 +58,13 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/opensearchexporter/go.mod
+++ b/exporter/opensearchexporter/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/opensearch-project/opensearch-go/v2 v2.3.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -57,15 +57,15 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/exporter/otelarrowexporter/go.mod
+++ b/exporter/otelarrowexporter/go.mod
@@ -6,16 +6,16 @@ require (
 	github.com/open-telemetry/otel-arrow v0.18.0
 	github.com/open-telemetry/otel-arrow/collector v0.18.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -55,14 +55,14 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/otelarrowexporter/go.mod
+++ b/exporter/otelarrowexporter/go.mod
@@ -8,15 +8,15 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	google.golang.org/grpc v1.62.1
@@ -61,7 +61,7 @@ require (
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/prometheusexporter/go.mod
+++ b/exporter/prometheusexporter/go.mod
@@ -11,15 +11,15 @@ require (
 	github.com/prometheus/client_model v0.6.0
 	github.com/prometheus/common v0.48.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -137,15 +137,15 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/prometheusexporter/go.mod
+++ b/exporter/prometheusexporter/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -139,14 +139,14 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -16,13 +16,13 @@ require (
 	github.com/tidwall/wal v1.1.7
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -62,12 +62,12 @@ require (
 	github.com/tidwall/tinylru v1.1.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -14,14 +14,14 @@ require (
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/wal v1.1.7
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -60,16 +60,16 @@ require (
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/tidwall/tinylru v1.1.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/pulsarexporter/go.mod
+++ b/exporter/pulsarexporter/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/pulsarexporter/go.mod
+++ b/exporter/pulsarexporter/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0
@@ -68,10 +68,10 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -12,12 +12,12 @@ require (
 	github.com/signalfx/sapm-proto v0.14.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/exporter/sapmexporter/go.mod
+++ b/exporter/sapmexporter/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/signalfx/sapm-proto v0.14.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -50,11 +50,11 @@ require (
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/sentryexporter/go.mod
+++ b/exporter/sentryexporter/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/sentryexporter/go.mod
+++ b/exporter/sentryexporter/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -40,12 +40,12 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -17,16 +17,16 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -71,15 +71,15 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/signalfxexporter/go.mod
+++ b/exporter/signalfxexporter/go.mod
@@ -19,13 +19,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -73,12 +73,12 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/skywalkingexporter/go.mod
+++ b/exporter/skywalkingexporter/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -53,13 +53,13 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/skywalkingexporter/go.mod
+++ b/exporter/skywalkingexporter/go.mod
@@ -7,16 +7,16 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	google.golang.org/grpc v1.62.1
@@ -51,16 +51,16 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/splunkhecexporter/go.mod
+++ b/exporter/splunkhecexporter/go.mod
@@ -13,16 +13,16 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -89,15 +89,15 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/splunkhecexporter/go.mod
+++ b/exporter/splunkhecexporter/go.mod
@@ -15,13 +15,13 @@ require (
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -91,12 +91,12 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/sumologicexporter/go.mod
+++ b/exporter/sumologicexporter/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 )
@@ -46,14 +46,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/exporter/sumologicexporter/go.mod
+++ b/exporter/sumologicexporter/go.mod
@@ -4,12 +4,12 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -44,17 +44,17 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/syslogexporter/go.mod
+++ b/exporter/syslogexporter/go.mod
@@ -4,10 +4,10 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
@@ -27,11 +27,11 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.24.0 // indirect
@@ -49,8 +49,8 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/syslogexporter/go.mod
+++ b/exporter/syslogexporter/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -28,7 +28,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/exporter/tencentcloudlogserviceexporter/go.mod
+++ b/exporter/tencentcloudlogserviceexporter/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.857
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/exporter/tencentcloudlogserviceexporter/go.mod
+++ b/exporter/tencentcloudlogserviceexporter/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/pierrec/lz4 v2.6.1+incompatible
 	github.com/stretchr/testify v1.9.0
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.857
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -43,12 +43,12 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/exporter/zipkinexporter/go.mod
+++ b/exporter/zipkinexporter/go.mod
@@ -9,15 +9,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.96.0
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -54,16 +54,16 @@ require (
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/exporter/zipkinexporter/go.mod
+++ b/exporter/zipkinexporter/go.mod
@@ -16,7 +16,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -56,13 +56,13 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/extension/ackextension/go.mod
+++ b/extension/ackextension/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/extension/ackextension/go.mod
+++ b/extension/ackextension/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 )
@@ -21,8 +21,8 @@ require (
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/extension/asapauthextension/go.mod
+++ b/extension/asapauthextension/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/SermoDigital/jose v0.9.2-0.20180104203859-803625baeddc
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
@@ -40,7 +40,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/vincent-petithory/dataurl v1.0.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/asapauthextension/go.mod
+++ b/extension/asapauthextension/go.mod
@@ -6,11 +6,11 @@ require (
 	bitbucket.org/atlassian/go-asap/v2 v2.8.0
 	github.com/SermoDigital/jose v0.9.2-0.20180104203859-803625baeddc
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0
@@ -39,7 +39,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/vincent-petithory/dataurl v1.0.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/awsproxy/go.mod
+++ b/extension/awsproxy/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -40,7 +40,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/extension/awsproxy/go.mod
+++ b/extension/awsproxy/go.mod
@@ -39,10 +39,10 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/basicauthextension/go.mod
+++ b/extension/basicauthextension/go.mod
@@ -5,12 +5,12 @@ go 1.21
 require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tg123/go-htpasswd v1.2.2
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -37,7 +37,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/basicauthextension/go.mod
+++ b/extension/basicauthextension/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/tg123/go-htpasswd v1.2.2
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
@@ -38,7 +38,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/bearertokenauthextension/go.mod
+++ b/extension/bearertokenauthextension/go.mod
@@ -5,11 +5,11 @@ go 1.21
 require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/bearertokenauthextension/go.mod
+++ b/extension/bearertokenauthextension/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
@@ -37,7 +37,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/encoding/go.mod
+++ b/extension/encoding/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 )
 
 require (

--- a/extension/encoding/go.mod
+++ b/extension/encoding/go.mod
@@ -3,7 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/extension/encod
 go 1.21
 
 require (
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 )
 
@@ -21,9 +21,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/extension/encoding/jaegerencodingextension/go.mod
+++ b/extension/encoding/jaegerencodingextension/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -40,8 +40,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/encoding/jaegerencodingextension/go.mod
+++ b/extension/encoding/jaegerencodingextension/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/extension/encoding/jsonlogencodingextension/go.mod
+++ b/extension/encoding/jsonlogencodingextension/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/extension/encoding/jsonlogencodingextension/go.mod
+++ b/extension/encoding/jsonlogencodingextension/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/encoding/otlpencodingextension/go.mod
+++ b/extension/encoding/otlpencodingextension/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/extension/encoding/otlpencodingextension/go.mod
+++ b/extension/encoding/otlpencodingextension/go.mod
@@ -5,9 +5,9 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/encoding/textencodingextension/go.mod
+++ b/extension/encoding/textencodingextension/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/extension/encoding/textencodingextension/go.mod
+++ b/extension/encoding/textencodingextension/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -37,7 +37,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/encoding/zipkinencodingextension/go.mod
+++ b/extension/encoding/zipkinencodingextension/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/extension/encoding/zipkinencodingextension/go.mod
+++ b/extension/encoding/zipkinencodingextension/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -41,8 +41,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/headerssetterextension/go.mod
+++ b/extension/headerssetterextension/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/headerssetterextension/go.mod
+++ b/extension/headerssetterextension/go.mod
@@ -4,11 +4,11 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -35,7 +35,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -46,13 +46,13 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -44,13 +44,13 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/extension/httpforwarderextension/go.mod
+++ b/extension/httpforwarderextension/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
@@ -44,12 +44,12 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/httpforwarderextension/go.mod
+++ b/extension/httpforwarderextension/go.mod
@@ -5,12 +5,12 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -42,12 +42,12 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/extension/jaegerremotesampling/go.mod
+++ b/extension/jaegerremotesampling/go.mod
@@ -8,14 +8,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tilinna/clock v1.1.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -64,12 +64,12 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.18.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/extension/jaegerremotesampling/go.mod
+++ b/extension/jaegerremotesampling/go.mod
@@ -12,11 +12,11 @@ require (
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -66,11 +66,11 @@ require (
 	github.com/subosito/gotenv v1.6.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/extension/oauth2clientauthextension/go.mod
+++ b/extension/oauth2clientauthextension/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
@@ -49,11 +49,11 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/oauth2clientauthextension/go.mod
+++ b/extension/oauth2clientauthextension/go.mod
@@ -4,13 +4,13 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -47,11 +47,11 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/extension/observer/dockerobserver/go.mod
+++ b/extension/observer/dockerobserver/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/observer/dockerobserver/go.mod
+++ b/extension/observer/dockerobserver/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -68,7 +68,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/observer/ecsobserver/go.mod
+++ b/extension/observer/ecsobserver/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/observer/ecsobserver/go.mod
+++ b/extension/observer/ecsobserver/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/aws/aws-sdk-go v1.50.27
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -37,7 +37,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/observer/ecstaskobserver/go.mod
+++ b/extension/observer/ecstaskobserver/go.mod
@@ -44,14 +44,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/observer/ecstaskobserver/go.mod
+++ b/extension/observer/ecstaskobserver/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -42,14 +42,14 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/extension/observer/hostobserver/go.mod
+++ b/extension/observer/hostobserver/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/observer/hostobserver/go.mod
+++ b/extension/observer/hostobserver/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.96.0
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -41,7 +41,7 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/observer/k8sobserver/go.mod
+++ b/extension/observer/k8sobserver/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/observer/k8sobserver/go.mod
+++ b/extension/observer/k8sobserver/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -54,7 +54,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/oidcauthextension/go.mod
+++ b/extension/oidcauthextension/go.mod
@@ -5,11 +5,11 @@ go 1.21
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -35,7 +35,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/oidcauthextension/go.mod
+++ b/extension/oidcauthextension/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/oklog/ulid/v2 v2.1.0
 	github.com/open-telemetry/opamp-go v0.12.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -44,7 +44,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/opampextension/go.mod
+++ b/extension/opampextension/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/open-telemetry/opamp-go v0.12.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/extension/pprofextension/go.mod
+++ b/extension/pprofextension/go.mod
@@ -5,10 +5,10 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -35,7 +35,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/extension/pprofextension/go.mod
+++ b/extension/pprofextension/go.mod
@@ -36,8 +36,8 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/remotetapextension/go.mod
+++ b/extension/remotetapextension/go.mod
@@ -40,14 +40,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/remotetapextension/go.mod
+++ b/extension/remotetapextension/go.mod
@@ -4,10 +4,10 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -38,14 +38,14 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/extension/sigv4authextension/go.mod
+++ b/extension/sigv4authextension/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/sigv4authextension/go.mod
+++ b/extension/sigv4authextension/go.mod
@@ -8,10 +8,10 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.4
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -46,7 +46,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/solarwindsapmsettingsextension/go.mod
+++ b/extension/solarwindsapmsettingsextension/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/solarwindsapmsettingsextension/go.mod
+++ b/extension/solarwindsapmsettingsextension/go.mod
@@ -4,9 +4,9 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -31,7 +31,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/storage/dbstorage/go.mod
+++ b/extension/storage/dbstorage/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/jackc/pgx/v4 v4.18.3
 	github.com/mattn/go-sqlite3 v1.14.22
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -42,7 +42,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/storage/dbstorage/go.mod
+++ b/extension/storage/dbstorage/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/storage/filestorage/go.mod
+++ b/extension/storage/filestorage/go.mod
@@ -5,9 +5,9 @@ go 1.21
 require (
 	github.com/stretchr/testify v1.9.0
 	go.etcd.io/bbolt v1.3.9
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/storage/filestorage/go.mod
+++ b/extension/storage/filestorage/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -37,7 +37,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/extension/storage/go.mod
+++ b/extension/storage/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 
@@ -28,8 +28,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/extension/storage/go.mod
+++ b/extension/storage/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/extension/sumologicextension/go.mod
+++ b/extension/sumologicextension/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/mitchellh/go-ps v1.0.0
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -52,13 +52,13 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/extension/sumologicextension/go.mod
+++ b/extension/sumologicextension/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -54,12 +54,12 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -626,11 +626,11 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -644,8 +644,8 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -166,22 +166,22 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/windowsperfcountersreceiver v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver v0.96.0
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/connector/forwardconnector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/loggingexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/connector/forwardconnector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/loggingexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 )
 
 require (
@@ -623,31 +623,31 @@ require (
 	go.mongodb.org/atlas v0.36.0 // indirect
 	go.mongodb.org/mongo-driver v1.14.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/internal/aws/containerinsight/go.mod
+++ b/internal/aws/containerinsight/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )

--- a/internal/aws/cwlogs/go.mod
+++ b/internal/aws/cwlogs/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/internal/aws/cwlogs/go.mod
+++ b/internal/aws/cwlogs/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/aws/aws-sdk-go v1.50.27
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -23,8 +23,8 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/internal/aws/ecsutil/go.mod
+++ b/internal/aws/ecsutil/go.mod
@@ -5,8 +5,8 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -36,16 +36,16 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/internal/aws/ecsutil/go.mod
+++ b/internal/aws/ecsutil/go.mod
@@ -38,16 +38,16 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/internal/aws/proxy/go.mod
+++ b/internal/aws/proxy/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/internal/aws/proxy/go.mod
+++ b/internal/aws/proxy/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/aws/aws-sdk-go v1.50.27
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/zap v1.27.0
 )
 

--- a/internal/aws/xray/go.mod
+++ b/internal/aws/xray/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.27
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -24,8 +24,8 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/internal/aws/xray/go.mod
+++ b/internal/aws/xray/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/internal/common/go.mod
+++ b/internal/common/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )

--- a/internal/coreinternal/go.mod
+++ b/internal/coreinternal/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -78,8 +78,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/internal/coreinternal/go.mod
+++ b/internal/coreinternal/go.mod
@@ -12,8 +12,8 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel v1.24.0

--- a/internal/datadog/go.mod
+++ b/internal/datadog/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.13.4
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.13.4
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
@@ -75,9 +75,9 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/internal/datadog/go.mod
+++ b/internal/datadog/go.mod
@@ -10,8 +10,8 @@ require (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.13.4
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/sdk/metric v1.24.0

--- a/internal/exp/metrics/go.mod
+++ b/internal/exp/metrics/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 )
 
 require (

--- a/internal/filter/go.mod
+++ b/internal/filter/go.mod
@@ -11,8 +11,8 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0

--- a/internal/filter/go.mod
+++ b/internal/filter/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -45,7 +45,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/internal/kafka/go.mod
+++ b/internal/kafka/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/aws/aws-sdk-go v1.50.27
 	github.com/stretchr/testify v1.9.0
 	github.com/xdg-go/scram v1.1.2
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/internal/kafka/go.mod
+++ b/internal/kafka/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	golang.org/x/crypto v0.19.0 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect

--- a/internal/kubelet/go.mod
+++ b/internal/kubelet/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/oauth2 v0.14.0 // indirect

--- a/internal/kubelet/go.mod
+++ b/internal/kubelet/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	k8s.io/client-go v0.29.2

--- a/internal/metadataproviders/go.mod
+++ b/internal/metadataproviders/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/consul/api v1.28.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0
 	go.uber.org/goleak v1.3.0

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 
@@ -27,8 +27,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/internal/sharedcomponent/go.mod
+++ b/internal/sharedcomponent/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/internal/splunk/go.mod
+++ b/internal/splunk/go.mod
@@ -4,10 +4,10 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )
@@ -27,12 +27,12 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/internal/splunk/go.mod
+++ b/internal/splunk/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0

--- a/internal/sqlquery/go.mod
+++ b/internal/sqlquery/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/snowflakedb/gosnowflake v1.8.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0

--- a/internal/sqlquery/go.mod
+++ b/internal/sqlquery/go.mod
@@ -10,9 +10,9 @@ require (
 	github.com/sijms/go-ora/v2 v2.8.9
 	github.com/snowflakedb/gosnowflake v1.8.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 )
@@ -85,10 +85,10 @@ require (
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -15,8 +15,8 @@ require (
 	go.opentelemetry.io/build-tools/crosslink v0.13.0
 	go.opentelemetry.io/build-tools/issuegenerator v0.13.0
 	go.opentelemetry.io/build-tools/multimod v0.13.0
-	go.opentelemetry.io/collector/cmd/builder v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/cmd/mdatagen v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/cmd/builder v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/cmd/mdatagen v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/tools v0.19.0
 	golang.org/x/vuln v1.0.4
@@ -226,10 +226,10 @@ require (
 	gitlab.com/bosi/decorder v0.4.1 // indirect
 	go-simpler.org/sloglint v0.1.2 // indirect
 	go.opentelemetry.io/build-tools v0.13.0 // indirect
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -230,7 +230,7 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/pkg/batchperresourceattr/go.mod
+++ b/pkg/batchperresourceattr/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0

--- a/pkg/batchperresourceattr/go.mod
+++ b/pkg/batchperresourceattr/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/pkg/batchpersignal/go.mod
+++ b/pkg/batchpersignal/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/pkg/experimentalmetricmetadata/go.mod
+++ b/pkg/experimentalmetricmetadata/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/pkg/golden/go.mod
+++ b/pkg/golden/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -41,8 +41,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/pkg/ottl/go.mod
+++ b/pkg/ottl/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0

--- a/pkg/pdatatest/go.mod
+++ b/pkg/pdatatest/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/pkg/pdatautil/go.mod
+++ b/pkg/pdatautil/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/cespare/xxhash/v2 v2.2.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/pkg/resourcetotelemetry/go.mod
+++ b/pkg/resourcetotelemetry/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/pkg/resourcetotelemetry/go.mod
+++ b/pkg/resourcetotelemetry/go.mod
@@ -5,8 +5,8 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
@@ -25,9 +25,9 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/pkg/sampling/go.mod
+++ b/pkg/sampling/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/multierr v1.11.0
 )
 

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -14,14 +14,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/valyala/fastjson v1.6.4
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
@@ -56,9 +56,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -19,8 +19,8 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
@@ -57,7 +57,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/pkg/translator/azure/go.mod
+++ b/pkg/translator/azure/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/relvacode/iso8601 v1.4.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc
@@ -30,8 +30,8 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/otel/trace v1.24.0 // indirect

--- a/pkg/translator/azure/go.mod
+++ b/pkg/translator/azure/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/relvacode/iso8601 v1.4.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0

--- a/pkg/translator/jaeger/go.mod
+++ b/pkg/translator/jaeger/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/pkg/translator/jaeger/go.mod
+++ b/pkg/translator/jaeger/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jaegertracing/jaeger v1.55.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 )

--- a/pkg/translator/loki/go.mod
+++ b/pkg/translator/loki/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/pkg/translator/loki/go.mod
+++ b/pkg/translator/loki/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/common v0.48.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 )
@@ -35,7 +35,7 @@ require (
 	github.com/prometheus/client_golang v1.19.0 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect

--- a/pkg/translator/opencensus/go.mod
+++ b/pkg/translator/opencensus/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	google.golang.org/protobuf v1.33.0

--- a/pkg/translator/opencensus/go.mod
+++ b/pkg/translator/opencensus/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	google.golang.org/protobuf v1.33.0
 )

--- a/pkg/translator/prometheus/go.mod
+++ b/pkg/translator/prometheus/go.mod
@@ -5,8 +5,8 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/pkg/translator/prometheusremotewrite/go.mod
+++ b/pkg/translator/prometheusremotewrite/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/prometheus/common v0.48.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
@@ -24,7 +24,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	golang.org/x/net v0.21.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect

--- a/pkg/translator/prometheusremotewrite/go.mod
+++ b/pkg/translator/prometheusremotewrite/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/pkg/translator/signalfx/go.mod
+++ b/pkg/translator/signalfx/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 )

--- a/pkg/translator/skywalking/go.mod
+++ b/pkg/translator/skywalking/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	skywalking.apache.org/repo/goapi v0.0.0-20240104145220-ba7202308dd4

--- a/pkg/translator/skywalking/go.mod
+++ b/pkg/translator/skywalking/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	skywalking.apache.org/repo/goapi v0.0.0-20240104145220-ba7202308dd4
 )

--- a/pkg/translator/zipkin/go.mod
+++ b/pkg/translator/zipkin/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 )

--- a/pkg/translator/zipkin/go.mod
+++ b/pkg/translator/zipkin/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -50,8 +50,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/attributesprocessor/go.mod
+++ b/processor/attributesprocessor/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -52,7 +52,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/cumulativetodeltaprocessor/go.mod
+++ b/processor/cumulativetodeltaprocessor/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/cumulativetodeltaprocessor/go.mod
+++ b/processor/cumulativetodeltaprocessor/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -40,8 +40,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/deltatocumulativeprocessor/go.mod
+++ b/processor/deltatocumulativeprocessor/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/deltatocumulativeprocessor/go.mod
+++ b/processor/deltatocumulativeprocessor/go.mod
@@ -5,11 +5,11 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -38,8 +38,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/deltatorateprocessor/go.mod
+++ b/processor/deltatorateprocessor/go.mod
@@ -4,11 +4,11 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -37,8 +37,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/deltatorateprocessor/go.mod
+++ b/processor/deltatorateprocessor/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -53,7 +53,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/filterprocessor/go.mod
+++ b/processor/filterprocessor/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/sdk/metric v1.24.0
@@ -51,10 +51,10 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
 	golang.org/x/exp v0.0.0-20240103183307-be819d1f06fc // indirect

--- a/processor/groupbyattrsprocessor/go.mod
+++ b/processor/groupbyattrsprocessor/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/processor/groupbyattrsprocessor/go.mod
+++ b/processor/groupbyattrsprocessor/go.mod
@@ -5,11 +5,11 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/sdk/metric v1.24.0
@@ -40,8 +40,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/processor/groupbytraceprocessor/go.mod
+++ b/processor/groupbytraceprocessor/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/groupbytraceprocessor/go.mod
+++ b/processor/groupbytraceprocessor/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0
@@ -39,8 +39,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/intervalprocessor/go.mod
+++ b/processor/intervalprocessor/go.mod
@@ -4,11 +4,11 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -36,8 +36,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/intervalprocessor/go.mod
+++ b/processor/intervalprocessor/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/k8sattributesprocessor/go.mod
+++ b/processor/k8sattributesprocessor/go.mod
@@ -13,8 +13,8 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
@@ -84,11 +84,11 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/processor/k8sattributesprocessor/go.mod
+++ b/processor/k8sattributesprocessor/go.mod
@@ -9,16 +9,16 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8stest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -83,17 +83,17 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/processor/logstransformprocessor/go.mod
+++ b/processor/logstransformprocessor/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -50,7 +50,7 @@ require (
 	github.com/valyala/fastjson v1.6.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/logstransformprocessor/go.mod
+++ b/processor/logstransformprocessor/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -48,10 +48,10 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -4,11 +4,11 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -37,8 +37,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/metricstransformprocessor/go.mod
+++ b/processor/metricstransformprocessor/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -40,8 +40,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/metricstransformprocessor/go.mod
+++ b/processor/metricstransformprocessor/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/probabilisticsamplerprocessor/go.mod
+++ b/processor/probabilisticsamplerprocessor/go.mod
@@ -6,14 +6,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -58,19 +58,19 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/processor/probabilisticsamplerprocessor/go.mod
+++ b/processor/probabilisticsamplerprocessor/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -68,7 +68,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/processor/redactionprocessor/go.mod
+++ b/processor/redactionprocessor/go.mod
@@ -4,11 +4,11 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -37,8 +37,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/redactionprocessor/go.mod
+++ b/processor/redactionprocessor/go.mod
@@ -7,7 +7,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/remotetapprocessor/go.mod
+++ b/processor/remotetapprocessor/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -49,14 +49,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/remotetapprocessor/go.mod
+++ b/processor/remotetapprocessor/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -47,15 +47,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -16,12 +16,12 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -112,7 +112,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/processor/resourcedetectionprocessor/go.mod
+++ b/processor/resourcedetectionprocessor/go.mod
@@ -14,16 +14,16 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders v0.96.0
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -110,13 +110,13 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/resourceprocessor/go.mod
+++ b/processor/resourceprocessor/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -41,8 +41,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/resourceprocessor/go.mod
+++ b/processor/resourceprocessor/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/routingprocessor/go.mod
+++ b/processor/routingprocessor/go.mod
@@ -5,15 +5,15 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -56,18 +56,18 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/routingprocessor/go.mod
+++ b/processor/routingprocessor/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -57,16 +57,16 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/schemaprocessor/go.mod
+++ b/processor/schemaprocessor/go.mod
@@ -4,12 +4,12 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/schema v0.0.7
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -46,15 +46,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/processor/schemaprocessor/go.mod
+++ b/processor/schemaprocessor/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/schema v0.0.7
@@ -48,14 +48,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/spanprocessor/go.mod
+++ b/processor/spanprocessor/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -50,7 +50,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/spanprocessor/go.mod
+++ b/processor/spanprocessor/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -48,8 +48,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/processor/sumologicprocessor/go.mod
+++ b/processor/sumologicprocessor/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -67,7 +67,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/processor/sumologicprocessor/go.mod
+++ b/processor/sumologicprocessor/go.mod
@@ -4,13 +4,13 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -56,20 +56,20 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -10,13 +10,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -50,7 +50,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/processor/tailsamplingprocessor/go.mod
+++ b/processor/tailsamplingprocessor/go.mod
@@ -14,8 +14,8 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/transformprocessor/go.mod
+++ b/processor/transformprocessor/go.mod
@@ -10,8 +10,8 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/processor/transformprocessor/go.mod
+++ b/processor/transformprocessor/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -49,8 +49,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/activedirectorydsreceiver/go.mod
+++ b/receiver/activedirectorydsreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/activedirectorydsreceiver/go.mod
+++ b/receiver/activedirectorydsreceiver/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,8 +43,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/aerospikereceiver/go.mod
+++ b/receiver/aerospikereceiver/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/aerospikereceiver/go.mod
+++ b/receiver/aerospikereceiver/go.mod
@@ -10,13 +10,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -82,8 +82,8 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yuin/gopher-lua v0.0.0-20220504180219-658193537a64 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/apachereceiver/go.mod
+++ b/receiver/apachereceiver/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -84,13 +84,13 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/apachereceiver/go.mod
+++ b/receiver/apachereceiver/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -82,14 +82,14 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/apachesparkreceiver/go.mod
+++ b/receiver/apachesparkreceiver/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -84,14 +84,14 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/apachesparkreceiver/go.mod
+++ b/receiver/apachesparkreceiver/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -82,15 +82,15 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/awscloudwatchmetricsreceiver/go.mod
+++ b/receiver/awscloudwatchmetricsreceiver/go.mod
@@ -4,10 +4,10 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -36,7 +36,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/awscloudwatchmetricsreceiver/go.mod
+++ b/receiver/awscloudwatchmetricsreceiver/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/awscloudwatchreceiver/go.mod
+++ b/receiver/awscloudwatchreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/awscontainerinsightreceiver/go.mod
+++ b/receiver/awscontainerinsightreceiver/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -117,14 +117,14 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/awscontainerinsightreceiver/go.mod
+++ b/receiver/awscontainerinsightreceiver/go.mod
@@ -13,12 +13,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kubelet v0.96.0
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -115,15 +115,15 @@ require (
 	github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852 // indirect
 	github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -48,15 +48,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/awsecscontainermetricsreceiver/go.mod
+++ b/receiver/awsecscontainermetricsreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -50,14 +50,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/awsfirehosereceiver/go.mod
+++ b/receiver/awsfirehosereceiver/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -50,12 +50,12 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/awsfirehosereceiver/go.mod
+++ b/receiver/awsfirehosereceiver/go.mod
@@ -5,15 +5,15 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -48,13 +48,13 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -12,14 +12,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -53,9 +53,9 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/awsxrayreceiver/go.mod
+++ b/receiver/awsxrayreceiver/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -54,9 +54,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -88,7 +88,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -77,21 +77,21 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/azureeventhubreceiver/go.mod
+++ b/receiver/azureeventhubreceiver/go.mod
@@ -11,14 +11,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure v0.96.0
 	github.com/relvacode/iso8601 v1.4.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -81,19 +81,19 @@ require (
 	github.com/valyala/fastjson v1.6.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/azureeventhubreceiver/go.mod
+++ b/receiver/azureeventhubreceiver/go.mod
@@ -16,7 +16,7 @@ require (
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -91,7 +91,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/receiver/azuremonitorreceiver/go.mod
+++ b/receiver/azuremonitorreceiver/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,8 +52,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/azuremonitorreceiver/go.mod
+++ b/receiver/azuremonitorreceiver/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/bigipreceiver/go.mod
+++ b/receiver/bigipreceiver/go.mod
@@ -8,14 +8,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -85,13 +85,13 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/bigipreceiver/go.mod
+++ b/receiver/bigipreceiver/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -87,12 +87,12 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/carbonreceiver/go.mod
+++ b/receiver/carbonreceiver/go.mod
@@ -5,12 +5,12 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -41,8 +41,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/carbonreceiver/go.mod
+++ b/receiver/carbonreceiver/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.24.0 // indirect

--- a/receiver/chronyreceiver/go.mod
+++ b/receiver/chronyreceiver/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tilinna/clock v1.1.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,8 +43,8 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/chronyreceiver/go.mod
+++ b/receiver/chronyreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/cloudflarereceiver/go.mod
+++ b/receiver/cloudflarereceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -45,9 +45,9 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/cloudflarereceiver/go.mod
+++ b/receiver/cloudflarereceiver/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -46,7 +46,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/cloudfoundryreceiver/go.mod
+++ b/receiver/cloudfoundryreceiver/go.mod
@@ -6,14 +6,14 @@ require (
 	code.cloudfoundry.org/go-loggregator v7.4.0+incompatible
 	github.com/cloudfoundry-incubator/uaago v0.0.0-20190307164349-8136b7bbe76e
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,13 +52,13 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/cloudfoundryreceiver/go.mod
+++ b/receiver/cloudfoundryreceiver/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -54,12 +54,12 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/collectdreceiver/go.mod
+++ b/receiver/collectdreceiver/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -49,15 +49,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/collectdreceiver/go.mod
+++ b/receiver/collectdreceiver/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -51,14 +51,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/couchdbreceiver/go.mod
+++ b/receiver/couchdbreceiver/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,13 +52,13 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/couchdbreceiver/go.mod
+++ b/receiver/couchdbreceiver/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -54,12 +54,12 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vmihailenco/msgpack/v4 v4.3.13
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,15 +52,15 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/tinylib/msgp v1.1.9 // indirect
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/datadogreceiver/go.mod
+++ b/receiver/datadogreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -54,14 +54,14 @@ require (
 	github.com/vmihailenco/tagparser v0.1.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/dockerstatsreceiver/go.mod
+++ b/receiver/dockerstatsreceiver/go.mod
@@ -10,13 +10,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -80,8 +80,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/dockerstatsreceiver/go.mod
+++ b/receiver/dockerstatsreceiver/go.mod
@@ -13,8 +13,8 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/receiver/elasticsearchreceiver/go.mod
+++ b/receiver/elasticsearchreceiver/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -85,13 +85,13 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/elasticsearchreceiver/go.mod
+++ b/receiver/elasticsearchreceiver/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -87,12 +87,12 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/expvarreceiver/go.mod
+++ b/receiver/expvarreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -50,14 +50,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/expvarreceiver/go.mod
+++ b/receiver/expvarreceiver/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -48,15 +48,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -47,9 +47,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -50,7 +50,7 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/filestatsreceiver/go.mod
+++ b/receiver/filestatsreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/filestatsreceiver/go.mod
+++ b/receiver/filestatsreceiver/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -77,8 +77,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/flinkmetricsreceiver/go.mod
+++ b/receiver/flinkmetricsreceiver/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -50,14 +50,14 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/flinkmetricsreceiver/go.mod
+++ b/receiver/flinkmetricsreceiver/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -52,13 +52,13 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/fluentforwardreceiver/go.mod
+++ b/receiver/fluentforwardreceiver/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/tinylib/msgp v1.1.9
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,8 +43,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/fluentforwardreceiver/go.mod
+++ b/receiver/fluentforwardreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/gitproviderreceiver/go.mod
+++ b/receiver/gitproviderreceiver/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -69,8 +69,8 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -84,7 +84,7 @@ require (
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/receiver/gitproviderreceiver/go.mod
+++ b/receiver/gitproviderreceiver/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/go-github/v59 v59.0.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -67,26 +67,26 @@ require (
 	github.com/vektah/gqlparser/v2 v2.5.11 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect

--- a/receiver/googlecloudpubsubreceiver/go.mod
+++ b/receiver/googlecloudpubsubreceiver/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/json-iterator/go v1.1.12
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0
@@ -60,10 +60,10 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.einride.tech/aip v0.66.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/googlecloudpubsubreceiver/go.mod
+++ b/receiver/googlecloudpubsubreceiver/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/googlecloudspannerreceiver/go.mod
+++ b/receiver/googlecloudspannerreceiver/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/ReneKroon/ttlcache/v2 v2.11.0
 	github.com/mitchellh/hashstructure v1.1.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -61,8 +61,8 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.48.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.48.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/googlecloudspannerreceiver/go.mod
+++ b/receiver/googlecloudspannerreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/haproxyreceiver/go.mod
+++ b/receiver/haproxyreceiver/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -84,14 +84,14 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/haproxyreceiver/go.mod
+++ b/receiver/haproxyreceiver/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -82,15 +82,15 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -15,9 +15,9 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/receiver/hostmetricsreceiver/go.mod
+++ b/receiver/hostmetricsreceiver/go.mod
@@ -12,14 +12,14 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
 	github.com/yusufpapurcu/wmi v1.2.4
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -91,19 +91,19 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/httpcheckreceiver/go.mod
+++ b/receiver/httpcheckreceiver/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -52,13 +52,13 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/httpcheckreceiver/go.mod
+++ b/receiver/httpcheckreceiver/go.mod
@@ -7,13 +7,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -50,14 +50,14 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/iisreceiver/go.mod
+++ b/receiver/iisreceiver/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/iisreceiver/go.mod
+++ b/receiver/iisreceiver/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -77,8 +77,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/influxdbreceiver/go.mod
+++ b/receiver/influxdbreceiver/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/influxdata/line-protocol/v2 v2.2.1
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -56,17 +56,17 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/influxdbreceiver/go.mod
+++ b/receiver/influxdbreceiver/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -58,14 +58,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/jaegerreceiver/go.mod
+++ b/receiver/jaegerreceiver/go.mod
@@ -16,8 +16,8 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -61,8 +61,8 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/receiver/jaegerreceiver/go.mod
+++ b/receiver/jaegerreceiver/go.mod
@@ -9,17 +9,17 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -59,14 +59,14 @@ require (
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/jmxreceiver/go.mod
+++ b/receiver/jmxreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
@@ -85,7 +85,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -94,8 +94,8 @@ require (
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/jmxreceiver/go.mod
+++ b/receiver/jmxreceiver/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -83,17 +83,17 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect

--- a/receiver/journaldreceiver/go.mod
+++ b/receiver/journaldreceiver/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,9 +43,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/journaldreceiver/go.mod
+++ b/receiver/journaldreceiver/go.mod
@@ -46,8 +46,8 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -16,13 +16,13 @@ require (
 	github.com/openshift/api v3.9.0+incompatible
 	github.com/openshift/client-go v0.0.0-20210521082421-73d9475a9142
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -84,18 +84,18 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/receiver/k8sclusterreceiver/go.mod
+++ b/receiver/k8sclusterreceiver/go.mod
@@ -19,7 +19,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
@@ -86,17 +86,17 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/k8seventsreceiver/go.mod
+++ b/receiver/k8seventsreceiver/go.mod
@@ -8,7 +8,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/receiver/k8seventsreceiver/go.mod
+++ b/receiver/k8seventsreceiver/go.mod
@@ -5,12 +5,12 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -58,8 +58,8 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/k8sobjectsreceiver/go.mod
+++ b/receiver/k8sobjectsreceiver/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
@@ -80,17 +80,17 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/k8sobjectsreceiver/go.mod
+++ b/receiver/k8sobjectsreceiver/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -78,18 +78,18 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/receiver/kafkametricsreceiver/go.mod
+++ b/receiver/kafkametricsreceiver/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -64,9 +64,9 @@ require (
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/kafkametricsreceiver/go.mod
+++ b/receiver/kafkametricsreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -65,7 +65,7 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -21,7 +21,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -75,7 +75,7 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/receiver/kafkareceiver/go.mod
+++ b/receiver/kafkareceiver/go.mod
@@ -17,13 +17,13 @@ require (
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -74,12 +74,12 @@ require (
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -16,7 +16,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
@@ -87,15 +87,15 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/kubeletstatsreceiver/go.mod
+++ b/receiver/kubeletstatsreceiver/go.mod
@@ -11,15 +11,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -85,16 +85,16 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/receiver/lokireceiver/go.mod
+++ b/receiver/lokireceiver/go.mod
@@ -15,19 +15,19 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/loki v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.96.0 // indirect
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/zap v1.27.0
 	google.golang.org/grpc v1.62.1
 )
 
 require (
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -66,16 +66,16 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/prometheus/prometheus v0.48.1 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/lokireceiver/go.mod
+++ b/receiver/lokireceiver/go.mod
@@ -28,7 +28,7 @@ require (
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -67,14 +67,14 @@ require (
 	github.com/prometheus/prometheus v0.48.1 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/receiver/memcachedreceiver/go.mod
+++ b/receiver/memcachedreceiver/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/memcachedreceiver/go.mod
+++ b/receiver/memcachedreceiver/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -77,8 +77,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -12,15 +12,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
 	go.mongodb.org/atlas v0.36.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -60,8 +60,8 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/mongodbatlasreceiver/go.mod
+++ b/receiver/mongodbatlasreceiver/go.mod
@@ -13,13 +13,13 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.mongodb.org/atlas v0.36.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -62,7 +62,7 @@ require (
 	github.com/valyala/fastjson v1.6.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/mongodbreceiver/go.mod
+++ b/receiver/mongodbreceiver/go.mod
@@ -13,12 +13,12 @@ require (
 	go.mongodb.org/mongo-driver v1.14.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/mongodbreceiver/go.mod
+++ b/receiver/mongodbreceiver/go.mod
@@ -11,15 +11,15 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.mongodb.org/mongo-driver v1.14.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -90,8 +90,8 @@ require (
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/mysqlreceiver/go.mod
+++ b/receiver/mysqlreceiver/go.mod
@@ -12,11 +12,11 @@ require (
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/mysqlreceiver/go.mod
+++ b/receiver/mysqlreceiver/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -81,8 +81,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/namedpipereceiver/go.mod
+++ b/receiver/namedpipereceiver/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -44,9 +44,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/namedpipereceiver/go.mod
+++ b/receiver/namedpipereceiver/go.mod
@@ -47,8 +47,8 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -15,7 +15,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -85,13 +85,13 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/nginxreceiver/go.mod
+++ b/receiver/nginxreceiver/go.mod
@@ -10,13 +10,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -83,14 +83,14 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/nsxtreceiver/go.mod
+++ b/receiver/nsxtreceiver/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vmware/go-vmware-nsxt v0.0.0-20230223012718-d31b8a1ca05e
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,14 +52,14 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/nsxtreceiver/go.mod
+++ b/receiver/nsxtreceiver/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/vmware/go-vmware-nsxt v0.0.0-20230223012718-d31b8a1ca05e
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -54,13 +54,13 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/opencensusreceiver/go.mod
+++ b/receiver/opencensusreceiver/go.mod
@@ -18,7 +18,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0
 	go.opentelemetry.io/otel v1.24.0
@@ -61,13 +61,13 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.24.0 // indirect

--- a/receiver/opencensusreceiver/go.mod
+++ b/receiver/opencensusreceiver/go.mod
@@ -12,14 +12,14 @@ require (
 	github.com/rs/cors v1.10.1
 	github.com/soheilhy/cmux v0.1.5
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -59,16 +59,16 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/receiver/oracledbreceiver/go.mod
+++ b/receiver/oracledbreceiver/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/sijms/go-ora/v2 v2.8.9
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -40,8 +40,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/oracledbreceiver/go.mod
+++ b/receiver/oracledbreceiver/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/osqueryreceiver/go.mod
+++ b/receiver/osqueryreceiver/go.mod
@@ -4,8 +4,8 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -25,10 +25,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/receiver/osqueryreceiver/go.mod
+++ b/receiver/osqueryreceiver/go.mod
@@ -29,7 +29,7 @@ require (
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect

--- a/receiver/otelarrowreceiver/go.mod
+++ b/receiver/otelarrowreceiver/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -62,13 +62,13 @@ require (
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/otelarrowreceiver/go.mod
+++ b/receiver/otelarrowreceiver/go.mod
@@ -7,15 +7,15 @@ require (
 	github.com/open-telemetry/otel-arrow v0.18.0
 	github.com/open-telemetry/otel-arrow/collector v0.18.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -60,14 +60,14 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/otlpjsonfilereceiver/go.mod
+++ b/receiver/otlpjsonfilereceiver/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -48,7 +48,7 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/otlpjsonfilereceiver/go.mod
+++ b/receiver/otlpjsonfilereceiver/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -45,9 +45,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/podmanreceiver/go.mod
+++ b/receiver/podmanreceiver/go.mod
@@ -4,13 +4,13 @@ go 1.21
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/multierr v1.11.0
@@ -40,8 +40,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/podmanreceiver/go.mod
+++ b/receiver/podmanreceiver/go.mod
@@ -5,10 +5,10 @@ go 1.21
 require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/receiver/postgresqlreceiver/go.mod
+++ b/receiver/postgresqlreceiver/go.mod
@@ -11,15 +11,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -85,8 +85,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/postgresqlreceiver/go.mod
+++ b/receiver/postgresqlreceiver/go.mod
@@ -13,12 +13,12 @@ require (
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/prometheusreceiver/go.mod
+++ b/receiver/prometheusreceiver/go.mod
@@ -19,9 +19,9 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
@@ -162,8 +162,8 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/receiver/prometheusreceiver/go.mod
+++ b/receiver/prometheusreceiver/go.mod
@@ -13,19 +13,19 @@ require (
 	github.com/prometheus/common v0.48.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -160,23 +160,23 @@ require (
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect

--- a/receiver/pulsarreceiver/go.mod
+++ b/receiver/pulsarreceiver/go.mod
@@ -12,10 +12,10 @@ require (
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/receiver/pulsarreceiver/go.mod
+++ b/receiver/pulsarreceiver/go.mod
@@ -11,13 +11,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.96.0
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -66,7 +66,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/purefareceiver/go.mod
+++ b/receiver/purefareceiver/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/prometheus/common v0.48.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -133,16 +133,16 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/purefareceiver/go.mod
+++ b/receiver/purefareceiver/go.mod
@@ -134,14 +134,14 @@ require (
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/purefbreceiver/go.mod
+++ b/receiver/purefbreceiver/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/prometheus/common v0.48.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -133,16 +133,16 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/purefbreceiver/go.mod
+++ b/receiver/purefbreceiver/go.mod
@@ -134,14 +134,14 @@ require (
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/rabbitmqreceiver/go.mod
+++ b/receiver/rabbitmqreceiver/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,13 +52,13 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/rabbitmqreceiver/go.mod
+++ b/receiver/rabbitmqreceiver/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -54,12 +54,12 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -74,7 +74,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect

--- a/receiver/receivercreator/go.mod
+++ b/receiver/receivercreator/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/spf13/cast v1.6.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -64,19 +64,19 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/redisreceiver/go.mod
+++ b/receiver/redisreceiver/go.mod
@@ -11,11 +11,11 @@ require (
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/redisreceiver/go.mod
+++ b/receiver/redisreceiver/go.mod
@@ -9,14 +9,14 @@ require (
 	github.com/redis/go-redis/v9 v9.5.1
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -81,8 +81,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/riakreceiver/go.mod
+++ b/receiver/riakreceiver/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,13 +52,13 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/riakreceiver/go.mod
+++ b/receiver/riakreceiver/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -54,12 +54,12 @@ require (
 	github.com/stretchr/objx v0.5.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/saphanareceiver/go.mod
+++ b/receiver/saphanareceiver/go.mod
@@ -8,14 +8,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -48,8 +48,8 @@ require (
 	github.com/prometheus/common v0.50.0 // indirect
 	github.com/prometheus/procfs v0.13.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/saphanareceiver/go.mod
+++ b/receiver/saphanareceiver/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -11,14 +11,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.96.0
 	github.com/signalfx/sapm-proto v0.14.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -54,16 +54,16 @@ require (
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -16,7 +16,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -56,15 +56,15 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -11,14 +11,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/signalfx v0.96.0
 	github.com/signalfx/com_signalfx_metrics_protobuf v0.0.3
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/zap v1.27.0
@@ -66,17 +66,17 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/signalfxreceiver/go.mod
+++ b/receiver/signalfxreceiver/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -68,14 +68,14 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/simpleprometheusreceiver/go.mod
+++ b/receiver/simpleprometheusreceiver/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/prometheus/common v0.48.0
 	github.com/prometheus/prometheus v0.48.1
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -131,17 +131,17 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/simpleprometheusreceiver/go.mod
+++ b/receiver/simpleprometheusreceiver/go.mod
@@ -133,14 +133,14 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -8,16 +8,16 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -58,14 +58,14 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -15,7 +15,7 @@ require (
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -60,13 +60,13 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.47.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/snmpreceiver/go.mod
+++ b/receiver/snmpreceiver/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -84,21 +84,21 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/propagators/b3 v1.24.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/snmpreceiver/go.mod
+++ b/receiver/snmpreceiver/go.mod
@@ -9,11 +9,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -95,7 +95,7 @@ require (
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect

--- a/receiver/snowflakereceiver/go.mod
+++ b/receiver/snowflakereceiver/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/snowflakedb/gosnowflake v1.8.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/snowflakereceiver/go.mod
+++ b/receiver/snowflakereceiver/go.mod
@@ -9,12 +9,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/snowflakedb/gosnowflake v1.8.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -81,8 +81,8 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/solacereceiver/go.mod
+++ b/receiver/solacereceiver/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/Azure/go-amqp v1.0.5
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -48,7 +48,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.24.0 // indirect

--- a/receiver/solacereceiver/go.mod
+++ b/receiver/solacereceiver/go.mod
@@ -10,11 +10,11 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0

--- a/receiver/splunkenterprisereceiver/go.mod
+++ b/receiver/splunkenterprisereceiver/go.mod
@@ -7,15 +7,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -52,12 +52,12 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/splunkenterprisereceiver/go.mod
+++ b/receiver/splunkenterprisereceiver/go.mod
@@ -10,11 +10,11 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -53,12 +53,12 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/splunkhecreceiver/go.mod
+++ b/receiver/splunkhecreceiver/go.mod
@@ -11,15 +11,15 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -58,15 +58,15 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/splunkhecreceiver/go.mod
+++ b/receiver/splunkhecreceiver/go.mod
@@ -17,7 +17,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -60,14 +60,14 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -134,8 +134,8 @@ require (
 	github.com/valyala/fastjson v1.6.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	github.com/zeebo/xxh3 v1.0.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -15,7 +15,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -136,7 +136,7 @@ require (
 	github.com/zeebo/xxh3 v1.0.2 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/sqlserverreceiver/go.mod
+++ b/receiver/sqlserverreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/sqlserverreceiver/go.mod
+++ b/receiver/sqlserverreceiver/go.mod
@@ -8,11 +8,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -44,8 +44,8 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/sshcheckreceiver/go.mod
+++ b/receiver/sshcheckreceiver/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/pkg/sftp v1.13.6
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	golang.org/x/crypto v0.21.0
@@ -25,8 +25,8 @@ require (
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 	github.com/knadh/koanf/v2 v2.1.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.96.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240123012728-ef4313101c80 // indirect
 )
 

--- a/receiver/sshcheckreceiver/go.mod
+++ b/receiver/sshcheckreceiver/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0

--- a/receiver/statsdreceiver/go.mod
+++ b/receiver/statsdreceiver/go.mod
@@ -7,14 +7,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/statsdreceiver/go.mod
+++ b/receiver/statsdreceiver/go.mod
@@ -12,7 +12,7 @@ require (
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel v1.24.0
@@ -48,7 +48,7 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.24.0 // indirect

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -6,11 +6,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -46,11 +46,11 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -47,11 +47,11 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -46,12 +46,12 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -5,10 +5,10 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -45,11 +45,11 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/udplogreceiver/go.mod
+++ b/receiver/udplogreceiver/go.mod
@@ -5,10 +5,10 @@ go 1.21
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -43,9 +43,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/udplogreceiver/go.mod
+++ b/receiver/udplogreceiver/go.mod
@@ -46,8 +46,8 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/vcenterreceiver/go.mod
+++ b/receiver/vcenterreceiver/go.mod
@@ -11,12 +11,12 @@ require (
 	github.com/stretchr/testify v1.9.0
 	github.com/vmware/govmomi v0.36.1
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/vcenterreceiver/go.mod
+++ b/receiver/vcenterreceiver/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vmware/govmomi v0.36.1
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -84,8 +84,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/wavefrontreceiver/go.mod
+++ b/receiver/wavefrontreceiver/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/carbonreceiver v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -41,8 +41,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/wavefrontreceiver/go.mod
+++ b/receiver/wavefrontreceiver/go.mod
@@ -11,7 +11,7 @@ require (
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -43,7 +43,7 @@ require (
 	github.com/prometheus/procfs v0.12.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/webhookeventreceiver/go.mod
+++ b/receiver/webhookeventreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -48,14 +48,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/webhookeventreceiver/go.mod
+++ b/receiver/webhookeventreceiver/go.mod
@@ -6,12 +6,12 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -46,15 +46,15 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/windowseventlogreceiver/go.mod
+++ b/receiver/windowseventlogreceiver/go.mod
@@ -6,10 +6,10 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -44,9 +44,9 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/valyala/fastjson v1.6.4 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/windowseventlogreceiver/go.mod
+++ b/receiver/windowseventlogreceiver/go.mod
@@ -47,8 +47,8 @@ require (
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/windowsperfcountersreceiver/go.mod
+++ b/receiver/windowsperfcountersreceiver/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/winperfcounters v0.96.0
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -42,8 +42,8 @@ require (
 	github.com/prometheus/client_model v0.6.0 // indirect
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/receiver/windowsperfcountersreceiver/go.mod
+++ b/receiver/windowsperfcountersreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0

--- a/receiver/zipkinreceiver/go.mod
+++ b/receiver/zipkinreceiver/go.mod
@@ -13,7 +13,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
@@ -53,14 +53,14 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/zipkinreceiver/go.mod
+++ b/receiver/zipkinreceiver/go.mod
@@ -9,13 +9,13 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.96.0
 	github.com/openzipkin/zipkin-go v0.4.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -51,15 +51,15 @@ require (
 	github.com/prometheus/common v0.49.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/receiver/zookeeperreceiver/go.mod
+++ b/receiver/zookeeperreceiver/go.mod
@@ -10,12 +10,12 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.96.0
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.27.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
@@ -78,8 +78,8 @@ require (
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect

--- a/receiver/zookeeperreceiver/go.mod
+++ b/receiver/zookeeperreceiver/go.mod
@@ -14,7 +14,7 @@ require (
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
@@ -80,7 +80,7 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.3 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -33,31 +33,31 @@ require (
 	github.com/prometheus/prometheus v0.48.1
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/confmap/provider/fileprovider v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/debugexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter/otlphttpexporter v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
-	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/semconv v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/processor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/receiver/otlpreceiver v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/semconv v0.96.1-0.20240313152028-cc485e0870b1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
@@ -214,20 +214,20 @@ require (
 	github.com/vultr/govultr/v2 v2.17.2 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opencensus.io v0.24.0 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/envprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/httpsprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/connector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/service v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.2
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/config/configgrpc v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/config/confignet v0.96.1-0.20240306115632-b2693620eff6
@@ -51,7 +51,7 @@ require (
 	go.opentelemetry.io/collector/extension/ballastextension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/extension/zpagesextension v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/otelcol v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/processor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/batchprocessor v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.96.1-0.20240306115632-b2693620eff6
@@ -216,7 +216,7 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/confmap/converter/expandconverter v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -226,7 +226,7 @@ require (
 	go.opentelemetry.io/collector/confmap/provider/yamlprovider v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/connector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/service v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/contrib/config v0.4.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 // indirect

--- a/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
@@ -5,10 +5,10 @@ go 1.21
 require (
 	github.com/DataDog/datadog-agent/pkg/trace/exportable v0.0.0-20201016145401-4646cf596b02
 	github.com/tinylib/msgp v1.1.9
-	go.opentelemetry.io/collector/component v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/component v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/consumer v0.96.1-0.20240313152028-cc485e0870b1
+	go.opentelemetry.io/collector/exporter v0.96.1-0.20240313152028-cc485e0870b1
 	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 )
 
@@ -40,17 +40,17 @@ require (
 	github.com/prometheus/common v0.48.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
-	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/internal v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/confmap v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension v0.96.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect

--- a/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/go.mod
@@ -9,7 +9,7 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/consumer v0.96.1-0.20240306115632-b2693620eff6
 	go.opentelemetry.io/collector/exporter v0.96.1-0.20240306115632-b2693620eff6
-	go.opentelemetry.io/collector/pdata v1.3.1-0.20240306115632-b2693620eff6
+	go.opentelemetry.io/collector/pdata v1.3.1-0.20240313152028-cc485e0870b1
 )
 
 require (
@@ -42,8 +42,8 @@ require (
 	github.com/rs/cors v1.10.1 // indirect
 	go.opentelemetry.io/collector v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configauth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configcompression v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/config/configcompression v1.3.1-0.20240313152028-cc485e0870b1 // indirect
+	go.opentelemetry.io/collector/config/configopaque v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/collector/config/configretry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/config/configtls v0.96.1-0.20240306115632-b2693620eff6 // indirect
@@ -51,7 +51,7 @@ require (
 	go.opentelemetry.io/collector/confmap v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension v0.96.1-0.20240306115632-b2693620eff6 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.96.1-0.20240306115632-b2693620eff6 // indirect
-	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240306115632-b2693620eff6 // indirect
+	go.opentelemetry.io/collector/featuregate v1.3.1-0.20240313152028-cc485e0870b1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 // indirect
 	go.opentelemetry.io/otel v1.24.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect


### PR DESCRIPTION
**Description:**

Update collector core to the latest release.  Blocking https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30934.  This will pull in https://github.com/open-telemetry/opentelemetry-collector/pull/9637.