### PR TITLE
[chore] fix linting

### DIFF
--- a/cmd/configschema/comments.go
+++ b/cmd/configschema/comments.go
@@ -30,7 +30,7 @@ func commentsForStruct(v reflect.Value, dr DirResolver) (map[string]string, erro
 
 func searchDirsForComments(packageDir, typeName string) (map[string]string, error) {
 	out := map[string]string{}
-	err := filepath.WalkDir(packageDir, func(path string, d fs.DirEntry, err error) error {
+	err := filepath.WalkDir(packageDir, func(path string, d fs.DirEntry, _ error) error {
 		if d.IsDir() {
 			commentsForStructName(out, path, typeName)
 		}

--- a/cmd/configschema/docsgen/docsgen/cli_test.go
+++ b/cmd/configschema/docsgen/docsgen/cli_test.go
@@ -33,7 +33,7 @@ func TestWriteConfigDoc(t *testing.T) {
 			Type:        component.MustNewType("redis"),
 			CfgInstance: cfg,
 		},
-		func(dir string, bytes []byte, perm os.FileMode) error {
+		func(dir string, _ []byte, _ os.FileMode) error {
 			outputFilename = dir
 			return nil
 		},
@@ -48,7 +48,7 @@ func TestHandleCLI_NoArgs(t *testing.T) {
 		defaultComponents(t),
 		configschema.NewDefaultDirResolver(),
 		testTemplate(t),
-		func(filename string, data []byte, perm os.FileMode) error { return nil },
+		func(_ string, _ []byte, _ os.FileMode) error { return nil },
 		wr,
 	)
 	assert.Equal(t, 3, len(wr.lines))

--- a/cmd/githubgen/main.go
+++ b/cmd/githubgen/main.go
@@ -117,7 +117,7 @@ func run(folder string, allowlistFilePath string, generators []generator) error 
 	var foldersList []string
 	maxLength := 0
 	allCodeowners := map[string]struct{}{}
-	err := filepath.Walk(folder, func(path string, info fs.FileInfo, err error) error {
+	err := filepath.Walk(folder, func(path string, info fs.FileInfo, _ error) error {
 		if info.Name() == "metadata.yaml" {
 			m, err := loadMetadata(path)
 			if err != nil {

--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -192,7 +192,7 @@ func (c *traceToMetricConnector) enrichStatsPayload(stats *pb.StatsPayload) {
 					tagList.Store(tag, struct{}{})
 				}
 				stat.Tags = make([]string, 0)
-				tagList.Range(func(key, value any) bool {
+				tagList.Range(func(key, _ any) bool {
 					stat.Tags = append(stat.Tags, key.(string))
 					return true
 				})

--- a/connector/datadogconnector/connector_test.go
+++ b/connector/datadogconnector/connector_test.go
@@ -138,7 +138,7 @@ func TestContainerTags(t *testing.T) {
 	// check if the container tags are added to the cache
 	assert.Equal(t, 1, len(connector.containerTagCache.Items()))
 	count := 0
-	connector.containerTagCache.Items()["my-container-id"].Object.(*sync.Map).Range(func(key, value any) bool {
+	connector.containerTagCache.Items()["my-container-id"].Object.(*sync.Map).Range(func(_, _ any) bool {
 		count++
 		return true
 	})

--- a/connector/grafanacloudconnector/connector.go
+++ b/connector/grafanacloudconnector/connector.go
@@ -47,7 +47,7 @@ func newConnector(logger *zap.Logger, set component.TelemetrySettings, config co
 		"grafanacloud_host_count",
 		metric.WithDescription("Number of unique hosts"),
 		metric.WithUnit("1"),
-		metric.WithInt64Callback(func(ctx context.Context, result metric.Int64Observer) error {
+		metric.WithInt64Callback(func(_ context.Context, result metric.Int64Observer) error {
 			result.Observe(int64(hm.count()))
 			return nil
 		}),

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -288,7 +288,7 @@ func TestUpdateDurationMetrics(t *testing.T) {
 		},
 	}
 	for _, tc := range testCases {
-		t.Run(tc.caseStr, func(t *testing.T) {
+		t.Run(tc.caseStr, func(_ *testing.T) {
 			p.updateDurationMetrics(metricKey, tc.duration, tc.duration)
 		})
 	}

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -495,7 +495,7 @@ func TestTranslateUnit(t *testing.T) {
 		"Bi":    "Bits",
 	}
 	for input, output := range translateUnitCases {
-		t.Run(input, func(tt *testing.T) {
+		t.Run(input, func(_ *testing.T) {
 			metric.SetUnit(input)
 
 			v := translateUnit(metric, translator.metricDescriptor)

--- a/exporter/awsxrayexporter/awsxray.go
+++ b/exporter/awsxrayexporter/awsxray.go
@@ -52,7 +52,7 @@ func newTracesExporter(
 		context.TODO(),
 		set,
 		cfg,
-		func(ctx context.Context, td ptrace.Traces) error {
+		func(_ context.Context, td ptrace.Traces) error {
 			var err error
 			logger.Debug("TracesExporter", typeLog, nameLog, zap.Int("#spans", td.SpanCount()))
 

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -39,7 +39,7 @@ func TestLogsExporter_New(t *testing.T) {
 	}
 
 	failWithMsg := func(msg string) validate {
-		return func(t *testing.T, exporter *logsExporter, err error) {
+		return func(t *testing.T, _ *logsExporter, err error) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), msg)
 		}

--- a/exporter/clickhouseexporter/exporter_metrics_test.go
+++ b/exporter/clickhouseexporter/exporter_metrics_test.go
@@ -37,7 +37,7 @@ func TestExporter_pushMetricsData(t *testing.T) {
 	t.Parallel()
 	t.Run("push success", func(t *testing.T) {
 		items := &atomic.Int32{}
-		initClickhouseTestServer(t, func(query string, values []driver.Value) error {
+		initClickhouseTestServer(t, func(query string, _ []driver.Value) error {
 			if strings.HasPrefix(query, "INSERT") {
 				items.Add(1)
 			}
@@ -49,7 +49,7 @@ func TestExporter_pushMetricsData(t *testing.T) {
 		require.Equal(t, int32(15), items.Load())
 	})
 	t.Run("push failure", func(t *testing.T) {
-		initClickhouseTestServer(t, func(query string, values []driver.Value) error {
+		initClickhouseTestServer(t, func(query string, _ []driver.Value) error {
 			if strings.HasPrefix(query, "INSERT") {
 				return fmt.Errorf("mock insert error")
 			}

--- a/exporter/clickhouseexporter/exporter_sql_test.go
+++ b/exporter/clickhouseexporter/exporter_sql_test.go
@@ -66,7 +66,7 @@ func testClusterConfig(t *testing.T, completion clusterTestCompletion) {
 
 	for _, tt := range tests {
 		t.Run("test cluster config "+tt.name, func(t *testing.T) {
-			initClickhouseTestServer(t, func(query string, values []driver.Value) error {
+			initClickhouseTestServer(t, func(query string, _ []driver.Value) error {
 				if tt.shouldPass {
 					require.NoError(t, checkClusterQueryDefinition(query, tt.cluster))
 				} else {
@@ -157,7 +157,7 @@ func testTableEngineConfig(t *testing.T, completion tableEngineTestCompletion) {
 		expectedEngineValue := fmt.Sprintf("%s(%s)", tt.expectedTableName, tt.engineParams)
 
 		t.Run("test table engine config "+tt.name, func(t *testing.T) {
-			initClickhouseTestServer(t, func(query string, values []driver.Value) error {
+			initClickhouseTestServer(t, func(query string, _ []driver.Value) error {
 				firstLine := getQueryFirstLine(query)
 				if !strings.HasPrefix(strings.ToLower(firstLine), "create table") {
 					return nil

--- a/exporter/datadogexporter/internal/hostmetadata/metadata_test.go
+++ b/exporter/datadogexporter/internal/hostmetadata/metadata_test.go
@@ -186,7 +186,7 @@ func TestPushMetadata(t *testing.T) {
 	}
 
 	handler := http.NewServeMux()
-	handler.HandleFunc("/intake", func(w http.ResponseWriter, r *http.Request) {
+	handler.HandleFunc("/intake", func(_ http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, r.Header.Get("DD-Api-Key"), "apikey")
 		assert.Equal(t, r.Header.Get("User-Agent"), "otelcontribcol/1.0")
 

--- a/exporter/datadogexporter/internal/testutil/test_utils.go
+++ b/exporter/datadogexporter/internal/testutil/test_utils.go
@@ -55,7 +55,7 @@ func DatadogServerMock(overwriteHandlerFuncs ...OverwriteHandleFunc) *DatadogSer
 		MetricV1Endpoint:       metricsEndpoint,
 		MetricV2Endpoint:       metricsV2Endpoint,
 		MetadataEndpoint:       newMetadataEndpoint(metadataChan),
-		"/":                    func(w http.ResponseWriter, r *http.Request) {},
+		"/":                    func(_ http.ResponseWriter, _ *http.Request) {},
 	}
 	for _, f := range overwriteHandlerFuncs {
 		p, hf := f()
@@ -84,7 +84,7 @@ type HTTPRequestRecorder struct {
 }
 
 func (rec *HTTPRequestRecorder) HandlerFunc() (string, http.HandlerFunc) {
-	return rec.Pattern, func(w http.ResponseWriter, r *http.Request) {
+	return rec.Pattern, func(_ http.ResponseWriter, r *http.Request) {
 		rec.Header = r.Header
 		rec.ByteBody, _ = io.ReadAll(r.Body)
 	}
@@ -97,7 +97,7 @@ type HTTPRequestRecorderWithChan struct {
 }
 
 func (rec *HTTPRequestRecorderWithChan) HandlerFunc() (string, http.HandlerFunc) {
-	return rec.Pattern, func(w http.ResponseWriter, r *http.Request) {
+	return rec.Pattern, func(_ http.ResponseWriter, r *http.Request) {
 		bytesBody, _ := io.ReadAll(r.Body)
 		rec.ReqChan <- bytesBody
 	}
@@ -163,7 +163,7 @@ func metricsV2Endpoint(w http.ResponseWriter, _ *http.Request) {
 }
 
 func newMetadataEndpoint(c chan []byte) func(http.ResponseWriter, *http.Request) {
-	return func(w http.ResponseWriter, r *http.Request) {
+	return func(_ http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		c <- body
 	}

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -120,7 +120,7 @@ func TestTracesSource(t *testing.T) {
 		assert.NoError(t, err)
 	}))
 	defer metricsServer.Close()
-	tracesServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	tracesServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusAccepted)
 	}))
 	defer tracesServer.Close()

--- a/exporter/dynatraceexporter/metrics_exporter_test.go
+++ b/exporter/dynatraceexporter/metrics_exporter_test.go
@@ -351,7 +351,7 @@ func Test_SumMetrics(t *testing.T) {
 }
 
 func Test_exporter_PushMetricsData_EmptyPayload(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Fatal("Server should not be called")
 	}))
 	defer ts.Close()
@@ -383,7 +383,7 @@ func Test_exporter_PushMetricsData_EmptyPayload(t *testing.T) {
 }
 
 func Test_exporter_PushMetricsData_isDisabled(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
 		t.Fatal("Server should not be called")
 	}))
 	defer ts.Close()
@@ -421,7 +421,7 @@ func Test_exporter_PushMetricsData_isDisabled(t *testing.T) {
 }
 
 func Test_exporter_send_BadRequest(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		body, _ := json.Marshal(metricsResponse{
 			Ok:      0,
@@ -450,7 +450,7 @@ func Test_exporter_send_BadRequest(t *testing.T) {
 }
 
 func Test_exporter_send_Unauthorized(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
 		_, _ = w.Write([]byte{})
 	}))
@@ -475,7 +475,7 @@ func Test_exporter_send_Unauthorized(t *testing.T) {
 }
 
 func Test_exporter_send_TooLarge(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusRequestEntityTooLarge)
 		_, _ = w.Write([]byte{})
 	}))
@@ -500,7 +500,7 @@ func Test_exporter_send_TooLarge(t *testing.T) {
 }
 
 func Test_exporter_send_NotFound(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(404)
 		_, _ = w.Write([]byte{})
 	}))
@@ -528,7 +528,7 @@ func Test_exporter_send_NotFound(t *testing.T) {
 }
 
 func Test_exporter_send_TooManyRequests(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusTooManyRequests)
 		_, _ = w.Write([]byte{})
 	}))
@@ -551,7 +551,7 @@ func Test_exporter_send_TooManyRequests(t *testing.T) {
 }
 
 func Test_exporter_send_MiscellaneousErrorCode(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusExpectationFailed)
 		_, _ = w.Write([]byte{})
 	}))
@@ -577,7 +577,7 @@ func Test_exporter_send_MiscellaneousErrorCode(t *testing.T) {
 func Test_exporter_send_chunking(t *testing.T) {
 	sentChunks := 0
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
 		body, _ := json.Marshal(metricsResponse{
 			Ok:      0,
@@ -617,7 +617,7 @@ func Test_exporter_send_chunking(t *testing.T) {
 }
 
 func Test_exporter_PushMetricsData_Error(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(200)
 	}))
 	ts.Close()

--- a/exporter/elasticsearchexporter/logs_exporter_test.go
+++ b/exporter/elasticsearchexporter/logs_exporter_test.go
@@ -357,7 +357,7 @@ func TestExporter_PushEvent(t *testing.T) {
 
 	t.Run("do not retry invalid request", func(t *testing.T) {
 		attempts := &atomic.Int64{}
-		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+		server := newESTestServer(t, func(_ []itemRequest) ([]itemResponse, error) {
 			attempts.Add(1)
 			return nil, &httpTestError{message: "oops", status: http.StatusBadRequest}
 		})

--- a/exporter/elasticsearchexporter/traces_exporter_test.go
+++ b/exporter/elasticsearchexporter/traces_exporter_test.go
@@ -338,7 +338,7 @@ func TestExporter_PushTraceRecord(t *testing.T) {
 
 	t.Run("do not retry invalid request", func(t *testing.T) {
 		attempts := &atomic.Int64{}
-		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+		server := newESTestServer(t, func(_ []itemRequest) ([]itemResponse, error) {
 			attempts.Add(1)
 			return nil, &httpTestError{message: "oops", status: http.StatusBadRequest}
 		})

--- a/exporter/elasticsearchexporter/utils_test.go
+++ b/exporter/elasticsearchexporter/utils_test.go
@@ -127,7 +127,7 @@ func (r *bulkRecorder) countItems() (count int) {
 func newESTestServer(t *testing.T, bulkHandler bulkHandler) *httptest.Server {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/", handleErr(func(w http.ResponseWriter, req *http.Request) error {
+	mux.HandleFunc("/", handleErr(func(w http.ResponseWriter, _ *http.Request) error {
 		w.Header().Add("X-Elastic-Product", "Elasticsearch")
 
 		enc := json.NewEncoder(w)

--- a/exporter/honeycombmarkerexporter/logs_exporter_test.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter_test.go
@@ -227,7 +227,7 @@ func TestExportMarkers_Error(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			markerServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			markerServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 				rw.WriteHeader(tt.responseCode)
 			}))
 			defer markerServer.Close()
@@ -277,7 +277,7 @@ func TestExportMarkers_NoAPICall(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			markerServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			markerServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 				assert.Fail(t, "should not call the markers api")
 				rw.WriteHeader(http.StatusBadRequest) // 400
 			}))

--- a/exporter/influxdbexporter/writer_test.go
+++ b/exporter/influxdbexporter/writer_test.go
@@ -107,7 +107,7 @@ func Test_influxHTTPWriterBatch_maxPayload(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			var httpRequests []*http.Request
 
-			mockHTTPService := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mockHTTPService := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				httpRequests = append(httpRequests, r)
 			}))
 			t.Cleanup(mockHTTPService.Close)
@@ -149,7 +149,7 @@ func Test_influxHTTPWriterBatch_maxPayload(t *testing.T) {
 func Test_influxHTTPWriterBatch_EnqueuePoint_emptyTagValue(t *testing.T) {
 	var recordedRequest *http.Request
 	var recordedRequestBody []byte
-	noopHTTPServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	noopHTTPServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		if assert.Nil(t, recordedRequest) {
 			recordedRequest = r
 			recordedRequestBody, _ = io.ReadAll(r.Body)

--- a/exporter/instanaexporter/exporter_test.go
+++ b/exporter/instanaexporter/exporter_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestPushConvertedTraces(t *testing.T) {
-	traceServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	traceServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		rw.WriteHeader(http.StatusAccepted)
 	}))
 	defer traceServer.Close()
@@ -55,7 +55,7 @@ func TestSelfSignedBackend(t *testing.T) {
 	var err error
 	caFile := "testdata/ca.crt"
 	handler := http.NewServeMux()
-	handler.HandleFunc("/bundle", func(w http.ResponseWriter, r *http.Request) {
+	handler.HandleFunc("/bundle", func(w http.ResponseWriter, _ *http.Request) {
 		_, err = io.WriteString(w, "Hello from CA self signed server")
 
 		if err != nil {

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -35,7 +35,7 @@ func TestLoadConfig(t *testing.T) {
 	}{
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
-			option: func(conf *Config) {
+			option: func(_ *Config) {
 				// intentionally left blank so we use default config
 			},
 			expected: &Config{

--- a/exporter/kineticaexporter/metrics_exporter.go
+++ b/exporter/kineticaexporter/metrics_exporter.go
@@ -208,7 +208,7 @@ func createTablesForMetricType(ctx context.Context, metricTypeDDLs []string, kiW
 		schema = ""
 	}
 
-	lo.ForEach(metricTypeDDLs, func(ddl string, index int) {
+	lo.ForEach(metricTypeDDLs, func(ddl string, _ int) {
 
 		stmt := strings.ReplaceAll(ddl, "%s", schema)
 		kiWriter.logger.Debug("Creating Table - ", zap.String("DDL", stmt))

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -201,7 +201,7 @@ func TestLoadBalancerShutdown(t *testing.T) {
 func TestOnBackendChanges(t *testing.T) {
 	// prepare
 	cfg := simpleConfig()
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
 	p, err := newLoadBalancer(exportertest.NewNopCreateSettings(), cfg, componentFactory)
@@ -223,7 +223,7 @@ func TestOnBackendChanges(t *testing.T) {
 func TestRemoveExtraExporters(t *testing.T) {
 	// prepare
 	cfg := simpleConfig()
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
 	p, err := newLoadBalancer(exportertest.NewNopCreateSettings(), cfg, componentFactory)
@@ -355,7 +355,7 @@ func TestFailedExporterInRing(t *testing.T) {
 			Static: &StaticResolver{Hostnames: []string{"endpoint-1", "endpoint-2"}},
 		},
 	}
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
 	p, err := newLoadBalancer(exportertest.NewNopCreateSettings(), cfg, componentFactory)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -88,12 +88,12 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	endpoints := make(map[*wrappedExporter]string)
 
 	for _, batch := range batches {
-		routingIds, err := routingIdentifiersFromMetrics(batch, e.routingKey)
+		routingIDs, err := routingIdentifiersFromMetrics(batch, e.routingKey)
 		if err != nil {
 			return err
 		}
 
-		for rid := range routingIds {
+		for rid := range routingIDs {
 			exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(rid))
 			if err != nil {
 				return err

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -163,7 +163,7 @@ func TestMetricsExporterShutdown(t *testing.T) {
 }
 
 func TestConsumeMetrics(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), serviceBasedRoutingConfig(), componentFactory)
@@ -179,7 +179,7 @@ func TestConsumeMetrics(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-1", "endpoint-2"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1", "endpoint-2"}, nil
 		},
 	}
@@ -206,12 +206,12 @@ func TestConsumeMetrics_ConcurrentResolverChange(t *testing.T) {
 
 	// imitate a slow exporter
 	te := &mockMetricsExporter{Component: mockComponent{}}
-	te.ConsumeMetricsFn = func(ctx context.Context, td pmetric.Metrics) error {
+	te.ConsumeMetricsFn = func(_ context.Context, _ pmetric.Metrics) error {
 		close(consumeStarted)
 		time.Sleep(50 * time.Millisecond)
 		return te.consumeErr
 	}
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return te, nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), simpleConfig(), componentFactory)
@@ -225,7 +225,7 @@ func TestConsumeMetrics_ConcurrentResolverChange(t *testing.T) {
 	endpoints := []string{"endpoint-1"}
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return endpoints, nil
 		},
 	}
@@ -252,7 +252,7 @@ func TestConsumeMetrics_ConcurrentResolverChange(t *testing.T) {
 }
 
 func TestConsumeMetricsServiceBased(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), serviceBasedRoutingConfig(), componentFactory)
@@ -268,7 +268,7 @@ func TestConsumeMetricsServiceBased(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-1"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1"}, nil
 		},
 	}
@@ -288,7 +288,7 @@ func TestConsumeMetricsServiceBased(t *testing.T) {
 }
 
 func TestConsumeMetricsResourceBased(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), resourceBasedRoutingConfig(), componentFactory)
@@ -304,7 +304,7 @@ func TestConsumeMetricsResourceBased(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-1"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1"}, nil
 		},
 	}
@@ -324,7 +324,7 @@ func TestConsumeMetricsResourceBased(t *testing.T) {
 }
 
 func TestConsumeMetricsMetricNameBased(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), metricNameBasedRoutingConfig(), componentFactory)
@@ -340,7 +340,7 @@ func TestConsumeMetricsMetricNameBased(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-1"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1"}, nil
 		},
 	}
@@ -383,7 +383,7 @@ func TestServiceBasedRoutingForSameMetricName(t *testing.T) {
 }
 
 func TestConsumeMetricsExporterNoEndpoint(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), serviceBasedRoutingConfig(), componentFactory)
@@ -396,7 +396,7 @@ func TestConsumeMetricsExporterNoEndpoint(t *testing.T) {
 
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return nil, nil
 		},
 	}
@@ -417,7 +417,7 @@ func TestConsumeMetricsExporterNoEndpoint(t *testing.T) {
 }
 
 func TestConsumeMetricsUnexpectedExporterType(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), serviceBasedRoutingConfig(), componentFactory)
@@ -433,7 +433,7 @@ func TestConsumeMetricsUnexpectedExporterType(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-2"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1", "endpoint-2"}, nil
 		},
 	}
@@ -483,7 +483,7 @@ func TestBuildExporterConfigUnknown(t *testing.T) {
 
 func TestBatchWithTwoMetrics(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newMockMetricsExporter(sink.ConsumeMetrics), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), serviceBasedRoutingConfig(), componentFactory)
@@ -645,7 +645,7 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 			DNS: &DNSResolver{Hostname: "service-1", Port: ""},
 		},
 	}
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockMetricsExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), cfg, componentFactory)
@@ -662,13 +662,13 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 	counter1 := &atomic.Int64{}
 	counter2 := &atomic.Int64{}
 	defaultExporters := map[string]*wrappedExporter{
-		"127.0.0.1:4317": newWrappedExporter(newMockMetricsExporter(func(ctx context.Context, td pmetric.Metrics) error {
+		"127.0.0.1:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
 			counter1.Add(1)
 			// simulate an unreachable backend
 			time.Sleep(10 * time.Second)
 			return nil
 		})),
-		"127.0.0.2:4317": newWrappedExporter(newMockMetricsExporter(func(ctx context.Context, td pmetric.Metrics) error {
+		"127.0.0.2:4317": newWrappedExporter(newMockMetricsExporter(func(_ context.Context, _ pmetric.Metrics) error {
 			counter2.Add(1)
 			return nil
 		})),
@@ -684,7 +684,7 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 	lb.updateLock.Lock()
 	lb.exporters = defaultExporters
 	lb.updateLock.Unlock()
-	lb.res.onChange(func(endpoints []string) {
+	lb.res.onChange(func(_ []string) {
 		lb.updateLock.Lock()
 		lb.exporters = defaultExporters
 		lb.updateLock.Unlock()
@@ -737,7 +737,7 @@ func appendSimpleMetricWithServiceName(metric pmetric.Metrics, serviceName strin
 
 func benchConsumeMetrics(b *testing.B, endpointsCount int, metricsCount int) {
 	sink := new(consumertest.MetricsSink)
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newMockMetricsExporter(sink.ConsumeMetrics), nil
 	}
 

--- a/exporter/loadbalancingexporter/resolver_dns_test.go
+++ b/exporter/loadbalancingexporter/resolver_dns_test.go
@@ -126,7 +126,7 @@ func TestOnChange(t *testing.T) {
 
 	// test
 	counter := &atomic.Int64{}
-	res.onChange(func(endpoints []string) {
+	res.onChange(func(_ []string) {
 		counter.Add(1)
 	})
 	require.NoError(t, res.start(context.Background()))
@@ -216,7 +216,7 @@ func TestPeriodicallyResolve(t *testing.T) {
 	}
 
 	wg := sync.WaitGroup{}
-	res.onChange(func(backends []string) {
+	res.onChange(func(_ []string) {
 		wg.Done()
 	})
 
@@ -284,7 +284,7 @@ func TestShutdownClearsCallbacks(t *testing.T) {
 	require.NoError(t, err)
 
 	res.resolver = &mockDNSResolver{}
-	res.onChange(func(s []string) {})
+	res.onChange(func(_ []string) {})
 	require.NoError(t, res.start(context.Background()))
 
 	// sanity check
@@ -298,7 +298,7 @@ func TestShutdownClearsCallbacks(t *testing.T) {
 	assert.Len(t, res.onChangeCallbacks, 0)
 
 	// check that we can add a new onChange before a new start
-	res.onChange(func(s []string) {})
+	res.onChange(func(_ []string) {})
 	assert.Len(t, res.onChangeCallbacks, 1)
 }
 

--- a/exporter/loadbalancingexporter/resolver_k8s.go
+++ b/exporter/loadbalancingexporter/resolver_k8s.go
@@ -173,7 +173,7 @@ func (r *k8sResolver) resolve(ctx context.Context) ([]string, error) {
 	defer r.shutdownWg.Done()
 
 	var backends []string
-	r.endpointsStore.Range(func(address, value any) bool {
+	r.endpointsStore.Range(func(address, _ any) bool {
 		addr := address.(string)
 		if len(r.port) == 0 {
 			backends = append(backends, addr)

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -101,7 +101,7 @@ func TestK8sResolve(t *testing.T) {
 				return err
 
 			},
-			verifyFn: func(ctx *suiteContext, args args) error {
+			verifyFn: func(ctx *suiteContext, _ args) error {
 				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
 					return err
 				}
@@ -139,7 +139,7 @@ func TestK8sResolve(t *testing.T) {
 				return err
 
 			},
-			verifyFn: func(ctx *suiteContext, args args) error {
+			verifyFn: func(ctx *suiteContext, _ args) error {
 				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
 					return err
 				}
@@ -163,7 +163,7 @@ func TestK8sResolve(t *testing.T) {
 				return suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
 					Delete(context.TODO(), args.service, metav1.DeleteOptions{})
 			},
-			verifyFn: func(suiteCtx *suiteContext, args args) error {
+			verifyFn: func(suiteCtx *suiteContext, _ args) error {
 				if _, err := suiteCtx.resolver.resolve(context.Background()); err != nil {
 					return err
 				}

--- a/exporter/loadbalancingexporter/resolver_static_test.go
+++ b/exporter/loadbalancingexporter/resolver_static_test.go
@@ -39,7 +39,7 @@ func TestResolvedOnlyOnce(t *testing.T) {
 	require.NoError(t, err)
 
 	counter := 0
-	res.onChange(func(endpoints []string) {
+	res.onChange(func(_ []string) {
 		counter++
 	})
 

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -120,7 +120,7 @@ func TestTracesExporterShutdown(t *testing.T) {
 }
 
 func TestConsumeTraces(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), simpleConfig(), componentFactory)
@@ -136,7 +136,7 @@ func TestConsumeTraces(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-1"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1"}, nil
 		},
 	}
@@ -162,12 +162,12 @@ func TestConsumeTraces_ConcurrentResolverChange(t *testing.T) {
 
 	// imitate a slow exporter
 	te := &mockTracesExporter{Component: mockComponent{}}
-	te.ConsumeTracesFn = func(ctx context.Context, td ptrace.Traces) error {
+	te.ConsumeTracesFn = func(_ context.Context, _ ptrace.Traces) error {
 		close(consumeStarted)
 		time.Sleep(50 * time.Millisecond)
 		return te.consumeErr
 	}
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return te, nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), simpleConfig(), componentFactory)
@@ -182,7 +182,7 @@ func TestConsumeTraces_ConcurrentResolverChange(t *testing.T) {
 	endpoints := []string{"endpoint-1"}
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return endpoints, nil
 		},
 	}
@@ -209,7 +209,7 @@ func TestConsumeTraces_ConcurrentResolverChange(t *testing.T) {
 }
 
 func TestConsumeTracesServiceBased(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), serviceBasedRoutingConfig(), componentFactory)
@@ -226,7 +226,7 @@ func TestConsumeTracesServiceBased(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-2"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1", "endpoint-2"}, nil
 		},
 	}
@@ -275,7 +275,7 @@ func TestServiceBasedRoutingForSameTraceId(t *testing.T) {
 }
 
 func TestConsumeTracesExporterNoEndpoint(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), simpleConfig(), componentFactory)
@@ -288,7 +288,7 @@ func TestConsumeTracesExporterNoEndpoint(t *testing.T) {
 
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return nil, nil
 		},
 	}
@@ -309,7 +309,7 @@ func TestConsumeTracesExporterNoEndpoint(t *testing.T) {
 }
 
 func TestConsumeTracesUnexpectedExporterType(t *testing.T) {
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), simpleConfig(), componentFactory)
@@ -324,7 +324,7 @@ func TestConsumeTracesUnexpectedExporterType(t *testing.T) {
 	lb.addMissingExporters(context.Background(), []string{"endpoint-1"})
 	lb.res = &mockResolver{
 		triggerCallbacks: true,
-		onResolve: func(ctx context.Context) ([]string, error) {
+		onResolve: func(_ context.Context) ([]string, error) {
 			return []string{"endpoint-1"}, nil
 		},
 	}
@@ -374,7 +374,7 @@ func TestBuildExporterConfig(t *testing.T) {
 
 func TestBatchWithTwoTraces(t *testing.T) {
 	sink := new(consumertest.TracesSink)
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newMockTracesExporter(sink.ConsumeTraces), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), simpleConfig(), componentFactory)
@@ -502,7 +502,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 			DNS: &DNSResolver{Hostname: "service-1", Port: ""},
 		},
 	}
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newNopMockTracesExporter(), nil
 	}
 	lb, err := newLoadBalancer(exportertest.NewNopCreateSettings(), cfg, componentFactory)
@@ -519,13 +519,13 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	counter1 := &atomic.Int64{}
 	counter2 := &atomic.Int64{}
 	defaultExporters := map[string]*wrappedExporter{
-		"127.0.0.1:4317": newWrappedExporter(newMockTracesExporter(func(ctx context.Context, td ptrace.Traces) error {
+		"127.0.0.1:4317": newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
 			counter1.Add(1)
 			// simulate an unreachable backend
 			time.Sleep(10 * time.Second)
 			return nil
 		})),
-		"127.0.0.2:4317": newWrappedExporter(newMockTracesExporter(func(ctx context.Context, td ptrace.Traces) error {
+		"127.0.0.2:4317": newWrappedExporter(newMockTracesExporter(func(_ context.Context, _ ptrace.Traces) error {
 			counter2.Add(1)
 			return nil
 		})),
@@ -541,7 +541,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	lb.updateLock.Lock()
 	lb.exporters = defaultExporters
 	lb.updateLock.Unlock()
-	lb.res.onChange(func(endpoints []string) {
+	lb.res.onChange(func(_ []string) {
 		lb.updateLock.Lock()
 		lb.exporters = defaultExporters
 		lb.updateLock.Unlock()
@@ -587,7 +587,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 
 func benchConsumeTraces(b *testing.B, endpointsCount int, tracesCount int) {
 	sink := new(consumertest.TracesSink)
-	componentFactory := func(ctx context.Context, endpoint string) (component.Component, error) {
+	componentFactory := func(_ context.Context, _ string) (component.Component, error) {
 		return newMockTracesExporter(sink.ConsumeTraces), nil
 	}
 

--- a/exporter/logicmonitorexporter/internal/logs/sender_test.go
+++ b/exporter/logicmonitorexporter/internal/logs/sender_test.go
@@ -23,7 +23,7 @@ import (
 func TestSendLogs(t *testing.T) {
 
 	t.Run("should not return error", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			response := lmsdklogs.LMLogIngestResponse{
 				Success: true,
 				Message: "Accepted",
@@ -45,7 +45,7 @@ func TestSendLogs(t *testing.T) {
 	})
 
 	t.Run("should return permanent failure error", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			response := lmsdklogs.LMLogIngestResponse{
 				Success: false,
 				Message: "The request is invalid. For example, it may be missing headers or the request body is incorrectly formatted.",
@@ -68,7 +68,7 @@ func TestSendLogs(t *testing.T) {
 	})
 
 	t.Run("should not return permanent failure error", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			response := lmsdklogs.LMLogIngestResponse{
 				Success: false,
 				Message: "A dependency failed to respond within a reasonable time.",

--- a/exporter/logicmonitorexporter/internal/traces/sender_test.go
+++ b/exporter/logicmonitorexporter/internal/traces/sender_test.go
@@ -26,7 +26,7 @@ func TestSendTraces(t *testing.T) {
 		BearerToken: "testToken",
 	}
 	t.Run("should not return error", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			response := lmsdktraces.LMTraceIngestResponse{
 				Success: true,
 				Message: "Accepted",
@@ -47,7 +47,7 @@ func TestSendTraces(t *testing.T) {
 	})
 
 	t.Run("should return permanent failure error", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			response := lmsdktraces.LMTraceIngestResponse{
 				Success: false,
 				Message: "The request is invalid. For example, it may be missing headers or the request body is incorrectly formatted.",
@@ -69,7 +69,7 @@ func TestSendTraces(t *testing.T) {
 	})
 
 	t.Run("should not return permanent failure error", func(t *testing.T) {
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			response := lmsdktraces.LMTraceIngestResponse{
 				Success: false,
 				Message: "A dependency failed to respond within a reasonable time.",

--- a/exporter/logicmonitorexporter/logs_exporter_test.go
+++ b/exporter/logicmonitorexporter/logs_exporter_test.go
@@ -57,7 +57,7 @@ func Test_NewLogsExporter(t *testing.T) {
 }
 
 func TestPushLogData(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := lmsdklogs.LMLogIngestResponse{
 			Success: true,
 			Message: "Accepted",

--- a/exporter/logicmonitorexporter/traces_exporter_test.go
+++ b/exporter/logicmonitorexporter/traces_exporter_test.go
@@ -33,7 +33,7 @@ func Test_NewTracesExporter(t *testing.T) {
 }
 
 func TestPushTraceData(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		response := lmsdktraces.LMTraceIngestResponse{
 			Success: true,
 			Message: "",

--- a/exporter/logzioexporter/exporter_test.go
+++ b/exporter/logzioexporter/exporter_test.go
@@ -184,7 +184,7 @@ func TestExportErrors(tester *testing.T) {
 		{http.StatusBadRequest},
 	}
 	for _, test := range ExportErrorsTests {
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			rw.WriteHeader(test.status)
 		}))
 		cfg := &Config{

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -63,7 +63,7 @@ func TestPushLogData(t *testing.T) {
 			actualPushRequest := &push.PushRequest{}
 
 			// prepare
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				encPayload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 
@@ -239,7 +239,7 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 			actualPushRequestPerTenant := map[string]*push.PushRequest{}
 
 			// prepare
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				encPayload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 

--- a/exporter/lokiexporter/factory_test.go
+++ b/exporter/lokiexporter/factory_test.go
@@ -47,7 +47,7 @@ func TestExporter_startReturnsErrorWhenInvalidHttpClientSettings(t *testing.T) {
 	config := &Config{
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "",
-			CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) {
+			CustomRoundTripper: func(_ http.RoundTripper) (http.RoundTripper, error) {
 				return nil, fmt.Errorf("this causes ClientConfig.ToClient() to error")
 			},
 		},

--- a/exporter/mezmoexporter/exporter_test.go
+++ b/exporter/mezmoexporter/exporter_test.go
@@ -169,7 +169,7 @@ func createLogger() (*zap.Logger, *observer.ObservedLogs) {
 func TestLogsExporter(t *testing.T) {
 	httpServerParams := testServerParams{
 		t: t,
-		assertionsCallback: func(req *http.Request, body mezmoLogBody) (int, string) {
+		assertionsCallback: func(req *http.Request, _ mezmoLogBody) (int, string) {
 			assert.Equal(t, "application/json", req.Header.Get("Content-Type"))
 			assert.Equal(t, "mezmo-otel-exporter/"+buildInfo.Version, req.Header.Get("User-Agent"))
 			return http.StatusOK, ""
@@ -240,7 +240,7 @@ func Test404IngestError(t *testing.T) {
 
 	httpServerParams := testServerParams{
 		t: t,
-		assertionsCallback: func(req *http.Request, body mezmoLogBody) (int, string) {
+		assertionsCallback: func(_ *http.Request, _ mezmoLogBody) (int, string) {
 			return http.StatusNotFound, `{"foo":"bar"}`
 		},
 	}

--- a/exporter/opensearchexporter/config_test.go
+++ b/exporter/opensearchexporter/config_test.go
@@ -81,7 +81,7 @@ func TestLoadConfig(t *testing.T) {
 				config.Dataset = ""
 				config.Namespace = "eu"
 			}),
-			configValidateAssert: func(t assert.TestingT, err error, i ...any) bool {
+			configValidateAssert: func(t assert.TestingT, err error, _ ...any) bool {
 				return assert.ErrorContains(t, err, errDatasetNoValue.Error())
 			},
 		},
@@ -92,7 +92,7 @@ func TestLoadConfig(t *testing.T) {
 				config.Dataset = "ngnix"
 				config.Namespace = ""
 			}),
-			configValidateAssert: func(t assert.TestingT, err error, i ...any) bool {
+			configValidateAssert: func(t assert.TestingT, err error, _ ...any) bool {
 				return assert.ErrorContains(t, err, errNamespaceNoValue.Error())
 			},
 		},
@@ -102,7 +102,7 @@ func TestLoadConfig(t *testing.T) {
 				config.Endpoint = sampleEndpoint
 				config.BulkAction = "delete"
 			}),
-			configValidateAssert: func(t assert.TestingT, err error, i ...any) bool {
+			configValidateAssert: func(t assert.TestingT, err error, _ ...any) bool {
 				return assert.ErrorContains(t, err, errBulkActionInvalid.Error())
 			},
 		},

--- a/exporter/opensearchexporter/log_bulk_indexer.go
+++ b/exporter/opensearchexporter/log_bulk_indexer.go
@@ -64,7 +64,7 @@ func (lbi *logBulkIndexer) submit(ctx context.Context, ld plog.Logs) {
 		if err != nil {
 			lbi.appendPermanentError(err)
 		} else {
-			ItemFailureHandler := func(ctx context.Context, item opensearchutil.BulkIndexerItem, resp opensearchutil.BulkIndexerResponseItem, itemErr error) {
+			ItemFailureHandler := func(_ context.Context, _ opensearchutil.BulkIndexerItem, resp opensearchutil.BulkIndexerResponseItem, itemErr error) {
 				// Setup error handler. The handler handles the per item response status based on the
 				// selective ACKing in the bulk response.
 				lbi.processItemFailure(resp, itemErr, makeLog(resource, resourceSchemaURL, scope, scopeSchemaURL, log))

--- a/exporter/opensearchexporter/trace_bulk_indexer.go
+++ b/exporter/opensearchexporter/trace_bulk_indexer.go
@@ -67,7 +67,7 @@ func (tbi *traceBulkIndexer) submit(ctx context.Context, td ptrace.Traces) {
 		if err != nil {
 			tbi.appendPermanentError(err)
 		} else {
-			ItemFailureHandler := func(ctx context.Context, item opensearchutil.BulkIndexerItem, resp opensearchutil.BulkIndexerResponseItem, itemErr error) {
+			ItemFailureHandler := func(_ context.Context, _ opensearchutil.BulkIndexerItem, resp opensearchutil.BulkIndexerResponseItem, itemErr error) {
 				// Setup error handler. The handler handles the per item response status based on the
 				// selective ACKing in the bulk response.
 				tbi.processItemFailure(resp, itemErr, makeTrace(resource, resourceSchemaURL, scope, scopeSchemaURL, span))

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -125,7 +125,7 @@ func TestAccumulateMetrics(t *testing.T) {
 		},
 		{
 			name: "Summary",
-			metric: func(ts time.Time, v float64, metrics pmetric.MetricSlice) {
+			metric: func(ts time.Time, _ float64, metrics pmetric.MetricSlice) {
 				metric := metrics.AppendEmpty()
 				metric.SetName("test_metric")
 				metric.SetDescription("test description")
@@ -194,7 +194,7 @@ func TestAccumulateMetrics(t *testing.T) {
 		},
 		{
 			name: "StalenessMarkerSummary",
-			metric: func(ts time.Time, v float64, metrics pmetric.MetricSlice) {
+			metric: func(ts time.Time, _ float64, metrics pmetric.MetricSlice) {
 				metric := metrics.AppendEmpty()
 				metric.SetName("test_metric")
 				metric.SetDescription("test description")

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -35,7 +35,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	var currentScrapeIndex = 0
 	wg.Add(1) // scrape one endpoint
 
-	dropWizardServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	dropWizardServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		// Serve back the metrics as if they were from DropWizard.
 		_, err := rw.Write([]byte(dropWizardResponse))
 		require.NoError(t, err)

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -327,7 +327,7 @@ func Test_export(t *testing.T) {
 }
 
 func TestNoMetricsNoError(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()
@@ -892,7 +892,7 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 	// receive the bytes uploaded to it by our exporter.
 	uploadedBytesCh := make(chan []byte, 1)
 	exiting := make(chan bool)
-	prweServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	prweServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		uploaded, err2 := io.ReadAll(req.Body)
 		assert.NoError(t, err2, "Error while reading from HTTP upload")
 		select {
@@ -1087,7 +1087,7 @@ func TestRetries(t *testing.T) {
 	for _, tt := range tts {
 		t.Run(tt.name, func(t *testing.T) {
 			totalAttempts := 0
-			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				if totalAttempts < tt.serverErrorCount {
 					http.Error(w, http.StatusText(tt.httpStatus), tt.httpStatus)
 				} else {

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -1140,7 +1140,7 @@ func TestConsumeMetadata(t *testing.T) {
 			wg := sync.WaitGroup{}
 			wg.Add(1)
 
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				b, err := io.ReadAll(r.Body)
 				assert.NoError(t, err)
 
@@ -1219,7 +1219,7 @@ func BenchmarkExporterConsumeData(b *testing.B) {
 		tmd.ResourceMetrics().At(0).CopyTo(metrics.ResourceMetrics().AppendEmpty())
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()
@@ -1354,7 +1354,7 @@ func TestTLSIngestConnection(t *testing.T) {
 	dp.Attributes().PutStr("k1", "v1")
 	dp.SetDoubleValue(123)
 
-	server, err := newLocalHTTPSTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server, err := newLocalHTTPSTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, "connection is successful")
 	}))
 	require.NoError(t, err)
@@ -1478,7 +1478,7 @@ func TestTLSAPIConnection(t *testing.T) {
 		},
 	}
 
-	server, err := newLocalHTTPSTestServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server, err := newLocalHTTPSTestServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprint(w, "connection is successful")
 	}))
 	require.NoError(t, err)
@@ -1584,7 +1584,7 @@ func BenchmarkExporterConsumeDataWithOTLPHistograms(b *testing.B) {
 		tmd.ResourceMetrics().At(0).CopyTo(metrics.ResourceMetrics().AppendEmpty())
 	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 	defer server.Close()

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker.go
@@ -162,7 +162,7 @@ func (a *ActiveServiceTracker) processEnvironment(res pcommon.Resource, now time
 					DimName:  dimName,
 					DimValue: dimValue,
 					Value:    environment,
-				}, func(cor *correlations.Correlation, err error) {
+				}, func(_ *correlations.Correlation, err error) {
 					if err == nil {
 						a.hostEnvironmentCache.UpdateOrCreate(&CacheKey{value: environment}, now)
 					}
@@ -191,7 +191,7 @@ func (a *ActiveServiceTracker) processEnvironment(res pcommon.Resource, now time
 					DimName:  dimName,
 					DimValue: val.Str(),
 					Value:    environment,
-				}, func(cor *correlations.Correlation, err error) {
+				}, func(_ *correlations.Correlation, err error) {
 					if err == nil {
 						a.tenantEnvironmentCache.UpdateOrCreate(&CacheKey{dimName: dimName, dimValue: val.Str()}, now)
 					}
@@ -221,7 +221,7 @@ func (a *ActiveServiceTracker) processService(res pcommon.Resource, now time.Tim
 					DimName:  dimName,
 					DimValue: dimValue,
 					Value:    service,
-				}, func(cor *correlations.Correlation, err error) {
+				}, func(_ *correlations.Correlation, err error) {
 					if err == nil {
 						a.hostServiceCache.UpdateOrCreate(&CacheKey{value: service}, now)
 					}
@@ -251,7 +251,7 @@ func (a *ActiveServiceTracker) processService(res pcommon.Resource, now time.Tim
 					DimName:  dimName,
 					DimValue: val.Str(),
 					Value:    service,
-				}, func(cor *correlations.Correlation, err error) {
+				}, func(_ *correlations.Correlation, err error) {
 					if err == nil {
 						a.tenantServiceCache.UpdateOrCreate(&CacheKey{dimName: dimName, dimValue: val.Str()}, now)
 					}
@@ -274,7 +274,7 @@ func (a *ActiveServiceTracker) Purge() {
 				DimName:  dimName,
 				DimValue: dimValue,
 				Value:    purged.value,
-			}, func(cor *correlations.Correlation) {
+			}, func(_ *correlations.Correlation) {
 				a.hostServiceCache.Delete(purged)
 			})
 		}
@@ -291,7 +291,7 @@ func (a *ActiveServiceTracker) Purge() {
 				DimName:  dimName,
 				DimValue: dimValue,
 				Value:    purged.value,
-			}, func(cor *correlations.Correlation) {
+			}, func(_ *correlations.Correlation) {
 				a.hostEnvironmentCache.Delete(purged)
 				a.log.WithFields(log.Fields{"environmentName": purged.value}).Debug("No longer tracking environment name from trace span")
 			})

--- a/exporter/signalfxexporter/internal/utils/histogram_utils.go
+++ b/exporter/signalfxexporter/internal/utils/histogram_utils.go
@@ -12,7 +12,7 @@ import (
 
 // removeAccessToken removes the SFX access token label if found in the give resource metric as a resource attribute
 func removeAccessToken(dest pmetric.ResourceMetrics) {
-	dest.Resource().Attributes().RemoveIf(func(k string, val pcommon.Value) bool {
+	dest.Resource().Attributes().RemoveIf(func(k string, _ pcommon.Value) bool {
 		return k == splunk.SFxAccessTokenLabel
 	})
 }

--- a/exporter/splunkhecexporter/heartbeat_test.go
+++ b/exporter/splunkhecexporter/heartbeat_test.go
@@ -82,7 +82,7 @@ func resetMetrics(metricsNames ...string) {
 func Test_newHeartbeater_disabled(t *testing.T) {
 	config := createTestConfig(map[string]string{}, false)
 	config.Heartbeat.Interval = 0
-	hb := newHeartbeater(config, component.NewDefaultBuildInfo(), func(ctx context.Context, ld plog.Logs) error {
+	hb := newHeartbeater(config, component.NewDefaultBuildInfo(), func(_ context.Context, _ plog.Logs) error {
 		return nil
 	})
 	assert.Nil(t, hb)
@@ -111,7 +111,7 @@ func Test_Heartbeat_success(t *testing.T) {
 
 	for _, tt := range tests {
 		consumeLogsChan := make(chan plog.Logs, 10)
-		consumeFn := func(ctx context.Context, ld plog.Logs) error {
+		consumeFn := func(_ context.Context, ld plog.Logs) error {
 			consumeLogsChan <- ld
 			return nil
 		}
@@ -142,7 +142,7 @@ func Test_Heartbeat_success(t *testing.T) {
 
 func Test_Heartbeat_failure(t *testing.T) {
 	resetMetrics()
-	consumeFn := func(ctx context.Context, ld plog.Logs) error {
+	consumeFn := func(_ context.Context, _ plog.Logs) error {
 		return errors.New("always error")
 	}
 	initHeartbeater(t, map[string]string{}, true, consumeFn)

--- a/exporter/sumologicexporter/exporter_test.go
+++ b/exporter/sumologicexporter/exporter_test.go
@@ -45,7 +45,7 @@ func TestInitExporter(t *testing.T) {
 
 func TestAllSuccess(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, `Example log`, body)
 			assert.Equal(t, "", req.Header.Get("X-Sumo-Fields"))
@@ -61,7 +61,7 @@ func TestAllSuccess(t *testing.T) {
 
 func TestResourceMerge(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, `Example log`, body)
 			assert.Equal(t, "key1=original_value, key2=additional_value", req.Header.Get("X-Sumo-Fields"))
@@ -113,7 +113,7 @@ func TestPartiallyFailed(t *testing.T) {
 			assert.Equal(t, "Example log", body)
 			assert.Equal(t, "key1=value1, key2=value2", req.Header.Get("X-Sumo-Fields"))
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, "Another example log", body)
 			assert.Equal(t, "key3=value3, key4=value4", req.Header.Get("X-Sumo-Fields"))
@@ -158,7 +158,7 @@ func TestInvalidHTTPCLient(t *testing.T) {
 		CompressEncoding: "gzip",
 		ClientConfig: confighttp.ClientConfig{
 			Endpoint: "test_endpoint",
-			CustomRoundTripper: func(next http.RoundTripper) (http.RoundTripper, error) {
+			CustomRoundTripper: func(_ http.RoundTripper) (http.RoundTripper, error) {
 				return nil, errors.New("roundTripperException")
 			},
 		},
@@ -172,7 +172,7 @@ func TestInvalidHTTPCLient(t *testing.T) {
 
 func TestPushInvalidCompressor(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, `Example log`, body)
 			assert.Equal(t, "", req.Header.Get("X-Sumo-Fields"))
@@ -228,7 +228,7 @@ func TestPushFailedBatch(t *testing.T) {
 
 func TestAllMetricsSuccess(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000
 gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
@@ -288,7 +288,7 @@ func TestMetricsPartiallyFailed(t *testing.T) {
 			assert.Equal(t, expected, body)
 			assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
@@ -317,7 +317,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 
 func TestPushMetricsInvalidCompressor(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, `Example log`, body)
 			assert.Equal(t, "", req.Header.Get("X-Sumo-Fields"))
@@ -346,7 +346,7 @@ func TestMetricsDifferentMetadata(t *testing.T) {
 			assert.Equal(t, expected, body)
 			assert.Equal(t, "application/vnd.sumologic.prometheus", req.Header.Get("Content-Type"))
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `gauge_metric_name{foo="bar",key2="value2",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",key2="value2",remote_name="156955",url="http://another_url"} 245 1608124662166`

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -168,7 +168,7 @@ func exampleMultitypeLogs() []plog.LogRecord {
 
 func TestSendLogs(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, "Example log\nAnother example log", body)
 			assert.Equal(t, "key1=value, key2=value2", req.Header.Get("X-Sumo-Fields"))
@@ -186,7 +186,7 @@ func TestSendLogs(t *testing.T) {
 
 func TestSendLogsMultitype(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `{"lk1":"lv1","lk2":13}
 ["lv2",13]`
@@ -206,11 +206,11 @@ func TestSendLogsMultitype(t *testing.T) {
 
 func TestSendLogsSplit(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, "Example log", body)
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, "Another example log", body)
 		},
@@ -230,7 +230,7 @@ func TestSendLogsSplitFailedOne(t *testing.T) {
 			body := extractBody(t, req)
 			assert.Equal(t, "Example log", body)
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, "Another example log", body)
 		},
@@ -276,7 +276,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 
 func TestSendLogsJson(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `{"key1":"value1","key2":"value2","log":"Example log"}
 {"key1":"value1","key2":"value2","log":"Another example log"}`
@@ -296,7 +296,7 @@ func TestSendLogsJson(t *testing.T) {
 
 func TestSendLogsJsonMultitype(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `{"key1":"value1","key2":"value2","log":{"lk1":"lv1","lk2":13}}
 {"key1":"value1","key2":"value2","log":["lv2",13]}`
@@ -316,11 +316,11 @@ func TestSendLogsJsonMultitype(t *testing.T) {
 
 func TestSendLogsJsonSplit(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, `{"key1":"value1","key2":"value2","log":"Example log"}`, body)
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, `{"key1":"value1","key2":"value2","log":"Another example log"}`, body)
 		},
@@ -342,7 +342,7 @@ func TestSendLogsJsonSplitFailedOne(t *testing.T) {
 			body := extractBody(t, req)
 			assert.Equal(t, `{"key1":"value1","key2":"value2","log":"Example log"}`, body)
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			assert.Equal(t, `{"key1":"value1","key2":"value2","log":"Another example log"}`, body)
 		},
@@ -388,7 +388,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 
 func TestSendLogsUnexpectedFormat(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, _ *http.Request) {
 		},
 	})
 	defer func() { test.srv.Close() }()
@@ -403,7 +403,7 @@ func TestSendLogsUnexpectedFormat(t *testing.T) {
 
 func TestOverrideSourceName(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			assert.Equal(t, "Test source name/test_name", req.Header.Get("X-Sumo-Name"))
 		},
 	})
@@ -418,7 +418,7 @@ func TestOverrideSourceName(t *testing.T) {
 
 func TestOverrideSourceCategory(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			assert.Equal(t, "Test source category/test_name", req.Header.Get("X-Sumo-Category"))
 		},
 	})
@@ -433,7 +433,7 @@ func TestOverrideSourceCategory(t *testing.T) {
 
 func TestOverrideSourceHost(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			assert.Equal(t, "Test source host/test_name", req.Header.Get("X-Sumo-Host"))
 		},
 	})
@@ -602,7 +602,7 @@ func TestInvalidContentEncoding(t *testing.T) {
 
 func TestSendMetrics(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000
 gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
@@ -629,12 +629,12 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 
 func TestSendMetricsSplit(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
@@ -662,7 +662,7 @@ func TestSendMetricsSplitFailedOne(t *testing.T) {
 			expected := `test_metric_data{test="test_value",test2="second_value"} 14500 1605534165000`
 			assert.Equal(t, expected, body)
 		},
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `gauge_metric_name{foo="bar",remote_name="156920",url="http://example_url"} 124 1608124661166
 gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1608124662166`
@@ -719,7 +719,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 
 func TestSendMetricsUnexpectedFormat(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, _ *http.Request) {
 		},
 	})
 	defer func() { test.srv.Close() }()
@@ -784,7 +784,7 @@ func TestMetricsBufferOverflow(t *testing.T) {
 
 func TestSendCarbon2Metrics(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `test=test_value test2=second_value _unit=m/s escape_me=:invalid_ metric=true metric=test.metric.data unit=bytes  14500 1605534165
 foo=bar metric=gauge_metric_name  124 1608124661
@@ -817,7 +817,7 @@ foo=bar metric=gauge_metric_name  245 1608124662`
 
 func TestSendGraphiteMetrics(t *testing.T) {
 	test := prepareSenderTest(t, []func(w http.ResponseWriter, req *http.Request){
-		func(w http.ResponseWriter, req *http.Request) {
+		func(_ http.ResponseWriter, req *http.Request) {
 			body := extractBody(t, req)
 			expected := `test_metric_data.true.m/s 14500 1605534165
 gauge_metric_name.. 124 1608124661

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -40,7 +40,7 @@ import (
 func TestZipkinExporter_roundtripJSON(t *testing.T) {
 	buf := new(bytes.Buffer)
 	var sizes []int64
-	cst := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	cst := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		s, _ := io.Copy(buf, r.Body)
 		sizes = append(sizes, s)
 		r.Body.Close()
@@ -286,7 +286,7 @@ func TestZipkinExporter_invalidFormat(t *testing.T) {
 func TestZipkinExporter_roundtripProto(t *testing.T) {
 	buf := new(bytes.Buffer)
 	var contentType string
-	cst := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	cst := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		_, err := io.Copy(buf, r.Body)
 		assert.NoError(t, err)
 		contentType = r.Header.Get("Content-Type")

--- a/extension/jaegerremotesampling/internal/http_test.go
+++ b/extension/jaegerremotesampling/internal/http_test.go
@@ -54,7 +54,7 @@ func TestEndpointsAreWired(t *testing.T) {
 		t.Run(tC.desc, func(t *testing.T) {
 			// prepare
 			s, err := NewHTTP(componenttest.NewNopTelemetrySettings(), confighttp.ServerConfig{}, &mockCfgMgr{
-				getSamplingStrategyFunc: func(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
+				getSamplingStrategyFunc: func(_ context.Context, _ string) (*api_v2.SamplingStrategyResponse, error) {
 					return &api_v2.SamplingStrategyResponse{
 						ProbabilisticSampling: &api_v2.ProbabilisticSamplingStrategy{
 							SamplingRate: 1,
@@ -110,7 +110,7 @@ func TestErrorFromClientConfigManager(t *testing.T) {
 	require.NotNil(t, s)
 
 	s.strategyStore = &mockCfgMgr{
-		getSamplingStrategyFunc: func(ctx context.Context, serviceName string) (*api_v2.SamplingStrategyResponse, error) {
+		getSamplingStrategyFunc: func(_ context.Context, _ string) (*api_v2.SamplingStrategyResponse, error) {
 			return nil, errors.New("some error")
 		},
 	}

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -290,7 +290,7 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 }
 
 func TestFailContactingOAuth(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(200)
 		_, err := w.Write([]byte("not-json"))
 		assert.NoError(t, err)

--- a/extension/observer/ecsobserver/internal/ecsmock/service_test.go
+++ b/extension/observer/ecsobserver/internal/ecsmock/service_test.go
@@ -63,7 +63,7 @@ func TestCluster_DescribeTasksWithContext(t *testing.T) {
 	ctx := context.Background()
 	c := NewClusterWithName("c1")
 	count := 10
-	c.SetTasks(GenTasks("p", count, func(i int, task *ecs.Task) {
+	c.SetTasks(GenTasks("p", count, func(_ int, task *ecs.Task) {
 		task.LastStatus = aws.String("running")
 	}))
 
@@ -95,7 +95,7 @@ func TestCluster_DescribeTaskDefinitionWithContext(t *testing.T) {
 	ctx := context.Background()
 	c := NewClusterWithName("c1")
 	c.SetTaskDefinitions(GenTaskDefinitions("foo", 10, 1, nil)) // accept nil
-	c.SetTaskDefinitions(GenTaskDefinitions("foo", 10, 1, func(i int, def *ecs.TaskDefinition) {
+	c.SetTaskDefinitions(GenTaskDefinitions("foo", 10, 1, func(_ int, def *ecs.TaskDefinition) {
 		def.NetworkMode = aws.String(ecs.NetworkModeBridge)
 	}))
 
@@ -151,14 +151,14 @@ func TestCluster_DescribeInstancesWithContext(t *testing.T) {
 
 	t.Run("get by id", func(t *testing.T) {
 		var ids []*string
-		nIds := 100
-		for i := 0; i < nIds; i++ {
+		nIDs := 100
+		for i := 0; i < nIDs; i++ {
 			ids = append(ids, aws.String(fmt.Sprintf("i-%d", i*10)))
 		}
 		req := &ec2.DescribeInstancesInput{InstanceIds: ids}
 		res, err := c.DescribeInstancesWithContext(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, nIds, len(res.Reservations[0].Instances))
+		assert.Equal(t, nIDs, len(res.Reservations[0].Instances))
 	})
 
 	t.Run("invalid id", func(t *testing.T) {
@@ -191,14 +191,14 @@ func TestCluster_DescribeContainerInstancesWithContext(t *testing.T) {
 
 	t.Run("get by id", func(t *testing.T) {
 		var ids []*string
-		nIds := count
-		for i := 0; i < nIds; i++ {
+		nIDs := count
+		for i := 0; i < nIDs; i++ {
 			ids = append(ids, aws.String(fmt.Sprintf("foo%d", i)))
 		}
 		req := &ecs.DescribeContainerInstancesInput{ContainerInstances: ids}
 		res, err := c.DescribeContainerInstancesWithContext(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, nIds, len(res.ContainerInstances))
+		assert.Equal(t, nIDs, len(res.ContainerInstances))
 		assert.Equal(t, 0, len(res.Failures))
 	})
 

--- a/extension/observer/ecsobserver/sd_test.go
+++ b/extension/observer/ecsobserver/sd_test.go
@@ -220,7 +220,7 @@ func newTestTaskFetcher(t *testing.T, c *ecsmock.Cluster, opts ...func(options *
 		Region:      "not used",
 		ecsOverride: c,
 		ec2Override: c,
-		serviceNameFilter: func(name string) bool {
+		serviceNameFilter: func(_ string) bool {
 			return true
 		},
 	}

--- a/extension/observer/ecsobserver/service.go
+++ b/extension/observer/ecsobserver/service.go
@@ -96,7 +96,7 @@ func (s *serviceMatcher) matchTargets(t *taskAnnotated, c *ecs.ContainerDefiniti
 func serviceConfigsToFilter(cfgs []ServiceConfig) (serviceNameFilter, error) {
 	// If no service config, don't describe any services
 	if len(cfgs) == 0 {
-		return func(name string) bool {
+		return func(_ string) bool {
 			return false
 		}, nil
 	}

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -510,7 +510,7 @@ func TestCollectEndpoints(t *testing.T) {
 			newProc: func(pid int32) (*process.Process, error) {
 				return &process.Process{Pid: pid}, nil
 			},
-			procDetails: func(proc *process.Process) (*processDetails, error) {
+			procDetails: func(_ *process.Process) (*processDetails, error) {
 				return nil, errors.New("always fail")
 			},
 			want: []observer.Endpoint{},

--- a/extension/oidcauthextension/oidc_server_test.go
+++ b/extension/oidcauthextension/oidc_server_test.go
@@ -36,7 +36,7 @@ func newOIDCServer() (*oidcServer, error) {
 	mux := http.NewServeMux()
 	server := httptest.NewUnstartedServer(mux)
 
-	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		err := json.NewEncoder(w).Encode(map[string]any{
 			"issuer":   server.URL,
@@ -47,7 +47,7 @@ func newOIDCServer() (*oidcServer, error) {
 			return
 		}
 	})
-	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/.well-known/jwks.json", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if err := json.NewEncoder(w).Encode(jwks); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
+++ b/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
@@ -53,7 +53,7 @@ func TestCredentialsStoreLocalFs(t *testing.T) {
 	var fileCounter int
 	require.NoError(t,
 		filepath.WalkDir(dir,
-			func(path string, d fs.DirEntry, err error) error {
+			func(_ string, d fs.DirEntry, _ error) error {
 				if d.IsDir() {
 					return nil
 				}

--- a/extension/sumologicextension/extension.go
+++ b/extension/sumologicextension/extension.go
@@ -444,7 +444,7 @@ func (se *SumologicExtension) registerCollector(ctx context.Context, collectorNa
 	se.logger.Info("Calling register API", zap.String("URL", u.String()))
 
 	client := *http.DefaultClient
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+	client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
 	res, err := client.Do(req)

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -109,7 +109,7 @@ func TestLogEventBatch_sortLogEvents(t *testing.T) {
 
 // Need to remove the tmp state folder after testing.
 func newMockPusher() *logPusher {
-	svc := newAlwaysPassMockLogClient(func(args mock.Arguments) {})
+	svc := newAlwaysPassMockLogClient(func(_ mock.Arguments) {})
 	return newLogPusher(StreamKey{
 		LogGroupName:  logGroup,
 		LogStreamName: logStreamName,
@@ -193,7 +193,7 @@ func TestAddLogEventWithValidation(t *testing.T) {
 }
 
 func TestStreamManager(t *testing.T) {
-	svc := newAlwaysPassMockLogClient(func(args mock.Arguments) {})
+	svc := newAlwaysPassMockLogClient(func(_ mock.Arguments) {})
 	mockCwAPI := svc.svc.(*mockCloudWatchLogsClient)
 	manager := NewLogStreamManager(*svc)
 
@@ -224,7 +224,7 @@ func TestStreamManager(t *testing.T) {
 }
 
 func TestMultiStreamFactory(t *testing.T) {
-	svc := newAlwaysPassMockLogClient(func(args mock.Arguments) {})
+	svc := newAlwaysPassMockLogClient(func(_ mock.Arguments) {})
 	logStreamManager := NewLogStreamManager(*svc)
 	factory := NewMultiStreamPusherFactory(logStreamManager, *svc, nil)
 

--- a/internal/aws/proxy/conn_test.go
+++ b/internal/aws/proxy/conn_test.go
@@ -389,7 +389,7 @@ func TestGetSTSCredsFromPrimaryRegionEndpoint(t *testing.T) {
 	assert.NoError(t, err, "no expected error")
 
 	called = false
-	fake.getSTSCredsFromRegionEndpoint = func(_ *zap.Logger, _ *session.Session, region, roleArn string) *credentials.Credentials {
+	fake.getSTSCredsFromRegionEndpoint = func(_ *zap.Logger, _ *session.Session, _, _ string) *credentials.Credentials {
 		called = true
 		return nil
 	}
@@ -446,7 +446,7 @@ func TestSTSRegionalEndpointDisabled(t *testing.T) {
 	expectedErr := &mockAWSErr{}
 	fake := &stsCalls{
 		log: logger,
-		getSTSCredsFromRegionEndpoint: func(_ *zap.Logger, _ *session.Session, region, roleArn string) *credentials.Credentials {
+		getSTSCredsFromRegionEndpoint: func(_ *zap.Logger, _ *session.Session, _, _ string) *credentials.Credentials {
 			called = true
 			return credentials.NewCredentials(&mockProvider{expectedErr})
 		},

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -189,7 +189,7 @@ func TestCantGetAWSConfigSession(t *testing.T) {
 	}()
 
 	expectedErr := errors.New("expected newAWSSessionError")
-	newAWSSession = func(roleArn string, region string, log *zap.Logger) (*session.Session, error) {
+	newAWSSession = func(_ string, _ string, _ *zap.Logger) (*session.Session, error) {
 		return nil, expectedErr
 	}
 	_, err := NewServer(cfg, logger)

--- a/internal/aws/xray/testdata/sampleserver/sample.go
+++ b/internal/aws/xray/testdata/sampleserver/sample.go
@@ -15,7 +15,7 @@ func main() {
 	mux := http.NewServeMux()
 	mux.Handle("/", xray.Handler(
 		xray.NewFixedSegmentNamer("SampleServer"), http.HandlerFunc(
-			func(w http.ResponseWriter, r *http.Request) {
+			func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write([]byte("Hello!"))
 			},
 		),

--- a/internal/coreinternal/attraction/attraction.go
+++ b/internal/coreinternal/attraction/attraction.go
@@ -447,7 +447,7 @@ func getMatchingKeys(regexp *regexp.Regexp, attrs pcommon.Map) []string {
 		return keys
 	}
 
-	attrs.Range(func(k string, v pcommon.Value) bool {
+	attrs.Range(func(k string, _ pcommon.Value) bool {
 		if regexp.MatchString(k) {
 			keys = append(keys, k)
 		}

--- a/internal/coreinternal/goldendataset/resource_generator_test.go
+++ b/internal/coreinternal/goldendataset/resource_generator_test.go
@@ -10,8 +10,8 @@ import (
 )
 
 func TestGenerateResource(t *testing.T) {
-	resourceIds := []PICTInputResource{ResourceEmpty, ResourceVMOnPrem, ResourceVMCloud, ResourceK8sOnPrem, ResourceK8sCloud, ResourceFaas, ResourceExec}
-	for _, rscID := range resourceIds {
+	resourceIDs := []PICTInputResource{ResourceEmpty, ResourceVMOnPrem, ResourceVMCloud, ResourceK8sOnPrem, ResourceK8sCloud, ResourceFaas, ResourceExec}
+	for _, rscID := range resourceIDs {
 		rsc := GenerateResource(rscID)
 		if rscID == ResourceEmpty {
 			assert.Equal(t, 0, rsc.Attributes().Len())

--- a/internal/filter/filterottl/functions.go
+++ b/internal/filter/filterottl/functions.go
@@ -68,7 +68,7 @@ func createHasAttributeOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl.Ar
 }
 
 func hasAttributeOnDatapoint(key string, expectedVal string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(ctx context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
 		return checkDataPoints(tCtx, key, &expectedVal)
 	}, nil
 }
@@ -92,7 +92,7 @@ func createHasAttributeKeyOnDatapointFunction(_ ottl.FunctionContext, oArgs ottl
 }
 
 func hasAttributeKeyOnDatapoint(key string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-	return func(ctx context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
 		return checkDataPoints(tCtx, key, nil)
 	}, nil
 }

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -130,7 +130,7 @@ func TestSvcAcctClient(t *testing.T) {
 }
 
 func TestSAClientBadTLS(t *testing.T) {
-	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		_, _ = rw.Write([]byte(`OK`))
 	}))
 	cert, err := tls.LoadX509KeyPair(certPath, keyFile)

--- a/internal/metadataproviders/azure/metadata_test.go
+++ b/internal/metadataproviders/azure/metadata_test.go
@@ -34,7 +34,7 @@ func TestQueryEndpointFailed(t *testing.T) {
 }
 
 func TestQueryEndpointMalformed(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, "{")
 		assert.NoError(t, err)
 	}))
@@ -61,7 +61,7 @@ func TestQueryEndpointCorrect(t *testing.T) {
 	marshalledMetadata, err := json.Marshal(sentMetadata)
 	require.NoError(t, err)
 
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err = w.Write(marshalledMetadata)
 		assert.NoError(t, err)
 	}))

--- a/internal/metadataproviders/docker/metadata_test.go
+++ b/internal/metadataproviders/docker/metadata_test.go
@@ -21,7 +21,7 @@ func TestDockerError(t *testing.T) {
 }
 
 func TestDocker(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		fmt.Fprintln(w, `{
 			"OSType":"linux",
 			"Name":"hostname"

--- a/internal/metadataproviders/openshift/metadata_test.go
+++ b/internal/metadataproviders/openshift/metadata_test.go
@@ -42,7 +42,7 @@ func TestQueryEndpointFailed(t *testing.T) {
 }
 
 func TestQueryEndpointMalformed(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintln(w, "{")
 		assert.NoError(t, err)
 	}))
@@ -59,7 +59,7 @@ func TestQueryEndpointMalformed(t *testing.T) {
 }
 
 func TestQueryEndpointCorrectK8SClusterVersion(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{
   "major": "1",
   "minor": "21",
@@ -88,7 +88,7 @@ func TestQueryEndpointCorrectK8SClusterVersion(t *testing.T) {
 }
 
 func TestQueryEndpointCorrectOpenShiftClusterVersion(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{
 "apiVersion": "config.openshift.io/v1",
 "kind": "ClusterVersion",
@@ -113,7 +113,7 @@ func TestQueryEndpointCorrectOpenShiftClusterVersion(t *testing.T) {
 }
 
 func TestQueryEndpointCorrectInfrastructureAWS(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{
 "apiVersion": "config.openshift.io/v1",
 "kind": "Infrastructure",
@@ -158,7 +158,7 @@ func TestQueryEndpointCorrectInfrastructureAWS(t *testing.T) {
 }
 
 func TestQueryEndpointCorrectInfrastructureAzure(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{
 "apiVersion": "config.openshift.io/v1",
 "kind": "Infrastructure",
@@ -203,7 +203,7 @@ func TestQueryEndpointCorrectInfrastructureAzure(t *testing.T) {
 }
 
 func TestQueryEndpointCorrectInfrastructureGCP(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{
 "apiVersion": "config.openshift.io/v1",
 "kind": "Infrastructure",
@@ -246,7 +246,7 @@ func TestQueryEndpointCorrectInfrastructureGCP(t *testing.T) {
 }
 
 func TestQueryEndpointCorrectInfrastructureIBMCloud(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{
 "apiVersion": "config.openshift.io/v1",
 "kind": "Infrastructure",
@@ -289,7 +289,7 @@ func TestQueryEndpointCorrectInfrastructureIBMCloud(t *testing.T) {
 }
 
 func TestQueryEndpointCorrectInfrastructureOpenstack(t *testing.T) {
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		_, err := fmt.Fprintf(w, `{
 "apiVersion": "config.openshift.io/v1",
 "kind": "Infrastructure",

--- a/internal/metadataproviders/system/metadata_test.go
+++ b/internal/metadataproviders/system/metadata_test.go
@@ -76,7 +76,7 @@ func TestHostID(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			p := fakeLinuxSystemMetadataProvider()
-			p.newResource = func(ctx context.Context, o ...resource.Option) (*resource.Resource, error) {
+			p.newResource = func(_ context.Context, _ ...resource.Option) (*resource.Resource, error) {
 				if tt.resValue == "" {
 					return resource.NewSchemaless(), tt.resError
 				}
@@ -119,13 +119,13 @@ func fakeLinuxNameInfoProvider() nameInfoProvider {
 		osHostname: func() (string, error) {
 			return "my-linux-vm", nil
 		},
-		lookupCNAME: func(s string) (string, error) {
+		lookupCNAME: func(_ string) (string, error) {
 			return "my-linux-vm.abcdefghijklmnopqrstuvwxyz.xx.internal.foo.net.", nil
 		},
-		lookupHost: func(s string) ([]string, error) {
+		lookupHost: func(_ string) ([]string, error) {
 			return []string{"172.24.0.4"}, nil
 		},
-		lookupAddr: func(s string) ([]string, error) {
+		lookupAddr: func(_ string) ([]string, error) {
 			return []string{"my-linux-vm.internal.foo.net."}, nil
 		},
 	}
@@ -137,10 +137,10 @@ func fakeWindowsNameInfoProvider() nameInfoProvider {
 		osHostname: func() (string, error) {
 			return "my-windows-vm", nil
 		},
-		lookupCNAME: func(s string) (string, error) {
+		lookupCNAME: func(_ string) (string, error) {
 			return fqdn, nil
 		},
-		lookupHost: func(s string) ([]string, error) {
+		lookupHost: func(_ string) ([]string, error) {
 			return []string{"ffff::0000:1111:2222:3333%Ethernet", "1.2.3.4"}, nil
 		},
 		lookupAddr: func(s string) ([]string, error) {

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -46,11 +46,11 @@ func TestSharedComponent(t *testing.T) {
 	calledStart := 0
 	calledStop := 0
 	comp := &mockComponent{
-		StartFunc: func(ctx context.Context, host component.Host) error {
+		StartFunc: func(_ context.Context, _ component.Host) error {
 			calledStart++
 			return wantErr
 		},
-		ShutdownFunc: func(ctx context.Context) error {
+		ShutdownFunc: func(_ context.Context) error {
 			calledStop++
 			return wantErr
 		},

--- a/pkg/ottl/boolean_value_test.go
+++ b/pkg/ottl/boolean_value_test.go
@@ -216,12 +216,12 @@ func Test_newConditionEvaluator_invalid(t *testing.T) {
 }
 
 func True() (ExprFunc[any], error) {
-	return func(ctx context.Context, tCtx any) (any, error) {
+	return func(_ context.Context, _ any) (any, error) {
 		return true, nil
 	}, nil
 }
 func False() (ExprFunc[any], error) {
-	return func(ctx context.Context, tCtx any) (any, error) {
+	return func(_ context.Context, _ any) (any, error) {
 		return false, nil
 	}, nil
 }

--- a/pkg/ottl/contexts/internal/metric.go
+++ b/pkg/ottl/contexts/internal/metric.go
@@ -53,10 +53,10 @@ func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K],
 
 func accessMetric[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetMetric(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newMetric, ok := val.(pmetric.Metric); ok {
 				newMetric.CopyTo(tCtx.GetMetric())
 			}
@@ -67,10 +67,10 @@ func accessMetric[K MetricContext]() ottl.StandardGetSetter[K] {
 
 func accessName[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetMetric().Name(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetMetric().SetName(str)
 			}
@@ -81,10 +81,10 @@ func accessName[K MetricContext]() ottl.StandardGetSetter[K] {
 
 func accessDescription[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetMetric().Description(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetMetric().SetDescription(str)
 			}
@@ -95,10 +95,10 @@ func accessDescription[K MetricContext]() ottl.StandardGetSetter[K] {
 
 func accessUnit[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetMetric().Unit(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetMetric().SetUnit(str)
 			}
@@ -109,10 +109,10 @@ func accessUnit[K MetricContext]() ottl.StandardGetSetter[K] {
 
 func accessType[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetMetric().Type()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, _ K, _ any) error {
 			// TODO Implement methods so correctly convert data types.
 			// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/10130
 			return nil
@@ -122,7 +122,7 @@ func accessType[K MetricContext]() ottl.StandardGetSetter[K] {
 
 func accessAggTemporality[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			metric := tCtx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
@@ -134,7 +134,7 @@ func accessAggTemporality[K MetricContext]() ottl.StandardGetSetter[K] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newAggTemporality, ok := val.(int64); ok {
 				metric := tCtx.GetMetric()
 				switch metric.Type() {
@@ -153,14 +153,14 @@ func accessAggTemporality[K MetricContext]() ottl.StandardGetSetter[K] {
 
 func accessIsMonotonic[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			metric := tCtx.GetMetric()
 			if metric.Type() == pmetric.MetricTypeSum {
 				return metric.Sum().IsMonotonic(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newIsMonotonic, ok := val.(bool); ok {
 				metric := tCtx.GetMetric()
 				if metric.Type() == pmetric.MetricTypeSum {
@@ -174,7 +174,7 @@ func accessIsMonotonic[K MetricContext]() ottl.StandardGetSetter[K] {
 
 func accessDataPoints[K MetricContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			metric := tCtx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:
@@ -190,7 +190,7 @@ func accessDataPoints[K MetricContext]() ottl.StandardGetSetter[K] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			metric := tCtx.GetMetric()
 			switch metric.Type() {
 			case pmetric.MetricTypeSum:

--- a/pkg/ottl/contexts/internal/metric_test.go
+++ b/pkg/ottl/contexts/internal/metric_test.go
@@ -71,7 +71,7 @@ func Test_MetricPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(pmetric.MetricTypeSum),
 			newVal: int64(pmetric.MetricTypeSum),
-			modified: func(metric pmetric.Metric) {
+			modified: func(_ pmetric.Metric) {
 			},
 		},
 		{

--- a/pkg/ottl/contexts/internal/resource.go
+++ b/pkg/ottl/contexts/internal/resource.go
@@ -34,10 +34,10 @@ func ResourcePathGetSetter[K ResourceContext](path ottl.Path[K]) (ottl.GetSetter
 
 func accessResource[K ResourceContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetResource(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newRes, ok := val.(pcommon.Resource); ok {
 				newRes.CopyTo(tCtx.GetResource())
 			}
@@ -48,10 +48,10 @@ func accessResource[K ResourceContext]() ottl.StandardGetSetter[K] {
 
 func accessResourceAttributes[K ResourceContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetResource().Attributes(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetResource().Attributes())
 			}
@@ -73,10 +73,10 @@ func accessResourceAttributesKey[K ResourceContext](keys []ottl.Key[K]) ottl.Sta
 
 func accessResourceDroppedAttributesCount[K ResourceContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetResource().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetResource().SetDroppedAttributesCount(uint32(i))
 			}

--- a/pkg/ottl/contexts/internal/resource_test.go
+++ b/pkg/ottl/contexts/internal/resource_test.go
@@ -142,7 +142,7 @@ func TestResourcePathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []any{},
-			modified: func(resource pcommon.Resource) {
+			modified: func(_ pcommon.Resource) {
 				// no-op
 			},
 		},

--- a/pkg/ottl/contexts/internal/scope.go
+++ b/pkg/ottl/contexts/internal/scope.go
@@ -39,10 +39,10 @@ func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path[K]) (ottl.
 
 func accessInstrumentationScope[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetInstrumentationScope(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newIl, ok := val.(pcommon.InstrumentationScope); ok {
 				newIl.CopyTo(tCtx.GetInstrumentationScope())
 			}
@@ -53,10 +53,10 @@ func accessInstrumentationScope[K InstrumentationScopeContext]() ottl.StandardGe
 
 func accessInstrumentationScopeAttributes[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetInstrumentationScope().Attributes(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetInstrumentationScope().Attributes())
 			}
@@ -78,10 +78,10 @@ func accessInstrumentationScopeAttributesKey[K InstrumentationScopeContext](keys
 
 func accessInstrumentationScopeName[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetInstrumentationScope().Name(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetInstrumentationScope().SetName(str)
 			}
@@ -92,10 +92,10 @@ func accessInstrumentationScopeName[K InstrumentationScopeContext]() ottl.Standa
 
 func accessInstrumentationScopeVersion[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetInstrumentationScope().Version(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetInstrumentationScope().SetVersion(str)
 			}
@@ -106,10 +106,10 @@ func accessInstrumentationScopeVersion[K InstrumentationScopeContext]() ottl.Sta
 
 func accessInstrumentationScopeDroppedAttributesCount[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetInstrumentationScope().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetInstrumentationScope().SetDroppedAttributesCount(uint32(i))
 			}

--- a/pkg/ottl/contexts/internal/scope_test.go
+++ b/pkg/ottl/contexts/internal/scope_test.go
@@ -174,7 +174,7 @@ func TestScopePathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []any{},
-			modified: func(is pcommon.InstrumentationScope) {
+			modified: func(_ pcommon.InstrumentationScope) {
 				// no-op
 			},
 		},

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -134,10 +134,10 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 
 func accessSpan[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newSpan, ok := val.(ptrace.Span); ok {
 				newSpan.CopyTo(tCtx.GetSpan())
 			}
@@ -148,10 +148,10 @@ func accessSpan[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessTraceID[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().TraceID(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newTraceID, ok := val.(pcommon.TraceID); ok {
 				tCtx.GetSpan().SetTraceID(newTraceID)
 			}
@@ -162,11 +162,11 @@ func accessTraceID[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStringTraceID[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			id := tCtx.GetSpan().TraceID()
 			return hex.EncodeToString(id[:]), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				id, err := ParseTraceID(str)
 				if err != nil {
@@ -181,10 +181,10 @@ func accessStringTraceID[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().SpanID(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newSpanID, ok := val.(pcommon.SpanID); ok {
 				tCtx.GetSpan().SetSpanID(newSpanID)
 			}
@@ -195,11 +195,11 @@ func accessSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStringSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			id := tCtx.GetSpan().SpanID()
 			return hex.EncodeToString(id[:]), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				id, err := ParseSpanID(str)
 				if err != nil {
@@ -214,10 +214,10 @@ func accessStringSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessTraceState[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().TraceState().AsRaw(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetSpan().TraceState().FromRaw(str)
 			}
@@ -266,10 +266,10 @@ func accessTraceStateKey[K SpanContext](keys []ottl.Key[K]) (ottl.StandardGetSet
 
 func accessParentSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().ParentSpanID(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if newParentSpanID, ok := val.(pcommon.SpanID); ok {
 				tCtx.GetSpan().SetParentSpanID(newParentSpanID)
 			}
@@ -280,11 +280,11 @@ func accessParentSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStringParentSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			id := tCtx.GetSpan().ParentSpanID()
 			return hex.EncodeToString(id[:]), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				id, err := ParseSpanID(str)
 				if err != nil {
@@ -299,10 +299,10 @@ func accessStringParentSpanID[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessSpanName[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().Name(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetSpan().SetName(str)
 			}
@@ -313,10 +313,10 @@ func accessSpanName[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessKind[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetSpan().Kind()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().SetKind(ptrace.SpanKind(i))
 			}
@@ -327,10 +327,10 @@ func accessKind[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStringKind[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().Kind().String(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if s, ok := val.(string); ok {
 				var kind ptrace.SpanKind
 				switch s {
@@ -358,10 +358,10 @@ func accessStringKind[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessDeprecatedStringKind[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return traceutil.SpanKindStr(tCtx.GetSpan().Kind()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if s, ok := val.(string); ok {
 				var kind ptrace.SpanKind
 				switch s {
@@ -389,10 +389,10 @@ func accessDeprecatedStringKind[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStartTimeUnixNano[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().StartTimestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().SetStartTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
@@ -403,10 +403,10 @@ func accessStartTimeUnixNano[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessEndTimeUnixNano[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().EndTimestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().SetEndTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
@@ -417,10 +417,10 @@ func accessEndTimeUnixNano[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStartTime[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().StartTimestamp().AsTime(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(time.Time); ok {
 				tCtx.GetSpan().SetStartTimestamp(pcommon.NewTimestampFromTime(i))
 			}
@@ -431,10 +431,10 @@ func accessStartTime[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessEndTime[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().EndTimestamp().AsTime(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(time.Time); ok {
 				tCtx.GetSpan().SetEndTimestamp(pcommon.NewTimestampFromTime(i))
 			}
@@ -445,10 +445,10 @@ func accessEndTime[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessAttributes[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().Attributes(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetSpan().Attributes())
 			}
@@ -470,10 +470,10 @@ func accessAttributesKey[K SpanContext](keys []ottl.Key[K]) ottl.StandardGetSett
 
 func accessSpanDroppedAttributesCount[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetSpan().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().SetDroppedAttributesCount(uint32(i))
 			}
@@ -484,12 +484,12 @@ func accessSpanDroppedAttributesCount[K SpanContext]() ottl.StandardGetSetter[K]
 
 func accessEvents[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().Events(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if slc, ok := val.(ptrace.SpanEventSlice); ok {
-				tCtx.GetSpan().Events().RemoveIf(func(event ptrace.SpanEvent) bool {
+				tCtx.GetSpan().Events().RemoveIf(func(_ ptrace.SpanEvent) bool {
 					return true
 				})
 				slc.CopyTo(tCtx.GetSpan().Events())
@@ -501,10 +501,10 @@ func accessEvents[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessDroppedEventsCount[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetSpan().DroppedEventsCount()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().SetDroppedEventsCount(uint32(i))
 			}
@@ -515,12 +515,12 @@ func accessDroppedEventsCount[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessLinks[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().Links(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if slc, ok := val.(ptrace.SpanLinkSlice); ok {
-				tCtx.GetSpan().Links().RemoveIf(func(event ptrace.SpanLink) bool {
+				tCtx.GetSpan().Links().RemoveIf(func(_ ptrace.SpanLink) bool {
 					return true
 				})
 				slc.CopyTo(tCtx.GetSpan().Links())
@@ -532,10 +532,10 @@ func accessLinks[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessDroppedLinksCount[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetSpan().DroppedLinksCount()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().SetDroppedLinksCount(uint32(i))
 			}
@@ -546,10 +546,10 @@ func accessDroppedLinksCount[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStatus[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().Status(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if status, ok := val.(ptrace.Status); ok {
 				status.CopyTo(tCtx.GetSpan().Status())
 			}
@@ -560,10 +560,10 @@ func accessStatus[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStatusCode[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return int64(tCtx.GetSpan().Status().Code()), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetSpan().Status().SetCode(ptrace.StatusCode(i))
 			}
@@ -574,10 +574,10 @@ func accessStatusCode[K SpanContext]() ottl.StandardGetSetter[K] {
 
 func accessStatusMessage[K SpanContext]() ottl.StandardGetSetter[K] {
 	return ottl.StandardGetSetter[K]{
-		Getter: func(ctx context.Context, tCtx K) (any, error) {
+		Getter: func(_ context.Context, tCtx K) (any, error) {
 			return tCtx.GetSpan().Status().Message(), nil
 		},
-		Setter: func(ctx context.Context, tCtx K, val any) error {
+		Setter: func(_ context.Context, tCtx K, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetSpan().Status().SetMessage(str)
 			}

--- a/pkg/ottl/contexts/internal/span_test.go
+++ b/pkg/ottl/contexts/internal/span_test.go
@@ -326,7 +326,7 @@ func TestSpanPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []any{},
-			modified: func(span ptrace.Span) {
+			modified: func(_ ptrace.Span) {
 				// no-op
 			},
 		},

--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -227,10 +227,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.getCache(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(tCtx.getCache())
 			}
@@ -252,7 +252,7 @@ func accessCacheKey(key []ottl.Key[TransformContext]) ottl.StandardGetSetter[Tra
 
 func accessAttributes() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				return tCtx.GetDataPoint().(pmetric.NumberDataPoint).Attributes(), nil
@@ -265,7 +265,7 @@ func accessAttributes() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				if attrs, ok := val.(pcommon.Map); ok {
@@ -322,7 +322,7 @@ func accessAttributesKey(key []ottl.Key[TransformContext]) ottl.StandardGetSette
 
 func accessStartTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				return tCtx.GetDataPoint().(pmetric.NumberDataPoint).StartTimestamp().AsTime().UnixNano(), nil
@@ -335,7 +335,7 @@ func accessStartTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newTime, ok := val.(int64); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -355,7 +355,7 @@ func accessStartTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 
 func accessStartTime() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				return tCtx.GetDataPoint().(pmetric.NumberDataPoint).StartTimestamp().AsTime(), nil
@@ -368,7 +368,7 @@ func accessStartTime() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newTime, ok := val.(time.Time); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -388,7 +388,7 @@ func accessStartTime() ottl.StandardGetSetter[TransformContext] {
 
 func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				return tCtx.GetDataPoint().(pmetric.NumberDataPoint).Timestamp().AsTime().UnixNano(), nil
@@ -401,7 +401,7 @@ func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newTime, ok := val.(int64); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -421,7 +421,7 @@ func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 
 func accessTime() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				return tCtx.GetDataPoint().(pmetric.NumberDataPoint).Timestamp().AsTime(), nil
@@ -434,7 +434,7 @@ func accessTime() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newTime, ok := val.(time.Time); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -454,13 +454,13 @@ func accessTime() ottl.StandardGetSetter[TransformContext] {
 
 func accessDoubleValue() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if numberDataPoint, ok := tCtx.GetDataPoint().(pmetric.NumberDataPoint); ok {
 				return numberDataPoint.DoubleValue(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newDouble, ok := val.(float64); ok {
 				if numberDataPoint, ok := tCtx.GetDataPoint().(pmetric.NumberDataPoint); ok {
 					numberDataPoint.SetDoubleValue(newDouble)
@@ -473,13 +473,13 @@ func accessDoubleValue() ottl.StandardGetSetter[TransformContext] {
 
 func accessIntValue() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if numberDataPoint, ok := tCtx.GetDataPoint().(pmetric.NumberDataPoint); ok {
 				return numberDataPoint.IntValue(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newInt, ok := val.(int64); ok {
 				if numberDataPoint, ok := tCtx.GetDataPoint().(pmetric.NumberDataPoint); ok {
 					numberDataPoint.SetIntValue(newInt)
@@ -492,7 +492,7 @@ func accessIntValue() ottl.StandardGetSetter[TransformContext] {
 
 func accessExemplars() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				return tCtx.GetDataPoint().(pmetric.NumberDataPoint).Exemplars(), nil
@@ -503,7 +503,7 @@ func accessExemplars() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newExemplars, ok := val.(pmetric.ExemplarSlice); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -521,7 +521,7 @@ func accessExemplars() ottl.StandardGetSetter[TransformContext] {
 
 func accessFlags() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.NumberDataPoint:
 				return int64(tCtx.GetDataPoint().(pmetric.NumberDataPoint).Flags()), nil
@@ -534,7 +534,7 @@ func accessFlags() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newFlags, ok := val.(int64); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.NumberDataPoint:
@@ -554,7 +554,7 @@ func accessFlags() ottl.StandardGetSetter[TransformContext] {
 
 func accessCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
 				return int64(tCtx.GetDataPoint().(pmetric.HistogramDataPoint).Count()), nil
@@ -565,7 +565,7 @@ func accessCount() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newCount, ok := val.(int64); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
@@ -583,7 +583,7 @@ func accessCount() ottl.StandardGetSetter[TransformContext] {
 
 func accessSum() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			switch tCtx.GetDataPoint().(type) {
 			case pmetric.HistogramDataPoint:
 				return tCtx.GetDataPoint().(pmetric.HistogramDataPoint).Sum(), nil
@@ -594,7 +594,7 @@ func accessSum() ottl.StandardGetSetter[TransformContext] {
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newSum, ok := val.(float64); ok {
 				switch tCtx.GetDataPoint().(type) {
 				case pmetric.HistogramDataPoint:
@@ -612,13 +612,13 @@ func accessSum() ottl.StandardGetSetter[TransformContext] {
 
 func accessExplicitBounds() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
 				return histogramDataPoint.ExplicitBounds().AsRaw(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newExplicitBounds, ok := val.([]float64); ok {
 				if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
 					histogramDataPoint.ExplicitBounds().FromRaw(newExplicitBounds)
@@ -631,13 +631,13 @@ func accessExplicitBounds() ottl.StandardGetSetter[TransformContext] {
 
 func accessBucketCounts() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
 				return histogramDataPoint.BucketCounts().AsRaw(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newBucketCount, ok := val.([]uint64); ok {
 				if histogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.HistogramDataPoint); ok {
 					histogramDataPoint.BucketCounts().FromRaw(newBucketCount)
@@ -650,13 +650,13 @@ func accessBucketCounts() ottl.StandardGetSetter[TransformContext] {
 
 func accessScale() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return int64(expoHistogramDataPoint.Scale()), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newScale, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.SetScale(int32(newScale))
@@ -669,13 +669,13 @@ func accessScale() ottl.StandardGetSetter[TransformContext] {
 
 func accessZeroCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return int64(expoHistogramDataPoint.ZeroCount()), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newZeroCount, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.SetZeroCount(uint64(newZeroCount))
@@ -688,13 +688,13 @@ func accessZeroCount() ottl.StandardGetSetter[TransformContext] {
 
 func accessPositive() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return expoHistogramDataPoint.Positive(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newPositive, ok := val.(pmetric.ExponentialHistogramDataPointBuckets); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					newPositive.CopyTo(expoHistogramDataPoint.Positive())
@@ -707,13 +707,13 @@ func accessPositive() ottl.StandardGetSetter[TransformContext] {
 
 func accessPositiveOffset() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return int64(expoHistogramDataPoint.Positive().Offset()), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newPositiveOffset, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Positive().SetOffset(int32(newPositiveOffset))
@@ -726,13 +726,13 @@ func accessPositiveOffset() ottl.StandardGetSetter[TransformContext] {
 
 func accessPositiveBucketCounts() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return expoHistogramDataPoint.Positive().BucketCounts().AsRaw(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newPositiveBucketCounts, ok := val.([]uint64); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Positive().BucketCounts().FromRaw(newPositiveBucketCounts)
@@ -745,13 +745,13 @@ func accessPositiveBucketCounts() ottl.StandardGetSetter[TransformContext] {
 
 func accessNegative() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return expoHistogramDataPoint.Negative(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newNegative, ok := val.(pmetric.ExponentialHistogramDataPointBuckets); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					newNegative.CopyTo(expoHistogramDataPoint.Negative())
@@ -764,13 +764,13 @@ func accessNegative() ottl.StandardGetSetter[TransformContext] {
 
 func accessNegativeOffset() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return int64(expoHistogramDataPoint.Negative().Offset()), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newNegativeOffset, ok := val.(int64); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Negative().SetOffset(int32(newNegativeOffset))
@@ -783,13 +783,13 @@ func accessNegativeOffset() ottl.StandardGetSetter[TransformContext] {
 
 func accessNegativeBucketCounts() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 				return expoHistogramDataPoint.Negative().BucketCounts().AsRaw(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newNegativeBucketCounts, ok := val.([]uint64); ok {
 				if expoHistogramDataPoint, ok := tCtx.GetDataPoint().(pmetric.ExponentialHistogramDataPoint); ok {
 					expoHistogramDataPoint.Negative().BucketCounts().FromRaw(newNegativeBucketCounts)
@@ -802,13 +802,13 @@ func accessNegativeBucketCounts() ottl.StandardGetSetter[TransformContext] {
 
 func accessQuantileValues() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			if summaryDataPoint, ok := tCtx.GetDataPoint().(pmetric.SummaryDataPoint); ok {
 				return summaryDataPoint.QuantileValues(), nil
 			}
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newQuantileValues, ok := val.(pmetric.SummaryDataPointValueAtQuantileSlice); ok {
 				if summaryDataPoint, ok := tCtx.GetDataPoint().(pmetric.SummaryDataPoint); ok {
 					newQuantileValues.CopyTo(summaryDataPoint.QuantileValues())

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -1999,7 +1999,7 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 			},
 			orig:   int64(pmetric.MetricTypeSum),
 			newVal: int64(pmetric.MetricTypeSum),
-			modified: func(metric pmetric.Metric) {
+			modified: func(_ pmetric.Metric) {
 			},
 		},
 		{

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -222,10 +222,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.getCache(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(tCtx.getCache())
 			}
@@ -247,10 +247,10 @@ func accessCacheKey(key []ottl.Key[TransformContext]) ottl.StandardGetSetter[Tra
 
 func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().Timestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetLogRecord().SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
@@ -261,10 +261,10 @@ func accessTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 
 func accessObservedTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().ObservedTimestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetLogRecord().SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, i)))
 			}
@@ -275,10 +275,10 @@ func accessObservedTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 
 func accessTime() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().Timestamp().AsTime(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if i, ok := val.(time.Time); ok {
 				tCtx.GetLogRecord().SetTimestamp(pcommon.NewTimestampFromTime(i))
 			}
@@ -289,10 +289,10 @@ func accessTime() ottl.StandardGetSetter[TransformContext] {
 
 func accessObservedTime() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().ObservedTimestamp().AsTime(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if i, ok := val.(time.Time); ok {
 				tCtx.GetLogRecord().SetObservedTimestamp(pcommon.NewTimestampFromTime(i))
 			}
@@ -303,10 +303,10 @@ func accessObservedTime() ottl.StandardGetSetter[TransformContext] {
 
 func accessSeverityNumber() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return int64(tCtx.GetLogRecord().SeverityNumber()), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetLogRecord().SetSeverityNumber(plog.SeverityNumber(i))
 			}
@@ -317,10 +317,10 @@ func accessSeverityNumber() ottl.StandardGetSetter[TransformContext] {
 
 func accessSeverityText() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().SeverityText(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if s, ok := val.(string); ok {
 				tCtx.GetLogRecord().SetSeverityText(s)
 			}
@@ -331,10 +331,10 @@ func accessSeverityText() ottl.StandardGetSetter[TransformContext] {
 
 func accessBody() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return ottlcommon.GetValue(tCtx.GetLogRecord().Body()), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			return internal.SetValue(tCtx.GetLogRecord().Body(), val)
 		},
 	}
@@ -369,10 +369,10 @@ func accessBodyKey(key []ottl.Key[TransformContext]) ottl.StandardGetSetter[Tran
 
 func accessStringBody() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().Body().AsString(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if str, ok := val.(string); ok {
 				tCtx.GetLogRecord().Body().SetStr(str)
 			}
@@ -383,10 +383,10 @@ func accessStringBody() ottl.StandardGetSetter[TransformContext] {
 
 func accessAttributes() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().Attributes(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetLogRecord().Attributes())
 			}
@@ -408,10 +408,10 @@ func accessAttributesKey(key []ottl.Key[TransformContext]) ottl.StandardGetSette
 
 func accessDroppedAttributesCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return int64(tCtx.GetLogRecord().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetLogRecord().SetDroppedAttributesCount(uint32(i))
 			}
@@ -422,10 +422,10 @@ func accessDroppedAttributesCount() ottl.StandardGetSetter[TransformContext] {
 
 func accessFlags() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return int64(tCtx.GetLogRecord().Flags()), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if i, ok := val.(int64); ok {
 				tCtx.GetLogRecord().SetFlags(plog.LogRecordFlags(i))
 			}
@@ -436,10 +436,10 @@ func accessFlags() ottl.StandardGetSetter[TransformContext] {
 
 func accessTraceID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().TraceID(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newTraceID, ok := val.(pcommon.TraceID); ok {
 				tCtx.GetLogRecord().SetTraceID(newTraceID)
 			}
@@ -450,11 +450,11 @@ func accessTraceID() ottl.StandardGetSetter[TransformContext] {
 
 func accessStringTraceID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			id := tCtx.GetLogRecord().TraceID()
 			return hex.EncodeToString(id[:]), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if str, ok := val.(string); ok {
 				id, err := internal.ParseTraceID(str)
 				if err != nil {
@@ -469,10 +469,10 @@ func accessStringTraceID() ottl.StandardGetSetter[TransformContext] {
 
 func accessSpanID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetLogRecord().SpanID(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newSpanID, ok := val.(pcommon.SpanID); ok {
 				tCtx.GetLogRecord().SetSpanID(newSpanID)
 			}
@@ -483,11 +483,11 @@ func accessSpanID() ottl.StandardGetSetter[TransformContext] {
 
 func accessStringSpanID() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			id := tCtx.GetLogRecord().SpanID()
 			return hex.EncodeToString(id[:]), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if str, ok := val.(string); ok {
 				id, err := internal.ParseSpanID(str)
 				if err != nil {

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -65,7 +65,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -76,7 +76,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -87,7 +87,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -98,7 +98,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -109,7 +109,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(plog.SeverityNumberFatal),
 			newVal: int64(3),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetSeverityNumber(plog.SeverityNumberTrace3)
 			},
 		},
@@ -120,7 +120,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "blue screen of death",
 			newVal: "black screen of death",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetSeverityText("black screen of death")
 			},
 		},
@@ -131,7 +131,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "body",
 			newVal: "head",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Body().SetStr("head")
 			},
 		},
@@ -145,7 +145,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return log.Body().Map()
 			}(),
 			newVal: newBodyMap,
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				newBodyMap.CopyTo(log.Body().Map())
 			},
 			bodyType: "map",
@@ -162,7 +162,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "val",
 			newVal: "val2",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Body().Map().PutStr("key", "val2")
 			},
 			bodyType: "map",
@@ -177,7 +177,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return log.Body().Slice()
 			}(),
 			newVal: newBodySlice,
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				fmt.Println(log.Body().Slice().At(0).AsString())
 				newBodySlice.CopyTo(log.Body().Slice())
 				fmt.Println(log.Body().Slice().At(0).AsString())
@@ -197,7 +197,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "body",
 			newVal: "head",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Body().Slice().At(0).SetStr("head")
 			},
 			bodyType: "slice",
@@ -212,7 +212,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "1",
 			newVal: "2",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Body().SetStr("2")
 			},
 			bodyType: "int",
@@ -224,7 +224,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(4),
 			newVal: int64(5),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetFlags(plog.LogRecordFlags(5))
 			},
 		},
@@ -235,7 +235,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.TraceID(traceID),
 			newVal: pcommon.TraceID(traceID2),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetTraceID(traceID2)
 			},
 		},
@@ -246,7 +246,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.SpanID(spanID),
 			newVal: pcommon.SpanID(spanID2),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetSpanID(spanID2)
 			},
 		},
@@ -260,7 +260,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   hex.EncodeToString(traceID[:]),
 			newVal: hex.EncodeToString(traceID2[:]),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetTraceID(traceID2)
 			},
 		},
@@ -274,7 +274,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   hex.EncodeToString(spanID[:]),
 			newVal: hex.EncodeToString(spanID2[:]),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetSpanID(spanID2)
 			},
 		},
@@ -285,7 +285,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				newCache.CopyTo(cache)
 			},
 		},
@@ -301,7 +301,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   nil,
 			newVal: "new value",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				cache.PutStr("temp", "new value")
 			},
 		},
@@ -312,7 +312,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refLog.Attributes(),
 			newVal: newAttrs,
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				newAttrs.CopyTo(log.Attributes())
 			},
 		},
@@ -328,7 +328,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "val",
 			newVal: "newVal",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutStr("str", "newVal")
 			},
 		},
@@ -344,7 +344,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   true,
 			newVal: false,
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutBool("bool", false)
 			},
 		},
@@ -360,7 +360,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutInt("int", 20)
 			},
 		},
@@ -376,7 +376,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutDouble("double", 2.4)
 			},
 		},
@@ -392,7 +392,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
@@ -411,7 +411,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []string{"new"},
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
 		},
@@ -430,7 +430,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []bool{false},
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
 		},
@@ -449,7 +449,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []int64{20},
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
 		},
@@ -468,7 +468,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []float64{2.0},
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
 		},
@@ -487,7 +487,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: [][]byte{{9, 6, 4}},
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
@@ -506,7 +506,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newPMap,
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := log.Attributes().PutEmptyMap("pMap")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -527,7 +527,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newMap,
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := log.Attributes().PutEmptyMap("map")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -555,7 +555,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Str()
 			}(),
 			newVal: "new",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
 			},
 		},
@@ -579,7 +579,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return nil
 			}(),
 			newVal: "new",
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				s := log.Attributes().PutEmptySlice("new")
 				s.AppendEmpty()
 				s.AppendEmpty()
@@ -593,7 +593,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetDroppedAttributesCount(20)
 			},
 		},
@@ -604,7 +604,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ plog.LogRecord, il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				pcommon.NewInstrumentationScope().CopyTo(il)
 			},
 		},
@@ -615,7 +615,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
-			modified: func(log plog.LogRecord, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ plog.LogRecord, _ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
 				pcommon.NewResource().CopyTo(resource)
 			},
 		},

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -145,10 +145,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.getCache(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(tCtx.getCache())
 			}

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -44,7 +44,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "name",
 			newVal: "new name",
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(metric pmetric.Metric, _ pcommon.Map) {
 				metric.SetName("new name")
 			},
 		},
@@ -55,7 +55,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "description",
 			newVal: "new description",
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(metric pmetric.Metric, _ pcommon.Map) {
 				metric.SetDescription("new description")
 			},
 		},
@@ -66,7 +66,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "unit",
 			newVal: "new unit",
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(metric pmetric.Metric, _ pcommon.Map) {
 				metric.SetUnit("new unit")
 			},
 		},
@@ -77,7 +77,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(pmetric.MetricTypeSum),
 			newVal: int64(pmetric.MetricTypeSum),
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(_ pmetric.Metric, _ pcommon.Map) {
 			},
 		},
 		{
@@ -87,7 +87,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(2),
 			newVal: int64(1),
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(metric pmetric.Metric, _ pcommon.Map) {
 				metric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 			},
 		},
@@ -98,7 +98,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   true,
 			newVal: false,
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(metric pmetric.Metric, _ pcommon.Map) {
 				metric.Sum().SetIsMonotonic(false)
 			},
 		},
@@ -109,7 +109,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refMetric.Sum().DataPoints(),
 			newVal: newDataPoints,
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(metric pmetric.Metric, _ pcommon.Map) {
 				newDataPoints.CopyTo(metric.Sum().DataPoints())
 			},
 		},
@@ -120,7 +120,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(_ pmetric.Metric, cache pcommon.Map) {
 				newCache.CopyTo(cache)
 			},
 		},
@@ -136,7 +136,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   nil,
 			newVal: "new value",
-			modified: func(metric pmetric.Metric, cache pcommon.Map) {
+			modified: func(_ pmetric.Metric, cache pcommon.Map) {
 				cache.PutStr("temp", "new value")
 			},
 		},

--- a/pkg/ottl/contexts/ottlresource/resource.go
+++ b/pkg/ottl/contexts/ottlresource/resource.go
@@ -112,10 +112,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.getCache(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(tCtx.getCache())
 			}

--- a/pkg/ottl/contexts/ottlresource/resource_test.go
+++ b/pkg/ottl/contexts/ottlresource/resource_test.go
@@ -47,7 +47,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ pcommon.Resource, cache pcommon.Map) {
 				newCache.CopyTo(cache)
 			},
 		},
@@ -63,7 +63,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   nil,
 			newVal: "new value",
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ pcommon.Resource, cache pcommon.Map) {
 				cache.PutStr("temp", "new value")
 			},
 		},
@@ -74,7 +74,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refResource.Attributes(),
 			newVal: newAttrs,
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				newAttrs.CopyTo(resource.Attributes())
 			},
 		},
@@ -90,7 +90,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "val",
 			newVal: "newVal",
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutStr("str", "newVal")
 			},
 		},
@@ -106,7 +106,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   true,
 			newVal: false,
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutBool("bool", false)
 			},
 		},
@@ -122,7 +122,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutInt("int", 20)
 			},
 		},
@@ -138,7 +138,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutDouble("double", 2.4)
 			},
 		},
@@ -154,7 +154,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
@@ -173,7 +173,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []string{"new"},
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
 		},
@@ -192,7 +192,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []bool{false},
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
 		},
@@ -211,7 +211,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []int64{20},
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
 		},
@@ -230,7 +230,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []float64{2.0},
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
 		},
@@ -249,7 +249,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: [][]byte{{9, 6, 4}},
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
@@ -268,7 +268,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newPMap,
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				m := resource.Attributes().PutEmptyMap("pMap")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -289,7 +289,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newMap,
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				m := resource.Attributes().PutEmptyMap("map")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -317,7 +317,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Str()
 			}(),
 			newVal: "new",
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
 			},
 		},
@@ -341,7 +341,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return nil
 			}(),
 			newVal: "new",
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				s := resource.Attributes().PutEmptySlice("new")
 				s.AppendEmpty()
 				s.AppendEmpty()
@@ -355,7 +355,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(resource pcommon.Resource, _ pcommon.Map) {
 				resource.SetDroppedAttributesCount(20)
 			},
 		},

--- a/pkg/ottl/contexts/ottlscope/scope.go
+++ b/pkg/ottl/contexts/ottlscope/scope.go
@@ -121,10 +121,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.getCache(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(tCtx.getCache())
 			}

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -47,7 +47,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
-			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				newCache.CopyTo(cache)
 			},
 		},
@@ -63,7 +63,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   nil,
 			newVal: "new value",
-			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				cache.PutStr("temp", "new value")
 			},
 		},
@@ -74,7 +74,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refIS.Attributes(),
 			newVal: newAttrs,
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				newAttrs.CopyTo(is.Attributes())
 			},
 		},
@@ -90,7 +90,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "val",
 			newVal: "newVal",
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutStr("str", "newVal")
 			},
 		},
@@ -106,7 +106,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   true,
 			newVal: false,
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutBool("bool", false)
 			},
 		},
@@ -122,7 +122,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutInt("int", 20)
 			},
 		},
@@ -138,7 +138,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutDouble("double", 2.4)
 			},
 		},
@@ -154,7 +154,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
@@ -173,7 +173,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []string{"new"},
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
 		},
@@ -192,7 +192,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []bool{false},
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
 		},
@@ -211,7 +211,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []int64{20},
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
 		},
@@ -230,7 +230,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []float64{2.0},
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
 		},
@@ -249,7 +249,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: [][]byte{{9, 6, 4}},
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
@@ -268,7 +268,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newPMap,
-			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := il.Attributes().PutEmptyMap("pMap")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -289,7 +289,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newMap,
-			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := il.Attributes().PutEmptyMap("map")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -317,7 +317,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Str()
 			}(),
 			newVal: "new",
-			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				il.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
 			},
 		},
@@ -341,7 +341,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return nil
 			}(),
 			newVal: "new",
-			modified: func(il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				s := il.Attributes().PutEmptySlice("new")
 				s.AppendEmpty()
 				s.AppendEmpty()
@@ -355,7 +355,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.SetDroppedAttributesCount(20)
 			},
 		},
@@ -366,7 +366,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refIS.Name(),
 			newVal: "newname",
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.SetName("newname")
 			},
 		},
@@ -377,7 +377,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refIS.Version(),
 			newVal: "next",
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.SetVersion("next")
 			},
 		},
@@ -388,7 +388,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
-			modified: func(is pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
 				pcommon.NewResource().CopyTo(resource)
 			},
 		},

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -136,10 +136,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.getCache(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(tCtx.getCache())
 			}

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -66,7 +66,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				newCache.CopyTo(cache)
 			},
 		},
@@ -82,7 +82,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   nil,
 			newVal: "new value",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				cache.PutStr("temp", "new value")
 			},
 		},
@@ -93,7 +93,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.TraceID(traceID),
 			newVal: pcommon.TraceID(traceID2),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetTraceID(traceID2)
 			},
 		},
@@ -104,7 +104,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.SpanID(spanID),
 			newVal: pcommon.SpanID(spanID2),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetSpanID(spanID2)
 			},
 		},
@@ -118,7 +118,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   hex.EncodeToString(traceID[:]),
 			newVal: hex.EncodeToString(traceID2[:]),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetTraceID(traceID2)
 			},
 		},
@@ -132,7 +132,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   hex.EncodeToString(spanID[:]),
 			newVal: hex.EncodeToString(spanID2[:]),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetSpanID(spanID2)
 			},
 		},
@@ -143,7 +143,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "key1=val1,key2=val2",
 			newVal: "key=newVal",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.TraceState().FromRaw("key=newVal")
 			},
 		},
@@ -159,7 +159,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "val1",
 			newVal: "newVal",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.TraceState().FromRaw("key1=newVal,key2=val2")
 			},
 		},
@@ -170,7 +170,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.SpanID(spanID2),
 			newVal: pcommon.SpanID(spanID),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetParentSpanID(spanID)
 			},
 		},
@@ -181,7 +181,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "bear",
 			newVal: "cat",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetName("cat")
 			},
 		},
@@ -192,7 +192,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(2),
 			newVal: int64(3),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetKind(ptrace.SpanKindClient)
 			},
 		},
@@ -206,7 +206,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "Server",
 			newVal: "Client",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetKind(ptrace.SpanKindClient)
 			},
 		},
@@ -220,7 +220,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "SPAN_KIND_SERVER",
 			newVal: "SPAN_KIND_CLIENT",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetKind(ptrace.SpanKindClient)
 			},
 		},
@@ -231,7 +231,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -242,7 +242,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(500_000_000),
 			newVal: int64(200_000_000),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -253,7 +253,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetStartTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -264,7 +264,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 500000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetEndTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -275,7 +275,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refSpan.Attributes(),
 			newVal: newAttrs,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				newAttrs.CopyTo(span.Attributes())
 			},
 		},
@@ -291,7 +291,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "val",
 			newVal: "newVal",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutStr("str", "newVal")
 			},
 		},
@@ -307,7 +307,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   true,
 			newVal: false,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutBool("bool", false)
 			},
 		},
@@ -324,7 +324,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutInt("int", 20)
 			},
 		},
@@ -342,7 +342,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutDouble("double", 2.4)
 			},
 		},
@@ -360,7 +360,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
@@ -381,7 +381,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []string{"new"},
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
 		},
@@ -402,7 +402,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []bool{false},
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
 		},
@@ -423,7 +423,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []int64{20},
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
 		},
@@ -444,7 +444,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []float64{2.0},
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
 		},
@@ -465,7 +465,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: [][]byte{{9, 6, 4}},
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
@@ -486,7 +486,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newPMap,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := span.Attributes().PutEmptyMap("pMap")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -509,7 +509,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newMap,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := span.Attributes().PutEmptyMap("map")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -537,7 +537,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Str()
 			}(),
 			newVal: "new",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
 			},
 		},
@@ -561,7 +561,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return nil
 			}(),
 			newVal: "new",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				s := span.Attributes().PutEmptySlice("new")
 				s.AppendEmpty()
 				s.AppendEmpty()
@@ -575,7 +575,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetDroppedAttributesCount(20)
 			},
 		},
@@ -586,7 +586,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refSpan.Events(),
 			newVal: newEvents,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Events().RemoveIf(func(_ ptrace.SpanEvent) bool {
 					return true
 				})
@@ -600,7 +600,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(20),
 			newVal: int64(30),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetDroppedEventsCount(30)
 			},
 		},
@@ -611,7 +611,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refSpan.Links(),
 			newVal: newLinks,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Links().RemoveIf(func(_ ptrace.SpanLink) bool {
 					return true
 				})
@@ -625,7 +625,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(30),
 			newVal: int64(40),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.SetDroppedLinksCount(40)
 			},
 		},
@@ -636,7 +636,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refSpan.Status(),
 			newVal: newStatus,
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				newStatus.CopyTo(span.Status())
 			},
 		},
@@ -650,7 +650,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(ptrace.StatusCodeOk),
 			newVal: int64(ptrace.StatusCodeError),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Status().SetCode(ptrace.StatusCodeError)
 			},
 		},
@@ -664,7 +664,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "good span",
 			newVal: "bad span",
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Status().SetMessage("bad span")
 			},
 		},
@@ -675,7 +675,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.Span, il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				pcommon.NewInstrumentationScope().CopyTo(il)
 			},
 		},
@@ -686,7 +686,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
-			modified: func(span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.Span, _ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
 				pcommon.NewResource().CopyTo(resource)
 			},
 		},

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -159,10 +159,10 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 }
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.getCache(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if m, ok := val.(pcommon.Map); ok {
 				m.CopyTo(tCtx.getCache())
 			}
@@ -184,10 +184,10 @@ func accessCacheKey(key []ottl.Key[TransformContext]) ottl.StandardGetSetter[Tra
 
 func accessSpanEventTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetSpanEvent().Timestamp().AsTime().UnixNano(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newTimestamp, ok := val.(int64); ok {
 				tCtx.GetSpanEvent().SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(0, newTimestamp)))
 			}
@@ -198,10 +198,10 @@ func accessSpanEventTimeUnixNano() ottl.StandardGetSetter[TransformContext] {
 
 func accessSpanEventTime() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetSpanEvent().Timestamp().AsTime(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newTimestamp, ok := val.(time.Time); ok {
 				tCtx.GetSpanEvent().SetTimestamp(pcommon.NewTimestampFromTime(newTimestamp))
 			}
@@ -212,10 +212,10 @@ func accessSpanEventTime() ottl.StandardGetSetter[TransformContext] {
 
 func accessSpanEventName() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetSpanEvent().Name(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newName, ok := val.(string); ok {
 				tCtx.GetSpanEvent().SetName(newName)
 			}
@@ -226,10 +226,10 @@ func accessSpanEventName() ottl.StandardGetSetter[TransformContext] {
 
 func accessSpanEventAttributes() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return tCtx.GetSpanEvent().Attributes(), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if attrs, ok := val.(pcommon.Map); ok {
 				attrs.CopyTo(tCtx.GetSpanEvent().Attributes())
 			}
@@ -251,10 +251,10 @@ func accessSpanEventAttributesKey(key []ottl.Key[TransformContext]) ottl.Standar
 
 func accessSpanEventDroppedAttributeCount() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{
-		Getter: func(ctx context.Context, tCtx TransformContext) (any, error) {
+		Getter: func(_ context.Context, tCtx TransformContext) (any, error) {
 			return int64(tCtx.GetSpanEvent().DroppedAttributesCount()), nil
 		},
-		Setter: func(ctx context.Context, tCtx TransformContext, val any) error {
+		Setter: func(_ context.Context, tCtx TransformContext, val any) error {
 			if newCount, ok := val.(int64); ok {
 				tCtx.GetSpanEvent().SetDroppedAttributesCount(uint32(newCount))
 			}

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -62,7 +62,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   time.Date(1970, 1, 1, 0, 0, 0, 100000000, time.UTC),
 			newVal: time.Date(1970, 1, 1, 0, 0, 0, 200000000, time.UTC),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -73,7 +73,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   pcommon.NewMap(),
 			newVal: newCache,
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				newCache.CopyTo(cache)
 			},
 		},
@@ -89,7 +89,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   nil,
 			newVal: "new value",
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, cache pcommon.Map) {
 				cache.PutStr("temp", "new value")
 			},
 		},
@@ -100,7 +100,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "bear",
 			newVal: "cat",
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.SetName("cat")
 			},
 		},
@@ -111,7 +111,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(100_000_000),
 			newVal: int64(200_000_000),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.SetTimestamp(pcommon.NewTimestampFromTime(time.UnixMilli(200)))
 			},
 		},
@@ -122,7 +122,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refSpanEvent.Attributes(),
 			newVal: newAttrs,
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				newAttrs.CopyTo(spanEvent.Attributes())
 			},
 		},
@@ -138,7 +138,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   "val",
 			newVal: "newVal",
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutStr("str", "newVal")
 			},
 		},
@@ -154,7 +154,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   true,
 			newVal: false,
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutBool("bool", false)
 			},
 		},
@@ -170,7 +170,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutInt("int", 20)
 			},
 		},
@@ -186,7 +186,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   float64(1.2),
 			newVal: float64(2.4),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutDouble("double", 2.4)
 			},
 		},
@@ -202,7 +202,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   []byte{1, 3, 2},
 			newVal: []byte{2, 3, 4},
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutEmptyBytes("bytes").FromRaw([]byte{2, 3, 4})
 			},
 		},
@@ -221,7 +221,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []string{"new"},
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutEmptySlice("arr_str").AppendEmpty().SetStr("new")
 			},
 		},
@@ -240,7 +240,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []bool{false},
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutEmptySlice("arr_bool").AppendEmpty().SetBool(false)
 			},
 		},
@@ -259,7 +259,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []int64{20},
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutEmptySlice("arr_int").AppendEmpty().SetInt(20)
 			},
 		},
@@ -278,7 +278,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: []float64{2.0},
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutEmptySlice("arr_float").AppendEmpty().SetDouble(2.0)
 			},
 		},
@@ -297,7 +297,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Slice()
 			}(),
 			newVal: [][]byte{{9, 6, 4}},
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutEmptySlice("arr_bytes").AppendEmpty().SetEmptyBytes().FromRaw([]byte{9, 6, 4})
 			},
 		},
@@ -316,7 +316,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newPMap,
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := spanEvent.Attributes().PutEmptyMap("pMap")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -337,7 +337,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Map()
 			}(),
 			newVal: newMap,
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				m := spanEvent.Attributes().PutEmptyMap("map")
 				m2 := m.PutEmptyMap("k2")
 				m2.PutStr("k1", "string")
@@ -365,7 +365,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return val.Str()
 			}(),
 			newVal: "new",
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.Attributes().PutEmptySlice("slice").AppendEmpty().SetEmptyMap().PutStr("map", "new")
 			},
 		},
@@ -389,7 +389,7 @@ func Test_newPathGetSetter(t *testing.T) {
 				return nil
 			}(),
 			newVal: "new",
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				s := spanEvent.Attributes().PutEmptySlice("new")
 				s.AppendEmpty()
 				s.AppendEmpty()
@@ -403,7 +403,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   int64(10),
 			newVal: int64(20),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.SetDroppedAttributesCount(20)
 			},
 		},
@@ -414,7 +414,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refIS,
 			newVal: pcommon.NewInstrumentationScope(),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.SpanEvent, _ ptrace.Span, il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				pcommon.NewInstrumentationScope().CopyTo(il)
 			},
 		},
@@ -425,7 +425,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refResource,
 			newVal: pcommon.NewResource(),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
 				pcommon.NewResource().CopyTo(resource)
 			},
 		},
@@ -436,7 +436,7 @@ func Test_newPathGetSetter(t *testing.T) {
 			},
 			orig:   refSpan,
 			newVal: ptrace.NewSpan(),
-			modified: func(spanEvent ptrace.SpanEvent, span ptrace.Span, il pcommon.InstrumentationScope, resource pcommon.Resource, cache pcommon.Map) {
+			modified: func(_ ptrace.SpanEvent, span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				ptrace.NewSpan().CopyTo(span)
 			},
 		},

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -78,7 +78,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `flatten(attributes, depth=0)`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 		{
 			statement: `flatten(attributes, depth=1)`,
@@ -110,7 +110,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `limit(attributes, 100, [])`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 		{
 			statement: `limit(attributes, 1, ["total.string"])`,
@@ -196,11 +196,11 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], nil)`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 		{
 			statement: `set(attributes["test"], attributes["unknown"])`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 		{
 			statement: `set(attributes["foo"]["test"], "pass")`,
@@ -211,7 +211,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `truncate_all(attributes, 100)`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 		{
 			statement: `truncate_all(attributes, 1)`,
@@ -650,7 +650,7 @@ func Test_e2e_ottl_features(t *testing.T) {
 		{
 			name:      "where clause",
 			statement: `set(attributes["test"], "pass") where body == "operationB"`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 		{
 			name:      "reach upwards",
@@ -704,7 +704,7 @@ func Test_e2e_ottl_features(t *testing.T) {
 		{
 			name:      "complex indexing not found",
 			statement: `set(attributes["test"], attributes["metadata"]["uid"])`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 	}
 

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -18,13 +18,13 @@ import (
 )
 
 func hello() (ExprFunc[any], error) {
-	return func(ctx context.Context, tCtx any) (any, error) {
+	return func(_ context.Context, _ any) (any, error) {
 		return "world", nil
 	}, nil
 }
 
 func pmap() (ExprFunc[any], error) {
-	return func(ctx context.Context, tCtx any) (any, error) {
+	return func(_ context.Context, _ any) (any, error) {
 		m := pcommon.NewMap()
 		m.PutEmptyMap("foo").PutStr("bar", "pass")
 		return m, nil
@@ -32,7 +32,7 @@ func pmap() (ExprFunc[any], error) {
 }
 
 func basicMap() (ExprFunc[any], error) {
-	return func(ctx context.Context, tCtx any) (any, error) {
+	return func(_ context.Context, _ any) (any, error) {
 		return map[string]any{
 			"foo": map[string]any{
 				"bar": "pass",
@@ -42,7 +42,7 @@ func basicMap() (ExprFunc[any], error) {
 }
 
 func pslice() (ExprFunc[any], error) {
-	return func(ctx context.Context, tCtx any) (any, error) {
+	return func(_ context.Context, _ any) (any, error) {
 		s := pcommon.NewSlice()
 		s.AppendEmpty().SetEmptySlice().AppendEmpty().SetStr("pass")
 		return s, nil
@@ -50,7 +50,7 @@ func pslice() (ExprFunc[any], error) {
 }
 
 func basicSlice() (ExprFunc[any], error) {
-	return func(ctx context.Context, tCtx any) (any, error) {
+	return func(_ context.Context, _ any) (any, error) {
 		return []any{
 			[]any{
 				"pass",
@@ -625,7 +625,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "str", nil
 				},
 			},
@@ -635,7 +635,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "ValueTypeString type",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return pcommon.NewValueStr("str"), nil
 				},
 			},
@@ -645,7 +645,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -655,7 +655,7 @@ func Test_StandardStringGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -716,7 +716,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "function getter",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "str", nil
 				},
 			},
@@ -727,7 +727,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "function getter nil",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -739,7 +739,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "function arg mismatch",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -751,7 +751,7 @@ func Test_FunctionGetter(t *testing.T) {
 		{
 			name: "Cannot create function",
 			getter: StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -784,7 +784,7 @@ func Test_FunctionGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardStringGetter_WrappedError(t *testing.T) {
 	getter := StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -805,7 +805,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "str", nil
 				},
 			},
@@ -815,7 +815,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "bool type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -825,7 +825,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -835,7 +835,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -845,7 +845,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "byte[] type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return []byte{0}, nil
 				},
 			},
@@ -855,7 +855,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.map type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("test", "passed")
 					return m, nil
@@ -867,7 +867,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.slice type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					s := pcommon.NewSlice()
 					v := s.AppendEmpty()
 					v.SetStr("test")
@@ -880,7 +880,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueInt(int64(100))
 					return v, nil
 				},
@@ -891,7 +891,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -901,7 +901,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return make(chan int), nil
 				},
 			},
@@ -931,7 +931,7 @@ func Test_StandardStringLikeGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardStringLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardStringLikeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -952,7 +952,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardFloatGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -962,7 +962,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "ValueTypeFloat type",
 			getter: StandardFloatGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return pcommon.NewValueDouble(1.1), nil
 				},
 			},
@@ -972,7 +972,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardFloatGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -982,7 +982,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardFloatGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1008,7 +1008,7 @@ func Test_StandardFloatGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardFloatGetter_WrappedError(t *testing.T) {
 	getter := StandardFloatGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1029,7 +1029,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "1.0", nil
 				},
 			},
@@ -1039,7 +1039,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -1049,7 +1049,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -1059,7 +1059,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "float64 bool true",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1069,7 +1069,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "float64 bool false",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return false, nil
 				},
 			},
@@ -1079,7 +1079,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type int",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueInt(int64(100))
 					return v, nil
 				},
@@ -1090,7 +1090,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type float",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueDouble(float64(1.1))
 					return v, nil
 				},
@@ -1101,7 +1101,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type string",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueStr("1.1")
 					return v, nil
 				},
@@ -1112,7 +1112,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool true",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueBool(true)
 					return v, nil
 				},
@@ -1123,7 +1123,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool false",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueBool(false)
 					return v, nil
 				},
@@ -1134,7 +1134,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1144,7 +1144,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return []byte{}, nil
 				},
 			},
@@ -1154,7 +1154,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 		{
 			name: "invalid pcommon.Value type",
 			getter: StandardFloatLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueMap()
 					return v, nil
 				},
@@ -1185,7 +1185,7 @@ func Test_StandardFloatLikeGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardFloatLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardFloatLikeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1206,7 +1206,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardIntGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -1216,7 +1216,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "ValueTypeInt type",
 			getter: StandardIntGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return pcommon.NewValueInt(1), nil
 				},
 			},
@@ -1226,7 +1226,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardIntGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1236,7 +1236,7 @@ func Test_StandardIntGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardIntGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1262,7 +1262,7 @@ func Test_StandardIntGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardIntGetter_WrappedError(t *testing.T) {
 	getter := StandardIntGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1283,7 +1283,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "string type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "1", nil
 				},
 			},
@@ -1293,7 +1293,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "int64 type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -1303,7 +1303,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -1313,7 +1313,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "primitive bool true",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1323,7 +1323,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "primitive bool false",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return false, nil
 				},
 			},
@@ -1333,7 +1333,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type int",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueInt(int64(100))
 					return v, nil
 				},
@@ -1344,7 +1344,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type float",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueDouble(float64(1.9))
 					return v, nil
 				},
@@ -1355,7 +1355,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type string",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueStr("1")
 					return v, nil
 				},
@@ -1366,7 +1366,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool true",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueBool(true)
 					return v, nil
 				},
@@ -1377,7 +1377,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool false",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueBool(false)
 					return v, nil
 				},
@@ -1388,7 +1388,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1398,7 +1398,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return []byte{}, nil
 				},
 			},
@@ -1408,7 +1408,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 		{
 			name: "invalid pcommon.Value type",
 			getter: StandardIntLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueMap()
 					return v, nil
 				},
@@ -1439,7 +1439,7 @@ func Test_StandardIntLikeGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardIntLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardIntLikeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1460,7 +1460,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "primitive bool type",
 			getter: StandardBoolGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1470,7 +1470,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "ValueTypeBool type",
 			getter: StandardBoolGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return pcommon.NewValueBool(true), nil
 				},
 			},
@@ -1480,7 +1480,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardBoolGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 1, nil
 				},
 			},
@@ -1490,7 +1490,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardBoolGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1516,7 +1516,7 @@ func Test_StandardBoolGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardBoolGetter_WrappedError(t *testing.T) {
 	getter := StandardBoolGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1537,7 +1537,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "string type true",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "true", nil
 				},
 			},
@@ -1547,7 +1547,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "string type false",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "false", nil
 				},
 			},
@@ -1557,7 +1557,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "int type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 0, nil
 				},
 			},
@@ -1567,7 +1567,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "float64 type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return float64(0.0), nil
 				},
 			},
@@ -1577,7 +1577,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type int",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueInt(int64(0))
 					return v, nil
 				},
@@ -1588,7 +1588,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type string",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueStr("false")
 					return v, nil
 				},
@@ -1599,7 +1599,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type bool",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueBool(true)
 					return v, nil
 				},
@@ -1610,7 +1610,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "pcommon.value type double",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueDouble(float64(0.0))
 					return v, nil
 				},
@@ -1621,7 +1621,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1631,7 +1631,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "invalid type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return []byte{}, nil
 				},
 			},
@@ -1641,7 +1641,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 		{
 			name: "invalid pcommon.value type",
 			getter: StandardBoolLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueMap()
 					return v, nil
 				},
@@ -1672,7 +1672,7 @@ func Test_StandardBoolLikeGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardBoolLikeGetter_WrappedError(t *testing.T) {
 	getter := StandardBoolLikeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1693,7 +1693,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "pcommon.map type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return pcommon.NewMap(), nil
 				},
 			},
@@ -1703,7 +1703,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "map[string]any type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return make(map[string]any), nil
 				},
 			},
@@ -1713,7 +1713,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "ValueTypeMap type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return pcommon.NewValueMap(), nil
 				},
 			},
@@ -1723,7 +1723,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "Incorrect type",
 			getter: StandardPMapGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1733,7 +1733,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardPMapGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1759,7 +1759,7 @@ func Test_StandardPMapGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardPMapGetter_WrappedError(t *testing.T) {
 	getter := StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1789,7 +1789,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "complex duration",
 			getter: StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h1m1s")
 				},
 			},
@@ -1799,7 +1799,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "simple duration",
 			getter: StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100ns")
 				},
 			},
@@ -1809,7 +1809,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "complex duation values less than 1 seconc",
 			getter: StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("10ms66us7000ns")
 				},
 			},
@@ -1819,7 +1819,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "invalid duration units",
 			getter: StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("70ps")
 				},
 			},
@@ -1829,7 +1829,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "wrong type - int",
 			getter: StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 1, nil
 				},
 			},
@@ -1839,7 +1839,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1864,7 +1864,7 @@ func Test_StandardDurationGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardDurationGetter_WrappedError(t *testing.T) {
 	getter := StandardDurationGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}
@@ -1885,7 +1885,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "2023 time",
 			getter: StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2023, 8, 17, 1, 1, 1, 1, time.UTC), nil
 				},
 			},
@@ -1895,7 +1895,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "before 2000 time",
 			getter: StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(1999, 12, 1, 10, 59, 58, 57, time.UTC), nil
 				},
 			},
@@ -1905,7 +1905,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "wrong type - duration",
 			getter: StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("70ns")
 				},
 			},
@@ -1915,7 +1915,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "wrong type - bool",
 			getter: StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -1925,7 +1925,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 		{
 			name: "nil",
 			getter: StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -1953,7 +1953,7 @@ func Test_StandardTimeGetter(t *testing.T) {
 // nolint:errorlint
 func Test_StandardTimeGetter_WrappedError(t *testing.T) {
 	getter := StandardTimeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return nil, TypeError("")
 		},
 	}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -1975,7 +1975,7 @@ func functionWithEnum(Enum) (ExprFunc[any], error) {
 }
 
 func createFactory[A any](name string, args A, fn any) Factory[any] {
-	createFunction := func(fCtx FunctionContext, oArgs Arguments) (ExprFunc[any], error) {
+	createFunction := func(_ FunctionContext, oArgs Arguments) (ExprFunc[any], error) {
 		fArgs, ok := oArgs.(A)
 
 		if !ok {

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -66,7 +66,7 @@ func testTime[K any](time string, format string) (ExprFunc[K], error) {
 	if err != nil {
 		return nil, err
 	}
-	return func(_ context.Context, tCtx K) (any, error) {
+	return func(_ context.Context, _ K) (any, error) {
 		timestamp, err := timeutils.ParseStrptime(format, time, loc)
 		return timestamp, err
 	}, nil
@@ -74,7 +74,7 @@ func testTime[K any](time string, format string) (ExprFunc[K], error) {
 
 func testDuration[K any](duration string) (ExprFunc[K], error) {
 	if duration != "" {
-		return func(_ context.Context, tCtx K) (any, error) {
+		return func(_ context.Context, _ K) (any, error) {
 			dur, err := time.ParseDuration(duration)
 			return dur, err
 		}, nil

--- a/pkg/ottl/ottlfuncs/func_concat_test.go
+++ b/pkg/ottl/ottlfuncs/func_concat_test.go
@@ -24,12 +24,12 @@ func Test_concat(t *testing.T) {
 			name: "concat strings",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "world", nil
 					},
 				},
@@ -41,17 +41,17 @@ func Test_concat(t *testing.T) {
 			name: "nil",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return nil, nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "world", nil
 					},
 				},
@@ -63,12 +63,12 @@ func Test_concat(t *testing.T) {
 			name: "integers",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return int64(1), nil
 					},
 				},
@@ -80,12 +80,12 @@ func Test_concat(t *testing.T) {
 			name: "floats",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return 3.14159, nil
 					},
 				},
@@ -97,12 +97,12 @@ func Test_concat(t *testing.T) {
 			name: "booleans",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "hello", nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return true, nil
 					},
 				},
@@ -114,7 +114,7 @@ func Test_concat(t *testing.T) {
 			name: "byte slices",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0e, 0xd2, 0xe6, 0x3c, 0xbe, 0x71, 0xf5, 0xa8}, nil
 					},
 				},
@@ -126,14 +126,14 @@ func Test_concat(t *testing.T) {
 			name: "pcommon.Slice",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						s := pcommon.NewSlice()
 						_ = s.FromRaw([]any{1, 2})
 						return s, nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						s := pcommon.NewSlice()
 						_ = s.FromRaw([]any{3, 4})
 						return s, nil
@@ -147,14 +147,14 @@ func Test_concat(t *testing.T) {
 			name: "maps",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						m := pcommon.NewMap()
 						m.PutStr("a", "b")
 						return m, nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						m := pcommon.NewMap()
 						m.PutStr("c", "d")
 						return m, nil
@@ -168,17 +168,17 @@ func Test_concat(t *testing.T) {
 			name: "empty string values",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "", nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "", nil
 					},
 				},
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "", nil
 					},
 				},
@@ -190,7 +190,7 @@ func Test_concat(t *testing.T) {
 			name: "single argument",
 			vals: []ottl.StandardStringLikeGetter[any]{
 				{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "hello", nil
 					},
 				},
@@ -229,7 +229,7 @@ func Test_concat(t *testing.T) {
 
 func Test_concat_error(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return make(chan int), nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_convert_case_test.go
+++ b/pkg/ottl/ottlfuncs/func_convert_case_test.go
@@ -24,7 +24,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake simple convert",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "simpleString", nil
 				},
 			},
@@ -34,7 +34,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake noop already snake case",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "simple_string", nil
 				},
 			},
@@ -44,7 +44,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake multiple uppercase",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "CPUUtilizationMetric", nil
 				},
 			},
@@ -54,7 +54,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake hyphens",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "simple-string", nil
 				},
 			},
@@ -64,7 +64,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -75,7 +75,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "camel simple convert",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "simple_string", nil
 				},
 			},
@@ -85,7 +85,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake noop already snake case",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "SimpleString", nil
 				},
 			},
@@ -95,7 +95,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake hyphens",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "simple-string", nil
 				},
 			},
@@ -105,7 +105,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "snake empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -116,7 +116,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "upper simple",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "simple", nil
 				},
 			},
@@ -126,7 +126,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "upper complex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
 			},
@@ -136,7 +136,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "upper empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -147,7 +147,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "lower simple",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "SIMPLE", nil
 				},
 			},
@@ -157,7 +157,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "lower complex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "complex_SET-of.WORDS1234", nil
 				},
 			},
@@ -167,7 +167,7 @@ func Test_convertCase(t *testing.T) {
 		{
 			name: "lower empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -195,7 +195,7 @@ func Test_convertCaseError(t *testing.T) {
 		{
 			name: "error bad case",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "simpleString", nil
 				},
 			},
@@ -221,7 +221,7 @@ func Test_convertCaseRuntimeError(t *testing.T) {
 		{
 			name: "non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 10, nil
 				},
 			},
@@ -231,7 +231,7 @@ func Test_convertCaseRuntimeError(t *testing.T) {
 		{
 			name: "nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_delete_key_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_key_test.go
@@ -20,7 +20,7 @@ func Test_deleteKey(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -81,7 +81,7 @@ func Test_deleteKey(t *testing.T) {
 func Test_deleteKey_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -95,7 +95,7 @@ func Test_deleteKey_bad_input(t *testing.T) {
 
 func Test_deleteKey_get_nil(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_delete_matching_keys_test.go
@@ -21,7 +21,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -81,7 +81,7 @@ func Test_deleteMatchingKeys(t *testing.T) {
 func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -95,7 +95,7 @@ func Test_deleteMatchingKeys_bad_input(t *testing.T) {
 
 func Test_deleteMatchingKeys_get_nil(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -108,7 +108,7 @@ func Test_deleteMatchingKeys_get_nil(t *testing.T) {
 
 func Test_deleteMatchingKeys_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_duration_test.go
+++ b/pkg/ottl/ottlfuncs/func_duration_test.go
@@ -23,7 +23,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "100 milliseconds",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "100ms", nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Duration(t *testing.T) {
 		}, {
 			name: "234 microseconds",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "234us", nil
 				},
 			},
@@ -39,7 +39,7 @@ func Test_Duration(t *testing.T) {
 		}, {
 			name: "777 nanoseconds",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "777ns", nil
 				},
 			},
@@ -48,7 +48,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "one second",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "1s", nil
 				},
 			},
@@ -57,7 +57,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "two hundred second",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "200s", nil
 				},
 			},
@@ -66,7 +66,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "three minutes",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "3m", nil
 				},
 			},
@@ -75,7 +75,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "45 minutes",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "45m", nil
 				},
 			},
@@ -84,7 +84,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "7 mins, 12 secs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "7m12s", nil
 				},
 			},
@@ -93,7 +93,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "4 hours",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "4h", nil
 				},
 			},
@@ -102,7 +102,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "5 hours, 23 mins, 59 secs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "5h23m59s", nil
 				},
 			},
@@ -111,7 +111,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "5 hours, 59 secs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "5h59s", nil
 				},
 			},
@@ -120,7 +120,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "5 hours, 23 mins",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "5h23m", nil
 				},
 			},
@@ -129,7 +129,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "2 mins, 1 sec, 64 microsecs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "2m1s64us", nil
 				},
 			},
@@ -138,7 +138,7 @@ func Test_Duration(t *testing.T) {
 		{
 			name: "59 hours, 1 min, 78 millisecs",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "59h1m78ms", nil
 				},
 			},
@@ -165,7 +165,7 @@ func Test_DurationError(t *testing.T) {
 		{
 			name: "empty duration",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -174,7 +174,7 @@ func Test_DurationError(t *testing.T) {
 		{
 			name: "empty duration",
 			duration: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "one second", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_patterns_test.go
@@ -16,7 +16,7 @@ import (
 
 func Test_extractPatterns(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return `a=b c=d`, nil
 		},
 	}
@@ -39,7 +39,7 @@ func Test_extractPatterns(t *testing.T) {
 			name:    "no pattern found",
 			target:  target,
 			pattern: `^a=(?P<a>\w+)$`,
-			want:    func(expectedMap pcommon.Map) {},
+			want:    func(_ pcommon.Map) {},
 		},
 	}
 	for _, tt := range tests {
@@ -57,7 +57,7 @@ func Test_extractPatterns(t *testing.T) {
 			tt.want(expected)
 
 			assert.Equal(t, expected.Len(), resultMap.Len())
-			expected.Range(func(k string, v pcommon.Value) bool {
+			expected.Range(func(k string, _ pcommon.Value) bool {
 				ev, _ := expected.Get(k)
 				av, _ := resultMap.Get(k)
 				assert.Equal(t, ev, av)
@@ -76,7 +76,7 @@ func Test_extractPatterns_validation(t *testing.T) {
 		{
 			name: "bad regex",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "foobar", nil
 				},
 			},
@@ -85,7 +85,7 @@ func Test_extractPatterns_validation(t *testing.T) {
 		{
 			name: "no named capture group",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "foobar", nil
 				},
 			},
@@ -110,7 +110,7 @@ func Test_extractPatterns_bad_input(t *testing.T) {
 		{
 			name: "target is non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 123, nil
 				},
 			},
@@ -119,7 +119,7 @@ func Test_extractPatterns_bad_input(t *testing.T) {
 		{
 			name: "target is nil",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_flatten_test.go
+++ b/pkg/ottl/ottlfuncs/func_flatten_test.go
@@ -152,7 +152,7 @@ func Test_flatten(t *testing.T) {
 			err := m.FromRaw(tt.target)
 			assert.NoError(t, err)
 			target := ottl.StandardPMapGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return m, nil
 				},
 			}
@@ -168,7 +168,7 @@ func Test_flatten(t *testing.T) {
 }
 func Test_flatten_bad_target(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return 1, nil
 		},
 	}
@@ -180,7 +180,7 @@ func Test_flatten_bad_target(t *testing.T) {
 
 func Test_flatten_bad_depth(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return pcommon.NewMap(), nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_hour_test.go
+++ b/pkg/ottl/ottlfuncs/func_hour_test.go
@@ -22,7 +22,7 @@ func Test_Hour(t *testing.T) {
 		{
 			name: "some time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_Hour(t *testing.T) {
 
 func Test_Hour_Error(t *testing.T) {
 	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return "not a time", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_hours_test.go
+++ b/pkg/ottl/ottlfuncs/func_hours_test.go
@@ -22,7 +22,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "100 hours",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "1 min",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100m")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "234 milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("234ms")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Hours(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_is_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_is_match_test.go
@@ -24,7 +24,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match true",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "hello world", nil
 				},
 			},
@@ -34,7 +34,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match false",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "goodbye world", nil
 				},
 			},
@@ -44,7 +44,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "replace match complex",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "-12.001", nil
 				},
 			},
@@ -54,7 +54,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target bool",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return true, nil
 				},
 			},
@@ -64,7 +64,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target int",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return int64(1), nil
 				},
 			},
@@ -74,7 +74,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target float",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 1.1, nil
 				},
 			},
@@ -84,7 +84,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "target pcommon.Value",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					v := pcommon.NewValueEmpty()
 					v.SetStr("test")
 					return v, nil
@@ -96,7 +96,7 @@ func Test_isMatch(t *testing.T) {
 		{
 			name: "nil target",
 			target: &ottl.StandardStringLikeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},
@@ -117,7 +117,7 @@ func Test_isMatch(t *testing.T) {
 
 func Test_isMatch_validation(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return "anything", nil
 		},
 	}
@@ -127,7 +127,7 @@ func Test_isMatch_validation(t *testing.T) {
 
 func Test_isMatch_error(t *testing.T) {
 	target := &ottl.StandardStringLikeGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return make(chan int), nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_keep_keys.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys.go
@@ -42,7 +42,7 @@ func keepKeys[K any](target ottl.PMapGetter[K], keys []string) ottl.ExprFunc[K] 
 		if err != nil {
 			return nil, err
 		}
-		val.RemoveIf(func(key string, value pcommon.Value) bool {
+		val.RemoveIf(func(key string, _ pcommon.Value) bool {
 			_, ok := keySet[key]
 			return !ok
 		})

--- a/pkg/ottl/ottlfuncs/func_keep_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_keys_test.go
@@ -20,7 +20,7 @@ func Test_keepKeys(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -52,13 +52,13 @@ func Test_keepKeys(t *testing.T) {
 			name:   "keep none",
 			target: target,
 			keys:   []string{},
-			want:   func(expectedMap pcommon.Map) {},
+			want:   func(_ pcommon.Map) {},
 		},
 		{
 			name:   "no match",
 			target: target,
 			keys:   []string{"no match"},
-			want:   func(expectedMap pcommon.Map) {},
+			want:   func(_ pcommon.Map) {},
 		},
 	}
 	for _, tt := range tests {
@@ -82,7 +82,7 @@ func Test_keepKeys(t *testing.T) {
 func Test_keepKeys_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -97,7 +97,7 @@ func Test_keepKeys_bad_input(t *testing.T) {
 
 func Test_keepKeys_get_nil(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_len_test.go
+++ b/pkg/ottl/ottlfuncs/func_len_test.go
@@ -284,7 +284,7 @@ func Test_Len(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			exprFunc := computeLen[any](&ottl.StandardGetSetter[any]{
-				Getter: func(context context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return tt.value, nil
 				},
 			})

--- a/pkg/ottl/ottlfuncs/func_limit.go
+++ b/pkg/ottl/ottlfuncs/func_limit.go
@@ -64,7 +64,7 @@ func limit[K any](target ottl.PMapGetter[K], limit int64, priorityKeys []string)
 			}
 		}
 
-		val.RemoveIf(func(key string, value pcommon.Value) bool {
+		val.RemoveIf(func(key string, _ pcommon.Value) bool {
 			if _, ok := keep[key]; ok {
 				return false
 			}

--- a/pkg/ottl/ottlfuncs/func_limit_test.go
+++ b/pkg/ottl/ottlfuncs/func_limit_test.go
@@ -20,7 +20,7 @@ func Test_limit(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -158,7 +158,7 @@ func Test_limit_validation(t *testing.T) {
 func Test_limit_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -171,7 +171,7 @@ func Test_limit_bad_input(t *testing.T) {
 
 func Test_limit_get_nil(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_merge_maps_test.go
+++ b/pkg/ottl/ottlfuncs/func_merge_maps_test.go
@@ -19,7 +19,7 @@ func Test_MergeMaps(t *testing.T) {
 	input.PutStr("attr1", "value1")
 
 	targetGetter := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -33,7 +33,7 @@ func Test_MergeMaps(t *testing.T) {
 		{
 			name: "Upsert no conflicting keys",
 			source: ottl.StandardPMapGetter[pcommon.Map]{
-				Getter: func(ctx context.Context, _ pcommon.Map) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Map) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr2", "value2")
 					return m, nil
@@ -48,7 +48,7 @@ func Test_MergeMaps(t *testing.T) {
 		{
 			name: "Upsert conflicting key",
 			source: ottl.StandardPMapGetter[pcommon.Map]{
-				Getter: func(ctx context.Context, _ pcommon.Map) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Map) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr1", "value3")
 					m.PutStr("attr2", "value2")
@@ -64,7 +64,7 @@ func Test_MergeMaps(t *testing.T) {
 		{
 			name: "Insert no conflicting keys",
 			source: ottl.StandardPMapGetter[pcommon.Map]{
-				Getter: func(ctx context.Context, _ pcommon.Map) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Map) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr2", "value2")
 					return m, nil
@@ -79,7 +79,7 @@ func Test_MergeMaps(t *testing.T) {
 		{
 			name: "Insert conflicting key",
 			source: ottl.StandardPMapGetter[pcommon.Map]{
-				Getter: func(ctx context.Context, _ pcommon.Map) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Map) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr1", "value3")
 					m.PutStr("attr2", "value2")
@@ -95,7 +95,7 @@ func Test_MergeMaps(t *testing.T) {
 		{
 			name: "Update no conflicting keys",
 			source: ottl.StandardPMapGetter[pcommon.Map]{
-				Getter: func(ctx context.Context, _ pcommon.Map) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Map) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr2", "value2")
 					return m, nil
@@ -109,7 +109,7 @@ func Test_MergeMaps(t *testing.T) {
 		{
 			name: "Update conflicting key",
 			source: ottl.StandardPMapGetter[pcommon.Map]{
-				Getter: func(ctx context.Context, _ pcommon.Map) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Map) (any, error) {
 					m := pcommon.NewMap()
 					m.PutStr("attr1", "value3")
 					return m, nil
@@ -143,12 +143,12 @@ func Test_MergeMaps(t *testing.T) {
 
 func Test_MergeMaps_bad_target(t *testing.T) {
 	input := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return 1, nil
 		},
 	}
@@ -161,12 +161,12 @@ func Test_MergeMaps_bad_target(t *testing.T) {
 
 func Test_MergeMaps_bad_input(t *testing.T) {
 	input := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return 1, nil
 		},
 	}
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_microseconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_microseconds_test.go
@@ -22,7 +22,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "100 microseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100us")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "1000 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "50 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("50m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Microseconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_milliseconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_milliseconds_test.go
@@ -22,7 +22,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "100 Milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100ms")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "1000 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "47 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("47m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Milliseconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_minutes_test.go
+++ b/pkg/ottl/ottlfuncs/func_minutes_test.go
@@ -22,7 +22,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "100 minutes",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100m")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "1 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "234 milliseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("234ms")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Minutes(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_nanoseconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_nanoseconds_test.go
@@ -22,7 +22,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "100 nanoseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100ns")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "1 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "23 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("23m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Nanoseconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_now.go
+++ b/pkg/ottl/ottlfuncs/func_now.go
@@ -11,7 +11,7 @@ import (
 )
 
 func now[K any]() (ottl.ExprFunc[K], error) {
-	return func(ctx context.Context, tCtx K) (any, error) {
+	return func(_ context.Context, _ K) (any, error) {
 		return time.Now(), nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_parse_csv_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_csv_test.go
@@ -28,12 +28,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse comma separated values",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -48,12 +48,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in first field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1\nnewline,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -68,12 +68,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in middle field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2\nnewline,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -88,12 +88,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in last field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2,val3\nnewline", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -108,12 +108,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline in multiple fields",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1\nnewline1,val2\nnewline2,val3\nnewline3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -128,12 +128,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with leading newline",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "\nval1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -148,12 +148,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with trailing newline",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2,val3\n", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -168,12 +168,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse with newline at end of field",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1\n,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -188,12 +188,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse comma separated values with explicit mode",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -209,12 +209,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse tab separated values",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1\tval2\tval3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1\tcol2\tcol3", nil
 					},
 				},
@@ -230,12 +230,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Header delimiter is different from row delimiter",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1\tval2\tval3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1 col2 col3", nil
 					},
 				},
@@ -252,12 +252,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid target (strict mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -268,12 +268,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid header (strict mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,val2`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
@@ -289,12 +289,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails due to header/row column mismatch",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,val2,val3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -305,12 +305,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails due to header/row column mismatch",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,val2,val3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -321,12 +321,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Empty header string (strict)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "", nil
 					},
 				},
@@ -337,12 +337,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails due to empty row",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -353,12 +353,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse fails for row with bare quotes",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,val2,v"al3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -371,12 +371,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse lazyQuotes with quote in row",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,val2,v"al3`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -392,12 +392,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse lazyQuotes invalid csv",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,"val2,"val3,val4"`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3,col4", nil
 					},
 				},
@@ -410,12 +410,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Parse quotes invalid csv",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,"val2,"val3,val4"`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3,col4", nil
 					},
 				},
@@ -432,12 +432,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid target (ignoreQuotes mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2", nil
 					},
 				},
@@ -449,12 +449,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Invalid header (ignoreQuotes mode)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1,val2`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return nil, errors.New("cannot get")
 					},
 				},
@@ -466,12 +466,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Empty header string (ignoreQuotes)",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return `val1`, nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "", nil
 					},
 				},
@@ -484,12 +484,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Delimiter is greater than one character",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -501,12 +501,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "HeaderDelimiter is greater than one character",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},
@@ -518,12 +518,12 @@ func Test_ParseCSV(t *testing.T) {
 			name: "Bad mode",
 			oArgs: &ParseCSVArguments[any]{
 				Target: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "val1,val2,val3", nil
 					},
 				},
 				Header: ottl.StandardStringGetter[any]{
-					Getter: func(ctx context.Context, tCtx any) (any, error) {
+					Getter: func(_ context.Context, _ any) (any, error) {
 						return "col1,col2,col3", nil
 					},
 				},

--- a/pkg/ottl/ottlfuncs/func_parse_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_json_test.go
@@ -23,7 +23,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle string",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test":"string value"}`, nil
 				},
 			},
@@ -34,7 +34,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle bool",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test":true}`, nil
 				},
 			},
@@ -45,7 +45,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle int",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test":1}`, nil
 				},
 			},
@@ -56,7 +56,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle float",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test":1.1}`, nil
 				},
 			},
@@ -67,7 +67,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle nil",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test":null}`, nil
 				},
 			},
@@ -78,7 +78,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle array",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test":["string","value"]}`, nil
 				},
 			},
@@ -91,7 +91,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "handle nested object",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test":{"nested":"true"}}`, nil
 				},
 			},
@@ -103,7 +103,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "updates existing",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"existing":"pass"}`, nil
 				},
 			},
@@ -114,7 +114,7 @@ func Test_ParseJSON(t *testing.T) {
 		{
 			name: "complex",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `{"test1":{"nested":"true"},"test2":"string","test3":1,"test4":1.1,"test5":[[1], [2, 3],[]],"test6":null}`, nil
 				},
 			},
@@ -148,7 +148,7 @@ func Test_ParseJSON(t *testing.T) {
 			tt.want(expected)
 
 			assert.Equal(t, expected.Len(), resultMap.Len())
-			expected.Range(func(k string, v pcommon.Value) bool {
+			expected.Range(func(k string, _ pcommon.Value) bool {
 				ev, _ := expected.Get(k)
 				av, _ := resultMap.Get(k)
 				assert.Equal(t, ev, av)
@@ -160,7 +160,7 @@ func Test_ParseJSON(t *testing.T) {
 
 func Test_ParseJSON_Error(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return 1, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_key_value_test.go
@@ -24,7 +24,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "simple",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "name=ottl func=key_value", nil
 				},
 			},
@@ -38,7 +38,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "large",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `name=ottl age=1 job="software engineering" location="grand rapids michigan" src="10.3.3.76" dst=172.217.0.10 protocol=udp sport=57112 port=443 translated_src_ip=96.63.176.3 translated_port=57112`, nil
 				},
 			},
@@ -61,7 +61,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "embedded double quotes in single quoted value",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `a=b c='this is a "co ol" value'`, nil
 				},
 			},
@@ -75,7 +75,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "double quotes",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `requestClientApplication="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0"`, nil
 				},
 			},
@@ -88,7 +88,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "single quotes",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "requestClientApplication='Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0'", nil
 				},
 			},
@@ -101,7 +101,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "double quotes strip leading & trailing spaces",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `name="   ottl " func="  key_ value"`, nil
 				},
 			},
@@ -115,7 +115,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "! delimiter && whitespace pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "   name!ottl     func!key_value hello!world  ", nil
 				},
 			},
@@ -130,7 +130,7 @@ func Test_parseKeyValue(t *testing.T) {
 		{
 			name: "!! delimiter && whitespace pair delimiter with newlines",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `   
 name!!ottl     
 func!!key_value                      hello!!world  `, nil
@@ -147,7 +147,7 @@ func!!key_value                      hello!!world  `, nil
 		{
 			name: "!! delimiter && newline pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `name!!ottl     
 func!!      key_value another!!pair
 hello!!world  `, nil
@@ -164,7 +164,7 @@ hello!!world  `, nil
 		{
 			name: "quoted value contains delimiter and pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `name="ottl="_func="=key_value"`, nil
 				},
 			},
@@ -178,7 +178,7 @@ hello!!world  `, nil
 		{
 			name: "complicated delimiters",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `k1@*v1_!_k2@**v2_!__k3@@*v3__`, nil
 				},
 			},
@@ -193,7 +193,7 @@ hello!!world  `, nil
 		{
 			name: "leading and trailing pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "   k1=v1   k2==v2       k3=v3= ", nil
 				},
 			},
@@ -208,7 +208,7 @@ hello!!world  `, nil
 		{
 			name: "embedded double quotes end single quoted value",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return `a=b c='this is a "co ol"'`, nil
 				},
 			},
@@ -222,7 +222,7 @@ hello!!world  `, nil
 		{
 			name: "more quotes",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "a=b c=d'='", nil
 				},
 			},
@@ -237,7 +237,7 @@ hello!!world  `, nil
 		{
 			name: "long pair delimiter",
 			target: ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "a=b c=d", nil
 				},
 			},
@@ -264,7 +264,7 @@ hello!!world  `, nil
 			assert.NoError(t, expected.FromRaw(tt.expected))
 
 			assert.Equal(t, expected.Len(), actual.Len())
-			expected.Range(func(k string, v pcommon.Value) bool {
+			expected.Range(func(k string, _ pcommon.Value) bool {
 				ev, _ := expected.Get(k)
 				av, ok := actual.Get(k)
 				assert.True(t, ok)
@@ -277,7 +277,7 @@ hello!!world  `, nil
 
 func Test_parseKeyValue_equal_delimiters(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return "", nil
 		},
 	}
@@ -293,7 +293,7 @@ func Test_parseKeyValue_equal_delimiters(t *testing.T) {
 
 func Test_parseKeyValue_bad_target(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return 1, nil
 		},
 	}
@@ -307,7 +307,7 @@ func Test_parseKeyValue_bad_target(t *testing.T) {
 
 func Test_parseKeyValue_empty_target(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return "", nil
 		},
 	}
@@ -321,7 +321,7 @@ func Test_parseKeyValue_empty_target(t *testing.T) {
 
 func Test_parseKeyValue_bad_split(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return "name=ottl!hello_world", nil
 		},
 	}
@@ -335,7 +335,7 @@ func Test_parseKeyValue_bad_split(t *testing.T) {
 
 func Test_parseKeyValue_mismatch_quotes(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return `k1=v1 k2='v2"`, nil
 		},
 	}
@@ -347,7 +347,7 @@ func Test_parseKeyValue_mismatch_quotes(t *testing.T) {
 
 func Test_parseKeyValue_bad_delimiter(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return "a=b c=d", nil
 		},
 	}
@@ -362,7 +362,7 @@ func Test_parseKeyValue_bad_delimiter(t *testing.T) {
 
 func Test_parseKeyValue_empty_delimiters(t *testing.T) {
 	target := ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return "a=b c=d", nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -74,7 +74,7 @@ func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replace
 				return nil, err
 			}
 		}
-		val.Range(func(key string, value pcommon.Value) bool {
+		val.Range(func(_ string, value pcommon.Value) bool {
 			if glob.Match(value.Str()) {
 				value.SetStr(replacementVal)
 			}

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -35,7 +35,7 @@ func Test_replaceAllMatches(t *testing.T) {
 	optionalArg := ottl.NewTestingOptional[ottl.FunctionGetter[pcommon.Map]](ottlValue)
 
 	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -124,7 +124,7 @@ func Test_replaceAllMatches(t *testing.T) {
 func Test_replaceAllMatches_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -145,7 +145,7 @@ func Test_replaceAllMatches_bad_input(t *testing.T) {
 func Test_replaceAllMatches_bad_function_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -169,7 +169,7 @@ func Test_replaceAllMatches_bad_function_input(t *testing.T) {
 func Test_replaceAllMatches_bad_function_result(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -197,7 +197,7 @@ func Test_replaceAllMatches_bad_function_result(t *testing.T) {
 
 func Test_replaceAllMatches_get_nil(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -43,7 +43,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 	optionalArg := ottl.NewTestingOptional[ottl.FunctionGetter[pcommon.Map]](ottlValue)
 
 	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -494,7 +494,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 func Test_replaceAllPatterns_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -516,7 +516,7 @@ func Test_replaceAllPatterns_bad_input(t *testing.T) {
 func Test_replaceAllPatterns_bad_function_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -540,7 +540,7 @@ func Test_replaceAllPatterns_bad_function_input(t *testing.T) {
 func Test_replaceAllPatterns_bad_function_result(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -568,7 +568,7 @@ func Test_replaceAllPatterns_bad_function_result(t *testing.T) {
 
 func Test_replaceAllPatterns_get_nil(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -589,7 +589,7 @@ func Test_replaceAllPatterns_get_nil(t *testing.T) {
 
 func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
 		},
@@ -611,7 +611,7 @@ func Test_replaceAllPatterns_invalid_pattern(t *testing.T) {
 
 func Test_replaceAllPatterns_invalid_model(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
 		},

--- a/pkg/ottl/ottlfuncs/func_replace_match_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_match_test.go
@@ -30,10 +30,10 @@ func Test_replaceMatch(t *testing.T) {
 	}
 	optionalArg := ottl.NewTestingOptional[ottl.FunctionGetter[pcommon.Value]](ottlValue)
 	target := &ottl.StandardGetSetter[pcommon.Value]{
-		Getter: func(ctx context.Context, tCtx pcommon.Value) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Value) (any, error) {
 			return tCtx.Str(), nil
 		},
-		Setter: func(ctx context.Context, tCtx pcommon.Value, val any) error {
+		Setter: func(_ context.Context, tCtx pcommon.Value, val any) error {
 			tCtx.SetStr(val.(string))
 			return nil
 		},
@@ -115,10 +115,10 @@ func Test_replaceMatch(t *testing.T) {
 func Test_replaceMatch_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -144,10 +144,10 @@ func Test_replaceMatch_bad_input(t *testing.T) {
 func Test_replaceMatch_bad_function_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -172,10 +172,10 @@ func Test_replaceMatch_bad_function_input(t *testing.T) {
 func Test_replaceMatch_bad_function_result(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -205,10 +205,10 @@ func Test_replaceMatch_bad_function_result(t *testing.T) {
 
 func Test_replaceMatch_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -65,10 +65,10 @@ func Test_replacePattern(t *testing.T) {
 	}
 	optionalArg := ottl.NewTestingOptional[ottl.FunctionGetter[pcommon.Value]](ottlValue)
 	target := &ottl.StandardGetSetter[pcommon.Value]{
-		Getter: func(ctx context.Context, tCtx pcommon.Value) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Value) (any, error) {
 			return tCtx.Str(), nil
 		},
-		Setter: func(ctx context.Context, tCtx pcommon.Value, val any) error {
+		Setter: func(_ context.Context, tCtx pcommon.Value, val any) error {
 			tCtx.SetStr(val.(string))
 			return nil
 		},
@@ -253,10 +253,10 @@ func Test_replacePattern(t *testing.T) {
 func Test_replacePattern_bad_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -281,10 +281,10 @@ func Test_replacePattern_bad_input(t *testing.T) {
 func Test_replacePattern_bad_function_input(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -309,10 +309,10 @@ func Test_replacePattern_bad_function_input(t *testing.T) {
 func Test_replacePattern_bad_function_result(t *testing.T) {
 	input := pcommon.NewValueInt(1)
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -342,10 +342,10 @@ func Test_replacePattern_bad_function_result(t *testing.T) {
 
 func Test_replacePattern_get_nil(t *testing.T) {
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -368,11 +368,11 @@ func Test_replacePattern_get_nil(t *testing.T) {
 
 func Test_replacePatterns_invalid_pattern(t *testing.T) {
 	target := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			t.Errorf("nothing should be received in this scenario")
 			return nil, nil
 		},
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
@@ -394,10 +394,10 @@ func Test_replacePatterns_invalid_pattern(t *testing.T) {
 func Test_replacePattern_bad_format_string(t *testing.T) {
 	input := pcommon.NewValueStr("application passwd=sensitivedtata otherarg=notsensitive key1 key2")
 	target := &ottl.StandardGetSetter[pcommon.Value]{
-		Getter: func(ctx context.Context, tCtx pcommon.Value) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Value) (any, error) {
 			return tCtx.Str(), nil
 		},
-		Setter: func(ctx context.Context, tCtx pcommon.Value, val any) error {
+		Setter: func(_ context.Context, tCtx pcommon.Value, val any) error {
 			tCtx.SetStr(val.(string))
 			return nil
 		},

--- a/pkg/ottl/ottlfuncs/func_seconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_seconds_test.go
@@ -22,7 +22,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "100 seconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100s")
 				},
 			},
@@ -31,7 +31,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "1 hour",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("100h")
 				},
 			},
@@ -40,7 +40,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "11 mins",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("11m")
 				},
 			},
@@ -49,7 +49,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "50 microseconds",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("11us")
 				},
 			},
@@ -58,7 +58,7 @@ func Test_Seconds(t *testing.T) {
 		{
 			name: "1 hour 40 mins 3 seconds 30 milliseconds 100 microseconds 1 nanosecond",
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.ParseDuration("1h40m3s30ms100us1ns")
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_set_test.go
+++ b/pkg/ottl/ottlfuncs/func_set_test.go
@@ -17,7 +17,7 @@ func Test_set(t *testing.T) {
 	input := pcommon.NewValueStr("original name")
 
 	target := &ottl.StandardGetSetter[pcommon.Value]{
-		Setter: func(ctx context.Context, tCtx pcommon.Value, val any) error {
+		Setter: func(_ context.Context, tCtx pcommon.Value, val any) error {
 			tCtx.SetStr(val.(string))
 			return nil
 		},
@@ -33,7 +33,7 @@ func Test_set(t *testing.T) {
 			name:   "set name",
 			setter: target,
 			getter: ottl.StandardGetSetter[pcommon.Value]{
-				Getter: func(ctx context.Context, tCtx pcommon.Value) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Value) (any, error) {
 					return "new name", nil
 				},
 			},
@@ -45,7 +45,7 @@ func Test_set(t *testing.T) {
 			name:   "set nil value",
 			setter: target,
 			getter: ottl.StandardGetSetter[pcommon.Value]{
-				Getter: func(ctx context.Context, tCtx pcommon.Value) (any, error) {
+				Getter: func(_ context.Context, _ pcommon.Value) (any, error) {
 					return nil, nil
 				},
 			},
@@ -74,14 +74,14 @@ func Test_set(t *testing.T) {
 
 func Test_set_get_nil(t *testing.T) {
 	setter := &ottl.StandardGetSetter[any]{
-		Setter: func(ctx context.Context, tCtx any, val any) error {
+		Setter: func(_ context.Context, _ any, _ any) error {
 			t.Errorf("nothing should be set in this scenario")
 			return nil
 		},
 	}
 
 	getter := &ottl.StandardGetSetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_split_test.go
+++ b/pkg/ottl/ottlfuncs/func_split_test.go
@@ -22,7 +22,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "A|B|C", nil
 				},
 			},
@@ -32,7 +32,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty delimiter",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "A|B|C", nil
 				},
 			},
@@ -52,7 +52,7 @@ func Test_split(t *testing.T) {
 		{
 			name: "split empty string and empty delimiter",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -72,7 +72,7 @@ func Test_split(t *testing.T) {
 
 func Test_Split_Error(t *testing.T) {
 	target := &ottl.StandardStringGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, _ any) (any, error) {
 			return 1, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -23,7 +23,7 @@ func Test_substring(t *testing.T) {
 		{
 			name: "substring",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -42,7 +42,7 @@ func Test_substring(t *testing.T) {
 		{
 			name: "substring with result of total string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -79,7 +79,7 @@ func Test_substring_validation(t *testing.T) {
 		{
 			name: "substring with result of empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -97,7 +97,7 @@ func Test_substring_validation(t *testing.T) {
 		{
 			name: "substring with invalid start index",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -133,7 +133,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring empty string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -151,7 +151,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring with invalid length index",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "123456789", nil
 				},
 			},
@@ -169,7 +169,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring non-string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return 123456789, nil
 				},
 			},
@@ -187,7 +187,7 @@ func Test_substring_error(t *testing.T) {
 		{
 			name: "substring nil string",
 			target: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return nil, nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_time_test.go
+++ b/pkg/ottl/ottlfuncs/func_time_test.go
@@ -24,7 +24,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "simple short form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "2023-04-12", nil
 				},
 			},
@@ -34,7 +34,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "simple short form with short year and slashes",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
@@ -44,7 +44,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "month day year",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "02/04/2023", nil
 				},
 			},
@@ -54,7 +54,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "simple long form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "July 31, 1993", nil
 				},
 			},
@@ -64,7 +64,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "date with timestamp",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "Mar 14 2023 17:02:59", nil
 				},
 			},
@@ -74,7 +74,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "day of the week long form",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "Monday, May 01, 2023", nil
 				},
 			},
@@ -84,7 +84,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "short weekday, short month, long format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "Sat, May 20, 2023", nil
 				},
 			},
@@ -94,7 +94,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "short months",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "Feb 15, 2023", nil
 				},
 			},
@@ -104,7 +104,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "timestamp with time zone offset",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "2023-05-26 12:34:56 HST", nil
 				},
 			},
@@ -114,7 +114,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "short date with timestamp without time zone offset",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "2023-05-26T12:34:56 GMT", nil
 				},
 			},
@@ -124,7 +124,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "RFC 3339 in custom format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "2012-11-01T22:08:41+0000 EST", nil
 				},
 			},
@@ -134,7 +134,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "RFC 3339 in custom format before 2000",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "1986-10-01T00:17:33 MST", nil
 				},
 			},
@@ -144,7 +144,7 @@ func Test_Time(t *testing.T) {
 		{
 			name: "no location",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "2022/01/01", nil
 				},
 			},
@@ -173,7 +173,7 @@ func Test_TimeError(t *testing.T) {
 		{
 			name: "invalid short format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
@@ -183,7 +183,7 @@ func Test_TimeError(t *testing.T) {
 		{
 			name: "invalid RFC3339 with no time",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "", nil
 				},
 			},
@@ -211,7 +211,7 @@ func Test_TimeFormatError(t *testing.T) {
 		{
 			name: "invalid short with no format",
 			time: &ottl.StandardStringGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "11/11/11", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_truncate_all.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all.go
@@ -44,7 +44,7 @@ func TruncateAll[K any](target ottl.PMapGetter[K], limit int64) (ottl.ExprFunc[K
 		if err != nil {
 			return nil, err
 		}
-		val.Range(func(key string, value pcommon.Value) bool {
+		val.Range(func(_ string, value pcommon.Value) bool {
 			stringVal := value.Str()
 			if int64(len(stringVal)) > limit {
 				value.SetStr(stringVal[:limit])

--- a/pkg/ottl/ottlfuncs/func_truncate_all_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_all_test.go
@@ -21,7 +21,7 @@ func Test_truncateAll(t *testing.T) {
 	input.PutBool("test3", true)
 
 	target := &ottl.StandardPMapGetter[pcommon.Map]{
-		Getter: func(ctx context.Context, tCtx pcommon.Map) (any, error) {
+		Getter: func(_ context.Context, tCtx pcommon.Map) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -102,7 +102,7 @@ func Test_truncateAll_validation(t *testing.T) {
 func Test_truncateAll_bad_input(t *testing.T) {
 	input := pcommon.NewValueStr("not a map")
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}
@@ -116,7 +116,7 @@ func Test_truncateAll_bad_input(t *testing.T) {
 
 func Test_truncateAll_get_nil(t *testing.T) {
 	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(ctx context.Context, tCtx any) (any, error) {
+		Getter: func(_ context.Context, tCtx any) (any, error) {
 			return tCtx, nil
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_truncate_time_test.go
+++ b/pkg/ottl/ottlfuncs/func_truncate_time_test.go
@@ -24,12 +24,12 @@ func Test_TruncateTime(t *testing.T) {
 		{
 			name: "truncate to 1s",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2022, 1, 1, 1, 1, 1, 999999999, time.UTC), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					d, _ := time.ParseDuration("1s")
 					return d, nil
 				},
@@ -39,12 +39,12 @@ func Test_TruncateTime(t *testing.T) {
 		{
 			name: "truncate to 1ms",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2022, 1, 1, 1, 1, 1, 999999999, time.UTC), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					d, _ := time.ParseDuration("1ms")
 					return d, nil
 				},
@@ -54,12 +54,12 @@ func Test_TruncateTime(t *testing.T) {
 		{
 			name: "truncate old time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(1980, 9, 9, 9, 59, 59, 999999999, time.UTC), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					d, _ := time.ParseDuration("1h")
 					return d, nil
 				},
@@ -88,12 +88,12 @@ func Test_TruncateTimeError(t *testing.T) {
 		{
 			name: "not a time",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "11/11/11", nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					d, _ := time.ParseDuration("1ms")
 					return d, nil
 				},
@@ -103,12 +103,12 @@ func Test_TruncateTimeError(t *testing.T) {
 		{
 			name: "not a duration",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Now(), nil
 				},
 			},
 			duration: &ottl.StandardDurationGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return "string", nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_micro_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_micro_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "January 1, 2023",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2023, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "April 30, 2001, 3pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2001, 4, 30, 15, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "November 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(1980, 11, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixMicro(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_milli_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_milli_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "January 1, 2022",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2022, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "May 30, 2002, 3pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2002, 5, 30, 15, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "September 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(1980, 9, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixMilli(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_nano_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_nano_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "January 1, 2023",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2023, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "April 30, 2000, 1pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2000, 4, 30, 13, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "December 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(1980, 12, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixNano(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_unix_seconds_test.go
+++ b/pkg/ottl/ottlfuncs/func_unix_seconds_test.go
@@ -22,7 +22,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "January 1, 2023",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2023, 1, 1, 0, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -31,7 +31,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "March 31, 2000, 4pm",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2000, 3, 31, 16, 0, 0, 0, time.Local), nil
 				},
 			},
@@ -40,7 +40,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "December 12, 1980, 4:35:01am",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(1980, 12, 12, 4, 35, 1, 0, time.Local), nil
 				},
 			},
@@ -49,7 +49,7 @@ func Test_TimeUnixSeconds(t *testing.T) {
 		{
 			name: "October 4, 2020, 5:05 5 microseconds 5 nanosecs",
 			time: &ottl.StandardTimeGetter[any]{
-				Getter: func(ctx context.Context, tCtx any) (any, error) {
+				Getter: func(_ context.Context, _ any) (any, error) {
 					return time.Date(2020, 10, 4, 5, 5, 5, 5, time.Local), nil
 				},
 			},

--- a/pkg/ottl/ottlfuncs/func_uuid.go
+++ b/pkg/ottl/ottlfuncs/func_uuid.go
@@ -12,7 +12,7 @@ import (
 )
 
 func uuid[K any]() (ottl.ExprFunc[K], error) {
-	return func(ctx context.Context, tCtx K) (any, error) {
+	return func(_ context.Context, _ K) (any, error) {
 		u := guuid.New()
 		return u.String(), nil
 	}, nil

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -1241,10 +1241,10 @@ func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
 		}
 
 		return &StandardGetSetter[any]{
-			Getter: func(ctx context.Context, tCtx any) (any, error) {
+			Getter: func(_ context.Context, tCtx any) (any, error) {
 				return tCtx, nil
 			},
-			Setter: func(ctx context.Context, tCtx any, val any) error {
+			Setter: func(_ context.Context, tCtx any, val any) error {
 				reflect.DeepEqual(tCtx, val)
 				return nil
 			},
@@ -1252,14 +1252,14 @@ func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
 	}
 	if p != nil && (p.Name() == "dur1" || p.Name() == "dur2") {
 		return &StandardGetSetter[any]{
-			Getter: func(ctx context.Context, tCtx any) (any, error) {
+			Getter: func(_ context.Context, tCtx any) (any, error) {
 				m, ok := tCtx.(map[string]time.Duration)
 				if !ok {
 					return nil, fmt.Errorf("unable to convert transform context to map of strings to times")
 				}
 				return m[p.Name()], nil
 			},
-			Setter: func(ctx context.Context, tCtx any, val any) error {
+			Setter: func(_ context.Context, tCtx any, val any) error {
 				reflect.DeepEqual(tCtx, val)
 				return nil
 			},
@@ -1267,14 +1267,14 @@ func testParsePath[K any](p Path[K]) (GetSetter[any], error) {
 	}
 	if p != nil && (p.Name() == "time1" || p.Name() == "time2") {
 		return &StandardGetSetter[any]{
-			Getter: func(ctx context.Context, tCtx any) (any, error) {
+			Getter: func(_ context.Context, tCtx any) (any, error) {
 				m, ok := tCtx.(map[string]time.Time)
 				if !ok {
 					return nil, fmt.Errorf("unable to convert transform context to map of strings to times")
 				}
 				return m[p.Name()], nil
 			},
-			Setter: func(ctx context.Context, tCtx any, val any) error {
+			Setter: func(_ context.Context, tCtx any, val any) error {
 				reflect.DeepEqual(tCtx, val)
 				return nil
 			},
@@ -1978,7 +1978,7 @@ func Test_Statement_Execute(t *testing.T) {
 		{
 			name:      "Condition matched",
 			condition: alwaysTrue[any],
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, nil
 			},
 			expectedCondition: true,
@@ -1987,7 +1987,7 @@ func Test_Statement_Execute(t *testing.T) {
 		{
 			name:      "Condition not matched",
 			condition: alwaysFalse[any],
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, nil
 			},
 			expectedCondition: false,
@@ -1996,7 +1996,7 @@ func Test_Statement_Execute(t *testing.T) {
 		{
 			name:      "No result",
 			condition: alwaysTrue[any],
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return nil, nil
 			},
 			expectedCondition: true,
@@ -2060,7 +2060,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, fmt.Errorf("test")
 			},
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, nil
 			},
 			errorMode: IgnoreError,
@@ -2070,7 +2070,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, fmt.Errorf("test")
 			},
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, nil
 			},
 			errorMode: PropagateError,
@@ -2080,7 +2080,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, nil
 			},
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, fmt.Errorf("test")
 			},
 			errorMode: IgnoreError,
@@ -2090,7 +2090,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, nil
 			},
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, fmt.Errorf("test")
 			},
 			errorMode: PropagateError,
@@ -2100,7 +2100,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, fmt.Errorf("test")
 			},
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, nil
 			},
 			errorMode: SilentError,
@@ -2110,7 +2110,7 @@ func Test_Statements_Execute_Error(t *testing.T) {
 			condition: func(context.Context, any) (bool, error) {
 				return true, nil
 			},
-			function: func(ctx context.Context, tCtx any) (any, error) {
+			function: func(_ context.Context, _ any) (any, error) {
 				return 1, fmt.Errorf("test")
 			},
 			errorMode: SilentError,

--- a/pkg/pdatautil/hash.go
+++ b/pkg/pdatautil/hash.go
@@ -82,7 +82,7 @@ func (hw *hashWriter) writeMapHash(m pcommon.Map) {
 	// on the first call due to it being cleared of any added keys at then end of the function.
 	nextIndex := len(hw.keysBuf)
 
-	m.Range(func(k string, v pcommon.Value) bool {
+	m.Range(func(k string, _ pcommon.Value) bool {
 		hw.keysBuf = append(hw.keysBuf, k)
 		return true
 	})

--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -35,7 +35,7 @@ func NewFactory(logReceiverType LogReceiverType, sl component.StabilityLevel) rc
 
 func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 	return func(
-		ctx context.Context,
+		_ context.Context,
 		params rcvr.CreateSettings,
 		cfg component.Config,
 		nextConsumer consumer.Logs,

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -449,7 +449,7 @@ func TestBuild(t *testing.T) {
 	}{
 		{
 			"Basic",
-			func(cfg *Config) {},
+			func(_ *Config) {},
 			require.NoError,
 			func(t *testing.T, m *Manager) {
 				require.Equal(t, m.pollInterval, 10*time.Millisecond)
@@ -486,7 +486,7 @@ func TestBuild(t *testing.T) {
 				cfg.SplitConfig.LineStartPattern = "START.*"
 			},
 			require.NoError,
-			func(t *testing.T, f *Manager) {},
+			func(_ *testing.T, _ *Manager) {},
 		},
 		{
 			"MultilineConfiguredEndPattern",
@@ -494,7 +494,7 @@ func TestBuild(t *testing.T) {
 				cfg.SplitConfig.LineEndPattern = "END.*"
 			},
 			require.NoError,
-			func(t *testing.T, f *Manager) {},
+			func(_ *testing.T, _ *Manager) {},
 		},
 		{
 			"InvalidEncoding",
@@ -515,9 +515,9 @@ func TestBuild(t *testing.T) {
 		},
 		{
 			"NoLineStartOrEnd",
-			func(cfg *Config) {},
+			func(_ *Config) {},
 			require.NoError,
-			func(t *testing.T, f *Manager) {},
+			func(_ *testing.T, _ *Manager) {},
 		},
 		{
 			"InvalidLineStartRegex",
@@ -616,7 +616,7 @@ func TestBuild(t *testing.T) {
 				}
 			},
 			require.NoError,
-			func(t *testing.T, f *Manager) {},
+			func(_ *testing.T, _ *Manager) {},
 		},
 	}
 
@@ -657,7 +657,7 @@ func TestBuildWithSplitFunc(t *testing.T) {
 	}{
 		{
 			"Basic",
-			func(cfg *Config) {},
+			func(_ *Config) {},
 			require.NoError,
 			func(t *testing.T, m *Manager) {
 				require.Equal(t, m.pollInterval, 10*time.Millisecond)

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -77,7 +77,7 @@ func TestTransformerDropOnError(t *testing.T) {
 	}
 	ctx := context.Background()
 	testEntry := entry.New()
-	transform := func(e *entry.Entry) error {
+	transform := func(_ *entry.Entry) error {
 		return fmt.Errorf("Failure")
 	}
 
@@ -104,7 +104,7 @@ func TestTransformerSendOnError(t *testing.T) {
 	}
 	ctx := context.Background()
 	testEntry := entry.New()
-	transform := func(e *entry.Entry) error {
+	transform := func(_ *entry.Entry) error {
 		return fmt.Errorf("Failure")
 	}
 
@@ -131,7 +131,7 @@ func TestTransformerProcessWithValid(t *testing.T) {
 	}
 	ctx := context.Background()
 	testEntry := entry.New()
-	transform := func(e *entry.Entry) error {
+	transform := func(_ *entry.Entry) error {
 		return nil
 	}
 

--- a/pkg/stanza/operator/helper/writer.go
+++ b/pkg/stanza/operator/helper/writer.go
@@ -94,8 +94,8 @@ func (w *WriterOperator) SetOutputs(operators []operator.Operator) error {
 }
 
 // SetOutputIDs will set the outputs of the operator.
-func (w *WriterOperator) SetOutputIDs(opIds []string) {
-	w.OutputIDs = opIds
+func (w *WriterOperator) SetOutputIDs(opIDs []string) {
+	w.OutputIDs = opIDs
 }
 
 // FindOperator will find an operator matching the supplied id.

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -442,7 +442,7 @@ func TestBuild(t *testing.T) {
 	}{
 		{
 			"Default",
-			func(cfg *Config) {},
+			func(_ *Config) {},
 			require.NoError,
 			func(t *testing.T, f *Input) {
 				require.Equal(t, f.OutputOperators[0], fakeOutput)
@@ -479,7 +479,7 @@ func TestBuild(t *testing.T) {
 				cfg.SplitConfig.LineStartPattern = "START.*"
 			},
 			require.NoError,
-			func(t *testing.T, f *Input) {},
+			func(_ *testing.T, _ *Input) {},
 		},
 		{
 			"MultilineConfiguredEndPattern",
@@ -487,7 +487,7 @@ func TestBuild(t *testing.T) {
 				cfg.SplitConfig.LineEndPattern = "END.*"
 			},
 			require.NoError,
-			func(t *testing.T, f *Input) {},
+			func(_ *testing.T, _ *Input) {},
 		},
 		{
 			"InvalidEncoding",
@@ -508,9 +508,9 @@ func TestBuild(t *testing.T) {
 		},
 		{
 			"NoLineStartOrEnd",
-			func(cfg *Config) {},
+			func(_ *Config) {},
 			require.NoError,
-			func(t *testing.T, f *Input) {},
+			func(_ *testing.T, _ *Input) {},
 		},
 		{
 			"InvalidLineStartRegex",

--- a/pkg/stanza/operator/input/journald/journald_test.go
+++ b/pkg/stanza/operator/input/journald/journald_test.go
@@ -67,7 +67,7 @@ func TestInputJournald(t *testing.T) {
 	err = op.SetOutputs([]operator.Operator{mockOutput})
 	require.NoError(t, err)
 
-	op.(*Input).newCmd = func(ctx context.Context, cursor []byte) cmd {
+	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
 		return &fakeJournaldCmd{}
 	}
 
@@ -125,13 +125,13 @@ func TestInputJournald(t *testing.T) {
 func TestBuildConfig(t *testing.T) {
 	testCases := []struct {
 		Name          string
-		Config        func(cfg *Config)
+		Config        func(_ *Config)
 		Expected      []string
 		ExpectedError string
 	}{
 		{
 			Name:     "empty config",
-			Config:   func(cfg *Config) {},
+			Config:   func(_ *Config) {},
 			Expected: []string{"--utc", "--output=json", "--follow", "--priority", "info"},
 		},
 		{
@@ -245,7 +245,7 @@ func TestInputJournaldError(t *testing.T) {
 	err = op.SetOutputs([]operator.Operator{mockOutput})
 	require.NoError(t, err)
 
-	op.(*Input).newCmd = func(ctx context.Context, cursor []byte) cmd {
+	op.(*Input).newCmd = func(_ context.Context, _ []byte) cmd {
 		return &fakeJournaldCmd{
 			exitError: &exec.ExitError{},
 			stdErr:    "stderr output\n",

--- a/pkg/stanza/operator/parser/json/json_test.go
+++ b/pkg/stanza/operator/parser/json/json_test.go
@@ -72,7 +72,7 @@ func TestParser(t *testing.T) {
 	}{
 		{
 			"simple",
-			func(p *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `{}`,
 			},
@@ -83,7 +83,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			"nested",
-			func(p *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `{"superkey":"superval"}`,
 			},

--- a/pkg/stanza/operator/parser/jsonarray/json_array_parser_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/json_array_parser_test.go
@@ -76,7 +76,7 @@ func TestParserJarray(t *testing.T) {
 		},
 		{
 			"basic-no-parse_to-fail",
-			func(p *Config) {
+			func(_ *Config) {
 			},
 			[]entry.Entry{
 				{

--- a/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/keyvalue_test.go
@@ -179,7 +179,7 @@ func TestParser(t *testing.T) {
 	}{
 		{
 			"simple",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: "name=stanza age=2",
 			},
@@ -261,7 +261,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			"user-agent",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `requestClientApplication="Mozilla/5.0 (Windows NT 6.1; WOW64; rv:40.0) Gecko/20100101 Firefox/40.0"`,
 			},
@@ -276,7 +276,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			"double-quotes-removed",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: "name=\"stanza\" age=2",
 			},
@@ -292,7 +292,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			"single-quotes-removed",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: "description='stanza deployment number 5' x=y",
 			},
@@ -308,7 +308,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			"double-quotes-spaces-removed",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `name=" stanza " age=2`,
 			},
@@ -324,7 +324,7 @@ func TestParser(t *testing.T) {
 		},
 		{
 			"leading-and-trailing-space",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `" name "=" stanza " age=2`,
 			},
@@ -426,7 +426,7 @@ key=value`,
 		},
 		{
 			"large",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: "name=stanza age=1 job=\"software engineering\" location=\"grand rapids michigan\" src=\"10.3.3.76\" dst=172.217.0.10 protocol=udp sport=57112 dport=443 translated_src_ip=96.63.176.3 translated_port=57112",
 			},
@@ -451,7 +451,7 @@ key=value`,
 		},
 		{
 			"dell-sonic-wall",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `id=LVM_Sonicwall sn=22255555 time="2021-09-22 16:30:31" fw=14.165.177.10 pri=6 c=1024 gcat=2 m=97 msg="Web site hit" srcMac=6c:0b:84:3f:fa:63 src=192.168.50.2:52006:X0 srcZone=LAN natSrc=14.165.177.10:58457 dstMac=08:b2:58:46:30:54 dst=15.159.150.83:443:X1 dstZone=WAN natDst=15.159.150.83:443 proto=tcp/https sent=1422 rcvd=5993 rule="6 (LAN->WAN)" app=48 dstname=example.space.dev.com arg=/ code=27 Category="Information Technology/Computers" note="Policy: a0, Info: 888 " n=3412158`,
 			},
@@ -493,7 +493,7 @@ key=value`,
 		},
 		{
 			"missing-delimiter",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `test text`,
 			},
@@ -505,7 +505,7 @@ key=value`,
 		},
 		{
 			"value-contains-delimiter",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `test=text=abc`,
 			},
@@ -520,7 +520,7 @@ key=value`,
 		},
 		{
 			"quoted-value-contains-whitespace-delimiter",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `msg="Message successfully sent at 2023-12-04 06:47:31.204222276 +0000 UTC m=+5115.932279346"`,
 			},
@@ -535,7 +535,7 @@ key=value`,
 		},
 		{
 			"multiple-values-contain-delimiter",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `one=1=i two="2=ii" three=3=iii`,
 			},
@@ -552,7 +552,7 @@ key=value`,
 		},
 		{
 			"empty-input",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{},
 			&entry.Entry{},
 			true,
@@ -608,7 +608,7 @@ key=value`,
 		},
 		{
 			"embedded double quotes in single quoted value",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `a=b c='this is a "co ol" value'`,
 			},
@@ -624,7 +624,7 @@ key=value`,
 		},
 		{
 			"embedded double quotes end single quoted value",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `a=b c='this is a "co ol"'`,
 			},
@@ -640,7 +640,7 @@ key=value`,
 		},
 		{
 			"leading and trailing pair delimiter w/o quotes",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: "   k1=v1   k2==v2       k3=v3= ",
 			},
@@ -677,7 +677,7 @@ key=value`,
 		},
 		{
 			"unclosed quotes",
-			func(kv *Config) {},
+			func(_ *Config) {},
 			&entry.Entry{
 				Body: `k1='v1' k2='v2`,
 			},

--- a/pkg/stanza/operator/transformer/filter/filter_test.go
+++ b/pkg/stanza/operator/transformer/filter/filter_test.go
@@ -164,7 +164,7 @@ func TestTransformer(t *testing.T) {
 
 			filtered := true
 			mockOutput := testutil.NewMockOperator("output")
-			mockOutput.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			mockOutput.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(_ mock.Arguments) {
 				filtered = false
 			})
 
@@ -189,7 +189,7 @@ func TestFilterDropRatio(t *testing.T) {
 
 	processedEntries := 0
 	mockOutput := testutil.NewMockOperator("output")
-	mockOutput.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+	mockOutput.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(_ mock.Arguments) {
 		processedEntries++
 	})
 

--- a/pkg/stanza/split/splittest/splittest.go
+++ b/pkg/stanza/split/splittest/splittest.go
@@ -51,7 +51,7 @@ func ExpectAdvanceNil(expectAdvance int) Step {
 
 func ExpectError(expectErr string) Step {
 	return Step{
-		validate: func(t *testing.T, advance int, token []byte, err error) {
+		validate: func(t *testing.T, _ int, _ []byte, err error) {
 			assert.EqualError(t, err, expectErr)
 		},
 	}

--- a/pkg/translator/azure/resourcelogs_to_logs.go
+++ b/pkg/translator/azure/resourcelogs_to_logs.go
@@ -86,17 +86,17 @@ func (r ResourceLogsUnmarshaler) UnmarshalLogs(buf []byte) (plog.Logs, error) {
 		return l, err
 	}
 
-	var resourceIds []string
+	var resourceIDs []string
 	azureResourceLogs := make(map[string][]azureLogRecord)
 	for _, azureLog := range azureLogs.Records {
 		azureResourceLogs[azureLog.ResourceID] = append(azureResourceLogs[azureLog.ResourceID], azureLog)
-		keyExists := slices.Contains(resourceIds, azureLog.ResourceID)
+		keyExists := slices.Contains(resourceIDs, azureLog.ResourceID)
 		if !keyExists {
-			resourceIds = append(resourceIds, azureLog.ResourceID)
+			resourceIDs = append(resourceIDs, azureLog.ResourceID)
 		}
 	}
 
-	for _, resourceID := range resourceIds {
+	for _, resourceID := range resourceIDs {
 		logs := azureResourceLogs[resourceID]
 		resourceLogs := l.ResourceLogs().AppendEmpty()
 		resourceLogs.Resource().Attributes().PutStr(azureResourceID, resourceID)

--- a/pkg/translator/jaeger/jaegerproto_to_traces_test.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces_test.go
@@ -536,7 +536,7 @@ func TestProtoBatchesToInternalTraces(t *testing.T) {
 	for i := 0; i < lenbatches; i++ {
 		rsExpected := expected.ResourceSpans().At(i)
 		for j := 0; j < lenbatches; j++ {
-			got.ResourceSpans().RemoveIf(func(rs ptrace.ResourceSpans) bool {
+			got.ResourceSpans().RemoveIf(func(_ ptrace.ResourceSpans) bool {
 				nameExpected := rsExpected.ScopeSpans().At(0).Spans().At(0).Name()
 				nameGot := got.ResourceSpans().At(j).ScopeSpans().At(0).Scope().Name()
 				if nameExpected == nameGot {

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -137,7 +137,7 @@ func parseAttributeNames(attrsToSelect pcommon.Value) []string {
 }
 
 func removeAttributes(attrs pcommon.Map, labels model.LabelSet) {
-	attrs.RemoveIf(func(s string, v pcommon.Value) bool {
+	attrs.RemoveIf(func(s string, _ pcommon.Value) bool {
 		if s == hintAttributes || s == hintResources || s == hintTenant || s == hintFormat {
 			return true
 		}

--- a/pkg/translator/opencensus/metrics_to_oc.go
+++ b/pkg/translator/opencensus/metrics_to_oc.go
@@ -149,7 +149,7 @@ func collectLabelKeysSummaryDataPoints(dhdp pmetric.SummaryDataPointSlice, keySe
 }
 
 func addLabelKeys(keySet map[string]struct{}, attributes pcommon.Map) {
-	attributes.Range(func(k string, v pcommon.Value) bool {
+	attributes.Range(func(k string, _ pcommon.Value) bool {
 		keySet[k] = struct{}{}
 		return true
 	})

--- a/pkg/translator/opencensus/oc_to_resource_test.go
+++ b/pkg/translator/opencensus/oc_to_resource_test.go
@@ -37,7 +37,7 @@ func TestOcNodeResourceToInternal(t *testing.T) {
 
 	// Make sure hard-coded fields override same-name values in Attributes.
 	// To do that add Attributes with same-name.
-	expectedAttrs.Range(func(k string, v pcommon.Value) bool {
+	expectedAttrs.Range(func(k string, _ pcommon.Value) bool {
 		// Set all except "attr1" which is not a hard-coded field to some bogus values.
 		if !strings.Contains(k, "-attr") {
 			ocNode.Attributes[k] = "this will be overridden 1"

--- a/pkg/translator/skywalking/skywalkingproto_to_traces_test.go
+++ b/pkg/translator/skywalking/skywalkingproto_to_traces_test.go
@@ -218,7 +218,7 @@ func Test_stringToTraceID_Unique(t *testing.T) {
 	var results [2][16]byte
 	for i := 0; i < 2; i++ {
 		tt := tests[i]
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_ *testing.T) {
 			got := swTraceIDToTraceID(tt.segmentObject.traceID)
 			results[i] = got
 		})
@@ -292,7 +292,7 @@ func Test_segmentIdToSpanId_Unique(t *testing.T) {
 	var results [2][8]byte
 	for i := 0; i < 2; i++ {
 		tt := tests[i]
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.name, func(_ *testing.T) {
 			got := segmentIDToSpanID(tt.args.segmentID, tt.args.spanID)
 			results[i] = got
 		})

--- a/processor/deltatocumulativeprocessor/internal/streams/data_test.go
+++ b/processor/deltatocumulativeprocessor/internal/streams/data_test.go
@@ -76,7 +76,7 @@ func TestAggregate(t *testing.T) {
 	dps := generate(total)
 
 	// inv aggregator inverts each sample
-	inv := aggr(func(id streams.Ident, n data.Number) (data.Number, error) {
+	inv := aggr(func(_ streams.Ident, n data.Number) (data.Number, error) {
 		dp := n.Clone()
 		dp.SetIntValue(-dp.IntValue())
 		return dp, nil

--- a/processor/filterprocessor/logs_test.go
+++ b/processor/filterprocessor/logs_test.go
@@ -741,7 +741,7 @@ func TestFilterLogProcessorWithOTTL(t *testing.T) {
 			conditions: []string{
 				`Substring("", 0, 100) == "test"`,
 			},
-			want:      func(ld plog.Logs) {},
+			want:      func(_ plog.Logs) {},
 			errorMode: ottl.IgnoreError,
 		},
 	}

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -772,7 +772,7 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 					`Substring("", 0, 100) == "test"`,
 				},
 			},
-			want:      func(md pmetric.Metrics) {},
+			want:      func(_ pmetric.Metrics) {},
 			errorMode: ottl.IgnoreError,
 		},
 		{

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -257,7 +257,7 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 					`Substring("", 0, 100) == "test"`,
 				},
 			},
-			want:      func(td ptrace.Traces) {},
+			want:      func(_ ptrace.Traces) {},
 			errorMode: ottl.IgnoreError,
 		},
 	}

--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -33,7 +33,7 @@ func TestTraceIsDispatchedAfterDuration(t *testing.T) {
 		NumWorkers:   4,
 	}
 	mockProcessor := &mockProcessor{
-		onTraces: func(ctx context.Context, received ptrace.Traces) error {
+		onTraces: func(_ context.Context, received ptrace.Traces) error {
 			assert.Equal(t, traces, received)
 			wgReceived.Done()
 			return nil
@@ -87,7 +87,7 @@ func TestInternalCacheLimit(t *testing.T) {
 
 	var receivedTraceIDs []pcommon.TraceID
 	mockProcessor := &mockProcessor{}
-	mockProcessor.onTraces = func(ctx context.Context, received ptrace.Traces) error {
+	mockProcessor.onTraces = func(_ context.Context, received ptrace.Traces) error {
 		traceID := received.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID()
 		receivedTraceIDs = append(receivedTraceIDs, traceID)
 		wg.Done()
@@ -303,7 +303,7 @@ func TestAddSpansToExistingTrace(t *testing.T) {
 
 	var receivedTraces []ptrace.ResourceSpans
 	next := &mockProcessor{
-		onTraces: func(ctx context.Context, traces ptrace.Traces) error {
+		onTraces: func(_ context.Context, traces ptrace.Traces) error {
 			require.Equal(t, 2, traces.ResourceSpans().Len())
 			receivedTraces = append(receivedTraces, traces.ResourceSpans().At(0))
 			receivedTraces = append(receivedTraces, traces.ResourceSpans().At(1))

--- a/processor/k8sattributesprocessor/internal/kube/fake_informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/fake_informer.go
@@ -56,7 +56,7 @@ func (f *FakeInformer) SetTransform(_ cache.TransformFunc) error {
 }
 
 func (f *FakeInformer) GetStore() cache.Store {
-	return cache.NewStore(func(obj any) (string, error) { return "", nil })
+	return cache.NewStore(func(_ any) (string, error) { return "", nil })
 }
 
 func (f *FakeInformer) GetController() cache.Controller {
@@ -81,7 +81,7 @@ func (f *FakeNamespaceInformer) AddEventHandlerWithResyncPeriod(_ cache.Resource
 }
 
 func (f *FakeNamespaceInformer) GetStore() cache.Store {
-	return cache.NewStore(func(obj any) (string, error) { return "", nil })
+	return cache.NewStore(func(_ any) (string, error) { return "", nil })
 }
 
 func (f *FakeNamespaceInformer) GetController() cache.Controller {
@@ -111,7 +111,7 @@ func (f *FakeReplicaSetInformer) SetTransform(_ cache.TransformFunc) error {
 }
 
 func (f *FakeReplicaSetInformer) GetStore() cache.Store {
-	return cache.NewStore(func(obj any) (string, error) { return "", nil })
+	return cache.NewStore(func(_ any) (string, error) { return "", nil })
 }
 
 func (f *FakeReplicaSetInformer) GetController() cache.Controller {
@@ -176,7 +176,7 @@ func (f *NoOpInformer) SetTransform(_ cache.TransformFunc) error {
 }
 
 func (f *NoOpInformer) GetStore() cache.Store {
-	return cache.NewStore(func(obj any) (string, error) { return "", nil })
+	return cache.NewStore(func(_ any) (string, error) { return "", nil })
 }
 
 func (f *NoOpInformer) GetController() cache.Controller {

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -111,7 +111,7 @@ func (ltp *logsTransformProcessor) Start(ctx context.Context, _ component.Host) 
 func (ltp *logsTransformProcessor) startFromConverter() {
 	ltp.fromConverter.Start()
 
-	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		ltp.fromConverter.Stop()
 		return nil
 	})
@@ -124,7 +124,7 @@ func (ltp *logsTransformProcessor) startConverterLoop(ctx context.Context) {
 	wg.Add(1)
 	go ltp.converterLoop(ctx, wg)
 
-	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		wg.Wait()
 		return nil
 	})
@@ -137,7 +137,7 @@ func (ltp *logsTransformProcessor) startPipeline() error {
 		return err
 	}
 
-	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		return ltp.pipe.Stop()
 	})
 
@@ -157,7 +157,7 @@ func (ltp *logsTransformProcessor) startEmitterLoop(ctx context.Context) {
 	wg.Add(1)
 	go ltp.emitterLoop(ctx, wg)
 
-	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		wg.Wait()
 		return nil
 	})
@@ -166,7 +166,7 @@ func (ltp *logsTransformProcessor) startEmitterLoop(ctx context.Context) {
 func (ltp *logsTransformProcessor) startConverter() {
 	ltp.converter.Start()
 
-	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		ltp.converter.Stop()
 		return nil
 	})
@@ -179,7 +179,7 @@ func (ltp *logsTransformProcessor) startConsumerLoop(ctx context.Context) {
 	wg.Add(1)
 	go ltp.consumerLoop(ctx, wg)
 
-	ltp.shutdownFns = append(ltp.shutdownFns, func(ctx context.Context) error {
+	ltp.shutdownFns = append(ltp.shutdownFns, func(_ context.Context) error {
 		wg.Wait()
 		return nil
 	})

--- a/processor/metricstransformprocessor/operation_aggregate_labels.go
+++ b/processor/metricstransformprocessor/operation_aggregate_labels.go
@@ -140,7 +140,7 @@ func filterAttrs(metric pmetric.Metric, filterAttrKeys map[string]bool) {
 		return
 	}
 	rangeDataPointAttributes(metric, func(attrs pcommon.Map) bool {
-		attrs.RemoveIf(func(k string, v pcommon.Value) bool {
+		attrs.RemoveIf(func(k string, _ pcommon.Value) bool {
 			return !filterAttrKeys[k]
 		})
 		return true

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -163,7 +163,7 @@ func MergeSchemaURL(currentSchemaURL string, newSchemaURL string) string {
 func filterAttributes(am pcommon.Map, attributesToKeep map[string]struct{}) []string {
 	if len(attributesToKeep) > 0 {
 		var droppedAttributes []string
-		am.RemoveIf(func(k string, v pcommon.Value) bool {
+		am.RemoveIf(func(k string, _ pcommon.Value) bool {
 			_, keep := attributesToKeep[k]
 			if !keep {
 				droppedAttributes = append(droppedAttributes, k)

--- a/processor/tailsamplingprocessor/internal/idbatcher/id_batcher_test.go
+++ b/processor/tailsamplingprocessor/internal/idbatcher/id_batcher_test.go
@@ -47,7 +47,7 @@ func TestMinBufferedChannels(t *testing.T) {
 }
 
 func BenchmarkConcurrentEnqueue(b *testing.B) {
-	ids := generateSequentialIds(1)
+	ids := generateSequentialIDs(1)
 	batcher, err := New(10, 100, uint64(4*runtime.NumCPU()))
 	defer batcher.Stop()
 	if err != nil {
@@ -101,7 +101,7 @@ func concurrencyTest(t *testing.T, numBatches, newBatchesInitialCapacity, batchC
 		}
 	}()
 
-	ids := generateSequentialIds(10000)
+	ids := generateSequentialIDs(10000)
 	wg := &sync.WaitGroup{}
 	// Limit the concurrency here to avoid creating too many goroutines and hit
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9126
@@ -143,9 +143,9 @@ func concurrencyTest(t *testing.T, numBatches, newBatchesInitialCapacity, batchC
 	}
 }
 
-func generateSequentialIds(numIds uint64) []pcommon.TraceID {
-	ids := make([]pcommon.TraceID, numIds)
-	for i := uint64(0); i < numIds; i++ {
+func generateSequentialIDs(numIDs uint64) []pcommon.TraceID {
+	ids := make([]pcommon.TraceID, numIDs)
+	for i := uint64(0); i < numIDs; i++ {
 		traceID := [16]byte{}
 		binary.BigEndian.PutUint64(traceID[:8], 0)
 		binary.BigEndian.PutUint64(traceID[8:], i)

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -162,10 +162,10 @@ func TestTraceIntegrity(t *testing.T) {
 }
 
 func TestSequentialTraceArrival(t *testing.T) {
-	traceIds, batches := generateIdsAndBatches(128)
+	traceIDs, batches := generateIDsAndBatches(128)
 	cfg := Config{
 		DecisionWait:            defaultTestDecisionWait,
-		NumTraces:               uint64(2 * len(traceIds)),
+		NumTraces:               uint64(2 * len(traceIDs)),
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
@@ -182,8 +182,8 @@ func TestSequentialTraceArrival(t *testing.T) {
 		require.NoError(t, tsp.ConsumeTraces(context.Background(), batch))
 	}
 
-	for i := range traceIds {
-		d, ok := tsp.idToTrace.Load(traceIds[i])
+	for i := range traceIDs {
+		d, ok := tsp.idToTrace.Load(traceIDs[i])
 		require.True(t, ok, "Missing expected traceId")
 		v := d.(*sampling.TraceData)
 		require.Equal(t, int64(i+1), v.SpanCount.Load(), "Incorrect number of spans for entry %d", i)
@@ -191,12 +191,12 @@ func TestSequentialTraceArrival(t *testing.T) {
 }
 
 func TestConcurrentTraceArrival(t *testing.T) {
-	traceIds, batches := generateIdsAndBatches(128)
+	traceIDs, batches := generateIDsAndBatches(128)
 
 	var wg sync.WaitGroup
 	cfg := Config{
 		DecisionWait:            defaultTestDecisionWait,
-		NumTraces:               uint64(2 * len(traceIds)),
+		NumTraces:               uint64(2 * len(traceIDs)),
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
@@ -231,8 +231,8 @@ func TestConcurrentTraceArrival(t *testing.T) {
 
 	wg.Wait()
 
-	for i := range traceIds {
-		d, ok := tsp.idToTrace.Load(traceIds[i])
+	for i := range traceIDs {
+		d, ok := tsp.idToTrace.Load(traceIDs[i])
 		require.True(t, ok, "Missing expected traceId")
 		v := d.(*sampling.TraceData)
 		require.Equal(t, int64(i+1)*2, v.SpanCount.Load(), "Incorrect number of spans for entry %d", i)
@@ -240,14 +240,14 @@ func TestConcurrentTraceArrival(t *testing.T) {
 }
 
 func TestConcurrentArrivalAndEvaluation(t *testing.T) {
-	traceIds, batches := generateIdsAndBatches(1)
+	traceIDs, batches := generateIDsAndBatches(1)
 	evalStarted := make(chan struct{})
 	continueEvaluation := make(chan struct{})
 
 	var wg sync.WaitGroup
 	cfg := Config{
 		DecisionWait:            defaultTestDecisionWait,
-		NumTraces:               uint64(2 * len(traceIds)),
+		NumTraces:               uint64(2 * len(traceIDs)),
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testLatencyPolicy,
 	}
@@ -285,7 +285,7 @@ func TestConcurrentArrivalAndEvaluation(t *testing.T) {
 }
 
 func TestSequentialTraceMapSize(t *testing.T) {
-	traceIds, batches := generateIdsAndBatches(210)
+	traceIDs, batches := generateIDsAndBatches(210)
 	const maxSize = 100
 	cfg := Config{
 		DecisionWait:            defaultTestDecisionWait,
@@ -306,15 +306,15 @@ func TestSequentialTraceMapSize(t *testing.T) {
 	}
 
 	// On sequential insertion it is possible to know exactly which traces should be still on the map.
-	for i := 0; i < len(traceIds)-maxSize; i++ {
-		_, ok := tsp.idToTrace.Load(traceIds[i])
-		require.False(t, ok, "Found unexpected traceId[%d] still on map (id: %v)", i, traceIds[i])
+	for i := 0; i < len(traceIDs)-maxSize; i++ {
+		_, ok := tsp.idToTrace.Load(traceIDs[i])
+		require.False(t, ok, "Found unexpected traceId[%d] still on map (id: %v)", i, traceIDs[i])
 	}
 }
 
 func TestConcurrentTraceMapSize(t *testing.T) {
 	t.Skip("Flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9126")
-	_, batches := generateIdsAndBatches(210)
+	_, batches := generateIDsAndBatches(210)
 	const maxSize = 100
 	var wg sync.WaitGroup
 	cfg := Config{
@@ -377,7 +377,7 @@ func TestSamplingPolicyTypicalPath(t *testing.T) {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
 
-	_, batches := generateIdsAndBatches(210)
+	_, batches := generateIDsAndBatches(210)
 	currItem := 0
 	numSpansPerBatchWindow := 10
 	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
@@ -439,7 +439,7 @@ func TestSamplingPolicyInvertSampled(t *testing.T) {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
 
-	_, batches := generateIdsAndBatches(210)
+	_, batches := generateIDsAndBatches(210)
 	currItem := 0
 	numSpansPerBatchWindow := 10
 	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
@@ -508,7 +508,7 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
 
-	_, batches := generateIdsAndBatches(210)
+	_, batches := generateIDsAndBatches(210)
 	currItem := 0
 	numSpansPerBatchWindow := 10
 	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
@@ -572,7 +572,7 @@ func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
 
-	_, batches := generateIdsAndBatches(210)
+	_, batches := generateIDsAndBatches(210)
 	currItem := 0
 	numSpansPerBatchWindow := 10
 	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
@@ -636,7 +636,7 @@ func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
 		require.NoError(t, tsp.Shutdown(context.Background()))
 	}()
 
-	_, batches := generateIdsAndBatches(210)
+	_, batches := generateIDsAndBatches(210)
 	currItem := 0
 	numSpansPerBatchWindow := 10
 	// First evaluations shouldn't have anything to evaluate, until decision wait time passed.
@@ -770,7 +770,7 @@ func TestMultipleBatchesAreCombinedIntoOne(t *testing.T) {
 
 	mpe.NextDecision = sampling.Sampled
 
-	traceIds, batches := generateIdsAndBatches(3)
+	traceIDs, batches := generateIDsAndBatches(3)
 	for _, batch := range batches {
 		require.NoError(t, tsp.ConsumeTraces(context.Background(), batch))
 	}
@@ -780,27 +780,27 @@ func TestMultipleBatchesAreCombinedIntoOne(t *testing.T) {
 
 	require.EqualValues(t, 3, len(msp.AllTraces()), "There should be three batches, one for each trace")
 
-	expectedSpanIds := make(map[int][]pcommon.SpanID)
-	expectedSpanIds[0] = []pcommon.SpanID{
+	expectedSpanIDs := make(map[int][]pcommon.SpanID)
+	expectedSpanIDs[0] = []pcommon.SpanID{
 		uInt64ToSpanID(uint64(1)),
 	}
-	expectedSpanIds[1] = []pcommon.SpanID{
+	expectedSpanIDs[1] = []pcommon.SpanID{
 		uInt64ToSpanID(uint64(2)),
 		uInt64ToSpanID(uint64(3)),
 	}
-	expectedSpanIds[2] = []pcommon.SpanID{
+	expectedSpanIDs[2] = []pcommon.SpanID{
 		uInt64ToSpanID(uint64(4)),
 		uInt64ToSpanID(uint64(5)),
 		uInt64ToSpanID(uint64(6)),
 	}
 
 	receivedTraces := msp.AllTraces()
-	for i, traceID := range traceIds {
+	for i, traceID := range traceIDs {
 		trace := findTrace(t, receivedTraces, traceID)
 		require.EqualValues(t, i+1, trace.SpanCount(), "The trace should have all of its spans in a single batch")
 
-		expected := expectedSpanIds[i]
-		got := collectSpanIds(trace)
+		expected := expectedSpanIDs[i]
+		got := collectSpanIDs(trace)
 
 		// might have received out of order, sort for comparison
 		sort.Slice(got, func(i, j int) bool {
@@ -891,7 +891,7 @@ func TestDuplicatePolicyName(t *testing.T) {
 	assert.Equal(t, err, errors.New(`duplicate policy name "always_sample"`))
 }
 
-func collectSpanIds(trace ptrace.Traces) []pcommon.SpanID {
+func collectSpanIDs(trace ptrace.Traces) []pcommon.SpanID {
 	var spanIDs []pcommon.SpanID
 
 	for i := 0; i < trace.ResourceSpans().Len(); i++ {
@@ -921,17 +921,17 @@ func findTrace(t *testing.T, a []ptrace.Traces, traceID pcommon.TraceID) ptrace.
 	return ptrace.Traces{}
 }
 
-func generateIdsAndBatches(numIds int) ([]pcommon.TraceID, []ptrace.Traces) {
-	traceIds := make([]pcommon.TraceID, numIds)
+func generateIDsAndBatches(numIDs int) ([]pcommon.TraceID, []ptrace.Traces) {
+	traceIDs := make([]pcommon.TraceID, numIDs)
 	spanID := 0
 	var tds []ptrace.Traces
-	for i := 0; i < numIds; i++ {
-		traceIds[i] = uInt64ToTraceID(uint64(i))
+	for i := 0; i < numIDs; i++ {
+		traceIDs[i] = uInt64ToTraceID(uint64(i))
 		// Send each span in a separate batch
 		for j := 0; j <= i; j++ {
 			td := simpleTraces()
 			span := td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
-			span.SetTraceID(traceIds[i])
+			span.SetTraceID(traceIDs[i])
 
 			spanID++
 			span.SetSpanID(uInt64ToSpanID(uint64(spanID)))
@@ -939,7 +939,7 @@ func generateIdsAndBatches(numIds int) ([]pcommon.TraceID, []ptrace.Traces) {
 		}
 	}
 
-	return traceIds, tds
+	return traceIDs, tds
 }
 
 func uInt64ToTraceID(id uint64) pcommon.TraceID {
@@ -1032,10 +1032,10 @@ func simpleTracesWithID(traceID pcommon.TraceID) ptrace.Traces {
 }
 
 func BenchmarkSampling(b *testing.B) {
-	traceIds, batches := generateIdsAndBatches(128)
+	traceIDs, batches := generateIDsAndBatches(128)
 	cfg := Config{
 		DecisionWait:            defaultTestDecisionWait,
-		NumTraces:               uint64(2 * len(traceIds)),
+		NumTraces:               uint64(2 * len(traceIDs)),
 		ExpectedNewTracesPerSec: 64,
 		PolicyCfgs:              testPolicy,
 	}
@@ -1059,7 +1059,7 @@ func BenchmarkSampling(b *testing.B) {
 	}
 
 	for i := 0; i < b.N; i++ {
-		for i, id := range traceIds {
+		for i, id := range traceIDs {
 			_, _ = tsp.makeDecision(id, sampleBatches[i], metrics)
 		}
 	}

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -41,7 +41,7 @@ func Test_ProcessLogs_ResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where attributes["host.name"] == "wrong"`,
-			want: func(td plog.Logs) {
+			want: func(_ plog.Logs) {
 			},
 		},
 	}
@@ -76,7 +76,7 @@ func Test_ProcessLogs_ScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where version == 2`,
-			want: func(td plog.Logs) {
+			want: func(_ plog.Logs) {
 			},
 		},
 	}
@@ -259,7 +259,7 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Split(attributes["not_exist"], "|"))`,
-			want:      func(td plog.Logs) {},
+			want:      func(_ plog.Logs) {},
 		},
 		{
 			statement: `set(attributes["test"], Substring(attributes["total.string"], 3, 3))`,
@@ -276,7 +276,7 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Substring(attributes["not_exist"], 3, 3))`,
-			want:      func(td plog.Logs) {},
+			want:      func(_ plog.Logs) {},
 		},
 		{
 			statement: `set(attributes["test"], ["A", "B", "C"]) where body == "operationA"`,
@@ -320,7 +320,7 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 		{
 			statement: `limit(attributes, 0, []) where body == "operationA"`,
 			want: func(td plog.Logs) {
-				td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
+				td.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
 			},
 		},
 		{
@@ -331,7 +331,7 @@ func Test_ProcessLogs_LogContext(t *testing.T) {
 		},
 		{
 			statement: `replace_match(body["metadata"]["uid"], "*", "12345")`,
-			want:      func(td plog.Logs) {},
+			want:      func(_ plog.Logs) {},
 		},
 	}
 

--- a/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_copy_metric_test.go
@@ -38,7 +38,7 @@ func Test_copyMetric(t *testing.T) {
 		{
 			testName: "set name",
 			name: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
 					return "new name", nil
 				},
 			}),
@@ -55,7 +55,7 @@ func Test_copyMetric(t *testing.T) {
 			testName: "set description",
 			name:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
 			desc: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
 					return "new desc", nil
 				},
 			}),
@@ -72,7 +72,7 @@ func Test_copyMetric(t *testing.T) {
 			name:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
 			desc:     ottl.Optional[ottl.StringGetter[ottlmetric.TransformContext]]{},
 			unit: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
 					return "new unit", nil
 				},
 			}),
@@ -86,17 +86,17 @@ func Test_copyMetric(t *testing.T) {
 		{
 			testName: "set all",
 			name: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
 					return "new name", nil
 				},
 			}),
 			desc: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
 					return "new desc", nil
 				},
 			}),
 			unit: ottl.NewTestingOptional[ottl.StringGetter[ottlmetric.TransformContext]](ottl.StandardStringGetter[ottlmetric.TransformContext]{
-				Getter: func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+				Getter: func(_ context.Context, _ ottlmetric.TransformContext) (any, error) {
 					return "new unit", nil
 				},
 			}),

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -37,7 +37,7 @@ func Test_ProcessMetrics_ResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where attributes["host.name"] == "wrong"`,
-			want: func(td pmetric.Metrics) {
+			want: func(_ pmetric.Metrics) {
 			},
 		},
 	}
@@ -72,7 +72,7 @@ func Test_ProcessMetrics_ScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where version == 2`,
-			want: func(td pmetric.Metrics) {
+			want: func(_ pmetric.Metrics) {
 			},
 		},
 	}
@@ -547,7 +547,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 		},
 		{
 			statements: []string{`set(attributes["test"], Split(attributes["not_exist"], "|"))`},
-			want:       func(td pmetric.Metrics) {},
+			want:       func(_ pmetric.Metrics) {},
 		},
 		{
 			statements: []string{`set(attributes["test"], Substring(attributes["total.string"], 3, 3))`},
@@ -567,7 +567,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 		},
 		{
 			statements: []string{`set(attributes["test"], Substring(attributes["not_exist"], 3, 3))`},
-			want:       func(td pmetric.Metrics) {},
+			want:       func(_ pmetric.Metrics) {},
 		},
 		{
 			statements: []string{
@@ -610,8 +610,8 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 		{
 			statements: []string{`limit(attributes, 0, []) where metric.name == "operationA"`},
 			want: func(td pmetric.Metrics) {
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
-				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
+				td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(1).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
 			},
 		},
 		{

--- a/processor/transformprocessor/internal/traces/processor_test.go
+++ b/processor/transformprocessor/internal/traces/processor_test.go
@@ -42,7 +42,7 @@ func Test_ProcessTraces_ResourceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where attributes["host.name"] == "wrong"`,
-			want: func(td ptrace.Traces) {
+			want: func(_ ptrace.Traces) {
 			},
 		},
 	}
@@ -77,7 +77,7 @@ func Test_ProcessTraces_ScopeContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], "pass") where version == 2`,
-			want: func(td ptrace.Traces) {
+			want: func(_ ptrace.Traces) {
 			},
 		},
 	}
@@ -298,7 +298,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Split(attributes["not_exist"], "|"))`,
-			want:      func(td ptrace.Traces) {},
+			want:      func(_ ptrace.Traces) {},
 		},
 		{
 			statement: `set(attributes["test"], Substring(attributes["total.string"], 3, 3))`,
@@ -315,7 +315,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 		},
 		{
 			statement: `set(attributes["test"], Substring(attributes["not_exist"], 3, 3))`,
-			want:      func(td ptrace.Traces) {},
+			want:      func(_ ptrace.Traces) {},
 		},
 		{
 			statement: `set(attributes["test"], ["A", "B", "C"]) where name == "operationA"`,
@@ -365,7 +365,7 @@ func Test_ProcessTraces_TraceContext(t *testing.T) {
 		{
 			statement: `limit(attributes, 0, []) where name == "operationA"`,
 			want: func(td ptrace.Traces) {
-				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().RemoveIf(func(s string, v pcommon.Value) bool { return true })
+				td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes().RemoveIf(func(_ string, _ pcommon.Value) bool { return true })
 			},
 		},
 		{

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux.go
@@ -176,7 +176,7 @@ func (c *Cadvisor) Shutdown() error {
 	return errs
 }
 
-func (c *Cadvisor) addEbsVolumeInfo(tags map[string]string, ebsVolumeIdsUsedAsPV map[string]string) {
+func (c *Cadvisor) addEbsVolumeInfo(tags map[string]string, ebsVolumeIDsUsedAsPV map[string]string) {
 	deviceName, ok := tags[ci.DiskDev]
 	if !ok {
 		return
@@ -190,7 +190,7 @@ func (c *Cadvisor) addEbsVolumeInfo(tags map[string]string, ebsVolumeIdsUsedAsPV
 
 	if tags[ci.MetricType] == ci.TypeContainerFS || tags[ci.MetricType] == ci.TypeNodeFS ||
 		tags[ci.MetricType] == ci.TypeNodeDiskIO || tags[ci.MetricType] == ci.TypeContainerDiskIO {
-		if volID := ebsVolumeIdsUsedAsPV[deviceName]; volID != "" {
+		if volID := ebsVolumeIDsUsedAsPV[deviceName]; volID != "" {
 			tags[ci.EbsVolumeID] = volID
 		}
 	}
@@ -256,11 +256,11 @@ func addECSResources(tags map[string]string) {
 }
 
 func (c *Cadvisor) decorateMetrics(cadvisormetrics []*extractors.CAdvisorMetric) []*extractors.CAdvisorMetric {
-	ebsVolumeIdsUsedAsPV := c.hostInfo.ExtractEbsIDsUsedByKubernetes()
+	ebsVolumeIDsUsedAsPV := c.hostInfo.ExtractEbsIDsUsedByKubernetes()
 	var result []*extractors.CAdvisorMetric
 	for _, m := range cadvisormetrics {
 		tags := m.GetTags()
-		c.addEbsVolumeInfo(tags, ebsVolumeIdsUsedAsPV)
+		c.addEbsVolumeInfo(tags, ebsVolumeIDsUsedAsPV)
 
 		// add version
 		tags[ci.Version] = c.version

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
@@ -50,22 +50,22 @@ func (m *mockCadvisorManager2) SubcontainersInfo(_ string, _ *info.ContainerInfo
 }
 
 func newMockCreateManager(t *testing.T) createCadvisorManager {
-	return func(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, housekeepingConfig manager.HousekeepingConfig,
-		includedMetricsSet container.MetricSet, collectorHTTPClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string,
-		perfEventsFile string) (cadvisorManager, error) {
+	return func(_ *memory.InMemoryCache, _ sysfs.SysFs, _ manager.HousekeepingConfig,
+		_ container.MetricSet, _ *http.Client, _ []string,
+		_ string) (cadvisorManager, error) {
 		return &mockCadvisorManager{t: t}, nil
 	}
 }
 
-var mockCreateManager2 = func(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, housekeepingConfig manager.HousekeepingConfig,
-	includedMetricsSet container.MetricSet, collectorHTTPClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string,
-	perfEventsFile string) (cadvisorManager, error) {
+var mockCreateManager2 = func(_ *memory.InMemoryCache, _ sysfs.SysFs, _ manager.HousekeepingConfig,
+	_ container.MetricSet, _ *http.Client, _ []string,
+	_ string) (cadvisorManager, error) {
 	return &mockCadvisorManager2{}, nil
 }
 
-var mockCreateManagerWithError = func(memoryCache *memory.InMemoryCache, sysfs sysfs.SysFs, housekeepingConfig manager.HousekeepingConfig,
-	includedMetricsSet container.MetricSet, collectorHTTPClient *http.Client, rawContainerCgroupPathPrefixWhiteList []string,
-	perfEventsFile string) (cadvisorManager, error) {
+var mockCreateManagerWithError = func(_ *memory.InMemoryCache, _ sysfs.SysFs, _ manager.HousekeepingConfig,
+	_ container.MetricSet, _ *http.Client, _ []string,
+	_ string) (cadvisorManager, error) {
 	return nil, errors.New("error")
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor.go
@@ -32,7 +32,7 @@ const (
 type podKey struct {
 	cgroupPath   string
 	podID        string
-	containerIds []string
+	containerIDs []string
 	podName      string
 	namespace    string
 }
@@ -59,7 +59,7 @@ func processContainers(cInfos []*cInfo.ContainerInfo, mInfo extractors.CPUMemInf
 				podKeys[outPodKey.cgroupPath] = *outPodKey
 			} else {
 				// collect the container ids associated with a pod
-				key.containerIds = append(key.containerIds, outPodKey.containerIds...)
+				key.containerIDs = append(key.containerIDs, outPodKey.containerIDs...)
 			}
 		}
 	}
@@ -136,7 +136,7 @@ func processContainer(info *cInfo.ContainerInfo, mInfo extractors.CPUMemInfoProv
 			tags[ci.ContainerNamekey] = containerName
 			containerID := path.Base(info.Name)
 			tags[ci.ContainerIDkey] = containerID
-			pKey.containerIds = []string{containerID}
+			pKey.containerIDs = []string{containerID}
 			containerType = ci.TypeContainer
 			// TODO(pvasir): wait for upstream fix https://github.com/google/cadvisor/issues/2785
 			if !info.Spec.HasFilesystem {

--- a/receiver/chronyreceiver/factory.go
+++ b/receiver/chronyreceiver/factory.go
@@ -38,7 +38,7 @@ func newMetricsReceiver(
 	scraper, err := scraperhelper.NewScraper(
 		metadata.Type.String(),
 		s.scrape,
-		scraperhelper.WithStart(func(ctx context.Context, host component.Host) error {
+		scraperhelper.WithStart(func(_ context.Context, _ component.Host) error {
 			chronyc, err := chrony.New(cfg.Endpoint, cfg.Timeout)
 			s.client = chronyc
 			return err

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -945,7 +945,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				req.Header.Set("Content-Type", "application/not-json")
 				return req
 			}(),
-			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+			assertResponse: func(t *testing.T, resp *http.Response, _ any) {
 				status := resp.StatusCode
 				assert.Equal(t, http.StatusOK, status)
 			},
@@ -982,7 +982,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				req := httptest.NewRequest("POST", "http://localhost/foo", strings.NewReader("foo\nbar"))
 				return req
 			}(),
-			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+			assertResponse: func(t *testing.T, resp *http.Response, _ any) {
 				status := resp.StatusCode
 				assert.Equal(t, http.StatusOK, status)
 			},

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -331,7 +331,7 @@ func Test_SplunkHecToLogData(t *testing.T) {
 	n := len(tests)
 	for _, tt := range tests[n-1:] {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := splunkHecToLogData(zap.NewNop(), tt.events, func(resource pcommon.Resource) {}, tt.hecConfig)
+			result, err := splunkHecToLogData(zap.NewNop(), tt.events, func(_ pcommon.Resource) {}, tt.hecConfig)
 			assert.Equal(t, tt.wantErr, err)
 			require.Equal(t, tt.output.Len(), result.ResourceLogs().Len())
 			for i := 0; i < result.ResourceLogs().Len(); i++ {
@@ -446,7 +446,7 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 			query: func() map[string][]string {
 				return map[string][]string{}
 			}(),
-			assertResource: func(t *testing.T, got plog.Logs, slLen int) {
+			assertResource: func(t *testing.T, got plog.Logs, _ int) {
 				assert.Equal(t, 1, got.LogRecordCount())
 				assert.Equal(t, time.Unix(testTimestampVal, 0).Unix(), got.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Timestamp().AsTime().Unix())
 			},
@@ -466,7 +466,7 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 			query: func() map[string][]string {
 				return map[string][]string{}
 			}(),
-			assertResource: func(t *testing.T, got plog.Logs, slLen int) {
+			assertResource: func(t *testing.T, got plog.Logs, _ int) {
 				assert.Equal(t, 3, got.LogRecordCount())
 			},
 			config: func() *Config {
@@ -477,7 +477,7 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, slLen, err := splunkHecRawToLogData(tt.sc, tt.query, func(resource pcommon.Resource) {}, tt.config, tt.time)
+			result, slLen, err := splunkHecRawToLogData(tt.sc, tt.query, func(_ pcommon.Resource) {}, tt.config, tt.time)
 			require.NoError(t, err)
 			tt.assertResource(t, result, slLen)
 		})

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -294,7 +294,7 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), []*splunk.Event{tt.splunkDataPoint}, func(resource pcommon.Resource) {}, tt.hecConfig)
+			md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), []*splunk.Event{tt.splunkDataPoint}, func(_ pcommon.Resource) {}, tt.hecConfig)
 			assert.Equal(t, tt.wantDroppedTimeseries, numDroppedTimeseries)
 			assert.NoError(t, pmetrictest.CompareMetrics(tt.wantMetricsData, md, pmetrictest.IgnoreMetricsOrder()))
 		})
@@ -441,7 +441,7 @@ func TestGroupMetricsByResource(t *testing.T) {
 		dataPt.SetTimestamp(pcommon.Timestamp(nanoseconds))
 		dataPt.Attributes().PutStr("field", "value2-1")
 	}
-	md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), events, func(resource pcommon.Resource) {}, defaultTestingHecConfig)
+	md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), events, func(_ pcommon.Resource) {}, defaultTestingHecConfig)
 	assert.Equal(t, 0, numDroppedTimeseries)
 	assert.EqualValues(t, metrics, md)
 }

--- a/receiver/sqlqueryreceiver/receiver.go
+++ b/receiver/sqlqueryreceiver/receiver.go
@@ -18,7 +18,7 @@ import (
 
 func createLogsReceiverFunc(sqlOpenerFunc sqlquery.SQLOpenerFunc, clientProviderFunc sqlquery.ClientProviderFunc) receiver.CreateLogsFunc {
 	return func(
-		ctx context.Context,
+		_ context.Context,
 		settings receiver.CreateSettings,
 		config component.Config,
 		consumer consumer.Logs,
@@ -30,7 +30,7 @@ func createLogsReceiverFunc(sqlOpenerFunc sqlquery.SQLOpenerFunc, clientProvider
 
 func createMetricsReceiverFunc(sqlOpenerFunc sqlquery.SQLOpenerFunc, clientProviderFunc sqlquery.ClientProviderFunc) receiver.CreateMetricsFunc {
 	return func(
-		ctx context.Context,
+		_ context.Context,
 		settings receiver.CreateSettings,
 		cfg component.Config,
 		consumer consumer.Metrics,

--- a/receiver/vcenterreceiver/integration_test.go
+++ b/receiver/vcenterreceiver/integration_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+	simulator.Test(func(_ context.Context, c *vim25.Client) {
 		pw, set := simulator.DefaultLogin.Password()
 		require.True(t, set)
 
@@ -55,7 +55,7 @@ func TestIntegration(t *testing.T) {
 		scraperinttest.NewIntegrationTest(
 			NewFactory(),
 			scraperinttest.WithCustomConfig(
-				func(t *testing.T, cfg component.Config, ci *scraperinttest.ContainerInfo) {
+				func(_ *testing.T, cfg component.Config, _ *scraperinttest.ContainerInfo) {
 					rCfg := cfg.(*Config)
 					rCfg.CollectionInterval = 2 * time.Second
 					rCfg.Endpoint = fmt.Sprintf("%s://%s", c.URL().Scheme, c.URL().Host)

--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -39,7 +39,7 @@ func TestReqToLog(t *testing.T) {
 				}
 				return v
 			}(),
-			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, settings receiver.CreateSettings) {
+			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, _ receiver.CreateSettings) {
 				require.Equal(t, 1, reqLen)
 
 				attributes := reqLog.ResourceLogs().At(0).Resource().Attributes()
@@ -66,7 +66,7 @@ func TestReqToLog(t *testing.T) {
 				reader := io.NopCloser(bytes.NewReader([]byte("this is a: log")))
 				return bufio.NewScanner(reader)
 			}(),
-			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, settings receiver.CreateSettings) {
+			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, _ receiver.CreateSettings) {
 				require.Equal(t, 1, reqLen)
 
 				attributes := reqLog.ResourceLogs().At(0).Resource().Attributes()

--- a/receiver/zookeeperreceiver/metrics.go
+++ b/receiver/zookeeperreceiver/metrics.go
@@ -57,7 +57,7 @@ func newMetricCreator(mb *metadata.MetricsBuilder) *metricCreator {
 func (m *metricCreator) recordDataPointsFunc(metric string) func(ts pcommon.Timestamp, val int64) {
 	switch metric {
 	case followersMetricKey:
-		return func(ts pcommon.Timestamp, val int64) {
+		return func(_ pcommon.Timestamp, val int64) {
 			m.computedMetricStore[followersMetricKey] = val
 		}
 	case syncedFollowersMetricKey:

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -191,7 +191,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 				"zk.version":   "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf",
 			},
 			expectedNumResourceMetrics: 1,
-			setConnectionDeadline: func(conn net.Conn, t time.Time) error {
+			setConnectionDeadline: func(_ net.Conn, _ time.Time) error {
 				return errors.New("")
 			},
 		},
@@ -221,7 +221,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 				"zk.version":   "3.4.14-4c25d480e66aadd371de8bd2fd8da255ac140bcf",
 			},
 			expectedNumResourceMetrics: 1,
-			closeConnection: func(conn net.Conn) error {
+			closeConnection: func(_ net.Conn) error {
 				return errors.New("")
 			},
 		},
@@ -237,7 +237,7 @@ func TestZookeeperMetricsScraperScrape(t *testing.T) {
 					level: zapcore.ErrorLevel,
 				},
 			},
-			sendCmd: func(conn net.Conn, s string) (*bufio.Scanner, error) {
+			sendCmd: func(_ net.Conn, _ string) (*bufio.Scanner, error) {
 				return nil, errors.New("")
 			},
 		},


### PR DESCRIPTION
**Description:** 
This PR should solve the related Issue linked below.
I tried to switch to blank identifiers instead of removing function arguments, so it could be adapted later on.

 linting erros in following pkgs:

- [x] cmd/configschema
- [x] cmd/githubgen
- [x] connector/datadogconnector
- [x] connector/grafanacloudconnector
- [x] connector/servicegraphconnector
- [x] exporter/awsemfexporter
- [x] exporter/awsxrayexporter
- [x] exporter/clickhouseexporter
- [x] exporter/datadogexporter
- [x] exporter/dynatraceexporter
- [x] exporter/elasticsearchexporter
- [x] exporter/honeycombmarkerexporter
- [x] exporter/influxdbexporter
- [x] exporter/instanaexporter
- [x] exporter/kafkaexporter
- [x] exporter/kineticaexporter
- [x] exporter/loadbalancingexporter
- [x] exporter/logicmonitorexporter
- [x] exporter/logzioexporter
- [x] exporter/lokiexporter
- [x] exporter/mezmoexporter
- [x] exporter/opensearchexporter
- [x] exporter/prometheusexporter
- [x] exporter/signalfxexporter
- [x] exporter/splunkhecexporter
- [x] exporter/sumologicexporter
- [x] exporter/zipkinexporter
- [x] extension/jaegerremotesampling
- [x] extension/oauth2clientauthextension
- [x] extension/observer
- [x] extension/oidcauthextension
- [x] extension/sumologicextension
- [x] internal/aws
- [x] internal/coreinternal
- [x] internal/filter
- [x] internal/kubelet
- [x] internal/metadataproviders
- [x] internal/sharedcomponent
- [x] pkg/ottl
- [x] pkg/pdatautil
- [x] pkg/stanza
- [x] pkg/translator
- [x] processor/deltatocumulativeprocessor
- [x] processor/filterprocessor
- [x] processor/groupbytraceprocessor
- [x] processor/k8sattributesprocessor
- [x] processor/logstransformprocessor
- [x] processor/metricstransformprocessor
- [x] processor/resourcedetectionprocessor
- [x] processor/tailsamplingprocessor
- [x] processor/transformprocessor
- [x] receiver/awscontainerinsightreceiver
- [x] receiver/chronyreceiver
- [x] receiver/splunkhecreceiver
- [x] receiver/sqlqueryreceiver
- [x] receiver/vcenterreceiver
- [x] receiver/webhookeventreceiver
- [x] receiver/zookeeperreceiver



**Link to tracking Issue:** 
- #31240 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>