### PR TITLE
[chore][receiver/podman] Enable goleak check

### DIFF
--- a/receiver/podmanreceiver/go.mod
+++ b/receiver/podmanreceiver/go.mod
@@ -13,6 +13,7 @@ require (
 	go.opentelemetry.io/collector/semconv v0.97.1-0.20240404121116-4f1a8936d26b
 	go.opentelemetry.io/otel/metric v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.21.0

--- a/receiver/podmanreceiver/package_test.go
+++ b/receiver/podmanreceiver/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package podmanreceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -134,7 +134,9 @@ func TestEventLoopHandlesError(t *testing.T) {
 	cli := newContainerScraper(client, zap.New(observed), config)
 	assert.NotNil(t, cli)
 
-	go cli.containerEventLoop(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	go cli.containerEventLoop(ctx)
+	defer cancel()
 
 	assert.Eventually(t, func() bool {
 		for _, l := range logs.All() {
@@ -176,7 +178,10 @@ func TestEventLoopHandles(t *testing.T) {
 
 	assert.Equal(t, 0, len(cli.containers))
 
-	go cli.containerEventLoop(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	go cli.containerEventLoop(ctx)
+	defer cancel()
+
 	eventChan <- event{ID: "c1", Status: "start"}
 
 	assert.Eventually(t, func() bool {

--- a/receiver/podmanreceiver/receiver_test.go
+++ b/receiver/podmanreceiver/receiver_test.go
@@ -57,7 +57,10 @@ func TestScraperLoop(t *testing.T) {
 	client := make(mockClient)
 	consumer := make(mockConsumer)
 
-	r, err := newMetricsReceiver(context.Background(), receivertest.NewNopCreateSettings(), cfg, consumer, client.factory)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	r, err := newMetricsReceiver(ctx, receivertest.NewNopCreateSettings(), cfg, consumer, client.factory)
 	require.NoError(t, err)
 	assert.NotNil(t, r)
 
@@ -70,12 +73,12 @@ func TestScraperLoop(t *testing.T) {
 		}
 	}()
 
-	assert.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
 
 	md := <-consumer
 	assert.Equal(t, md.ResourceMetrics().Len(), 1)
 
-	assert.NoError(t, r.Shutdown(context.Background()))
+	assert.NoError(t, r.Shutdown(ctx))
 }
 
 type mockClient chan containerStatsReport


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable `goleak` checking on the Podman receiver to help ensure no goroutines are being leaked. This is a test only change.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` check.