### PR TITLE
[chore][receiver/purefb] Enable goleak check

### DIFF
--- a/receiver/purefbreceiver/metrics_receiver_test.go
+++ b/receiver/purefbreceiver/metrics_receiver_test.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
-func TestStart(t *testing.T) {
+func TestStartAndShutdown(t *testing.T) {
 	// prepare
 	cfg, ok := createDefaultConfig().(*Config)
 	require.True(t, ok)
@@ -22,27 +22,7 @@ func TestStart(t *testing.T) {
 	sink := &consumertest.MetricsSink{}
 	recv := newReceiver(cfg, receivertest.NewNopCreateSettings(), sink)
 
-	// test
-	err := recv.Start(context.Background(), componenttest.NewNopHost())
-
 	// verify
-	assert.NoError(t, err)
-}
-
-func TestShutdown(t *testing.T) {
-	// prepare
-	cfg, ok := createDefaultConfig().(*Config)
-	require.True(t, ok)
-
-	sink := &consumertest.MetricsSink{}
-	recv := newReceiver(cfg, receivertest.NewNopCreateSettings(), sink)
-
-	err := recv.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
-
-	// test
-	err = recv.Shutdown(context.Background())
-
-	// verify
-	assert.NoError(t, err)
+	assert.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, recv.Shutdown(context.Background()))
 }

--- a/receiver/purefbreceiver/package_test.go
+++ b/receiver/purefbreceiver/package_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package purefbreceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// See https://github.com/census-instrumentation/opencensus-go/issues/1191 for more information on opencensus ignore.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This change enables `goleak` checks on the Pure Storage FlashBlade receiver to help ensure no goroutines are being leaked. This is a test only change as a test was missing a shutdown call.

This looks like I deleted a test, but the two tests were identical, other than a missing shutdown call. Once the missing call was added they were identical, so I decided to delete one. I also consolidated err checking to remove the `err` variable and directly check the result of the `Start` and `Shutdown` methods.

**Link to tracking Issue:** <Issue number if applicable>
#30438 

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` check.