### PR TITLE
[receiver/hostmetrics] Add cache_boot_time field to process scrapers

### DIFF
--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/config.go
@@ -13,4 +13,8 @@ type Config struct {
 	// MetricsBuilderConfig allows customizing scraped metrics/attributes representation.
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	internal.ScraperConfig
+
+	// CacheBootTime enables caching of the boot time of the system and each process. This means the
+	// boot times will never be updated as long as the collector is running.
+	CacheBootTime bool `mapstructure:"cache_boot_time"`
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper.go
@@ -55,6 +55,10 @@ type processesMetadata struct {
 
 // newProcessesScraper creates a set of Processes related metrics
 func newProcessesScraper(_ context.Context, settings receiver.CreateSettings, cfg *Config) *scraper {
+	if cfg.CacheBootTime {
+		host.EnableBootTimeCache(true)
+		process.EnableBootTimeCache(true)
+	}
 	return &scraper{
 		settings:     settings,
 		config:       cfg,

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/config.go
@@ -46,6 +46,11 @@ type Config struct {
 	// ScrapeProcessDelay is used to indicate the minimum amount of time a process must be running
 	// before metrics are scraped for it.  The default value is 0 seconds (0s)
 	ScrapeProcessDelay time.Duration `mapstructure:"scrape_process_delay"`
+
+	// CacheBootTime is used to enable functionality to cache the system boot time at the start of
+	// the process. With this enabled, the boot time will never update as long as the collector process
+	// is running.
+	CacheBootTime bool `mapstructure:"cache_boot_time"`
 }
 
 type MatchConfig struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper.go
@@ -93,6 +93,10 @@ func newProcessScraper(settings receiver.CreateSettings, cfg *Config) (*scraper,
 
 	scraper.logicalCores = logicalCores
 
+	if cfg.CacheBootTime {
+		process.EnableBootTimeCache(true)
+	}
+
 	return scraper, nil
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR adds the `cache_boot_time` config option to the `process` and `processes` scrapers. This allows an option for `gopsutil` functionality that will cache boot times after the first time they are fetched. It has a significant positive effect on the CPU usage of these scrapers.

**Link to tracking Issue:** <Issue number if applicable>
#28849

**Testing:** <Describe what testing was performed and which tests were added.>
Tested a build of the collector with these fields on and off and took CPU profiles to check the difference and see that `common.BootTimeWithContext` calls disappear after the first scrape.

**Documentation:** <Describe the documentation added.>
TODO