### PR TITLE
[chore][internal/docker] Enable goleak check

### DIFF
--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -230,7 +230,9 @@ func TestEventLoopHandlesError(t *testing.T) {
 	assert.NotNil(t, cli)
 	assert.NoError(t, err)
 
-	go cli.ContainerEventLoop(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	go cli.ContainerEventLoop(ctx)
+	defer cancel()
 
 	assert.Eventually(t, func() bool {
 		for _, l := range logs.All() {

--- a/internal/docker/go.mod
+++ b/internal/docker/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/docker/docker v25.0.5+incompatible
 	github.com/gobwas/glob v0.2.3
 	github.com/stretchr/testify v1.9.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
 

--- a/internal/docker/package_test.go
+++ b/internal/docker/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package docker
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables `goleak` to help ensure no goroutines are being leaked in the `internal/docker` package. This is a test only change, an existing test was leaking a goroutine because it wasn't cancelling a context properly.

**Link to tracking Issue:** <Issue number if applicable>
#30438 

**Testing:** <Describe what testing was performed and which tests were added.>
Existing tests are passing, as well as added `goleak` check.