### PR TITLE
[exporter/datadogexporter] Log warning for noAPMStatsFeatureGate

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -382,6 +382,13 @@ func (f *factory) createTracesExporter(
 	c component.Config,
 ) (exporter.Traces, error) {
 	cfg := checkAndCastConfig(c, set.TelemetrySettings.Logger)
+	if noAPMStatsFeatureGate.IsEnabled() {
+		set.Logger.Warn(
+			"Trace metrics are now disabled in the Datadog Exporter by default. To continue receiving Trace Metrics, configure the Datadog Connector or disable the feature gate.",
+			zap.String("documentation", "https://docs.datadoghq.com/opentelemetry/guide/migration/"),
+			zap.String("feature gate ID", noAPMStatsFeatureGate.ID()),
+		)
+	}
 
 	var (
 		pusher consumer.ConsumeTracesFunc


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
We disabled APM Stats computation in the Datadog Exporter by default in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31219. This PR adds a warn log in the Datadog Exporter traces pipeline to bring visibility to this breaking change and links to migration documentation. The log shows as follows:
```
❯ ./bin/otelcontribcol_darwin_arm64
2024-03-26T13:29:58.641-0400	info	service@v0.96.1-0.20240322165517-15201f1e5967/telemetry.go:55	Setting up own telemetry...
2024-03-26T13:29:58.641-0400	info	service@v0.96.1-0.20240322165517-15201f1e5967/telemetry.go:97	Serving metrics	{"address": ":8888", "level": "Basic"}
2024-03-26T13:29:58.641-0400	debug	exporter@v0.96.1-0.20240322165517-15201f1e5967/exporter.go:273	Beta component. May change in the future.	{"kind": "exporter", "data_type": "traces", "name": "datadog/api"}
2024-03-26T13:29:58.641-0400	warn	datadogexporter@v0.96.0/factory.go:386	Trace metrics are now disabled in the Datadog Exporter by default. To continue receiving Trace Metrics, configure the Datadog Connector or disable the feature gate.	{"kind": "exporter", "data_type": "traces", "name": "datadog/api", "documentation": "https://docs.datadoghq.com/opentelemetry/guide/migration/", "feature gate ID": "exporter.datadogexporter.DisableAPMStats"}
```

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>