### PR TITLE
[pkg/stanza] Revert recombine operator 'overwrite_with' change

### DIFF
--- a/.chloggen/pkg-stanza-revert-overwrite-with.yaml
+++ b/.chloggen/pkg-stanza-revert-overwrite-with.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Revert recombine operator's 'overwrite_with' default value.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30783]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+    Restores the previous the default value of `oldest`, meaning that the recombine operator will emit the
+    first entry from each batch (with the recombined field). This fixes the bug introduced by 30783 and restores
+    the default setting so as to effectively cancel out the bug for users who were not using this setting.
+    For users who were explicitly setting `overwrite_with`, this corrects the intended behavior.
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/transformer/recombine/config.go
+++ b/pkg/stanza/operator/transformer/recombine/config.go
@@ -38,7 +38,7 @@ func NewConfigWithID(operatorID string) *Config {
 		MaxBatchSize:      1000,
 		MaxSources:        1000,
 		CombineWith:       defaultCombineWith,
-		OverwriteWith:     "newest",
+		OverwriteWith:     "oldest",
 		ForceFlushTimeout: 5 * time.Second,
 		SourceIdentifier:  entry.NewAttributeField("file.path"),
 	}
@@ -94,12 +94,12 @@ func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		return nil, fmt.Errorf("missing required argument 'combine_field'")
 	}
 
-	var overwriteWithOldest bool
+	var overwriteWithNewest bool
 	switch c.OverwriteWith {
 	case "newest":
-		overwriteWithOldest = false
+		overwriteWithNewest = true
 	case "oldest", "":
-		overwriteWithOldest = true
+		overwriteWithNewest = false
 	default:
 		return nil, fmt.Errorf("invalid value '%s' for parameter 'overwrite_with'", c.OverwriteWith)
 	}
@@ -110,7 +110,7 @@ func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		prog:                prog,
 		maxBatchSize:        c.MaxBatchSize,
 		maxSources:          c.MaxSources,
-		overwriteWithOldest: overwriteWithOldest,
+		overwriteWithNewest: overwriteWithNewest,
 		batchMap:            make(map[string]*sourceBatch),
 		batchPool: sync.Pool{
 			New: func() any {

--- a/pkg/stanza/operator/transformer/recombine/transformer.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer.go
@@ -26,7 +26,7 @@ type Transformer struct {
 	prog                *vm.Program
 	maxBatchSize        int
 	maxSources          int
-	overwriteWithOldest bool
+	overwriteWithNewest bool
 	combineField        entry.Field
 	combineWith         string
 	ticker              *time.Ticker
@@ -154,7 +154,7 @@ func (t *Transformer) addToBatch(ctx context.Context, e *entry.Entry, source str
 		batch = t.addNewBatch(source, e)
 	} else {
 		batch.numEntries++
-		if t.overwriteWithOldest {
+		if t.overwriteWithNewest {
 			batch.baseEntry = e
 		}
 	}

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -123,12 +123,12 @@ func TestTransformer(t *testing.T) {
 				return cfg
 			}(),
 			[]*entry.Entry{
-				entryWithBody(t1, "test1"),
-				entryWithBody(t2, "test2"),
-				entryWithBody(t2, "test1"),
+				entryWithBodyAttr(t1, "test1", map[string]string{"base": "false"}),
+				entryWithBodyAttr(t2, "test2", map[string]string{"base": "true"}),
+				entryWithBodyAttr(t2, "test1", map[string]string{"base": "false"}),
 			},
 			[]*entry.Entry{
-				entryWithBody(t1, "test1\ntest2"),
+				entryWithBodyAttr(t2, "test1\ntest2", map[string]string{"base": "true"}),
 			},
 		},
 		{
@@ -142,12 +142,12 @@ func TestTransformer(t *testing.T) {
 				return cfg
 			}(),
 			[]*entry.Entry{
-				entryWithBody(t1, "test1"),
-				entryWithBody(t2, "test2"),
-				entryWithBody(t2, "test1"),
+				entryWithBodyAttr(t1, "test1", map[string]string{"base": "true"}),
+				entryWithBodyAttr(t2, "test2", map[string]string{"base": "false"}),
+				entryWithBodyAttr(t2, "test1", map[string]string{"base": "true"}),
 			},
 			[]*entry.Entry{
-				entryWithBody(t2, "test1\ntest2"),
+				entryWithBodyAttr(t1, "test1\ntest2", map[string]string{"base": "true"}),
 			},
 		},
 		{
@@ -157,7 +157,7 @@ func TestTransformer(t *testing.T) {
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsFirstEntry = "$body == 'test1'"
 				cfg.OutputIDs = []string{"fake"}
-				cfg.OverwriteWith = "newest"
+				cfg.OverwriteWith = "oldest"
 				cfg.ForceFlushTimeout = 10 * time.Millisecond
 				return cfg
 			}(),
@@ -177,7 +177,7 @@ func TestTransformer(t *testing.T) {
 				cfg.CombineField = entry.NewBodyField()
 				cfg.IsFirstEntry = "body == 'start'"
 				cfg.OutputIDs = []string{"fake"}
-				cfg.OverwriteWith = "oldest"
+				cfg.OverwriteWith = "newest"
 				cfg.ForceFlushTimeout = 10 * time.Millisecond
 				return cfg
 			}(),
@@ -286,7 +286,7 @@ func TestTransformer(t *testing.T) {
 				cfg.CombineField = entry.NewBodyField("message")
 				cfg.CombineWith = ""
 				cfg.IsLastEntry = "body.logtag == 'F'"
-				cfg.OverwriteWith = "oldest"
+				cfg.OverwriteWith = "newest"
 				cfg.OutputIDs = []string{"fake"}
 				return cfg
 			}(),
@@ -380,7 +380,7 @@ func TestTransformer(t *testing.T) {
 				cfg.IsLastEntry = "body == 'end'"
 				cfg.OutputIDs = []string{"fake"}
 				cfg.MaxSources = 1
-				cfg.OverwriteWith = "oldest"
+				cfg.OverwriteWith = "newest"
 				cfg.ForceFlushTimeout = 10 * time.Millisecond
 				return cfg
 			}(),

--- a/tmp
+++ b/tmp
@@ -1,0 +1,9439 @@
+Check License finished successfully
+running /Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/.tools/misspell -error
+/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/.tools/golangci-lint run --allow-parallel-runners --verbose --build-tags integration --timeout=30m --path-prefix stanza
+/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/.tools/gotestsum --rerun-fails=1 --packages="./..." -- -race -timeout 300s -parallel 4 --tags=""
+∅  decode
+✓  errors (cached)
+✓  adapter (cached)
+✓  entry (cached)
+∅  fileconsumer/emit
+∅  fileconsumer/internal/filetest (cached)
+✓  fileconsumer/internal/fileset (cached)
+✓  fileconsumer/internal/checkpoint (cached)
+✓  fileconsumer/internal/emittest (cached)
+✓  fileconsumer/internal/fingerprint (cached)
+✓  fileconsumer/internal/header (cached)
+✓  fileconsumer/attrs (cached)
+✓  fileconsumer/internal/reader (cached)
+✓  fileconsumer (cached)
+✓  fileconsumer/internal/scanner (cached)
+✓  fileconsumer/internal/trie (cached)
+✓  fileconsumer/internal/util (cached)
+✓  fileconsumer/matcher (cached)
+✓  fileconsumer/matcher/internal/filter (cached)
+✓  fileconsumer/matcher/internal/finder (cached)
+∅  operator/input/journald (cached)
+✓  operator/input/stdin (cached)
+∅  operator/input/namedpipe (cached)
+✓  operator (cached)
+✓  operator/input/generate (cached)
+✓  flush (cached)
+✓  operator/input/tcp (cached)
+✓  operator/input/syslog (cached)
+✓  operator/input/file (cached)
+✓  operator/input/udp (cached)
+✓  operator/helper (cached)
+✓  operator/input/windows (cached)
+∅  operator/operatortest (1ms)
+✓  operator/output/drop (cached)
+✓  operator/output/stdout (cached)
+∅  operator/output/file
+✓  operator/parser/json (cached)
+✓  operator/parser/csv (cached)
+✓  operator/parser/jsonarray (cached)
+✓  operator/parser/keyvalue (cached)
+✓  operator/parser/regex (cached)
+✓  operator/parser/scope (cached)
+✓  operator/parser/severity (cached)
+✓  operator/parser/syslog (cached)
+✓  operator/parser/trace (cached)
+✓  operator/parser/time (cached)
+✓  operator/parser/uri (cached)
+✓  operator/transformer/add (cached)
+✓  operator/transformer/assignkeys (cached)
+✓  operator/transformer/copy (cached)
+✓  operator/transformer/filter (cached)
+✓  operator/transformer/flatten (cached)
+✓  operator/transformer/move (cached)
+✓  operator/transformer/noop (cached)
+∅  testutil
+✓  operator/transformer/unquote (cached)
+✓  operator/transformer/router (cached)
+✓  operator/transformer/remove (cached)
+✓  operator/transformer/retain (cached)
+✓  split/splittest (cached)
+✓  trim (cached)
+✓  pipeline (cached)
+✓  split (cached)
+✖  operator/transformer/recombine (481ms)
+
+DONE 3233 tests, 1 skipped, 3 failures in 1.661s
+
+✖  operator/transformer/recombine (220ms)
+✖  operator/transformer/recombine (227ms)
+
+=== Skipped
+=== SKIP: operator/transformer/assignkeys TestBuildAndProcess/BuildandProcess/assign_keys_missing_keys (0.00s)
+
+=== Failed
+=== FAIL: operator/transformer/recombine TestTransformer/ThreeEntriesFirstNewest (0.04s)
+    mocks.go:117: 
+        	Error Trace:	/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil/mocks.go:117
+        	            				/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer_test.go:518
+        	Error:      	elements differ
+        	            	
+        	            	extra elements in list A:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	extra elements in list B:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listA:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) (len=5) "Local",
+        	            	    zone: ([]time.zone) (len=8) {
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "LMT",
+        	            	      offset: (int) -21036,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CDT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "EST",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CWT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CPT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     }
+        	            	    },
+        	            	    tx: ([]time.zoneTrans) (len=236) {
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -2717647200,
+        	            	      index: (uint8) 3,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1633276800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1615136400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1601827200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1583686800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1563724800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1551632400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1538928000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1520182800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1504454400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1491757200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1473004800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1459702800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1441555200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1428253200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1410105600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1396803600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1378656000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1365354000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1347206400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1333904400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1315152000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1301850000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1283702400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1270400400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1252252800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1238950800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1220803200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1207501200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1189353600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1176051600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1157299200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1144602000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1125849600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1112547600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1094400000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1081098000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1067788800,
+        	            	      index: (uint8) 4,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1045414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1031500800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1018198800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1000051200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -986749200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -967996800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -955299600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -936547200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -923245200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -905097600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -891795600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -880214400,
+        	            	      index: (uint8) 5,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -769395600,
+        	            	      index: (uint8) 6,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -765392400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -747244800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -733942800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -715795200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -702493200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -684345600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -671043600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -652896000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -639594000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -620841600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -608144400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -589392000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -576090000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -557942400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -544640400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -526492800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -513190800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -495043200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -481741200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -463593600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -447267600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -431539200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -415818000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -400089600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -384368400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -368640000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -352918800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -337190400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -321469200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -305740800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -289414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -273686400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -257965200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -242236800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -226515600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -210787200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -195066000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -179337600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -163616400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -147888000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -131562000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -116438400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -100112400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -84384000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -68662800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -52934400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -37213200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -21484800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -5763600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 9964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 25686000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 41414400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 57740400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 73468800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 89190000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 104918400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 120639600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 126691200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 152089200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 162374400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 183538800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 199267200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 215593200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 230716800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 247042800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 262771200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 278492400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 294220800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 309942000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 325670400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 341391600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 357120000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 372841200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 388569600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 404895600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 420019200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 436345200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 452073600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 467794800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 483523200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 499244400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 514972800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 530694000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 544608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 562143600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 576057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 594198000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 607507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 625647600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 638956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 657097200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 671011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 688546800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 702460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 719996400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 733910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 752050800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 765360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 783500400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 796809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 814950000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 828864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 846399600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 860313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 877849200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 891763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 909298800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 923212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 941353200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 954662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 972802800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 986112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1004252400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1018166400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1035702000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1049616000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1067151600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1081065600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1099206000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1112515200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1130655600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1143964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1162105200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1173600000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1194159600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1205049600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1225609200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1236499200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1257058800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1268553600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1289113200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1300003200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1320562800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1331452800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1352012400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1362902400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1383462000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1394352000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1414911600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1425801600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1446361200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1457856000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1478415600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1489305600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1509865200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1520755200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1541314800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1552204800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1572764400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1583654400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1604214000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1615708800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1636268400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1647158400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1667718000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1678608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1699167600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1710057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1730617200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1741507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1762066800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1772956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1793516400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1805011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1825570800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1836460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1857020400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1867910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1888470000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1899360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1919919600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1930809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1951369200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1962864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1983423600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1994313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2014873200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2025763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2046322800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2057212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2077772400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2088662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2109222000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2120112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2140671600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     }
+        	            	    },
+        	            	    extend: (string) (len=22) "CST6CDT,M3.2.0,M11.1.0",
+        	            	    cacheStart: (int64) 1710057600,
+        	            	    cacheEnd: (int64) 1730617200,
+        	            	    cacheZone: (*time.zone)({
+        	            	     name: (string) (len=3) "CDT",
+        	            	     offset: (int) -18000,
+        	            	     isDST: (bool) true
+        	            	    })
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listB:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) (len=5) "Local",
+        	            	    zone: ([]time.zone) (len=8) {
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "LMT",
+        	            	      offset: (int) -21036,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CDT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "EST",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CWT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CPT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     }
+        	            	    },
+        	            	    tx: ([]time.zoneTrans) (len=236) {
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -2717647200,
+        	            	      index: (uint8) 3,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1633276800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1615136400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1601827200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1583686800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1563724800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1551632400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1538928000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1520182800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1504454400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1491757200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1473004800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1459702800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1441555200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1428253200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1410105600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1396803600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1378656000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1365354000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1347206400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1333904400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1315152000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1301850000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1283702400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1270400400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1252252800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1238950800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1220803200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1207501200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1189353600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1176051600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1157299200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1144602000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1125849600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1112547600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1094400000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1081098000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1067788800,
+        	            	      index: (uint8) 4,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1045414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1031500800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1018198800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1000051200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -986749200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -967996800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -955299600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -936547200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -923245200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -905097600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -891795600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -880214400,
+        	            	      index: (uint8) 5,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -769395600,
+        	            	      index: (uint8) 6,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -765392400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -747244800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -733942800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -715795200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -702493200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -684345600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -671043600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -652896000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -639594000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -620841600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -608144400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -589392000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -576090000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -557942400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -544640400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -526492800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -513190800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -495043200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -481741200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -463593600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -447267600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -431539200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -415818000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -400089600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -384368400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -368640000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -352918800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -337190400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -321469200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -305740800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -289414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -273686400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -257965200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -242236800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -226515600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -210787200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -195066000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -179337600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -163616400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -147888000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -131562000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -116438400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -100112400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -84384000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -68662800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -52934400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -37213200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -21484800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -5763600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 9964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 25686000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 41414400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 57740400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 73468800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 89190000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 104918400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 120639600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 126691200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 152089200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 162374400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 183538800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 199267200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 215593200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 230716800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 247042800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 262771200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 278492400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 294220800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 309942000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 325670400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 341391600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 357120000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 372841200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 388569600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 404895600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 420019200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 436345200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 452073600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 467794800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 483523200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 499244400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 514972800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 530694000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 544608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 562143600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 576057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 594198000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 607507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 625647600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 638956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 657097200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 671011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 688546800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 702460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 719996400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 733910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 752050800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 765360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 783500400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 796809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 814950000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 828864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 846399600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 860313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 877849200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 891763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 909298800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 923212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 941353200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 954662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 972802800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 986112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1004252400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1018166400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1035702000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1049616000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1067151600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1081065600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1099206000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1112515200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1130655600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1143964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1162105200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1173600000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1194159600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1205049600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1225609200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1236499200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1257058800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1268553600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1289113200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1300003200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1320562800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1331452800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1352012400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1362902400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1383462000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1394352000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1414911600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1425801600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1446361200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1457856000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1478415600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1489305600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1509865200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1520755200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1541314800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1552204800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1572764400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1583654400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1604214000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1615708800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1636268400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1647158400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1667718000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1678608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1699167600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1710057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1730617200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1741507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1762066800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1772956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1793516400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1805011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1825570800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1836460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1857020400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1867910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1888470000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1899360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1919919600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1930809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1951369200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1962864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1983423600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1994313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2014873200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2025763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2046322800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2057212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2077772400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2088662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2109222000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2120112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2140671600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     }
+        	            	    },
+        	            	    extend: (string) (len=22) "CST6CDT,M3.2.0,M11.1.0",
+        	            	    cacheStart: (int64) 1710057600,
+        	            	    cacheEnd: (int64) 1730617200,
+        	            	    cacheZone: (*time.zone)({
+        	            	     name: (string) (len=3) "CDT",
+        	            	     offset: (int) -18000,
+        	            	     isDST: (bool) true
+        	            	    })
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	Test:       	TestTransformer/ThreeEntriesFirstNewest
+
+=== FAIL: operator/transformer/recombine TestTransformer/ThreeEntriesFirstOldest (0.03s)
+    mocks.go:117: 
+        	Error Trace:	/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil/mocks.go:117
+        	            				/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer_test.go:518
+        	Error:      	elements differ
+        	            	
+        	            	extra elements in list A:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) (len=5) "Local",
+        	            	    zone: ([]time.zone) (len=8) {
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "LMT",
+        	            	      offset: (int) -21036,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CDT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "EST",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CWT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CPT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     }
+        	            	    },
+        	            	    tx: ([]time.zoneTrans) (len=236) {
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -2717647200,
+        	            	      index: (uint8) 3,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1633276800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1615136400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1601827200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1583686800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1563724800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1551632400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1538928000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1520182800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1504454400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1491757200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1473004800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1459702800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1441555200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1428253200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1410105600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1396803600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1378656000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1365354000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1347206400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1333904400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1315152000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1301850000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1283702400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1270400400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1252252800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1238950800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1220803200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1207501200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1189353600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1176051600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1157299200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1144602000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1125849600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1112547600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1094400000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1081098000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1067788800,
+        	            	      index: (uint8) 4,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1045414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1031500800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1018198800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1000051200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -986749200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -967996800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -955299600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -936547200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -923245200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -905097600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -891795600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -880214400,
+        	            	      index: (uint8) 5,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -769395600,
+        	            	      index: (uint8) 6,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -765392400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -747244800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -733942800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -715795200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -702493200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -684345600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -671043600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -652896000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -639594000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -620841600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -608144400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -589392000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -576090000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -557942400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -544640400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -526492800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -513190800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -495043200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -481741200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -463593600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -447267600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -431539200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -415818000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -400089600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -384368400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -368640000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -352918800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -337190400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -321469200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -305740800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -289414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -273686400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -257965200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -242236800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -226515600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -210787200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -195066000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -179337600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -163616400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -147888000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -131562000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -116438400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -100112400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -84384000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -68662800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -52934400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -37213200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -21484800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -5763600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 9964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 25686000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 41414400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 57740400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 73468800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 89190000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 104918400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 120639600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 126691200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 152089200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 162374400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 183538800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 199267200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 215593200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 230716800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 247042800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 262771200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 278492400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 294220800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 309942000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 325670400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 341391600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 357120000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 372841200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 388569600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 404895600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 420019200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 436345200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 452073600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 467794800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 483523200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 499244400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 514972800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 530694000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 544608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 562143600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 576057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 594198000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 607507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 625647600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 638956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 657097200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 671011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 688546800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 702460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 719996400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 733910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 752050800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 765360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 783500400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 796809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 814950000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 828864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 846399600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 860313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 877849200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 891763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 909298800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 923212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 941353200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 954662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 972802800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 986112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1004252400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1018166400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1035702000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1049616000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1067151600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1081065600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1099206000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1112515200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1130655600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1143964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1162105200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1173600000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1194159600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1205049600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1225609200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1236499200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1257058800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1268553600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1289113200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1300003200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1320562800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1331452800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1352012400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1362902400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1383462000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1394352000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1414911600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1425801600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1446361200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1457856000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1478415600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1489305600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1509865200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1520755200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1541314800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1552204800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1572764400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1583654400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1604214000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1615708800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1636268400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1647158400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1667718000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1678608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1699167600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1710057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1730617200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1741507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1762066800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1772956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1793516400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1805011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1825570800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1836460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1857020400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1867910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1888470000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1899360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1919919600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1930809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1951369200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1962864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1983423600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1994313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2014873200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2025763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2046322800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2057212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2077772400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2088662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2109222000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2120112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2140671600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     }
+        	            	    },
+        	            	    extend: (string) (len=22) "CST6CDT,M3.2.0,M11.1.0",
+        	            	    cacheStart: (int64) 1710057600,
+        	            	    cacheEnd: (int64) 1730617200,
+        	            	    cacheZone: (*time.zone)({
+        	            	     name: (string) (len=3) "CDT",
+        	            	     offset: (int) -18000,
+        	            	     isDST: (bool) true
+        	            	    })
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	extra elements in list B:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) (len=5) "Local",
+        	            	    zone: ([]time.zone) (len=8) {
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "LMT",
+        	            	      offset: (int) -21036,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CDT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "EST",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CWT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CPT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     }
+        	            	    },
+        	            	    tx: ([]time.zoneTrans) (len=236) {
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -2717647200,
+        	            	      index: (uint8) 3,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1633276800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1615136400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1601827200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1583686800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1563724800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1551632400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1538928000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1520182800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1504454400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1491757200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1473004800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1459702800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1441555200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1428253200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1410105600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1396803600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1378656000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1365354000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1347206400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1333904400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1315152000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1301850000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1283702400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1270400400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1252252800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1238950800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1220803200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1207501200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1189353600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1176051600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1157299200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1144602000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1125849600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1112547600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1094400000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1081098000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1067788800,
+        	            	      index: (uint8) 4,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1045414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1031500800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1018198800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1000051200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -986749200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -967996800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -955299600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -936547200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -923245200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -905097600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -891795600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -880214400,
+        	            	      index: (uint8) 5,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -769395600,
+        	            	      index: (uint8) 6,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -765392400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -747244800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -733942800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -715795200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -702493200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -684345600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -671043600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -652896000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -639594000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -620841600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -608144400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -589392000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -576090000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -557942400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -544640400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -526492800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -513190800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -495043200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -481741200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -463593600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -447267600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -431539200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -415818000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -400089600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -384368400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -368640000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -352918800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -337190400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -321469200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -305740800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -289414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -273686400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -257965200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -242236800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -226515600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -210787200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -195066000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -179337600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -163616400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -147888000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -131562000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -116438400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -100112400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -84384000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -68662800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -52934400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -37213200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -21484800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -5763600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 9964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 25686000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 41414400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 57740400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 73468800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 89190000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 104918400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 120639600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 126691200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 152089200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 162374400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 183538800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 199267200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 215593200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 230716800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 247042800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 262771200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 278492400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 294220800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 309942000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 325670400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 341391600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 357120000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 372841200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 388569600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 404895600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 420019200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 436345200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 452073600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 467794800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 483523200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 499244400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 514972800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 530694000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 544608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 562143600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 576057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 594198000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 607507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 625647600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 638956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 657097200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 671011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 688546800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 702460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 719996400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 733910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 752050800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 765360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 783500400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 796809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 814950000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 828864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 846399600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 860313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 877849200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 891763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 909298800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 923212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 941353200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 954662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 972802800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 986112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1004252400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1018166400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1035702000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1049616000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1067151600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1081065600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1099206000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1112515200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1130655600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1143964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1162105200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1173600000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1194159600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1205049600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1225609200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1236499200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1257058800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1268553600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1289113200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1300003200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1320562800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1331452800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1352012400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1362902400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1383462000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1394352000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1414911600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1425801600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1446361200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1457856000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1478415600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1489305600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1509865200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1520755200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1541314800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1552204800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1572764400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1583654400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1604214000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1615708800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1636268400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1647158400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1667718000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1678608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1699167600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1710057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1730617200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1741507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1762066800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1772956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1793516400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1805011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1825570800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1836460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1857020400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1867910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1888470000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1899360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1919919600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1930809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1951369200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1962864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1983423600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1994313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2014873200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2025763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2046322800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2057212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2077772400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2088662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2109222000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2120112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2140671600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     }
+        	            	    },
+        	            	    extend: (string) (len=22) "CST6CDT,M3.2.0,M11.1.0",
+        	            	    cacheStart: (int64) 1710057600,
+        	            	    cacheEnd: (int64) 1730617200,
+        	            	    cacheZone: (*time.zone)({
+        	            	     name: (string) (len=3) "CDT",
+        	            	     offset: (int) -18000,
+        	            	     isDST: (bool) true
+        	            	    })
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listA:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) (len=5) "Local",
+        	            	    zone: ([]time.zone) (len=8) {
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "LMT",
+        	            	      offset: (int) -21036,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CDT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "EST",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CWT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CPT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     }
+        	            	    },
+        	            	    tx: ([]time.zoneTrans) (len=236) {
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -2717647200,
+        	            	      index: (uint8) 3,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1633276800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1615136400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1601827200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1583686800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1563724800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1551632400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1538928000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1520182800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1504454400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1491757200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1473004800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1459702800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1441555200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1428253200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1410105600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1396803600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1378656000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1365354000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1347206400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1333904400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1315152000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1301850000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1283702400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1270400400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1252252800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1238950800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1220803200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1207501200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1189353600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1176051600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1157299200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1144602000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1125849600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1112547600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1094400000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1081098000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1067788800,
+        	            	      index: (uint8) 4,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1045414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1031500800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1018198800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1000051200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -986749200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -967996800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -955299600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -936547200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -923245200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -905097600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -891795600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -880214400,
+        	            	      index: (uint8) 5,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -769395600,
+        	            	      index: (uint8) 6,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -765392400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -747244800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -733942800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -715795200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -702493200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -684345600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -671043600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -652896000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -639594000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -620841600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -608144400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -589392000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -576090000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -557942400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -544640400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -526492800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -513190800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -495043200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -481741200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -463593600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -447267600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -431539200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -415818000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -400089600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -384368400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -368640000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -352918800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -337190400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -321469200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -305740800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -289414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -273686400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -257965200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -242236800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -226515600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -210787200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -195066000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -179337600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -163616400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -147888000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -131562000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -116438400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -100112400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -84384000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -68662800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -52934400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -37213200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -21484800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -5763600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 9964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 25686000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 41414400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 57740400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 73468800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 89190000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 104918400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 120639600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 126691200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 152089200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 162374400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 183538800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 199267200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 215593200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 230716800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 247042800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 262771200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 278492400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 294220800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 309942000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 325670400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 341391600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 357120000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 372841200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 388569600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 404895600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 420019200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 436345200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 452073600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 467794800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 483523200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 499244400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 514972800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 530694000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 544608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 562143600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 576057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 594198000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 607507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 625647600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 638956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 657097200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 671011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 688546800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 702460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 719996400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 733910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 752050800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 765360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 783500400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 796809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 814950000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 828864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 846399600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 860313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 877849200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 891763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 909298800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 923212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 941353200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 954662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 972802800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 986112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1004252400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1018166400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1035702000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1049616000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1067151600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1081065600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1099206000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1112515200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1130655600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1143964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1162105200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1173600000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1194159600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1205049600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1225609200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1236499200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1257058800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1268553600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1289113200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1300003200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1320562800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1331452800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1352012400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1362902400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1383462000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1394352000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1414911600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1425801600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1446361200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1457856000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1478415600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1489305600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1509865200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1520755200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1541314800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1552204800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1572764400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1583654400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1604214000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1615708800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1636268400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1647158400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1667718000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1678608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1699167600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1710057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1730617200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1741507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1762066800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1772956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1793516400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1805011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1825570800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1836460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1857020400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1867910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1888470000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1899360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1919919600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1930809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1951369200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1962864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1983423600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1994313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2014873200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2025763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2046322800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2057212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2077772400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2088662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2109222000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2120112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2140671600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     }
+        	            	    },
+        	            	    extend: (string) (len=22) "CST6CDT,M3.2.0,M11.1.0",
+        	            	    cacheStart: (int64) 1710057600,
+        	            	    cacheEnd: (int64) 1730617200,
+        	            	    cacheZone: (*time.zone)({
+        	            	     name: (string) (len=3) "CDT",
+        	            	     offset: (int) -18000,
+        	            	     isDST: (bool) true
+        	            	    })
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listB:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869024355453696,
+        	            	   ext: (int64) 16346418,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) (len=5) "Local",
+        	            	    zone: ([]time.zone) (len=8) {
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "LMT",
+        	            	      offset: (int) -21036,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CDT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "EST",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) false
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CWT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CPT",
+        	            	      offset: (int) -18000,
+        	            	      isDST: (bool) true
+        	            	     },
+        	            	     (time.zone) {
+        	            	      name: (string) (len=3) "CST",
+        	            	      offset: (int) -21600,
+        	            	      isDST: (bool) false
+        	            	     }
+        	            	    },
+        	            	    tx: ([]time.zoneTrans) (len=236) {
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -2717647200,
+        	            	      index: (uint8) 3,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1633276800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1615136400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1601827200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1583686800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1563724800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1551632400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) true,
+        	            	      isutc: (bool) true
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1538928000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1520182800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1504454400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1491757200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1473004800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1459702800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1441555200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1428253200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1410105600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1396803600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1378656000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1365354000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1347206400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1333904400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1315152000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1301850000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1283702400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1270400400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1252252800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1238950800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1220803200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1207501200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1189353600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1176051600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1157299200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1144602000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1125849600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1112547600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1094400000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1081098000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1067788800,
+        	            	      index: (uint8) 4,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1045414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1031500800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1018198800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -1000051200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -986749200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -967996800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -955299600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -936547200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -923245200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -905097600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -891795600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -880214400,
+        	            	      index: (uint8) 5,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -769395600,
+        	            	      index: (uint8) 6,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -765392400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -747244800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -733942800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -715795200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -702493200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -684345600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -671043600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -652896000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -639594000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -620841600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -608144400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -589392000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -576090000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -557942400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -544640400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -526492800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -513190800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -495043200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -481741200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -463593600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -447267600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -431539200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -415818000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -400089600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -384368400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -368640000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -352918800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -337190400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -321469200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -305740800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -289414800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -273686400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -257965200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -242236800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -226515600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -210787200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -195066000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -179337600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -163616400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -147888000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -131562000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -116438400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -100112400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -84384000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -68662800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -52934400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -37213200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -21484800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) -5763600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 9964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 25686000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 41414400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 57740400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 73468800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 89190000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 104918400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 120639600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 126691200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 152089200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 162374400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 183538800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 199267200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 215593200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 230716800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 247042800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 262771200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 278492400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 294220800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 309942000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 325670400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 341391600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 357120000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 372841200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 388569600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 404895600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 420019200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 436345200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 452073600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 467794800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 483523200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 499244400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 514972800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 530694000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 544608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 562143600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 576057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 594198000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 607507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 625647600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 638956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 657097200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 671011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 688546800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 702460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 719996400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 733910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 752050800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 765360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 783500400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 796809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 814950000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 828864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 846399600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 860313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 877849200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 891763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 909298800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 923212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 941353200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 954662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 972802800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 986112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1004252400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1018166400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1035702000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1049616000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1067151600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1081065600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1099206000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1112515200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1130655600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1143964800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1162105200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1173600000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1194159600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1205049600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1225609200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1236499200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1257058800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1268553600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1289113200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1300003200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1320562800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1331452800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1352012400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1362902400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1383462000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1394352000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1414911600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1425801600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1446361200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1457856000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1478415600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1489305600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1509865200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1520755200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1541314800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1552204800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1572764400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1583654400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1604214000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1615708800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1636268400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1647158400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1667718000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1678608000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1699167600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1710057600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1730617200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1741507200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1762066800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1772956800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1793516400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1805011200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1825570800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1836460800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1857020400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1867910400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1888470000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1899360000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1919919600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1930809600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1951369200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1962864000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1983423600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 1994313600,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2014873200,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2025763200,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2046322800,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2057212800,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2077772400,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2088662400,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2109222000,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2120112000,
+        	            	      index: (uint8) 1,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     },
+        	            	     (time.zoneTrans) {
+        	            	      when: (int64) 2140671600,
+        	            	      index: (uint8) 2,
+        	            	      isstd: (bool) false,
+        	            	      isutc: (bool) false
+        	            	     }
+        	            	    },
+        	            	    extend: (string) (len=22) "CST6CDT,M3.2.0,M11.1.0",
+        	            	    cacheStart: (int64) 1710057600,
+        	            	    cacheEnd: (int64) 1730617200,
+        	            	    cacheZone: (*time.zone)({
+        	            	     name: (string) (len=3) "CDT",
+        	            	     offset: (int) -18000,
+        	            	     isDST: (bool) true
+        	            	    })
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	Test:       	TestTransformer/ThreeEntriesFirstOldest
+
+=== FAIL: operator/transformer/recombine TestTransformer (0.15s)
+
+=== FAIL: operator/transformer/recombine TestTransformer/ThreeEntriesFirstNewest (re-run 1) (0.00s)
+    mocks.go:117: 
+        	Error Trace:	/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil/mocks.go:117
+        	            				/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer_test.go:518
+        	Error:      	elements differ
+        	            	
+        	            	extra elements in list A:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869025452357520,
+        	            	   ext: (int64) 10310001,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	extra elements in list B:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869025452357520,
+        	            	   ext: (int64) 10310001,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listA:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869025452357520,
+        	            	   ext: (int64) 10310001,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listB:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869025452357520,
+        	            	   ext: (int64) 10310001,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	Test:       	TestTransformer/ThreeEntriesFirstNewest
+
+=== FAIL: operator/transformer/recombine TestTransformer (re-run 1) (0.01s)
+
+=== FAIL: operator/transformer/recombine TestTransformer/ThreeEntriesFirstOldest (re-run 1) (0.00s)
+    mocks.go:117: 
+        	Error Trace:	/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil/mocks.go:117
+        	            				/Users/djaglowski/go/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/recombine/transformer_test.go:518
+        	Error:      	elements differ
+        	            	
+        	            	extra elements in list A:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869026300005344,
+        	            	   ext: (int64) 10407043,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	extra elements in list B:
+        	            	([]interface {}) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869026300005344,
+        	            	   ext: (int64) 10407043,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listA:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869026300005344,
+        	            	   ext: (int64) 10407043,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237642,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	            	
+        	            	
+        	            	listB:
+        	            	([]*entry.Entry) (len=1) {
+        	            	 (*entry.Entry)({
+        	            	  ObservedTimestamp: (time.Time) {
+        	            	   wall: (uint64) 13941869026300005344,
+        	            	   ext: (int64) 10407043,
+        	            	   loc: (*time.Location)({
+        	            	    name: (string) "",
+        	            	    zone: ([]time.zone) <nil>,
+        	            	    tx: ([]time.zoneTrans) <nil>,
+        	            	    extend: (string) "",
+        	            	    cacheStart: (int64) 0,
+        	            	    cacheEnd: (int64) 0,
+        	            	    cacheZone: (*time.zone)(<nil>)
+        	            	   })
+        	            	  },
+        	            	  Timestamp: (time.Time) {
+        	            	   wall: (uint64) 0,
+        	            	   ext: (int64) 63722237641,
+        	            	   loc: (*time.Location)(<nil>)
+        	            	  },
+        	            	  Body: (string) (len=11) "test1\ntest2",
+        	            	  Attributes: (map[string]interface {}) (len=1) {
+        	            	   (string) (len=4) "base": (string) (len=4) "true"
+        	            	  },
+        	            	  Resource: (map[string]interface {}) <nil>,
+        	            	  SeverityText: (string) "",
+        	            	  SpanID: ([]uint8) <nil>,
+        	            	  TraceID: ([]uint8) <nil>,
+        	            	  TraceFlags: ([]uint8) <nil>,
+        	            	  Severity: (entry.Severity) 0,
+        	            	  ScopeName: (string) ""
+        	            	 })
+        	            	}
+        	Test:       	TestTransformer/ThreeEntriesFirstOldest
+
+=== FAIL: operator/transformer/recombine TestTransformer (re-run 1) (0.01s)
+
+DONE 2 runs, 3237 tests, 1 skipped, 7 failures in 3.220s


### PR DESCRIPTION
Effectively reverts #30786, due to error pointed out by @yutingcaicyt [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30786#discussion_r1548862662).