### PR TITLE
[receiver/statsd] Add self-telemetry

### DIFF
--- a/receiver/statsdreceiver/internal/transport/mock_reporter.go
+++ b/receiver/statsdreceiver/internal/transport/mock_reporter.go
@@ -25,6 +25,10 @@ func NewMockReporter(expectedOnMetricsProcessedCalls int) *MockReporter {
 func (m *MockReporter) OnDebugf(_ string, _ ...any) {
 }
 
+func (m *MockReporter) RecordAcceptedMetric() {}
+
+func (m *MockReporter) RecordRefusedMetric() {}
+
 // WaitAllOnMetricsProcessedCalls blocks until the number of expected calls
 // specified at creation of the reporter is completed.
 func (m *MockReporter) WaitAllOnMetricsProcessedCalls() {

--- a/receiver/statsdreceiver/internal/transport/mock_reporter.go
+++ b/receiver/statsdreceiver/internal/transport/mock_reporter.go
@@ -25,9 +25,9 @@ func NewMockReporter(expectedOnMetricsProcessedCalls int) *MockReporter {
 func (m *MockReporter) OnDebugf(_ string, _ ...any) {
 }
 
-func (m *MockReporter) RecordAcceptedMetric() {}
+func (m *MockReporter) RecordReceivedMetric(_ error) {}
 
-func (m *MockReporter) RecordRefusedMetric() {}
+func (m *MockReporter) RecordFlushedMetrics(_ int64, _ error) {}
 
 // WaitAllOnMetricsProcessedCalls blocks until the number of expected calls
 // specified at creation of the reporter is completed.

--- a/receiver/statsdreceiver/internal/transport/server.go
+++ b/receiver/statsdreceiver/internal/transport/server.go
@@ -42,6 +42,6 @@ type Reporter interface {
 		template string,
 		args ...any)
 
-	RecordAcceptedMetric()
-	RecordRefusedMetric()
+	RecordReceivedMetric(err error)
+	RecordFlushedMetrics(count int64, err error)
 }

--- a/receiver/statsdreceiver/internal/transport/server.go
+++ b/receiver/statsdreceiver/internal/transport/server.go
@@ -41,4 +41,7 @@ type Reporter interface {
 	OnDebugf(
 		template string,
 		args ...any)
+
+	RecordAcceptedMetric()
+	RecordRefusedMetric()
 }

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -112,7 +112,7 @@ func (r *statsdReceiver) Start(ctx context.Context, _ component.Host) error {
 					batchCtx := client.NewContext(ctx, batch.Info)
 
 					err := r.Flush(batchCtx, batch.Metrics, r.nextConsumer)
-					r.reporter.RecordFlushedMetrics(int64(batch.Metrics.MetricCount()), err)
+					r.reporter.RecordFlushedMetrics(int64(batch.Metrics.DataPointCount()), err)
 					if err != nil {
 						r.reporter.OnDebugf("Error flushing metrics", zap.Error(err))
 					}

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -116,8 +116,12 @@ func (r *statsdReceiver) Start(ctx context.Context, _ component.Host) error {
 					}
 				}
 			case metric := <-transferChan:
-				if err := r.parser.Aggregate(metric.Raw, metric.Addr); err != nil {
+				err := r.parser.Aggregate(metric.Raw, metric.Addr)
+				if err != nil {
 					r.reporter.OnDebugf("Error aggregating metric", zap.Error(err))
+					r.reporter.RecordRefusedMetric()
+				} else {
+					r.reporter.RecordAcceptedMetric()
 				}
 			case <-ctx.Done():
 				ticker.Stop()

--- a/receiver/statsdreceiver/reporter.go
+++ b/receiver/statsdreceiver/reporter.go
@@ -4,19 +4,27 @@
 package statsdreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 
 import (
+	"context"
+
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport"
 )
 
 // reporter struct implements the transport.Reporter interface to give consistent
 // observability per Collector metric observability package.
 type reporter struct {
-	logger        *zap.Logger
-	sugaredLogger *zap.SugaredLogger // Used for generic debug logging
-	obsrecv       *receiverhelper.ObsReport
+	logger               *zap.Logger
+	sugaredLogger        *zap.SugaredLogger // Used for generic debug logging
+	obsrecv              *receiverhelper.ObsReport
+	staticAttrs          []attribute.KeyValue
+	acceptedMetricPoints metric.Int64Counter
+	refusedMetricPoints  metric.Int64Counter
 }
 
 var _ transport.Reporter = (*reporter)(nil)
@@ -30,15 +38,50 @@ func newReporter(set receiver.CreateSettings) (transport.Reporter, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &reporter{
+
+	r := &reporter{
 		logger:        set.Logger,
 		sugaredLogger: set.Logger.Sugar(),
 		obsrecv:       obsrecv,
-	}, nil
+		staticAttrs: []attribute.KeyValue{
+			attribute.String("receiver", set.ID.String()),
+		},
+	}
+
+	// See https://github.com/open-telemetry/opentelemetry-collector/blob/241334609fc47927b4a8533dfca28e0f65dad9fe/receiver/receiverhelper/obsreport.go#L104
+	// for the metric naming conventions
+
+	r.acceptedMetricPoints, err = metadata.Meter(set.TelemetrySettings).Int64Counter(
+		"receiver/accepted_metric_points",
+		metric.WithDescription("Number of metric data points accepted"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	r.refusedMetricPoints, err = metadata.Meter(set.TelemetrySettings).Int64Counter(
+		"receiver/refused_metric_points",
+		metric.WithDescription("Number of metric data points refused"),
+		metric.WithUnit("1"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return r, nil
 }
 
 func (r *reporter) OnDebugf(template string, args ...any) {
 	if r.logger.Check(zap.DebugLevel, "debug") != nil {
 		r.sugaredLogger.Debugf(template, args...)
 	}
+}
+
+func (r *reporter) RecordAcceptedMetric() {
+	r.acceptedMetricPoints.Add(context.Background(), 1, metric.WithAttributes(r.staticAttrs...))
+}
+
+func (r *reporter) RecordRefusedMetric() {
+	r.refusedMetricPoints.Add(context.Background(), 1, metric.WithAttributes(r.staticAttrs...))
 }


### PR DESCRIPTION
**Description:**
Add telemetry to statsdreceiver
* `otelcol_receiver_accepted_metric_points`
* `otelcol_receiver_refused_metric_points`
* `otelcol_receiver_statsd_flushed_metric_points`
* `otelcol_receiver_statsd_flushes`

### Implementation note
I debated trying to use the existing `receiverhelper.ObsReport` for this but rejected that approach for a few reasons
1. It's less code to just create the instruments directly and use them here.
2. I don't think we really want `Span`s getting created for every single statsd line that's sent through the system.
3. This wouldn't support the statsd-specific metric for `flush`es

**Link to tracking Issue:** #24278

**Testing:**
Tested locally using prometheus
```
$ nc -u -q0 localhost 8125 <<EOF
a:1|c
a:2|c
a:3|c
b:4|c
b:5|c
EOF
```
```
$ http :8888/metrics | grep -e '^otelcol.*statsd' -e '^otelcol.*sent.*debug'
otelcol_receiver_accepted_metric_points{receiver="statsd",service_instance_id="d9fcd320-9662-47ad-b6b4-e901e3b40592",service_name="collector",service_version="development"} 5
otelcol_receiver_statsd_flushed_metric_points{receiver="statsd",service_instance_id="d9fcd320-9662-47ad-b6b4-e901e3b40592",service_name="collector",service_version="development",status="success"} 2
otelcol_receiver_statsd_flushes{receiver="statsd",service_instance_id="d9fcd320-9662-47ad-b6b4-e901e3b40592",service_name="collector",service_version="development",status="success"} 1

otelcol_exporter_sent_metric_points{exporter="debug",service_instance_id="d9fcd320-9662-47ad-b6b4-e901e3b40592",service_name="collector",service_version="development"} 2
```