### PR TITLE
[chore] [receiver/kafka] Enable lifecycle tests

### DIFF
--- a/receiver/kafkareceiver/generated_component_test.go
+++ b/receiver/kafkareceiver/generated_component_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver"
@@ -57,6 +58,18 @@ func TestComponentLifecycle(t *testing.T) {
 			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)
+		})
+		t.Run(test.name+"-lifecycle", func(t *testing.T) {
+			firstRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
+			require.NoError(t, err)
+			host := componenttest.NewNopHost()
+			require.NoError(t, err)
+			require.NoError(t, firstRcvr.Start(context.Background(), host))
+			require.NoError(t, firstRcvr.Shutdown(context.Background()))
+			secondRcvr, err := test.createFn(context.Background(), receivertest.NewNopCreateSettings(), cfg)
+			require.NoError(t, err)
+			require.NoError(t, secondRcvr.Start(context.Background(), host))
+			require.NoError(t, secondRcvr.Shutdown(context.Background()))
 		})
 	}
 }

--- a/receiver/kafkareceiver/metadata.yaml
+++ b/receiver/kafkareceiver/metadata.yaml
@@ -15,7 +15,3 @@ status:
   - sumo
   codeowners:
     active: [pavolloffay, MovieStoreGuy]
-
-# TODO: Update the receiver to pass the tests
-tests:
-  skip_lifecycle: true


### PR DESCRIPTION
Thanks to @povilasv, the test was fixed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31927.