### PR TITLE
[connector/exceptions] copy span attributes to generate logs from exceptions

### DIFF
--- a/.chloggen/exceptionsconnector_copy_span_attrs.yaml
+++ b/.chloggen/exceptionsconnector_copy_span_attrs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exceptionsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Copy span attributes to the generated log from exception.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24410]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/exceptionsconnector/README.md
+++ b/connector/exceptionsconnector/README.md
@@ -36,7 +36,7 @@ With the provided default config, each **metric** and **log** will also have the
 
 Each log will additionally have the following attributes:
 - Exception stacktrace
-- HTTP attributes from spans starting with `http.`.
+- Span attributes. If you want to filter out some attributes (like only copying HTTP attributes starting with `http.`) use [Transform Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor/).
 
 ## Configurations
 

--- a/connector/exceptionsconnector/README.md
+++ b/connector/exceptionsconnector/README.md
@@ -36,7 +36,7 @@ With the provided default config, each **metric** and **log** will also have the
 
 Each log will additionally have the following attributes:
 - Exception stacktrace
-- Span attributes. If you want to filter out some attributes (like only copying HTTP attributes starting with `http.`) use [Transform Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor/).
+- Span attributes. If you want to filter out some attributes (like only copying HTTP attributes starting with `http.`) use the [transform processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/transformprocessor/).
 
 ## Configurations
 

--- a/connector/exceptionsconnector/testdata/logs.yml
+++ b/connector/exceptionsconnector/testdata/logs.yml
@@ -3,6 +3,26 @@ resourceLogs:
     scopeLogs:
       - logRecords:
           - attributes:
+              - key: stringAttrName
+                value:
+                  stringValue: stringAttrValue
+              - key: intAttrName
+                value:
+                  intValue: "99"
+              - key: doubleAttrName
+                value:
+                  doubleValue: 99.99
+              - key: boolAttrName
+                value:
+                  boolValue: true
+              - key: nullAttrName
+                value: {}
+              - key: mapAttrName
+                value:
+                  kvlistValue: {}
+              - key: arrayAttrName
+                value:
+                  arrayValue: {}
               - key: span.kind
                 value:
                   stringValue: SPAN_KIND_SERVER
@@ -27,6 +47,26 @@ resourceLogs:
             spanId: 2a00000000000000
             traceId: 2a000000000000000000000000000000
           - attributes:
+              - key: stringAttrName
+                value:
+                  stringValue: stringAttrValue
+              - key: intAttrName
+                value:
+                  intValue: "99"
+              - key: doubleAttrName
+                value:
+                  doubleValue: 99.99
+              - key: boolAttrName
+                value:
+                  boolValue: true
+              - key: nullAttrName
+                value: {}
+              - key: mapAttrName
+                value:
+                  kvlistValue: {}
+              - key: arrayAttrName
+                value:
+                  arrayValue: {}
               - key: span.kind
                 value:
                   stringValue: SPAN_KIND_CLIENT
@@ -55,6 +95,26 @@ resourceLogs:
     scopeLogs:
       - logRecords:
           - attributes:
+              - key: stringAttrName
+                value:
+                  stringValue: stringAttrValue
+              - key: intAttrName
+                value:
+                  intValue: "99"
+              - key: doubleAttrName
+                value:
+                  doubleValue: 99.99
+              - key: boolAttrName
+                value:
+                  boolValue: true
+              - key: nullAttrName
+                value: {}
+              - key: mapAttrName
+                value:
+                  kvlistValue: {}
+              - key: arrayAttrName
+                value:
+                  arrayValue: {}
               - key: span.kind
                 value:
                   stringValue: SPAN_KIND_SERVER


### PR DESCRIPTION
**Description:** In #24410 we discussed the idea of making configurable the list of span attributes to copy
over to generated logs. By default only HTTP were copied. This PR changes the default behavior to copy
all span attributes and recommend to use transformprocessor to remove all unwanted attributes. 

**Link to tracking Issue:** Resolves #24410

**Documentation:** Clarified in docs which attributes are copied.