### PR TITLE
[pkg/stanza] Switch from SugaredLogger to Logger

### DIFF
--- a/.chloggen/pkg-stanza-rm-sugared-api.yaml
+++ b/.chloggen/pkg-stanza-rm-sugared-api.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The internal logger has been changed from zap.SugaredLogger to zap.Logger.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32177]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Functions accepting a SugaredLogger, and fields of type SugaredLogger, have been deprecated.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/pkg-stanza-rm-sugared.yaml
+++ b/.chloggen/pkg-stanza-rm-sugared.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelog, journald, tcp, udp, syslog, windowseventlog receivers
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The internal logger has been changed from zap.SugaredLogger to zap.Logger.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32177]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This should not have any meaningful impact on most users but the logging format for some logs may have changed.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/adapter/converter_test.go
+++ b/pkg/stanza/adapter/converter_test.go
@@ -14,9 +14,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 )
@@ -391,7 +392,9 @@ func TestAllConvertedEntriesScopeGrouping(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			converter := NewConverter(zap.NewNop())
+			set := componenttest.NewNopTelemetrySettings()
+			set.Logger = zaptest.NewLogger(t)
+			converter := NewConverter(set)
 			converter.Start()
 			defer converter.Stop()
 
@@ -458,7 +461,9 @@ func TestAllConvertedEntriesAreSentAndReceived(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 
-			converter := NewConverter(zap.NewNop())
+			set := componenttest.NewNopTelemetrySettings()
+			set.Logger = zaptest.NewLogger(t)
+			converter := NewConverter(set)
 			converter.Start()
 			defer converter.Stop()
 
@@ -520,7 +525,9 @@ func TestAllConvertedEntriesAreSentAndReceived(t *testing.T) {
 }
 
 func TestConverterCancelledContextCancellsTheFlush(t *testing.T) {
-	converter := NewConverter(zap.NewNop())
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+	converter := NewConverter(set)
 	converter.Start()
 	defer converter.Stop()
 	var wg sync.WaitGroup
@@ -932,8 +939,9 @@ func BenchmarkConverter(b *testing.B) {
 	for _, wc := range workerCounts {
 		b.Run(fmt.Sprintf("worker_count=%d", wc), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-
-				converter := NewConverter(zap.NewNop(), withWorkerCount(wc))
+				set := componenttest.NewNopTelemetrySettings()
+				set.Logger = zaptest.NewLogger(b)
+				converter := NewConverter(set, withWorkerCount(wc))
 				converter.Start()
 				defer converter.Stop()
 

--- a/pkg/stanza/adapter/emitter.go
+++ b/pkg/stanza/adapter/emitter.go
@@ -4,15 +4,16 @@
 package adapter // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
 
-// Deprecated [v0.100.0] Use helper.LogEmitter directly instead
+// Deprecated [v0.101.0] Use helper.LogEmitter directly instead
 type LogEmitter = helper.LogEmitter
 
-// Deprecated [v0.100.0] Use helper.NewLogEmitter directly instead
+// Deprecated [v0.101.0] Use helper.NewLogEmitter directly instead
 func NewLogEmitter(logger *zap.SugaredLogger, opts ...helper.EmitterOption) *LogEmitter {
-	return helper.NewLogEmitter(logger, opts...)
+	return helper.NewLogEmitter(component.TelemetrySettings{Logger: logger.Desugar()}, opts...)
 }

--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -53,7 +53,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 		if baseCfg.flushInterval > 0 {
 			emitterOpts = append(emitterOpts, helper.WithFlushInterval(baseCfg.flushInterval))
 		}
-		emitter := helper.NewLogEmitter(params.Logger.Sugar(), emitterOpts...)
+		emitter := helper.NewLogEmitter(params.TelemetrySettings, emitterOpts...)
 		pipe, err := pipeline.Config{
 			Operators:     operators,
 			DefaultOutput: emitter,
@@ -66,7 +66,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 		if baseCfg.numWorkers > 0 {
 			converterOpts = append(converterOpts, withWorkerCount(baseCfg.numWorkers))
 		}
-		converter := NewConverter(params.Logger, converterOpts...)
+		converter := NewConverter(params.TelemetrySettings, converterOpts...)
 		obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 			ReceiverID:             params.ID,
 			ReceiverCreateSettings: params,
@@ -75,11 +75,11 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 			return nil, err
 		}
 		return &receiver{
+			set:       params.TelemetrySettings,
 			id:        params.ID,
 			pipe:      pipe,
 			emitter:   emitter,
 			consumer:  consumerretry.NewLogs(baseCfg.RetryOnFailure, params.Logger, nextConsumer),
-			logger:    params.Logger,
 			converter: converter,
 			obsrecv:   obsrecv,
 			storageID: baseCfg.StorageID,

--- a/pkg/stanza/adapter/frompdataconverter_test.go
+++ b/pkg/stanza/adapter/frompdataconverter_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
@@ -126,7 +127,7 @@ func BenchmarkFromPdataConverter(b *testing.B) {
 		b.Run(fmt.Sprintf("worker_count=%d", wc), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 
-				converter := NewFromPdataConverter(wc, nil)
+				converter := NewFromPdataConverter(componenttest.NewNopTelemetrySettings(), wc)
 				converter.Start()
 				defer converter.Stop()
 				b.ResetTimer()

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -24,9 +24,9 @@ import (
 )
 
 func createNoopReceiver(nextConsumer consumer.Logs) (*receiver, error) {
-	emitter := helper.NewLogEmitter(zap.NewNop().Sugar())
-
 	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.NewNop()
+	emitter := helper.NewLogEmitter(set)
 	pipe, err := pipeline.Config{
 		Operators: []operator.Config{
 			{
@@ -48,12 +48,12 @@ func createNoopReceiver(nextConsumer consumer.Logs) (*receiver, error) {
 	}
 
 	return &receiver{
+		set:       set,
 		id:        component.MustNewID("testReceiver"),
 		pipe:      pipe,
 		emitter:   emitter,
 		consumer:  nextConsumer,
-		logger:    zap.NewNop(),
-		converter: NewConverter(zap.NewNop()),
+		converter: NewConverter(componenttest.NewNopTelemetrySettings()),
 		obsrecv:   obsrecv,
 	}, nil
 }

--- a/pkg/stanza/adapter/receiver.go
+++ b/pkg/stanza/adapter/receiver.go
@@ -21,6 +21,7 @@ import (
 )
 
 type receiver struct {
+	set    component.TelemetrySettings
 	id     component.ID
 	wg     sync.WaitGroup
 	cancel context.CancelFunc
@@ -29,7 +30,6 @@ type receiver struct {
 	emitter   *helper.LogEmitter
 	consumer  consumer.Logs
 	converter *Converter
-	logger    *zap.Logger
 	obsrecv   *receiverhelper.ObsReport
 
 	storageID     *component.ID
@@ -43,7 +43,7 @@ var _ rcvr.Logs = (*receiver)(nil)
 func (r *receiver) Start(ctx context.Context, host component.Host) error {
 	rctx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
-	r.logger.Info("Starting stanza receiver")
+	r.set.Logger.Info("Starting stanza receiver")
 
 	if err := r.setStorageClient(ctx, host); err != nil {
 		return fmt.Errorf("storage client: %w", err)
@@ -88,7 +88,7 @@ func (r *receiver) emitterLoop(ctx context.Context) {
 	for {
 		select {
 		case <-doneChan:
-			r.logger.Debug("Receive loop stopped")
+			r.set.Logger.Debug("Receive loop stopped")
 			return
 
 		case e, ok := <-r.emitter.OutChannel():
@@ -97,7 +97,7 @@ func (r *receiver) emitterLoop(ctx context.Context) {
 			}
 
 			if err := r.converter.Batch(e); err != nil {
-				r.logger.Error("Could not add entry to batch", zap.Error(err))
+				r.set.Logger.Error("Could not add entry to batch", zap.Error(err))
 			}
 		}
 	}
@@ -113,19 +113,19 @@ func (r *receiver) consumerLoop(ctx context.Context) {
 	for {
 		select {
 		case <-doneChan:
-			r.logger.Debug("Consumer loop stopped")
+			r.set.Logger.Debug("Consumer loop stopped")
 			return
 
 		case pLogs, ok := <-pLogsChan:
 			if !ok {
-				r.logger.Debug("Converter channel got closed")
+				r.set.Logger.Debug("Converter channel got closed")
 				continue
 			}
 			obsrecvCtx := r.obsrecv.StartLogsOp(ctx)
 			logRecordCount := pLogs.LogRecordCount()
 			cErr := r.consumer.ConsumeLogs(ctx, pLogs)
 			if cErr != nil {
-				r.logger.Error("ConsumeLogs() failed", zap.Error(cErr))
+				r.set.Logger.Error("ConsumeLogs() failed", zap.Error(cErr))
 			}
 			r.obsrecv.EndLogsOp(obsrecvCtx, "stanza", logRecordCount, cErr)
 		}
@@ -138,7 +138,7 @@ func (r *receiver) Shutdown(ctx context.Context) error {
 		return nil
 	}
 
-	r.logger.Info("Stopping stanza receiver")
+	r.set.Logger.Info("Stopping stanza receiver")
 	pipelineErr := r.pipe.Stop()
 	r.converter.Stop()
 	r.cancel()

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/storagetest"
@@ -134,12 +133,12 @@ func BenchmarkReadLine(b *testing.B) {
 	var operatorCfgs []operator.Config
 	require.NoError(b, yaml.Unmarshal([]byte(pipelineYaml), &operatorCfgs))
 
-	emitter := helper.NewLogEmitter(zap.NewNop().Sugar())
+	set := componenttest.NewNopTelemetrySettings()
+	emitter := helper.NewLogEmitter(set)
 	defer func() {
 		require.NoError(b, emitter.Stop())
 	}()
 
-	set := componenttest.NewNopTelemetrySettings()
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,
@@ -201,12 +200,12 @@ func BenchmarkParseAndMap(b *testing.B) {
 	var operatorCfgs []operator.Config
 	require.NoError(b, yaml.Unmarshal([]byte(pipelineYaml), &operatorCfgs))
 
-	emitter := helper.NewLogEmitter(zap.NewNop().Sugar())
+	set := componenttest.NewNopTelemetrySettings()
+	emitter := helper.NewLogEmitter(set)
 	defer func() {
 		require.NoError(b, emitter.Stop())
 	}()
 
-	set := componenttest.NewNopTelemetrySettings()
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/checkpoint"
@@ -21,7 +22,10 @@ import (
 )
 
 type Manager struct {
+	// Deprecated [v0.101.0]
 	*zap.SugaredLogger
+
+	set    component.TelemetrySettings
 	wg     sync.WaitGroup
 	cancel context.CancelFunc
 
@@ -40,7 +44,7 @@ func (m *Manager) Start(persister operator.Persister) error {
 	m.cancel = cancel
 
 	if _, err := m.fileMatcher.MatchFiles(); err != nil {
-		m.Warnf("finding files: %v", err)
+		m.set.Logger.Warn("finding files", zap.Error(err))
 	}
 
 	if persister != nil {
@@ -50,7 +54,7 @@ func (m *Manager) Start(persister operator.Persister) error {
 			return fmt.Errorf("read known files from database: %w", err)
 		}
 		if len(offsets) > 0 {
-			m.Infow("Resuming from previously known offset(s). 'start_at' setting is not applicable.")
+			m.set.Logger.Info("Resuming from previously known offset(s). 'start_at' setting is not applicable.")
 			m.readerFactory.FromBeginning = true
 			m.tracker.LoadMetadata(offsets)
 		}
@@ -72,7 +76,7 @@ func (m *Manager) Stop() error {
 	m.tracker.ClosePreviousFiles()
 	if m.persister != nil {
 		if err := checkpoint.Save(context.Background(), m.persister, m.tracker.GetMetadata()); err != nil {
-			m.Errorw("save offsets", zap.Error(err))
+			m.set.Logger.Error("save offsets", zap.Error(err))
 		}
 	}
 	return nil
@@ -107,9 +111,9 @@ func (m *Manager) poll(ctx context.Context) {
 	// Get the list of paths on disk
 	matches, err := m.fileMatcher.MatchFiles()
 	if err != nil {
-		m.Debugf("finding files: %v", err)
+		m.set.Logger.Debug("finding files", zap.Error(err))
 	}
-	m.Debugw("matched files", zap.Strings("paths", matches))
+	m.set.Logger.Debug("matched files", zap.Strings("paths", matches))
 
 	for len(matches) > m.maxBatchFiles {
 		m.consume(ctx, matches[:m.maxBatchFiles])
@@ -132,7 +136,7 @@ func (m *Manager) poll(ctx context.Context) {
 		metadata := m.tracker.GetMetadata()
 		if metadata != nil {
 			if err := checkpoint.Save(context.Background(), m.persister, metadata); err != nil {
-				m.Errorw("save offsets", zap.Error(err))
+				m.set.Logger.Error("save offsets", zap.Error(err))
 			}
 		}
 	}
@@ -141,7 +145,7 @@ func (m *Manager) poll(ctx context.Context) {
 }
 
 func (m *Manager) consume(ctx context.Context, paths []string) {
-	m.Debug("Consuming files", zap.Strings("paths", paths))
+	m.set.Logger.Debug("Consuming files", zap.Strings("paths", paths))
 	m.makeReaders(paths)
 
 	m.readLostFiles(ctx)
@@ -163,14 +167,14 @@ func (m *Manager) consume(ctx context.Context, paths []string) {
 func (m *Manager) makeFingerprint(path string) (*fingerprint.Fingerprint, *os.File) {
 	file, err := os.Open(path) // #nosec - operator must read in files defined by user
 	if err != nil {
-		m.Errorw("Failed to open file", zap.Error(err))
+		m.set.Logger.Error("Failed to open file", zap.Error(err))
 		return nil, nil
 	}
 
 	fp, err := m.readerFactory.NewFingerprint(file)
 	if err != nil {
 		if err = file.Close(); err != nil {
-			m.Debugw("problem closing file", zap.Error(err))
+			m.set.Logger.Debug("problem closing file", zap.Error(err))
 		}
 		return nil, nil
 	}
@@ -178,7 +182,7 @@ func (m *Manager) makeFingerprint(path string) (*fingerprint.Fingerprint, *os.Fi
 	if fp.Len() == 0 {
 		// Empty file, don't read it until we can compare its fingerprint
 		if err = file.Close(); err != nil {
-			m.Debugw("problem closing file", zap.Error(err))
+			m.set.Logger.Debug("problem closing file", zap.Error(err))
 		}
 		return nil, nil
 	}
@@ -201,14 +205,14 @@ func (m *Manager) makeReaders(paths []string) {
 			// re-add the reader as Match() removes duplicates
 			m.tracker.Add(r)
 			if err := file.Close(); err != nil {
-				m.Debugw("problem closing file", zap.Error(err))
+				m.set.Logger.Debug("problem closing file", zap.Error(err))
 			}
 			continue
 		}
 
 		r, err := m.newReader(file, fp)
 		if err != nil {
-			m.Errorw("Failed to create reader", zap.Error(err))
+			m.set.Logger.Error("Failed to create reader", zap.Error(err))
 			continue
 		}
 
@@ -228,6 +232,6 @@ func (m *Manager) newReader(file *os.File, fp *fingerprint.Fingerprint) (*reader
 	}
 
 	// If we don't match any previously known files, create a new reader from scratch
-	m.Infow("Started watching file", "path", file.Name())
+	m.set.Logger.Info("Started watching file", zap.String("path", file.Name()))
 	return m.readerFactory.NewReader(file, fp)
 }

--- a/pkg/stanza/fileconsumer/internal/header/config.go
+++ b/pkg/stanza/fileconsumer/internal/header/config.go
@@ -11,7 +11,6 @@ import (
 	"regexp"
 
 	"go.opentelemetry.io/collector/component"
-	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -26,7 +25,7 @@ type Config struct {
 	metadataOperators []operator.Config
 }
 
-func NewConfig(matchRegex string, metadataOperators []operator.Config, enc encoding.Encoding) (*Config, error) {
+func NewConfig(set component.TelemetrySettings, matchRegex string, metadataOperators []operator.Config, enc encoding.Encoding) (*Config, error) {
 	var err error
 	if len(metadataOperators) == 0 {
 		return nil, errors.New("at least one operator must be specified for `metadata_operators`")
@@ -36,11 +35,10 @@ func NewConfig(matchRegex string, metadataOperators []operator.Config, enc encod
 		return nil, errors.New("encoding must be specified")
 	}
 
-	nopLogger := zap.NewNop().Sugar()
 	p, err := pipeline.Config{
 		Operators:     metadataOperators,
-		DefaultOutput: newPipelineOutput(nopLogger),
-	}.Build(component.TelemetrySettings{Logger: nopLogger.Desugar()})
+		DefaultOutput: newPipelineOutput(set),
+	}.Build(set)
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipelines: %w", err)

--- a/pkg/stanza/fileconsumer/internal/header/config_test.go
+++ b/pkg/stanza/fileconsumer/internal/header/config_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap/zaptest"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
 
@@ -132,7 +134,9 @@ func TestBuild(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			h, err := NewConfig(tc.pattern, tc.ops, tc.enc)
+			set := componenttest.NewNopTelemetrySettings()
+			set.Logger = zaptest.NewLogger(t)
+			h, err := NewConfig(set, tc.pattern, tc.ops, tc.enc)
 			if tc.expectedErr != "" {
 				require.ErrorContains(t, err, tc.expectedErr)
 			} else {

--- a/pkg/stanza/fileconsumer/internal/header/output.go
+++ b/pkg/stanza/fileconsumer/internal/header/output.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -22,16 +22,11 @@ type pipelineOutput struct {
 }
 
 // newPipelineOutput creates a new receiver output
-func newPipelineOutput(logger *zap.SugaredLogger) *pipelineOutput {
+func newPipelineOutput(set component.TelemetrySettings) *pipelineOutput {
+	op, _ := helper.NewOutputConfig(pipelineOutputType, pipelineOutputType).Build(set)
 	return &pipelineOutput{
-		OutputOperator: helper.OutputOperator{
-			BasicOperator: helper.BasicOperator{
-				OperatorID:    pipelineOutputType,
-				OperatorType:  pipelineOutputType,
-				SugaredLogger: logger,
-			},
-		},
-		logChan: make(chan *entry.Entry, 1),
+		OutputOperator: op,
+		logChan:        make(chan *entry.Entry, 1),
 	}
 }
 

--- a/pkg/stanza/fileconsumer/internal/header/reader.go
+++ b/pkg/stanza/fileconsumer/internal/header/reader.go
@@ -10,7 +10,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/experimental/storage"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/pipeline"
@@ -19,20 +18,20 @@ import (
 var ErrEndOfHeader = errors.New("end of header")
 
 type Reader struct {
-	logger   *zap.SugaredLogger
+	set      component.TelemetrySettings
 	cfg      Config
 	pipeline pipeline.Pipeline
 	output   *pipelineOutput
 }
 
-func NewReader(logger *zap.SugaredLogger, cfg Config) (*Reader, error) {
-	r := &Reader{logger: logger, cfg: cfg}
+func NewReader(set component.TelemetrySettings, cfg Config) (*Reader, error) {
+	r := &Reader{set: set, cfg: cfg}
 	var err error
-	r.output = newPipelineOutput(logger)
+	r.output = newPipelineOutput(set)
 	r.pipeline, err = pipeline.Config{
 		Operators:     cfg.metadataOperators,
 		DefaultOutput: r.output,
-	}.Build(component.TelemetrySettings{Logger: logger.Desugar()})
+	}.Build(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipeline: %w", err)
 	}

--- a/pkg/stanza/fileconsumer/internal/header/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/header/reader_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap/zaptest"
 	"golang.org/x/text/encoding/unicode"
 
@@ -19,8 +20,6 @@ import (
 )
 
 func TestReader(t *testing.T) {
-	logger := zaptest.NewLogger(t).Sugar()
-
 	regexConf := regex.NewConfig()
 	regexConf.Regex = "^#(?P<header_line>.*)"
 	regexConf.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
@@ -29,13 +28,15 @@ func TestReader(t *testing.T) {
 	kvConf.ParseFrom = entry.NewBodyField("header_line")
 	kvConf.Delimiter = ":"
 
-	cfg, err := NewConfig("^#", []operator.Config{
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+	cfg, err := NewConfig(set, "^#", []operator.Config{
 		{Builder: regexConf},
 		{Builder: kvConf},
 	}, unicode.UTF8)
 	require.NoError(t, err)
 
-	reader, err := NewReader(logger, *cfg)
+	reader, err := NewReader(set, *cfg)
 	assert.NoError(t, err)
 
 	attrs := make(map[string]any)
@@ -50,8 +51,6 @@ func TestReader(t *testing.T) {
 }
 
 func TestSkipUnmatchedHeaderLine(t *testing.T) {
-	logger := zaptest.NewLogger(t).Sugar()
-
 	regexConf := regex.NewConfig()
 	regexConf.Regex = "^#(?P<header_line>.*)"
 	regexConf.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
@@ -60,13 +59,15 @@ func TestSkipUnmatchedHeaderLine(t *testing.T) {
 	kvConf.ParseFrom = entry.NewBodyField("header_line")
 	kvConf.Delimiter = ":"
 
-	cfg, err := NewConfig("^#", []operator.Config{
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+	cfg, err := NewConfig(set, "^#", []operator.Config{
 		{Builder: regexConf},
 		{Builder: kvConf},
 	}, unicode.UTF8)
 	require.NoError(t, err)
 
-	reader, err := NewReader(logger, *cfg)
+	reader, err := NewReader(set, *cfg)
 	assert.NoError(t, err)
 
 	attrs := make(map[string]any)
@@ -82,6 +83,8 @@ func TestSkipUnmatchedHeaderLine(t *testing.T) {
 }
 
 func TestNewReaderErr(t *testing.T) {
-	_, err := NewReader(zaptest.NewLogger(t).Sugar(), Config{})
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+	_, err := NewReader(set, Config{})
 	assert.Error(t, err)
 }

--- a/pkg/stanza/fileconsumer/internal/reader/factory_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/scanner"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/split"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/trim"
 )
 
@@ -50,7 +50,7 @@ func testFactory(t *testing.T, opts ...testFactoryOpt) (*Factory, *emittest.Sink
 
 	sink := emittest.NewSink(emittest.WithCallBuffer(cfg.sinkChanSize))
 	return &Factory{
-		SugaredLogger:     testutil.Logger(t),
+		TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 		FromBeginning:     cfg.fromBeginning,
 		FingerprintSize:   cfg.fingerprintSize,
 		InitialBufferSize: cfg.initialBufferSize,

--- a/pkg/stanza/fileconsumer/internal/reader/split_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/split_test.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
@@ -199,7 +201,9 @@ func TestHeaderFingerprintIncluded(t *testing.T) {
 	enc, err := decode.LookupEncoding("utf-8")
 	require.NoError(t, err)
 
-	h, err := header.NewConfig("^#", []operator.Config{{Builder: regexConf}}, enc)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+	h, err := header.NewConfig(set, "^#", []operator.Config{{Builder: regexConf}}, enc)
 	require.NoError(t, err)
 	f.HeaderConfig = h
 

--- a/pkg/stanza/operator/helper/emitter.go
+++ b/pkg/stanza/operator/helper/emitter.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -61,20 +61,15 @@ func (o flushIntervalOption) apply(e *LogEmitter) {
 }
 
 // NewLogEmitter creates a new receiver output
-func NewLogEmitter(logger *zap.SugaredLogger, opts ...EmitterOption) *LogEmitter {
+func NewLogEmitter(set component.TelemetrySettings, opts ...EmitterOption) *LogEmitter {
+	op, _ := NewOutputConfig("log_emitter", "log_emitter").Build(set)
 	e := &LogEmitter{
-		OutputOperator: OutputOperator{
-			BasicOperator: BasicOperator{
-				OperatorID:    "log_emitter",
-				OperatorType:  "log_emitter",
-				SugaredLogger: logger,
-			},
-		},
-		logChan:       make(chan []*entry.Entry),
-		maxBatchSize:  defaultMaxBatchSize,
-		batch:         make([]*entry.Entry, 0, defaultMaxBatchSize),
-		flushInterval: defaultFlushInterval,
-		cancel:        func() {},
+		OutputOperator: op,
+		logChan:        make(chan []*entry.Entry),
+		maxBatchSize:   defaultMaxBatchSize,
+		batch:          make([]*entry.Entry, 0, defaultMaxBatchSize),
+		flushInterval:  defaultFlushInterval,
+		cancel:         func() {},
 	}
 	for _, opt := range opts {
 		opt.apply(e)

--- a/pkg/stanza/operator/helper/emitter_test.go
+++ b/pkg/stanza/operator/helper/emitter_test.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 )
 
 func TestLogEmitter(t *testing.T) {
-	emitter := NewLogEmitter(zaptest.NewLogger(t).Sugar())
+	emitter := NewLogEmitter(componenttest.NewNopTelemetrySettings())
 
 	require.NoError(t, emitter.Start(nil))
 
@@ -43,7 +43,7 @@ func TestLogEmitterEmitsOnMaxBatchSize(t *testing.T) {
 		maxBatchSize = 100
 		timeout      = time.Second
 	)
-	emitter := NewLogEmitter(zaptest.NewLogger(t).Sugar())
+	emitter := NewLogEmitter(componenttest.NewNopTelemetrySettings())
 
 	require.NoError(t, emitter.Start(nil))
 	defer func() {
@@ -74,7 +74,7 @@ func TestLogEmitterEmitsOnFlushInterval(t *testing.T) {
 		flushInterval = 100 * time.Millisecond
 		timeout       = time.Second
 	)
-	emitter := NewLogEmitter(zaptest.NewLogger(t).Sugar())
+	emitter := NewLogEmitter(componenttest.NewNopTelemetrySettings())
 
 	require.NoError(t, emitter.Start(nil))
 	defer func() {

--- a/pkg/stanza/operator/helper/input.go
+++ b/pkg/stanza/operator/helper/input.go
@@ -84,7 +84,7 @@ func (i *InputOperator) CanProcess() bool {
 
 // Process will always return an error if called.
 func (i *InputOperator) Process(_ context.Context, _ *entry.Entry) error {
-	i.Errorw("Operator received an entry, but can not process")
+	i.Logger().Error("Operator received an entry, but can not process")
 	return errors.NewError(
 		"Operator can not process logs.",
 		"Ensure that operator is not configured to receive logs from other operators",

--- a/pkg/stanza/operator/helper/input_test.go
+++ b/pkg/stanza/operator/helper/input_test.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestInputConfigMissingBase(t *testing.T) {
@@ -59,12 +59,14 @@ func TestInputConfigValid(t *testing.T) {
 }
 
 func TestInputOperatorCanProcess(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	input := InputOperator{
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: testutil.Logger(t),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 		},
 	}
@@ -72,12 +74,14 @@ func TestInputOperatorCanProcess(t *testing.T) {
 }
 
 func TestInputOperatorProcess(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	input := InputOperator{
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: testutil.Logger(t),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 		},
 	}
@@ -97,6 +101,9 @@ func TestInputOperatorNewEntry(t *testing.T) {
 	resourceExpr, err := ExprStringConfig("resource").Build()
 	require.NoError(t, err)
 
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+
 	input := InputOperator{
 		Attributer: Attributer{
 			attributes: map[string]*ExprString{
@@ -110,9 +117,9 @@ func TestInputOperatorNewEntry(t *testing.T) {
 		},
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: testutil.Logger(t),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 		},
 	}

--- a/pkg/stanza/operator/helper/operator.go
+++ b/pkg/stanza/operator/helper/operator.go
@@ -62,10 +62,11 @@ func (c BasicConfig) Build(set component.TelemetrySettings) (BasicOperator, erro
 		)
 	}
 
+	set.Logger = set.Logger.With(zap.String("operator_id", c.ID()), zap.String("operator_type", c.Type()))
 	operator := BasicOperator{
-		OperatorID:    c.ID(),
-		OperatorType:  c.Type(),
-		SugaredLogger: set.Logger.Sugar().With("operator_id", c.ID(), "operator_type", c.Type()),
+		OperatorID:   c.ID(),
+		OperatorType: c.Type(),
+		set:          set,
 	}
 
 	return operator, nil
@@ -75,7 +76,7 @@ func (c BasicConfig) Build(set component.TelemetrySettings) (BasicOperator, erro
 type BasicOperator struct {
 	OperatorID   string
 	OperatorType string
-	*zap.SugaredLogger
+	set          component.TelemetrySettings
 }
 
 // ID will return the operator id.
@@ -92,8 +93,8 @@ func (p *BasicOperator) Type() string {
 }
 
 // Logger returns the operator's scoped logger.
-func (p *BasicOperator) Logger() *zap.SugaredLogger {
-	return p.SugaredLogger
+func (p *BasicOperator) Logger() *zap.Logger {
+	return p.set.Logger
 }
 
 // Start will start the operator.

--- a/pkg/stanza/operator/helper/operator_test.go
+++ b/pkg/stanza/operator/helper/operator_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
-	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
@@ -93,13 +93,14 @@ func TestBasicOperatorType(t *testing.T) {
 }
 
 func TestBasicOperatorLogger(t *testing.T) {
-	logger := &zap.SugaredLogger{}
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	operator := BasicOperator{
-		OperatorID:    "test-id",
-		OperatorType:  "test-type",
-		SugaredLogger: logger,
+		OperatorID:   "test-id",
+		OperatorType: "test-type",
+		set:          set,
 	}
-	require.Equal(t, logger, operator.Logger())
+	require.Equal(t, set.Logger, operator.Logger())
 }
 
 func TestBasicOperatorStart(t *testing.T) {

--- a/pkg/stanza/operator/helper/output_test.go
+++ b/pkg/stanza/operator/helper/output_test.go
@@ -8,9 +8,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestOutputConfigMissingBase(t *testing.T) {
@@ -34,44 +34,52 @@ func TestOutputConfigBuildValid(t *testing.T) {
 }
 
 func TestOutputOperatorCanProcess(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	output := OutputOperator{
 		BasicOperator: BasicOperator{
-			OperatorID:    "test-id",
-			OperatorType:  "test-type",
-			SugaredLogger: testutil.Logger(t),
+			OperatorID:   "test-id",
+			OperatorType: "test-type",
+			set:          set,
 		},
 	}
 	require.True(t, output.CanProcess())
 }
 
 func TestOutputOperatorCanOutput(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	output := OutputOperator{
 		BasicOperator: BasicOperator{
-			OperatorID:    "test-id",
-			OperatorType:  "test-type",
-			SugaredLogger: testutil.Logger(t),
+			OperatorID:   "test-id",
+			OperatorType: "test-type",
+			set:          set,
 		},
 	}
 	require.False(t, output.CanOutput())
 }
 
 func TestOutputOperatorOutputs(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	output := OutputOperator{
 		BasicOperator: BasicOperator{
-			OperatorID:    "test-id",
-			OperatorType:  "test-type",
-			SugaredLogger: testutil.Logger(t),
+			OperatorID:   "test-id",
+			OperatorType: "test-type",
+			set:          set,
 		},
 	}
 	require.Equal(t, []operator.Operator{}, output.Outputs())
 }
 
 func TestOutputOperatorSetOutputs(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	output := OutputOperator{
 		BasicOperator: BasicOperator{
-			OperatorID:    "test-id",
-			OperatorType:  "test-type",
-			SugaredLogger: testutil.Logger(t),
+			OperatorID:   "test-id",
+			OperatorType: "test-type",
+			set:          set,
 		},
 	}
 

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -102,13 +102,15 @@ func TestParserConfigBuildValid(t *testing.T) {
 }
 
 func TestParserMissingField(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	parser := ParserOperator{
 		TransformerOperator: TransformerOperator{
 			WriterOperator: WriterOperator{
 				BasicOperator: BasicOperator{
-					OperatorID:    "test-id",
-					OperatorType:  "test-type",
-					SugaredLogger: zaptest.NewLogger(t).Sugar(),
+					OperatorID:   "test-id",
+					OperatorType: "test-type",
+					set:          set,
 				},
 			},
 			OnError: DropOnError,
@@ -245,13 +247,15 @@ func TestParserInvalidSeverityParseDrop(t *testing.T) {
 }
 
 func TestParserInvalidTimeValidSeverityParse(t *testing.T) {
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	parser := ParserOperator{
 		TransformerOperator: TransformerOperator{
 			WriterOperator: WriterOperator{
 				BasicOperator: BasicOperator{
-					OperatorID:    "test-id",
-					OperatorType:  "test-type",
-					SugaredLogger: testutil.Logger(t),
+					OperatorID:   "test-id",
+					OperatorType: "test-type",
+					set:          set,
 				},
 			},
 			OnError: DropOnError,
@@ -298,13 +302,16 @@ func TestParserValidTimeInvalidSeverityParse(t *testing.T) {
 	expected, err := time.ParseInLocation(layout, sample, hst)
 	require.NoError(t, err)
 
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+
 	parser := ParserOperator{
 		TransformerOperator: TransformerOperator{
 			WriterOperator: WriterOperator{
 				BasicOperator: BasicOperator{
-					OperatorID:    "test-id",
-					OperatorType:  "test-type",
-					SugaredLogger: testutil.Logger(t),
+					OperatorID:   "test-id",
+					OperatorType: "test-type",
+					set:          set,
 				},
 			},
 			OnError: DropOnError,
@@ -343,14 +350,17 @@ func TestParserOutput(t *testing.T) {
 	output.On("ID").Return("test-output")
 	output.On("Process", mock.Anything, mock.Anything).Return(nil)
 
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
+
 	parser := ParserOperator{
 		TransformerOperator: TransformerOperator{
 			OnError: DropOnError,
 			WriterOperator: WriterOperator{
 				BasicOperator: BasicOperator{
-					OperatorID:    "test-id",
-					OperatorType:  "test-type",
-					SugaredLogger: testutil.Logger(t),
+					OperatorID:   "test-id",
+					OperatorType: "test-type",
+					set:          set,
 				},
 				OutputOperators: []operator.Operator{output},
 			},
@@ -667,11 +677,13 @@ func NewTestParserConfig() ParserConfig {
 
 func writerWithFakeOut(t *testing.T) (*WriterOperator, *testutil.FakeOutput) {
 	fakeOut := testutil.NewFakeOutput(t)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	writer := &WriterOperator{
 		BasicOperator: BasicOperator{
-			OperatorID:    "test-id",
-			OperatorType:  "test-type",
-			SugaredLogger: testutil.Logger(t),
+			OperatorID:   "test-id",
+			OperatorType: "test-type",
+			set:          set,
 		},
 		OutputIDs: []string{fakeOut.ID()},
 	}

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -97,9 +97,9 @@ func (t *TransformerOperator) ProcessWith(ctx context.Context, entry *entry.Entr
 // HandleEntryError will handle an entry error using the on_error strategy.
 func (t *TransformerOperator) HandleEntryError(ctx context.Context, entry *entry.Entry, err error) error {
 	if t.OnError == SendOnErrorQuiet || t.OnError == DropOnErrorQuiet {
-		t.Debugw("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError))
+		t.Logger().Debug("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError))
 	} else {
-		t.Errorw("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError))
+		t.Logger().Error("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError))
 	}
 	if t.OnError == SendOnError || t.OnError == SendOnErrorQuiet {
 		t.Write(ctx, entry)

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -75,15 +76,16 @@ func TestTransformerDropOnError(t *testing.T) {
 	output.On("Process", mock.Anything, mock.Anything).Return(nil)
 
 	obs, logs := observer.New(zap.WarnLevel)
-	logger := zap.New(obs)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.New(obs)
 
 	transformer := TransformerOperator{
 		OnError: DropOnError,
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: logger.Sugar(),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 			OutputOperators: []operator.Operator{output},
 			OutputIDs:       []string{"test-output"},
@@ -119,15 +121,16 @@ func TestTransformerDropOnErrorQuiet(t *testing.T) {
 	output.On("Process", mock.Anything, mock.Anything).Return(nil)
 
 	obs, logs := observer.New(zap.DebugLevel)
-	logger := zap.New(obs)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.New(obs)
 
 	transformer := TransformerOperator{
 		OnError: DropOnErrorQuiet,
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: logger.Sugar(),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 			OutputOperators: []operator.Operator{output},
 			OutputIDs:       []string{"test-output"},
@@ -163,15 +166,16 @@ func TestTransformerSendOnError(t *testing.T) {
 	output.On("Process", mock.Anything, mock.Anything).Return(nil)
 
 	obs, logs := observer.New(zap.WarnLevel)
-	logger := zap.New(obs)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.New(obs)
 
 	transformer := TransformerOperator{
 		OnError: SendOnError,
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: logger.Sugar(),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 			OutputOperators: []operator.Operator{output},
 			OutputIDs:       []string{"test-output"},
@@ -207,15 +211,16 @@ func TestTransformerSendOnErrorQuiet(t *testing.T) {
 	output.On("Process", mock.Anything, mock.Anything).Return(nil)
 
 	obs, logs := observer.New(zap.DebugLevel)
-	logger := zap.New(obs)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zap.New(obs)
 
 	transformer := TransformerOperator{
 		OnError: SendOnErrorQuiet,
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: logger.Sugar(),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 			OutputOperators: []operator.Operator{output},
 			OutputIDs:       []string{"test-output"},
@@ -249,13 +254,15 @@ func TestTransformerProcessWithValid(t *testing.T) {
 	output := &testutil.Operator{}
 	output.On("ID").Return("test-output")
 	output.On("Process", mock.Anything, mock.Anything).Return(nil)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = zaptest.NewLogger(t)
 	transformer := TransformerOperator{
 		OnError: SendOnError,
 		WriterOperator: WriterOperator{
 			BasicOperator: BasicOperator{
-				OperatorID:    "test-id",
-				OperatorType:  "test-type",
-				SugaredLogger: testutil.Logger(t),
+				OperatorID:   "test-id",
+				OperatorType: "test-type",
+				set:          set,
 			},
 			OutputOperators: []operator.Operator{output},
 			OutputIDs:       []string{"test-output"},

--- a/pkg/stanza/operator/input/file/input.go
+++ b/pkg/stanza/operator/input/file/input.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -46,7 +48,7 @@ func (i *Input) emit(ctx context.Context, token []byte, attrs map[string]any) er
 
 	for k, v := range attrs {
 		if err := ent.Set(entry.NewAttributeField(k), v); err != nil {
-			i.Errorf("set attribute: %w", err)
+			i.Logger().Error("set attribute", zap.Error(err))
 		}
 	}
 	i.Write(ctx, ent)

--- a/pkg/stanza/operator/input/journald/input.go
+++ b/pkg/stanza/operator/input/journald/input.go
@@ -104,7 +104,7 @@ func (operator *Input) Start(persister operator.Persister) error {
 		case failedChan <- f:
 		// log an error in case channel is closed
 		case <-time.After(waitDuration):
-			operator.Logger().Errorw("journalctl command exited", "error", f.err, "output", f.output)
+			operator.Logger().Error("journalctl command exited", zap.String("error", f.err), zap.String("output", f.output))
 		}
 	}()
 
@@ -120,7 +120,7 @@ func (operator *Input) Start(persister operator.Persister) error {
 			line, err := stderrBuf.ReadBytes('\n')
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
-					operator.Errorw("Received error reading from journalctl stderr", zap.Error(err))
+					operator.Logger().Error("Received error reading from journalctl stderr", zap.Error(err))
 				}
 				stderrChan <- strings.Join(messages, "\n")
 				return
@@ -140,18 +140,18 @@ func (operator *Input) Start(persister operator.Persister) error {
 			line, err := stdoutBuf.ReadBytes('\n')
 			if err != nil {
 				if !errors.Is(err, io.EOF) {
-					operator.Errorw("Received error reading from journalctl stdout", zap.Error(err))
+					operator.Logger().Error("Received error reading from journalctl stdout", zap.Error(err))
 				}
 				return
 			}
 
 			entry, cursor, err := operator.parseJournalEntry(line)
 			if err != nil {
-				operator.Warnw("Failed to parse journal entry", zap.Error(err))
+				operator.Logger().Warn("Failed to parse journal entry", zap.Error(err))
 				continue
 			}
 			if err := operator.persister.Set(ctx, lastReadCursorKey, []byte(cursor)); err != nil {
-				operator.Warnw("Failed to set offset", zap.Error(err))
+				operator.Logger().Warn("Failed to set offset", zap.Error(err))
 			}
 			operator.Write(ctx, entry)
 		}

--- a/pkg/stanza/operator/input/namedpipe/input.go
+++ b/pkg/stanza/operator/input/namedpipe/input.go
@@ -74,7 +74,7 @@ func (i *Input) Start(_ operator.Persister) error {
 	go func() {
 		defer i.wg.Done()
 		if err := watcher.Watch(ctx); err != nil {
-			i.Logger().Errorw("failed to watch named pipe", zap.Error(err))
+			i.Logger().Error("failed to watch named pipe", zap.Error(err))
 		}
 	}()
 
@@ -84,7 +84,7 @@ func (i *Input) Start(_ operator.Persister) error {
 			select {
 			case <-watcher.C:
 				if err := i.process(ctx, pipe); err != nil {
-					i.Logger().Errorw("failed to process named pipe", zap.Error(err))
+					i.Logger().Error("failed to process named pipe", zap.Error(err))
 				}
 			case <-ctx.Done():
 				return

--- a/pkg/stanza/operator/input/stdin/input.go
+++ b/pkg/stanza/operator/input/stdin/input.go
@@ -36,7 +36,7 @@ func (i *Input) Start(_ operator.Persister) error {
 	}
 
 	if stat.Mode()&os.ModeNamedPipe == 0 {
-		i.Warn("No data is being written to stdin")
+		i.Logger().Warn("No data is being written to stdin")
 		return nil
 	}
 
@@ -54,9 +54,9 @@ func (i *Input) Start(_ operator.Persister) error {
 
 			if ok := scanner.Scan(); !ok {
 				if err := scanner.Err(); err != nil {
-					i.Errorf("Scanning failed", zap.Error(err))
+					i.Logger().Error("Scanning failed", zap.Error(err))
 				}
-				i.Infow("Stdin has been closed")
+				i.Logger().Info("Stdin has been closed")
 				return
 			}
 

--- a/pkg/stanza/operator/input/udp/input.go
+++ b/pkg/stanza/operator/input/udp/input.go
@@ -98,7 +98,7 @@ func (i *Input) readAndProcessMessages(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			default:
-				i.Errorw("Failed reading messages", zap.Error(err))
+				i.Logger().Error("Failed reading messages", zap.Error(err))
 			}
 			break
 		}
@@ -123,7 +123,7 @@ func (i *Input) processMessage(ctx context.Context, message []byte, remoteAddr n
 		i.handleMessage(ctx, remoteAddr, dec, scanner.Bytes())
 	}
 	if err := scanner.Err(); err != nil {
-		i.Errorw("Scanner error", zap.Error(err))
+		i.Logger().Error("Scanner error", zap.Error(err))
 	}
 }
 
@@ -139,7 +139,7 @@ func (i *Input) readMessagesAsync(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			default:
-				i.Errorw("Failed reading messages", zap.Error(err))
+				i.Logger().Error("Failed reading messages", zap.Error(err))
 			}
 			break
 		}
@@ -192,14 +192,14 @@ func (i *Input) handleMessage(ctx context.Context, remoteAddr net.Addr, dec *dec
 		var err error
 		decoded, err = dec.Decode(log)
 		if err != nil {
-			i.Errorw("Failed to decode data", zap.Error(err))
+			i.Logger().Error("Failed to decode data", zap.Error(err))
 			return
 		}
 	}
 
 	entry, err := i.NewEntry(string(decoded))
 	if err != nil {
-		i.Errorw("Failed to create entry", zap.Error(err))
+		i.Logger().Error("Failed to create entry", zap.Error(err))
 		return
 	}
 
@@ -251,7 +251,7 @@ func (i *Input) Stop() error {
 		i.cancel()
 		if i.connection != nil {
 			if err := i.connection.Close(); err != nil {
-				i.Errorf("failed to close UDP connection: %s", err)
+				i.Logger().Error("failed to close UDP connection", zap.Error(err))
 			}
 		}
 		if i.AsyncConfig != nil {

--- a/pkg/stanza/operator/operator.go
+++ b/pkg/stanza/operator/operator.go
@@ -39,5 +39,5 @@ type Operator interface {
 	// Process will process an entry from an operator.
 	Process(context.Context, *entry.Entry) error
 	// Logger returns the operator's logger
-	Logger() *zap.SugaredLogger
+	Logger() *zap.Logger
 }

--- a/pkg/stanza/operator/output/file/output.go
+++ b/pkg/stanza/operator/output/file/output.go
@@ -10,6 +10,8 @@ import (
 	"os"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -44,7 +46,7 @@ func (o *Output) Start(_ operator.Persister) error {
 func (o *Output) Stop() error {
 	if o.file != nil {
 		if err := o.file.Close(); err != nil {
-			o.Errorf(err.Error())
+			o.Logger().Error("close", zap.Error(err))
 		}
 	}
 	return nil

--- a/pkg/stanza/operator/output/stdout/output.go
+++ b/pkg/stanza/operator/output/stdout/output.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"sync"
 
+	"go.uber.org/zap"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 )
@@ -25,7 +27,7 @@ func (o *Output) Process(_ context.Context, entry *entry.Entry) error {
 	err := o.encoder.Encode(entry)
 	if err != nil {
 		o.mux.Unlock()
-		o.Errorf("Failed to process entry: %s", err)
+		o.Logger().Error("Failed to process entry", zap.Error(err))
 		return err
 	}
 	o.mux.Unlock()

--- a/pkg/stanza/operator/parser/container/config.go
+++ b/pkg/stanza/operator/parser/container/config.go
@@ -52,7 +52,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		return nil, err
 	}
 
-	cLogEmitter := helper.NewLogEmitter(set.Logger.Sugar())
+	cLogEmitter := helper.NewLogEmitter(set)
 	recombineParser, err := createRecombine(set, cLogEmitter)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create internal recombine config: %w", err)

--- a/pkg/stanza/operator/parser/container/parser.go
+++ b/pkg/stanza/operator/parser/container/parser.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -92,12 +93,12 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 		p.criConsumerStartOnce.Do(func() {
 			err = p.crioLogEmitter.Start(nil)
 			if err != nil {
-				p.Logger().Warn("unable to start the internal LogEmitter: %w", err)
+				p.Logger().Error("unable to start the internal LogEmitter", zap.Error(err))
 				return
 			}
 			err = p.recombineParser.Start(nil)
 			if err != nil {
-				p.Logger().Warn("unable to start the internal recombine operator: %w", err)
+				p.Logger().Error("unable to start the internal recombine operator", zap.Error(err))
 				return
 			}
 			go p.crioConsumer(ctx)

--- a/pkg/stanza/operator/transformer/filter/transformer.go
+++ b/pkg/stanza/operator/transformer/filter/transformer.go
@@ -29,13 +29,13 @@ func (t *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
 
 	matches, err := vm.Run(t.expression, env)
 	if err != nil {
-		t.Errorf("Running expressing returned an error", zap.Error(err))
+		t.Logger().Error("Running expressing returned an error", zap.Error(err))
 		return nil
 	}
 
 	filtered, ok := matches.(bool)
 	if !ok {
-		t.Errorf("Expression did not compile as a boolean")
+		t.Logger().Error("Expression did not compile as a boolean")
 		return nil
 	}
 

--- a/pkg/stanza/operator/transformer/router/transformer.go
+++ b/pkg/stanza/operator/transformer/router/transformer.go
@@ -42,14 +42,14 @@ func (t *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
 	for _, route := range t.routes {
 		matches, err := vm.Run(route.Expression, env)
 		if err != nil {
-			t.Warnw("Running expression returned an error", zap.Error(err))
+			t.Logger().Warn("Running expression returned an error", zap.Error(err))
 			continue
 		}
 
 		// we compile the expression with "AsBool", so this should be safe
 		if matches.(bool) {
 			if err := route.Attribute(entry); err != nil {
-				t.Errorf("Failed to label entry: %s", err)
+				t.Logger().Error("Failed to label entry", zap.Error(err))
 				return err
 			}
 

--- a/pkg/stanza/pipeline/directed.go
+++ b/pkg/stanza/pipeline/directed.go
@@ -26,8 +26,9 @@ var alreadyStopped = stanzaerrors.NewError("pipeline already stopped", "")
 
 // DirectedPipeline is a pipeline backed by a directed graph
 type DirectedPipeline struct {
-	Graph *simple.DirectedGraph
+	// Deprecated [v0.101.0]
 	*zap.SugaredLogger
+	Graph     *simple.DirectedGraph
 	startOnce sync.Once
 	stopOnce  sync.Once
 }

--- a/pkg/stanza/pipeline/directed_test.go
+++ b/pkg/stanza/pipeline/directed_test.go
@@ -193,9 +193,9 @@ func TestPipelineStartOrder(t *testing.T) {
 	mockOperator2.On("SetOutputs", mock.Anything).Return(nil)
 	mockOperator3.On("SetOutputs", mock.Anything).Return(nil)
 
-	mockOperator1.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
-	mockOperator2.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
-	mockOperator3.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
+	mockOperator1.On("Logger", mock.Anything).Return(zap.NewNop())
+	mockOperator2.On("Logger", mock.Anything).Return(zap.NewNop())
+	mockOperator3.On("Logger", mock.Anything).Return(zap.NewNop())
 
 	mockOperator1.On("Start", testutil.NewMockPersister(mockOperator1.ID())).Return(fmt.Errorf("operator 1 failed to start"))
 	mockOperator2.On("Start", testutil.NewMockPersister(mockOperator2.ID())).Run(func(mock.Arguments) { mock2Started = true }).Return(nil)
@@ -227,9 +227,9 @@ func TestPipelineStopOrder(t *testing.T) {
 	mockOperator2.On("SetOutputs", mock.Anything).Return(nil)
 	mockOperator3.On("SetOutputs", mock.Anything).Return(nil)
 
-	mockOperator1.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
-	mockOperator2.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
-	mockOperator3.On("Logger", mock.Anything).Return(zap.NewNop().Sugar())
+	mockOperator1.On("Logger", mock.Anything).Return(zap.NewNop())
+	mockOperator2.On("Logger", mock.Anything).Return(zap.NewNop())
+	mockOperator3.On("Logger", mock.Anything).Return(zap.NewNop())
 
 	mockOperator1.On("Start", testutil.NewMockPersister(mockOperator1.ID())).Return(nil)
 	mockOperator2.On("Start", testutil.NewMockPersister(mockOperator2.ID())).Return(nil)

--- a/pkg/stanza/testutil/mocks.go
+++ b/pkg/stanza/testutil/mocks.go
@@ -28,14 +28,14 @@ func NewMockOperator(id string) *Operator {
 // FakeOutput is an empty output used primarily for testing
 type FakeOutput struct {
 	Received chan *entry.Entry
-	*zap.SugaredLogger
+	logger   *zap.Logger
 }
 
 // NewFakeOutput creates a new fake output with default settings
 func NewFakeOutput(t testing.TB) *FakeOutput {
 	return &FakeOutput{
-		Received:      make(chan *entry.Entry, 100),
-		SugaredLogger: zaptest.NewLogger(t).Sugar(),
+		Received: make(chan *entry.Entry, 100),
+		logger:   zaptest.NewLogger(t),
 	}
 }
 
@@ -49,7 +49,7 @@ func (f *FakeOutput) CanProcess() bool { return true }
 func (f *FakeOutput) ID() string { return "fake" }
 
 // Logger returns the logger of a fake output
-func (f *FakeOutput) Logger() *zap.SugaredLogger { return f.SugaredLogger }
+func (f *FakeOutput) Logger() *zap.Logger { return f.logger }
 
 // Outputs always returns nil for a fake output
 func (f *FakeOutput) Outputs() []operator.Operator { return nil }

--- a/pkg/stanza/testutil/operator.go
+++ b/pkg/stanza/testutil/operator.go
@@ -76,15 +76,15 @@ func (_m *Operator) ID() string {
 }
 
 // Logger provides a mock function with given fields:
-func (_m *Operator) Logger() *zap.SugaredLogger {
+func (_m *Operator) Logger() *zap.Logger {
 	ret := _m.Called()
 
-	var r0 *zap.SugaredLogger
-	if rf, ok := ret.Get(0).(func() *zap.SugaredLogger); ok {
+	var r0 *zap.Logger
+	if rf, ok := ret.Get(0).(func() *zap.Logger); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*zap.SugaredLogger)
+			r0 = ret.Get(0).(*zap.Logger)
 		}
 	}
 

--- a/pkg/stanza/testutil/util.go
+++ b/pkg/stanza/testutil/util.go
@@ -16,7 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-// Logger will return a new tesst logger
+// Deprecated [v0.101.0] Use zaptest.NewLogger directly instead
 func Logger(t testing.TB) *zap.SugaredLogger {
 	return zaptest.NewLogger(t, zaptest.Level(zapcore.ErrorLevel)).Sugar()
 }

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -23,7 +23,6 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/consumerretry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
@@ -81,7 +80,7 @@ func TestReadStaticFile(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 	cfg := testdataConfigYaml()
 
-	converter := adapter.NewConverter(zap.NewNop())
+	converter := adapter.NewConverter(componenttest.NewNopTelemetrySettings())
 	converter.Start()
 	defer converter.Stop()
 
@@ -168,7 +167,7 @@ func (rt *rotationTest) Run(t *testing.T) {
 
 	// Build expected outputs
 	expectedTimestamp, _ := time.ParseInLocation("2006-01-02", "2020-08-25", time.Local)
-	converter := adapter.NewConverter(zap.NewNop())
+	converter := adapter.NewConverter(componenttest.NewNopTelemetrySettings())
 	converter.Start()
 
 	var wg sync.WaitGroup

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -15,7 +15,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.26.0
 	go.opentelemetry.io/otel/trace v1.26.0
 	go.uber.org/goleak v1.3.0
-	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -56,6 +55,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.26.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.26.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect

--- a/receiver/namedpipereceiver/go.mod
+++ b/receiver/namedpipereceiver/go.mod
@@ -13,7 +13,6 @@ require (
 	go.opentelemetry.io/otel/metric v1.26.0
 	go.opentelemetry.io/otel/trace v1.26.0
 	go.uber.org/goleak v1.3.0
-	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -55,6 +54,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.26.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.26.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.24.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect
 	golang.org/x/text v0.15.0 // indirect

--- a/receiver/namedpipereceiver/namedpipe_test.go
+++ b/receiver/namedpipereceiver/namedpipe_test.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/consumerretry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/adapter"
@@ -56,7 +55,7 @@ func TestReadPipe(t *testing.T) {
 	sink := new(consumertest.LogsSink)
 	cfg := testdataConfigYaml()
 
-	converter := adapter.NewConverter(zap.NewNop())
+	converter := adapter.NewConverter(componenttest.NewNopTelemetrySettings())
 	converter.Start()
 	defer converter.Stop()
 


### PR DESCRIPTION
#32662 updated many exported functions to accept `component.TelemetrySettings` instead of `zap.SugaredLogger`. This PR continues from there by passing `component.TelemetrySettings` deeper into the inner packages, and migrates from using `zap.SugaredLogger` to instead using `zap.Logger` (as provided by `component.TelemetrySettings`).