### PR TITLE
[receiver/sqlquery] Fix memory leak and failing tests

### DIFF
--- a/.chloggen/sqlquery_shutdown.yaml
+++ b/.chloggen/sqlquery_shutdown.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlqueryreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix memory leak on shutdown for log telemetry
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31782]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -20,7 +20,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
 	go.uber.org/goleak v1.3.0
-	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 )
 
@@ -141,6 +140,7 @@ require (
 	go.opentelemetry.io/otel/exporters/prometheus v0.46.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.24.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.24.0 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.21.0 // indirect
 	golang.org/x/exp v0.0.0-20240205201215-2c58cdc269a3 // indirect
 	golang.org/x/mod v0.14.0 // indirect

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -298,7 +298,7 @@ func (queryReceiver *logsQueryReceiver) collect(ctx context.Context) (plog.Logs,
 			}
 		}
 	}
-	return logs, nil
+	return logs, errors.Join(errs...)
 }
 
 func (queryReceiver *logsQueryReceiver) storeTrackingValue(ctx context.Context, row sqlquery.StringMap) error {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR includes two changes that are dependent on each other.

1. Fix test failing in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31778. Explanation given [here.](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31778#issuecomment-2000561498) All changes in `integration_test.go` are related to this.
2. When the test was fixed, `goleak` started failing. The logs receiver opens a DB connection when it's started, but shutdown does not close the DB. This DB needs to be closed during shutdown to avoid a leaked goroutine. All changes outside of `integration_test.go` are for this.
3. Since the memory leak changes were modifying errors, I moved from using `multierr.append` to `errors.Join` as well.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #31782
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31778

**Testing:** <Describe what testing was performed and which tests were added.>
Tests are passing