### PR TITLE
[chore][receiver/snowflake] Enable goleak check

### DIFF
--- a/receiver/snowflakereceiver/client_test.go
+++ b/receiver/snowflakereceiver/client_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestDefaultClientCreation(t *testing.T) {
-	_, err := newDefaultClient(componenttest.NewNopTelemetrySettings(), Config{
+	c, err := newDefaultClient(componenttest.NewNopTelemetrySettings(), Config{
 		Username:  "testuser",
 		Password:  "testPassword",
 		Account:   "testAccount",
@@ -27,7 +27,8 @@ func TestDefaultClientCreation(t *testing.T) {
 		Database:  "testDatabase",
 		Role:      "testRole",
 	})
-	assert.Equal(t, nil, err)
+	assert.NoError(t, err)
+	assert.NoError(t, c.client.Close())
 }
 
 // test query wrapper

--- a/receiver/snowflakereceiver/package_test.go
+++ b/receiver/snowflakereceiver/package_test.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/goleak"
 )
 
+// Regarding the godbus/dbus ignore: see https://github.com/99designs/keyring/issues/103
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/godbus/dbus.(*Conn).inWorker"))
 }

--- a/receiver/snowflakereceiver/package_test.go
+++ b/receiver/snowflakereceiver/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package snowflakereceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/receiver/snowflakereceiver/scraper_test.go
+++ b/receiver/snowflakereceiver/scraper_test.go
@@ -72,6 +72,7 @@ func TestStart(t *testing.T) {
 	scraper := newSnowflakeMetricsScraper(receivertest.NewNopCreateSettings(), cfg)
 	err := scraper.start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err, "Problem starting scraper")
+	require.NoError(t, scraper.shutdown(context.Background()))
 }
 
 // wrapper type for convenience


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables the `goleak` check for the Snowflake receiver to help ensure no goroutines are being leaked. This is a test only change, a couple shutdown/close calls were missing.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` check.