### PR TITLE
[processor/filter] Update `HasAttrOnDatapoint` and `HasAttrKeyOnDatapoint` examples and docs

### DIFF
--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -149,13 +149,13 @@ Examples:
 
 - `HasAttrKeyOnDatapoint("http.method")`
 
-```
-  # Drops everything except good metrics
-  filter/keep_good_metrics:
-    error_mode: ignore
-    metrics:
-      metric:
-        - 'HasAttrKeyOnDatapoint("good.metric") == false'
+```yaml
+# Drops everything except good metrics
+filter/keep_good_metrics:
+  error_mode: ignore
+  metrics:
+    metric:
+      - 'HasAttrKeyOnDatapoint("good.metric") == false'
 ```
 
 #### HasAttrOnDatapoint
@@ -169,13 +169,13 @@ Examples:
 
 - `HasAttrOnDatapoint("http.method", "GET")`
 
-```
-  # Drops everything except good metrics
-  filter/keep_good_metrics:
-    error_mode: ignore
-    metrics:
-      metric:
-        - 'HasAttrOnDatapoint("good.metric", "true") == false'
+```yaml
+# Drops everything except good metrics
+filter/keep_good_metrics:
+  error_mode: ignore
+  metrics:
+    metric:
+      - 'HasAttrOnDatapoint("good.metric", "true") == false'
 ```
 
 ## Warnings

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -143,22 +143,40 @@ In addition, the processor defines a few of its own functions:
 `HasAttrKeyOnDatapoint(key)`
 
 Returns `true` if the given key appears in the attribute map of any datapoint on a metric.
-`key` must be a string.
+`key` and `value` must both be strings in the metric and function call. You must use the `metrics.metric` context.
 
 Examples:
 
 - `HasAttrKeyOnDatapoint("http.method")`
+
+```
+  # Drops everything except good metrics
+  filter/keep_good_metrics:
+    error_mode: ignore
+    metrics:
+      metric:
+        - 'HasAttrKeyOnDatapoint("good.metric") == false'
+```
 
 #### HasAttrOnDatapoint
 
 `HasAttrOnDatapoint(key, value)`
 
 Returns `true` if the given key and value appears in the attribute map of any datapoint on a metric.
-`key` and `value` must both be strings.
+`key` and `value` must both be strings in the metric and function call. You must use the `metrics.metric` context.
 
 Examples:
 
 - `HasAttrOnDatapoint("http.method", "GET")`
+
+```
+  # Drops everything except good metrics
+  filter/keep_good_metrics:
+    error_mode: ignore
+    metrics:
+      metric:
+        - 'HasAttrOnDatapoint("good.metric", "true") == false'
+```
 
 ## Warnings
 

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -163,7 +163,7 @@ filter/keep_good_metrics:
 `HasAttrOnDatapoint(key, value)`
 
 Returns `true` if the given key and value appears in the attribute map of any datapoint on a metric.
-`key` and `value` must both be strings in the metric and function call. You must use the `metrics.metric` context.
+`key` and `value` must both be strings. If the value of the attribute on the datapoint is not a string, `value` will be compared to `""`. You must use the `metrics.metric` context.
 
 Examples:
 

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -143,7 +143,7 @@ In addition, the processor defines a few of its own functions:
 `HasAttrKeyOnDatapoint(key)`
 
 Returns `true` if the given key appears in the attribute map of any datapoint on a metric.
-`key` and `value` must both be strings in the metric and function call. You must use the `metrics.metric` context.
+`key` must be a string. You must use the `metrics.metric` context.
 
 Examples:
 

--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -150,12 +150,12 @@ Examples:
 - `HasAttrKeyOnDatapoint("http.method")`
 
 ```yaml
-# Drops everything except good metrics
+# Drops metrics containing the 'bad.metric' attribute key
 filter/keep_good_metrics:
   error_mode: ignore
   metrics:
     metric:
-      - 'HasAttrKeyOnDatapoint("good.metric") == false'
+      - 'HasAttrKeyOnDatapoint("bad.metric")'
 ```
 
 #### HasAttrOnDatapoint
@@ -170,12 +170,12 @@ Examples:
 - `HasAttrOnDatapoint("http.method", "GET")`
 
 ```yaml
-# Drops everything except good metrics
+# Drops metrics containing the 'bad.metric' attribute key and 'true' value
 filter/keep_good_metrics:
   error_mode: ignore
   metrics:
     metric:
-      - 'HasAttrOnDatapoint("good.metric", "true") == false'
+      - 'HasAttrOnDatapoint("bad.metric", "true")'
 ```
 
 ## Warnings


### PR DESCRIPTION
**Description:**
- No full examples of this func so I added one
- Not explicitly mentioned that a metric with a bool value won't work so I mentioned that only strings work for both the query and metric points
- Mentioned you need to use the `metrics.metric` and not `metrics.datapoint` context

**Link to tracking Issue:** 
N/A

**Testing:**
N/A

**Documentation:**
- Added better examples
- Called out only string values work
- Mentioned specific context needed