### PR TITLE
[CI] refactor unittest-execution

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -234,6 +234,16 @@ jobs:
         run: |
           make generate-gh-issue-templates
           git diff --exit-code '.github/ISSUE_TEMPLATE' || (echo 'Dropdowns in issue templates are out of date, please run "make generate-gh-issue-templates" and commit the changes in this PR.' && exit 1)
+  go-versions:
+      name: Lookup Go versions
+      runs-on: ubuntu-latest
+      outputs:
+        version: ${{ steps.versions.outputs.go-mod-version }}
+        latest: ${{ steps.versions.outputs.latest }}
+      steps:
+        - uses: actions/checkout@v3
+        - uses: arnested/go-version-action@v1
+          id: versions
   unittest-matrix:
     strategy:
       matrix:
@@ -254,7 +264,7 @@ jobs:
           - cmd-1
           - other
     runs-on: ubuntu-latest
-    needs: [setup-environment]
+    needs: [setup-environment, go-versions]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -282,13 +292,13 @@ jobs:
           path: ~/.cache/go-build
           key: go-test-build-${{ runner.os }}-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
-        if: startsWith( matrix.go-version, '1.21' ) != true
+        if: startsWith( matrix.go-version, needs.go-versions.outputs.latest ) 
         run: make gotest GROUP=${{ matrix.group }}
       - name: Run Unit Tests With Coverage
-        if: startsWith( matrix.go-version, '1.21' ) # only run coverage on one version
+        if: startsWith( matrix.go-version, needs.go-versions.outputs.version ) # only run coverage on one version
         run: make gotest-with-cover GROUP=${{ matrix.group }}
       - uses: actions/upload-artifact@v4
-        if: startsWith( matrix.go-version, '1.21' ) # only upload artifact for one version
+        if: startsWith( matrix.go-version, needs.go-versions.outputs.version ) # only upload artifact for one version
         with:
           name: coverage-artifacts-${{ matrix.go-version }}-${{ matrix.group }}
           path: ${{ matrix.group }}-coverage.txt


### PR DESCRIPTION
**Description:** <Describe what has changed.>
I checked for GitHub-indices based on the go-version, but turns out that GitHub doesn't provide anything like that.

So i did some research and found a Github-Action which scans go.mod file/(s) and latest go-version. It can be stored into variables or a file. In this case we could use it to check our matrix-version, so that we later on can differenciate between unit tests and unit tests with coverage.

On top of that we could also refactor `unittest-matrix` to be replaced by a matrix, which is provided by this action. 
Code could like this:

```
  unittest-matrix:
    strategy:
      matrix:
        go-version: ${{ fromJSON(needs.go-versions.outputs.matrix)}} # 1.20 is interpreted as 1.2 without quotes

```
But this would only provide the used go-versions in go.mod-files + the latest go-version.
So if all go.mod-files only consist of go-version 1.21 we won't have the matrix testing version 1.21.8 but instead testing 1.21.
So i'm not quite sure if this is valuable enough.

**Link to tracking Issue:** <Issue number if applicable>
- #30358 

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** 

### GitHub-Action:
- [https://github.com/marketplace/actions/go-version-action](url)