### PR TITLE
[receiver/filelog] Fix log level when no matches found

### DIFF
--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -128,7 +128,7 @@ func (m *Manager) poll(ctx context.Context) {
 	// Get the list of paths on disk
 	matches, err := m.fileMatcher.MatchFiles()
 	if err != nil {
-		m.Warnf("finding files: %v", err)
+		m.Debugf("finding files: %v", err)
 	}
 	m.Debugw("matched files", zap.Strings("paths", matches))
 


### PR DESCRIPTION
Fixes #https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26525 again.