### PR TITLE
[chore] Run a check on codeowners, backed by a github token

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -224,6 +224,10 @@ jobs:
         run: |
           make gendistributions
           git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gendistributions" and commit the changes in this PR.' && exit 1)
+      - name: Gen CODEOWNERS
+        run: |
+          GITHUB_TOKEN=${{ secrets.READ_ORG_AND_USER_TOKEN }} make gengithub
+          git diff -s --exit-code || (echo 'Generated code is out of date, please apply this diff and commit the changes in this PR.' && git diff && exit 1)
       - name: CodeGen
         run: |
           make -j2 generate

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -225,6 +225,7 @@ jobs:
           make gendistributions
           git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gendistributions" and commit the changes in this PR.' && exit 1)
       - name: Gen CODEOWNERS
+        if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
         run: |
           GITHUB_TOKEN=${{ secrets.READ_ORG_AND_USER_TOKEN }} make gengithub
           git diff -s --exit-code || (echo 'Generated code is out of date, please apply this diff and commit the changes in this PR.' && git diff && exit 1)


### PR DESCRIPTION
This PR introduces a check backed by a github token that tests the content of .github/CODEOWNERS against the metadata of all the components. Given that a token is used, and won't be present in builds running with forks, this check is only made on the main branch of the repository `open-telemetry/opentelemetry-collector-contrib`.

As such, I can't really test if it all works. The token is provisioned by https://github.com/open-telemetry/community/issues/1659. More context in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30552