### PR TITLE
[chore] fix codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -89,6 +89,7 @@ extension/awsproxy/                                      @open-telemetry/collect
 extension/basicauthextension/                            @open-telemetry/collector-contrib-approvers @jpkrohling @frzifus
 extension/bearertokenauthextension/                      @open-telemetry/collector-contrib-approvers @jpkrohling @frzifus
 extension/encoding/                                      @open-telemetry/collector-contrib-approvers @atoulme @dao-jun @dmitryax @MovieStoreGuy @VihasMakwana
+extension/encoding/avrologencodingextension/             @open-telemetry/collector-contrib-approvers @thmshmm
 extension/encoding/jaegerencodingextension/              @open-telemetry/collector-contrib-approvers @MovieStoreGuy @atoulme
 extension/encoding/jsonlogencodingextension/             @open-telemetry/collector-contrib-approvers @VihasMakwana @atoulme
 extension/encoding/otlpencodingextension/                @open-telemetry/collector-contrib-approvers @dao-jun @VihasMakwana

--- a/cmd/githubgen/allowlist.txt
+++ b/cmd/githubgen/allowlist.txt
@@ -15,3 +15,4 @@ jcreixell
 rlankfo
 swar8080
 zpzhuSplunk
+thmshmm


### PR DESCRIPTION
This fixes the codeowners file content and explicitly adds @thmshmm to the allowlist.