### PR TITLE
[exporter/datadog] Change noAPMStatsFeatureGate log from warn to info

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -383,7 +383,7 @@ func (f *factory) createTracesExporter(
 ) (exporter.Traces, error) {
 	cfg := checkAndCastConfig(c, set.TelemetrySettings.Logger)
 	if noAPMStatsFeatureGate.IsEnabled() {
-		set.Logger.Warn(
+		set.Logger.Info(
 			"Trace metrics are now disabled in the Datadog Exporter by default. To continue receiving Trace Metrics, configure the Datadog Connector or disable the feature gate.",
 			zap.String("documentation", "https://docs.datadoghq.com/opentelemetry/guide/migration/"),
 			zap.String("feature gate ID", noAPMStatsFeatureGate.ID()),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Changes log introduced in #31981 from a warn log to an info log, since info is more appropriate for this message.
```
❯ ./bin/otelcontribcol_darwin_arm64
2024-04-03T11:04:48.974-0400    info    service@v0.97.1-0.20240327181407-1038b67c85a0/telemetry.go:55   Setting up own telemetry...
2024-04-03T11:04:48.974-0400    info    service@v0.97.1-0.20240327181407-1038b67c85a0/telemetry.go:97   Serving metrics {"address": ":8888", "level": "Basic"}
2024-04-03T11:04:48.975-0400    debug   exporter@v0.97.1-0.20240327181407-1038b67c85a0/exporter.go:273  Beta component. May change in the future.       {"kind": "exporter", "data_type": "traces", "name": "datadog/api"}
2024-04-03T11:04:48.975-0400    info    datadogexporter@v0.97.0/factory.go:386  Trace metrics are now disabled in the Datadog Exporter by default. To continue receiving Trace Metrics, configure the Datadog Connector or disable the feature gate.    {"kind": "exporter", "data_type": "traces", "name": "datadog/api", "documentation": "https://docs.datadoghq.com/opentelemetry/guide/migration/", "feature gate ID": "exporter.datadogexporter.DisableAPMStats"}
```

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>