### PR TITLE
[chore][receiver/purefa] Enable goleak check

### DIFF
--- a/receiver/purefareceiver/package_test.go
+++ b/receiver/purefareceiver/package_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package purefareceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// Regarding the OpenCensus ignore: see https://github.com/census-instrumentation/opencensus-go/issues/1191
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+}

--- a/receiver/purefareceiver/receiver_test.go
+++ b/receiver/purefareceiver/receiver_test.go
@@ -7,14 +7,13 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
-func TestStart(t *testing.T) {
+func TestStartAndShutdown(t *testing.T) {
 	// prepare
 	cfg, ok := createDefaultConfig().(*Config)
 	require.True(t, ok)
@@ -22,27 +21,6 @@ func TestStart(t *testing.T) {
 	sink := &consumertest.MetricsSink{}
 	recv := newReceiver(cfg, receivertest.NewNopCreateSettings(), sink)
 
-	// test
-	err := recv.Start(context.Background(), componenttest.NewNopHost())
-
-	// verify
-	assert.NoError(t, err)
-}
-
-func TestShutdown(t *testing.T) {
-	// prepare
-	cfg, ok := createDefaultConfig().(*Config)
-	require.True(t, ok)
-
-	sink := &consumertest.MetricsSink{}
-	recv := newReceiver(cfg, receivertest.NewNopCreateSettings(), sink)
-
-	err := recv.Start(context.Background(), componenttest.NewNopHost())
-	require.NoError(t, err)
-
-	// test
-	err = recv.Shutdown(context.Background())
-
-	// verify
-	assert.NoError(t, err)
+	require.NoError(t, recv.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, recv.Shutdown(context.Background()))
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable `goleak` check for the PureStorage Flash Array receiver to help ensure no goroutines are being leaked. This is a test only change. The `TestStart` test was missing a shutdown call, and once the shutdown call was added, it was a duplicate test to `TestShutdown`. I consolidated these two tests into one, called `TestStartAndShutdown`.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as the added `goleak` check.