### PR TITLE
[chore][receiver/k8sevent] Enable goleak check

### DIFF
--- a/receiver/k8seventsreceiver/factory_test.go
+++ b/receiver/k8seventsreceiver/factory_test.go
@@ -59,4 +59,5 @@ func TestCreateReceiver(t *testing.T) {
 	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.NoError(t, err)
+	require.NoError(t, r.Shutdown(context.Background()))
 }

--- a/receiver/k8seventsreceiver/go.mod
+++ b/receiver/k8seventsreceiver/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/semconv v0.96.1-0.20240315172937-3b5aee0c7a16
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3

--- a/receiver/k8seventsreceiver/package_test.go
+++ b/receiver/k8seventsreceiver/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package k8seventsreceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable goleak check to help ensure no goroutines are being leaked. This is a test only change, a test was missing a shutdown call.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30438

**Testing:** <Describe what testing was performed and which tests were added.>
Existing tests are passing, as well as added goleak check.