### PR TITLE
[receiver/filelog] Add test cases for recursive globs

### DIFF
--- a/pkg/stanza/fileconsumer/matcher/matcher_test.go
+++ b/pkg/stanza/fileconsumer/matcher/matcher_test.go
@@ -730,7 +730,22 @@ func TestMatcher(t *testing.T) {
 				"a/b/c/1.log",
 			},
 		},
-	}
+		{
+			name: "Recursive match - include and exclude",
+			files: []string{
+				"a/1.log",
+				"a/2.log",
+				"a/b/1.log",
+				"a/b/2.log",
+				"a/b/c/1.log",
+				"a/b/c/2.log",
+			},
+			include: []string{"**/1.log"},
+			exclude: []string{"**/b/**/1.log"},
+			expected: []string{
+				"a/1.log",
+			},
+		}}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/stanza/fileconsumer/matcher/matcher_test.go
+++ b/pkg/stanza/fileconsumer/matcher/matcher_test.go
@@ -712,6 +712,24 @@ func TestMatcher(t *testing.T) {
 			},
 			expected: []string{"err.b.1.2023020602.log"},
 		},
+		{
+			name: "Recursive match - include",
+			files: []string{
+				"a/1.log",
+				"a/2.log",
+				"a/b/1.log",
+				"a/b/2.log",
+				"a/b/c/1.log",
+				"a/b/c/2.log",
+			},
+			include: []string{"**/1.log"},
+			exclude: []string{},
+			expected: []string{
+				"a/1.log",
+				"a/b/1.log",
+				"a/b/c/1.log",
+			},
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
**Description:**

This PR adds a couple of unit test cases exercising recursive glob (`**`) usage in the `include` and `exclude` options of the `filelog` receiver.
