### PR TITLE
[pkg/stanza/adapter] Fix scope parsing

### DIFF
--- a/.chloggen/ft-scope-groupping.yaml
+++ b/.chloggen/ft-scope-groupping.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix missing scope name and group logs based on scope
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [23387]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,7 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
   
 - `opencensusreceiver`: Refactor the opencensusreceiver to pass lifecycle tests and avoid leaking gRPC connections. (#31643)
 - `sqlqueryreceiver`: Fix memory leak on shutdown for log telemetry (#31782)
+- `pkg/stanza/adapter`: Fix missing scope name and group logs based on scope ( #23387)
 
 ## v0.96.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,6 @@ If you are looking for developer-facing changes, check out [CHANGELOG-API.md](./
   
 - `opencensusreceiver`: Refactor the opencensusreceiver to pass lifecycle tests and avoid leaking gRPC connections. (#31643)
 - `sqlqueryreceiver`: Fix memory leak on shutdown for log telemetry (#31782)
-- `pkg/stanza/adapter`: Fix missing scope name and group logs based on scope ( #23387)
 
 ## v0.96.0
 

--- a/pkg/stanza/adapter/converter.go
+++ b/pkg/stanza/adapter/converter.go
@@ -148,20 +148,43 @@ func (c *Converter) workerLoop() {
 			}
 
 			resourceHashToIdx := make(map[uint64]int)
+			scopeIdxByResource := make(map[uint64]map[string]int)
 
 			pLogs := plog.NewLogs()
 			var sl plog.ScopeLogs
+
+			/**
+				[ {resourceId, scope name} ]
+			**/
 			for _, e := range entries {
 				resourceID := HashResource(e.Resource)
+				scopeName := e.ScopeName
+				var rl plog.ResourceLogs
+
 				resourceIdx, ok := resourceHashToIdx[resourceID]
 				if !ok {
 					resourceHashToIdx[resourceID] = pLogs.ResourceLogs().Len()
-					rl := pLogs.ResourceLogs().AppendEmpty()
+
+					rl = pLogs.ResourceLogs().AppendEmpty()
 					upsertToMap(e.Resource, rl.Resource().Attributes())
+
+					scopeIdxByResource[resourceID] = make(map[string]int)
+					scopeIdxByResource[resourceID][scopeName] = rl.ScopeLogs().Len()
 					sl = rl.ScopeLogs().AppendEmpty()
+					sl.Scope().SetName(scopeName)
 				} else {
-					sl = pLogs.ResourceLogs().At(resourceIdx).ScopeLogs().At(0)
+					rl = pLogs.ResourceLogs().At(resourceIdx)
+					scopesInThisResource, _ := scopeIdxByResource[resourceID]
+					scopeIdxInResource, ok := scopesInThisResource[scopeName]
+					if !ok {
+						scopesInThisResource[scopeName] = rl.ScopeLogs().Len()
+						sl = rl.ScopeLogs().AppendEmpty()
+						sl.Scope().SetName(scopeName)
+					} else {
+						sl = pLogs.ResourceLogs().At(resourceIdx).ScopeLogs().At(scopeIdxInResource)
+					}
 				}
+
 				convertInto(e, sl.LogRecords().AppendEmpty())
 			}
 

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -397,7 +397,7 @@ func TestAllConvertedEntriesScopeGrouping(t *testing.T) {
 
 			go func() {
 				entries := complexEntriesForNDifferentHostsMDifferentScopes(100, 1, tc.numberOFScopes)
-				converter.Batch(entries)
+				assert.NoError(t, converter.Batch(entries))
 			}()
 
 			var (

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -367,7 +367,7 @@ func TestHashResource(t *testing.T) {
 	}
 }
 
-func TestAllConvertedEntriesAndHaveScope(t *testing.T) {
+func TestAllConvertedEntriesScopeGrouping(t *testing.T) {
 	t.Parallel()
 
 	testcases := []struct {

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -89,6 +89,53 @@ func complexEntriesForNDifferentHosts(count int, n int) []*entry.Entry {
 	return ret
 }
 
+func complexEntriesForNDifferentHostsMDifferentScopes(count int, n int, m int) []*entry.Entry {
+	ret := make([]*entry.Entry, count)
+	for i := 0; i < count; i++ {
+		for j := 0; j < m; j++ {
+			e := entry.New()
+			e.Severity = entry.Error
+			e.Resource = map[string]any{
+				"host":   fmt.Sprintf("host-%d", i%n),
+				"bool":   true,
+				"int":    123,
+				"double": 12.34,
+				"string": "hello",
+				"object": map[string]any{
+					"bool":   true,
+					"int":    123,
+					"double": 12.34,
+					"string": "hello",
+				},
+			}
+			e.Body = map[string]any{
+				"bool":   true,
+				"int":    123,
+				"double": 12.34,
+				"string": "hello",
+				"bytes":  []byte("asdf"),
+				"object": map[string]any{
+					"bool":   true,
+					"int":    123,
+					"double": 12.34,
+					"string": "hello",
+					"bytes":  []byte("asdf"),
+					"object": map[string]any{
+						"bool":   true,
+						"int":    123,
+						"double": 12.34,
+						"string": "hello",
+						"bytes":  []byte("asdf"),
+					},
+				},
+			}
+			e.ScopeName = fmt.Sprintf("scope-%d", j)
+			ret[i] = e
+		}
+	}
+	return ret
+}
+
 func complexEntry() *entry.Entry {
 	e := entry.New()
 	e.Severity = entry.Error


### PR DESCRIPTION


**Description:** <Describe what has changed.>
Fix:   #23387 
Adds grouping of logrecords based on scope

 - adds scope grouping along with scope name
 - adds integration test for benchmark

**Link to tracking Issue:**  #23387 

**Testing:**
1. Did some benchmark on this build, results below:
On main branch: `BenchmarkEmitterToConsumer`: ~3.12
On my branch: `BenchmarkEmitterToConsumer`: ~3.26
on my branch: `BenchmarkEmitterToConsumerScopeGroupping` (with 2 host variation and 2 scope variation): ~4.2s
2. Added unit tests

**Documentation:** <Describe the documentation added.>