### PR TITLE
[receiver/bigip] avoid nil pointer dereference in getpoolmembers

### DIFF
--- a/.chloggen/bigip-getpoolsissue.yaml
+++ b/.chloggen/bigip-getpoolsissue.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: bigipreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix potential nil pointer usage in GetPoolMembers
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31899]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/bigipreceiver/scraper.go
+++ b/receiver/bigipreceiver/scraper.go
@@ -96,21 +96,23 @@ func (s *bigipScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		}
 	}
 
-	// scrape metrics for pool members
-	poolMembers, err := s.client.GetPoolMembers(ctx, pools)
-	if errors.Is(err, errCollectedNoPoolMembers) {
-		scrapeErrors.AddPartial(1, err)
-		s.logger.Warn("Failed to scrape pool member metrics", zap.Error(err))
-	} else {
-		if err != nil {
+	if pools != nil {
+		// scrape metrics for pool members
+		poolMembers, err := s.client.GetPoolMembers(ctx, pools)
+		if errors.Is(err, errCollectedNoPoolMembers) {
 			scrapeErrors.AddPartial(1, err)
-			s.logger.Warn("Failed to scrape some pool member metrics", zap.Error(err))
-		}
+			s.logger.Warn("Failed to scrape pool member metrics", zap.Error(err))
+		} else {
+			if err != nil {
+				scrapeErrors.AddPartial(1, err)
+				s.logger.Warn("Failed to scrape some pool member metrics", zap.Error(err))
+			}
 
-		collectedMetrics = true
-		for key := range poolMembers.Entries {
-			poolMemberStats := poolMembers.Entries[key]
-			s.collectPoolMembers(&poolMemberStats, now)
+			collectedMetrics = true
+			for key := range poolMembers.Entries {
+				poolMemberStats := poolMembers.Entries[key]
+				s.collectPoolMembers(&poolMemberStats, now)
+			}
 		}
 	}
 

--- a/receiver/bigipreceiver/scraper.go
+++ b/receiver/bigipreceiver/scraper.go
@@ -98,14 +98,14 @@ func (s *bigipScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 	if pools != nil {
 		// scrape metrics for pool members
-		poolMembers, err := s.client.GetPoolMembers(ctx, pools)
-		if errors.Is(err, errCollectedNoPoolMembers) {
-			scrapeErrors.AddPartial(1, err)
-			s.logger.Warn("Failed to scrape pool member metrics", zap.Error(err))
+		poolMembers, err2 := s.client.GetPoolMembers(ctx, pools)
+		if errors.Is(err2, errCollectedNoPoolMembers) {
+			scrapeErrors.AddPartial(1, err2)
+			s.logger.Warn("Failed to scrape pool member metrics", zap.Error(err2))
 		} else {
-			if err != nil {
-				scrapeErrors.AddPartial(1, err)
-				s.logger.Warn("Failed to scrape some pool member metrics", zap.Error(err))
+			if err2 != nil {
+				scrapeErrors.AddPartial(1, err2)
+				s.logger.Warn("Failed to scrape some pool member metrics", zap.Error(err2))
 			}
 
 			collectedMetrics = true

--- a/receiver/bigipreceiver/scraper_test.go
+++ b/receiver/bigipreceiver/scraper_test.go
@@ -152,8 +152,8 @@ func TestScaperScrape(t *testing.T) {
 				err := json.Unmarshal(data, &virtualServers)
 				require.NoError(t, err)
 				mockClient.On("GetVirtualServers", mock.Anything).Return(virtualServers, nil)
-
 				mockClient.On("GetPools", mock.Anything).Return(nil, errors.New("some pool api error"))
+				// with GetPools returning an error GetPoolMembers should not be called, so this error should no appear
 				mockClient.On("GetPoolMembers", mock.Anything, mock.Anything).Return(nil, errCollectedNoPoolMembers)
 				mockClient.On("GetNodes", mock.Anything).Return(nil, errors.New("some node api error"))
 
@@ -165,7 +165,7 @@ func TestScaperScrape(t *testing.T) {
 				require.NoError(t, err)
 				return expectedMetrics
 			},
-			expectedErr: scrapererror.NewPartialScrapeError(errors.New("some pool api error; all pool member requests have failed; some node api error"), 0),
+			expectedErr: scrapererror.NewPartialScrapeError(errors.New("some pool api error; some node api error"), 0),
 		},
 		{
 			desc: "Successful Partial Collection With Partial Members",
@@ -181,13 +181,19 @@ func TestScaperScrape(t *testing.T) {
 				mockClient.On("GetVirtualServers", mock.Anything).Return(virtualServers, nil)
 
 				// use helper function from client tests
+				data = loadAPIResponseData(t, poolsStatsResponseFile)
+				var pools *models.Pools
+				err = json.Unmarshal(data, &pools)
+				require.NoError(t, err)
+				mockClient.On("GetPools", mock.Anything).Return(pools, nil)
+
+				// use helper function from client tests
 				data = loadAPIResponseData(t, poolMembersCombinedFile)
 				var poolMembers *models.PoolMembers
 				err = json.Unmarshal(data, &poolMembers)
 				require.NoError(t, err)
 				mockClient.On("GetPoolMembers", mock.Anything, mock.Anything).Return(poolMembers, errors.New("some member api error"))
 
-				mockClient.On("GetPools", mock.Anything).Return(nil, errors.New("some pool api error"))
 				mockClient.On("GetNodes", mock.Anything).Return(nil, errors.New("some node api error"))
 
 				return &mockClient
@@ -198,7 +204,7 @@ func TestScaperScrape(t *testing.T) {
 				require.NoError(t, err)
 				return expectedMetrics
 			},
-			expectedErr: scrapererror.NewPartialScrapeError(errors.New("some pool api error; some member api error; some node api error"), 0),
+			expectedErr: scrapererror.NewPartialScrapeError(errors.New("some member api error; some node api error"), 0),
 		},
 		{
 			desc: "Successful Full Collection",

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.yaml
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.yaml
@@ -3,6 +3,278 @@ resourceMetrics:
       attributes:
         - key: bigip.pool.name
           value:
+            stringValue: /Common/test-pool-1
+    scopeMetrics:
+      - metrics:
+          - description: Availability of the pool.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: offline
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: unknown
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: bigip.pool.availability
+            unit: "1"
+          - description: Current number of connections to the pool.
+            name: bigip.pool.connection.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{connections}'
+          - description: Amount of data transmitted to and from the pool.
+            name: bigip.pool.data.transmitted
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: sent
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Enabled state of of the pool.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: disabled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: enabled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: bigip.pool.enabled
+            unit: "1"
+          - description: Total number of pool members.
+            name: bigip.pool.member.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: inactive
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{members}'
+          - description: Number of packets transmitted to and from the pool.
+            name: bigip.pool.packet.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: sent
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{packets}'
+          - description: Number of requests to the pool.
+            name: bigip.pool.request.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{requests}'
+        scope:
+          name: otelcol/bigipreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: bigip.pool.name
+          value:
+            stringValue: /Common/dev
+    scopeMetrics:
+      - metrics:
+          - description: Availability of the pool.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: offline
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: unknown
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: bigip.pool.availability
+            unit: "1"
+          - description: Current number of connections to the pool.
+            name: bigip.pool.connection.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{connections}'
+          - description: Amount of data transmitted to and from the pool.
+            name: bigip.pool.data.transmitted
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: sent
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Enabled state of of the pool.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: disabled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: enabled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: bigip.pool.enabled
+            unit: "1"
+          - description: Total number of pool members.
+            name: bigip.pool.member.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: inactive
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{members}'
+          - description: Number of packets transmitted to and from the pool.
+            name: bigip.pool.packet.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: sent
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{packets}'
+          - description: Number of requests to the pool.
+            name: bigip.pool.request.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{requests}'
+        scope:
+          name: otelcol/bigipreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: bigip.pool.name
+          value:
             stringValue: ""
         - key: bigip.virtual_server.destination
           value:


### PR DESCRIPTION
**Description:** fix nil pointer bug in receiver bigip

**Link to tracking Issue:** [31899](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31899)

If GetPools has an error, pools is set to nil.  However we then use this nil pointer in GetPoolMembers which results in a crash.