### PR TITLE
[chore] update triagers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 Triagers ([@open-telemetry/collector-contrib-triagers](https://github.com/orgs/open-telemetry/teams/collector-contrib-triagers))
 
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
-- [Goutham Veeramachaneni](https://github.com/gouthamve), Grafana
 - [Jared Tan](https://github.com/JaredTan95), DaoCloud
 - [Matt Wear](https://github.com/mwear), Lightstep
 - [Murphy Chen](https://github.com/Frapschen), DaoCloud
@@ -82,6 +81,7 @@ Emeritus Triagers:
 
 - [Alolita Sharma](https://github.com/alolita), AWS
 - [Gabriel Aszalos](https://github.com/gbbr), DataDog
+- [Goutham Veeramachaneni](https://github.com/gouthamve), Grafana
 - [Punya Biswal](https://github.com/punya), Google
 - [Steve Flanders](https://github.com/flands), Splunk
 


### PR DESCRIPTION
As confirmed with @gouthamve, they're no longer able to continue with triager responsibilities. Much appreciate all your contributions!
