### PR TITLE
[exporter/datadog] Report `otelcol_datadog_otlp_translator_resources_missing_source` metric

### DIFF
--- a/.chloggen/mx-psi_enable-internal-metric.yaml
+++ b/.chloggen/mx-psi_enable-internal-metric.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add new telemetry metric, `datadog.otlp_translator.resources.missing_source` that counts OTLP resources missing a hostname-identifying attribute.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31805]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  - Enable Collector metrics https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/troubleshooting.md#metrics to check for this metric.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/mx-psi_enable-internal-metric.yaml
+++ b/.chloggen/mx-psi_enable-internal-metric.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: datadogexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add new telemetry metric, `datadog.otlp_translator.resources.missing_source` that counts OTLP resources missing a hostname-identifying attribute.
+note: Add new telemetry metric, `otelcol_datadog_otlp_translator_resources_missing_source` that counts OTLP resources missing a hostname-identifying attribute.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [31805]

--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -30,7 +30,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"go.opentelemetry.io/otel/metric/noop"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 
@@ -106,9 +105,6 @@ func (f *factory) SourceProvider(set component.TelemetrySettings, configHostname
 
 func (f *factory) AttributesTranslator(set component.TelemetrySettings) (*attributes.Translator, error) {
 	f.onceAttributesTranslator.Do(func() {
-		// disable metrics for the translator
-		// Metrics are disabled until we figure out the details on how do we want to report the metric.
-		set.MeterProvider = noop.NewMeterProvider()
 		f.attributesTranslator, f.attributesErr = attributes.NewTranslator(set)
 	})
 	return f.attributesTranslator, f.attributesErr


### PR DESCRIPTION
**Description:** 

Adds new telemetry metric, `otelcol_datadog_otlp_translator_resources_missing_source`, that counts OTLP resources missing a hostname-identifying attribute.

Datadog correlation and infrastructure features may not work correctly or be fully featured if payloads are missing a hostname; this metric is useful to track this.

Internal reference: OTEL-1155

**Testing:** Tested with the following configuration:

<details>
<summary>Configuration (Click to expand)</summary>

```
receivers:
  prometheus:
    config:
      scrape_configs:
      - job_name: 'otelcol'
        scrape_interval: 10s
        static_configs:
        - targets: ['0.0.0.0:8888']
        metric_relabel_configs:
          - source_labels: [ __name__ ]
            regex: '.*grpc_io.*'
            action: drop
    
  hostmetrics:
    scrapers:
      load:

exporters:
  datadog:
    api::key: ${env:DD_API_KEY}
  debug:

service:
  pipelines:
    metrics:
      receivers: [prometheus, hostmetrics]
      exporters: [debug, datadog]
```

</details>

**Documentation:** To be added on Datadog docs