### PR TITLE
Add @ycombinator as codeowner for elasticsearchexporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -52,7 +52,7 @@ exporter/coralogixexporter/                              @open-telemetry/collect
 exporter/datadogexporter/                                @open-telemetry/collector-contrib-approvers @mx-psi @dineshg13 @liustanley @songy23 @mackjmr
 exporter/datasetexporter/                                @open-telemetry/collector-contrib-approvers @atoulme @martin-majlis-s1 @zdaratom-s1 @tomaz-s1
 exporter/dynatraceexporter/                              @open-telemetry/collector-contrib-approvers @dyladan @arminru @evan-bradley
-exporter/elasticsearchexporter/                          @open-telemetry/collector-contrib-approvers @JaredTan95
+exporter/elasticsearchexporter/                          @open-telemetry/collector-contrib-approvers @JaredTan95 @ycombinator
 exporter/fileexporter/                                   @open-telemetry/collector-contrib-approvers @atingchen
 exporter/googlecloudexporter/                            @open-telemetry/collector-contrib-approvers @aabmass @dashpole @jsuereth @punya @damemi @psx95
 exporter/googlecloudpubsubexporter/                      @open-telemetry/collector-contrib-approvers @alexvanboxel

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: traces, logs   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Felasticsearch%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Felasticsearch) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Felasticsearch%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Felasticsearch) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@JaredTan95](https://www.github.com/JaredTan95) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@JaredTan95](https://www.github.com/JaredTan95), [@ycombinator](https://www.github.com/ycombinator) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -7,7 +7,7 @@ status:
     beta: [traces, logs]
   distributions: [contrib]
   codeowners:
-    active: [JaredTan95]
+    active: [JaredTan95, ycombinator]
 
 tests:
   config:


### PR DESCRIPTION
**Description:** 

This PR proposes adding @ycombinator as a codeowner for the `elasticsearch` exporter component, being an [employee of Elastic](https://www.linkedin.com/company/elastic-co/people/?keywords=shaunak) and also meeting the codeowner [requirements](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#requirements):

1. [Be a member of the OpenTelemetry organization.](https://github.com/open-telemetry/community/blob/main/community-membership.md#member)
   * https://github.com/orgs/open-telemetry/people?query=ycombinator
2. (Code Owner Discretion) It is best to have resolved an issue related to the component, contributed directly to the component, and/or review component PRs. How much interaction with the component is required before becoming a Code Owner is up to any existing Code Owners.
   * Resolved https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/26647 via https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29619
   * Reviewed https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31553
   * Contributed https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31694 as follow up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31553
   * Reviewed https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31848

