### PR TITLE
[chore] lint fixes in cmd/telemetrygen & cmd/opampsupervisor

### DIFF
--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -368,12 +368,12 @@ func (s *Supervisor) startOpAMP() error {
 				s.logger.Error("Server returned an error response", zap.String("message", err.ErrorMessage))
 			},
 			OnMessageFunc: s.onMessage,
-			OnOpampConnectionSettingsFunc: func(_ context.Context, settings *protobufs.OpAMPConnectionSettings) error {
+			OnOpampConnectionSettingsFunc: func(_ context.Context, _ *protobufs.OpAMPConnectionSettings) error {
 				// TODO: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21043
 				s.logger.Debug("Received ConnectionSettings request")
 				return nil
 			},
-			OnOpampConnectionSettingsAcceptedFunc: func(_ context.Context, settings *protobufs.OpAMPConnectionSettings) {
+			OnOpampConnectionSettingsAcceptedFunc: func(_ context.Context, _ *protobufs.OpAMPConnectionSettings) {
 				// TODO: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21043
 				s.logger.Debug("ConnectionSettings accepted")
 			},
@@ -385,7 +385,7 @@ func (s *Supervisor) startOpAMP() error {
 				}
 				return nil
 			},
-			SaveRemoteConfigStatusFunc: func(_ context.Context, status *protobufs.RemoteConfigStatus) {
+			SaveRemoteConfigStatusFunc: func(_ context.Context, _ *protobufs.RemoteConfigStatus) {
 				// TODO: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21079
 			},
 			GetEffectiveConfigFunc: func(_ context.Context) (*protobufs.EffectiveConfig, error) {

--- a/cmd/telemetrygen/config.go
+++ b/cmd/telemetrygen/config.go
@@ -36,7 +36,7 @@ var tracesCmd = &cobra.Command{
 	Use:     "traces",
 	Short:   fmt.Sprintf("Simulates a client generating traces. (Stability level: %s)", metadata.TracesStability),
 	Example: "telemetrygen traces",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return traces.Start(tracesCfg)
 	},
 }
@@ -46,7 +46,7 @@ var metricsCmd = &cobra.Command{
 	Use:     "metrics",
 	Short:   fmt.Sprintf("Simulates a client generating metrics. (Stability level: %s)", metadata.MetricsStability),
 	Example: "telemetrygen metrics",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return metrics.Start(metricsCfg)
 	},
 }
@@ -56,7 +56,7 @@ var logsCmd = &cobra.Command{
 	Use:     "logs",
 	Short:   fmt.Sprintf("Simulates a client generating logs. (Stability level: %s)", metadata.LogsStability),
 	Example: "telemetrygen logs",
-	RunE: func(cmd *cobra.Command, args []string) error {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		return logs.Start(logsCfg)
 	},
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Linting Errors: 
[https://productionresultssa5.blob.core.windows.net/actions-results/44e4093a-f4c1-4e35-af4f-d630ea9b8d68/workflow-job-run-071cf28a-9760-544e-287f-c0f9ae5a03a4/logs/job/job-logs.txt?rsct=text%2Fplain&se=2024-03-25T12%3A45%3A21Z&sig=fRzhKwEpzDQDQZyUYwvEY%2BhkcFWOD3IY0EeCOE47AeU%3D&sp=r&spr=https&sr=b&st=2024-03-25T12%3A35%3A16Z&sv=2021-12-02](url)

- some linting errors will be fixed by 
#30237 


**Link to tracking Issue:** <Issue number if applicable>
- #31240 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>