### PR TITLE
[chore] reuse the timer object when parsing

### DIFF
--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -31,7 +31,7 @@ const NativeKey = "native" // provided for operator development
 // NewTimeParser creates a new time parser with default values
 func NewTimeParser() TimeParser {
 	return TimeParser{
-		LayoutType: StrptimeKey,
+		LayoutType: "strptime",
 	}
 }
 

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -31,7 +31,7 @@ const NativeKey = "native" // provided for operator development
 // NewTimeParser creates a new time parser with default values
 func NewTimeParser() TimeParser {
 	return TimeParser{
-		LayoutType: "strptime",
+		LayoutType: StrptimeKey,
 	}
 }
 
@@ -47,10 +47,12 @@ type TimeParser struct {
 
 // Unmarshal starting from default settings
 func (t *TimeParser) Unmarshal(component *confmap.Conf) error {
-	*t = NewTimeParser()
 	err := component.Unmarshal(t, confmap.WithIgnoreUnused())
 	if err != nil {
 		return err
+	}
+	if t.LayoutType == "" {
+		t.LayoutType = StrptimeKey
 	}
 	return nil
 }

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -47,12 +47,11 @@ type TimeParser struct {
 
 // Unmarshal starting from default settings
 func (t *TimeParser) Unmarshal(component *confmap.Conf) error {
-	cfg := NewTimeParser()
-	err := component.Unmarshal(&cfg, confmap.WithIgnoreUnused())
+	*t = NewTimeParser()
+	err := component.Unmarshal(t, confmap.WithIgnoreUnused())
 	if err != nil {
 		return err
 	}
-	*t = cfg
 	return nil
 }
 

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -51,9 +51,6 @@ func (t *TimeParser) Unmarshal(component *confmap.Conf) error {
 	if err != nil {
 		return err
 	}
-	if t.LayoutType == "" {
-		t.LayoutType = StrptimeKey
-	}
 	return nil
 }
 


### PR DESCRIPTION
**Description:**

This is a companion PR to handle recursive state of unmarshalers with https://github.com/open-telemetry/opentelemetry-collector/pull/9750.

By reusing the same struct when parsing its contents, we can avoid running into an infinite loop.