### PR TITLE
[chore] [exporter/clickhouse] add warnings to metadata

### DIFF
--- a/exporter/clickhouseexporter/metadata.yaml
+++ b/exporter/clickhouseexporter/metadata.yaml
@@ -6,6 +6,7 @@ status:
   stability:
     alpha: [traces, metrics, logs]
   distributions: [contrib]
+  warnings: []
   codeowners:
     active: [hanjm, dmitryax, Frapschen, SpencerTorres]
 


### PR DESCRIPTION
**Description:**
Resolves #32041

Also allows marking this exporter as completed on #19172

Declare in the `metadata.yaml` that this exporter has no warnings.
Because there are no warnings, there is no change to the `README.md` after running `make generate`
