### PR TITLE
[extension/storage/filestorage] Document how to read files created by the `file_storage` extension

### DIFF
--- a/extension/storage/filestorage/README.md
+++ b/extension/storage/filestorage/README.md
@@ -133,3 +133,27 @@ The schedule for this feature gate is:
 - Removed three releases after `stable`.
 
 [unicode_chars]: https://en.wikipedia.org/wiki/List_of_Unicode_characters
+
+## Reading File Storage files
+
+The simplest way to read files created by the File Storage extension is to use the strings utility ([Linux](https://linux.die.net/man/1/strings), 
+[Windows](https://learn.microsoft.com/en-us/sysinternals/downloads/strings)).
+
+For example, here are the contents of the file created by the File Storage extension when it's configured as the storage
+for the `filelog` receiver.
+
+```sh
+$ strings /tmp/otelcol/file_storage/filelogreceiver/receiver_filelog_
+default
+file_input.knownFiles2
+{"Fingerprint":{"first_bytes":"MzEwNzkKMjE5Cg=="},"Offset":10,"FileAttributes":{"log.file.name":"1.log"},"HeaderFinalized":false,"FlushState":{"LastDataChange":"2024-03-20T18:16:18.164331-07:00","LastDataLength":0}}
+{"Fingerprint":{"first_bytes":"MjQ0MDMK"},"Offset":6,"FileAttributes":{"log.file.name":"2.log"},"HeaderFinalized":false,"FlushState":{"LastDataChange":"2024-03-20T18:16:39.96429-07:00","LastDataLength":0}}
+default
+file_input.knownFiles2
+{"Fingerprint":{"first_bytes":"MzEwNzkKMjE5Cg=="},"Offset":10,"FileAttributes":{"log.file.name":"1.log"},"HeaderFinalized":false,"FlushState":{"LastDataChange":"2024-03-20T18:16:18.164331-07:00","LastDataLength":0}}
+{"Fingerprint":{"first_bytes":"MjQ0MDMK"},"Offset":6,"FileAttributes":{"log.file.name":"2.log"},"HeaderFinalized":false,"FlushState":{"LastDataChange":"2024-03-20T18:16:39.96429-07:00","LastDataLength":0}}
+default
+file_input.knownFiles2
+{"Fingerprint":{"first_bytes":"MzEwNzkKMjE5Cg=="},"Offset":10,"FileAttributes":{"log.file.name":"1.log"},"HeaderFinalized":false,"FlushState":{"LastDataChange":"2024-03-20T18:16:18.164331-07:00","LastDataLength":0}}
+{"Fingerprint":{"first_bytes":"MjQ0MDMK"},"Offset":6,"FileAttributes":{"log.file.name":"2.log"},"HeaderFinalized":false,"FlushState":{"LastDataChange":"2024-03-20T18:16:39.96429-07:00","LastDataLength":0}}
+```

--- a/extension/storage/filestorage/README.md
+++ b/extension/storage/filestorage/README.md
@@ -136,8 +136,12 @@ The schedule for this feature gate is:
 
 ## Troubleshooting
 
-When troubleshooting components that use file storage, it is sometimes helpful to read the raw contents of
-files created by the File Storage extension for the component that's using it.  The simplest way to read files
+_Currently, the File Storage extension uses [bbolt](https://github.com/etcd-io/bbolt) to store and read data on disk. The
+following troubleshooting method works for bbolt-managed files. As such, there is no guarantee that the following
+troubleshooting method will continue to work in the future, particularly if the extension switches away from bbolt._
+
+When troubleshooting components that use the File Storage extension, it is sometimes helpful to read the raw contents of
+files created by the extension for the component.  The simplest way to read files
 created by the File Storage extension is to use the strings utility ([Linux](https://linux.die.net/man/1/strings),
 [Windows](https://learn.microsoft.com/en-us/sysinternals/downloads/strings)).
 

--- a/extension/storage/filestorage/README.md
+++ b/extension/storage/filestorage/README.md
@@ -134,9 +134,11 @@ The schedule for this feature gate is:
 
 [unicode_chars]: https://en.wikipedia.org/wiki/List_of_Unicode_characters
 
-## Reading File Storage files
+## Troubleshooting
 
-The simplest way to read files created by the File Storage extension is to use the strings utility ([Linux](https://linux.die.net/man/1/strings),
+When troubleshooting components that use file storage, it is sometimes helpful to read the raw contents of
+files created by the File Storage extension for the component that's using it.  The simplest way to read files
+created by the File Storage extension is to use the strings utility ([Linux](https://linux.die.net/man/1/strings),
 [Windows](https://learn.microsoft.com/en-us/sysinternals/downloads/strings)).
 
 For example, here are the contents of the file created by the File Storage extension when it's configured as the storage

--- a/extension/storage/filestorage/README.md
+++ b/extension/storage/filestorage/README.md
@@ -136,7 +136,7 @@ The schedule for this feature gate is:
 
 ## Reading File Storage files
 
-The simplest way to read files created by the File Storage extension is to use the strings utility ([Linux](https://linux.die.net/man/1/strings), 
+The simplest way to read files created by the File Storage extension is to use the strings utility ([Linux](https://linux.die.net/man/1/strings),
 [Windows](https://learn.microsoft.com/en-us/sysinternals/downloads/strings)).
 
 For example, here are the contents of the file created by the File Storage extension when it's configured as the storage

--- a/extension/storage/filestorage/README.md
+++ b/extension/storage/filestorage/README.md
@@ -137,8 +137,7 @@ The schedule for this feature gate is:
 ## Troubleshooting
 
 _Currently, the File Storage extension uses [bbolt](https://github.com/etcd-io/bbolt) to store and read data on disk. The
-following troubleshooting method works for bbolt-managed files. As such, there is no guarantee that the following
-troubleshooting method will continue to work in the future, particularly if the extension switches away from bbolt._
+following troubleshooting method works for bbolt-managed files. As such, there is no guarantee that this method will continue to work in the future, particularly if the extension switches away from bbolt._
 
 When troubleshooting components that use the File Storage extension, it is sometimes helpful to read the raw contents of
 files created by the extension for the component.  The simplest way to read files


### PR DESCRIPTION
**Description:** 

This PR adds documentation explaining how to read the contents of files created by the `file_storage` extension.

**Link to tracking Issue:**
* Related to #30970
* Follow up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31886#discussion_r1542581347
