### PR TITLE
[chore] Sync internal/common/localhostgate

### DIFF
--- a/internal/common/localhostgate/featuregate.go
+++ b/internal/common/localhostgate/featuregate.go
@@ -18,9 +18,9 @@ import (
 
 const UseLocalHostAsDefaultHostID = "component.UseLocalHostAsDefaultHost"
 
-// useLocalHostAsDefaultHostfeatureGate is the feature gate that controls whether
+// UseLocalHostAsDefaultHostfeatureGate is the feature gate that controls whether
 // server-like receivers and extensions such as the OTLP receiver use localhost as the default host for their endpoints.
-var useLocalHostAsDefaultHostfeatureGate = mustRegisterOrLoad(
+var UseLocalHostAsDefaultHostfeatureGate = mustRegisterOrLoad(
 	featuregate.GlobalRegistry(),
 	UseLocalHostAsDefaultHostID,
 	featuregate.StageAlpha,
@@ -51,7 +51,7 @@ func mustRegisterOrLoad(reg *featuregate.Registry, id string, stage featuregate.
 // EndpointForPort gets the endpoint for a given port using localhost or 0.0.0.0 depending on the feature gate.
 func EndpointForPort(port int) string {
 	host := "localhost"
-	if !useLocalHostAsDefaultHostfeatureGate.IsEnabled() {
+	if !UseLocalHostAsDefaultHostfeatureGate.IsEnabled() {
 		host = "0.0.0.0"
 	}
 	return fmt.Sprintf("%s:%d", host, port)
@@ -59,7 +59,7 @@ func EndpointForPort(port int) string {
 
 // LogAboutUseLocalHostAsDefault logs about the upcoming change from 0.0.0.0 to localhost on server-like components.
 func LogAboutUseLocalHostAsDefault(logger *zap.Logger) {
-	if !useLocalHostAsDefaultHostfeatureGate.IsEnabled() {
+	if !UseLocalHostAsDefaultHostfeatureGate.IsEnabled() {
 		logger.Warn(
 			"The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.",
 			zap.String("feature gate ID", UseLocalHostAsDefaultHostID),

--- a/internal/common/localhostgate/featuregate_test.go
+++ b/internal/common/localhostgate/featuregate_test.go
@@ -49,7 +49,7 @@ func TestEndpointForPort(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.endpoint, func(t *testing.T) {
-			defer setFeatureGateForTest(t, useLocalHostAsDefaultHostfeatureGate, tt.enabled)()
+			defer setFeatureGateForTest(t, UseLocalHostAsDefaultHostfeatureGate, tt.enabled)()
 			assert.Equal(t, EndpointForPort(tt.port), tt.endpoint)
 		})
 	}


### PR DESCRIPTION
**Description:** Syncs localhostgate with core after changes in open-telemetry/opentelemetry-collector/pull/9852
