### PR TITLE
[chore][receiver/nginx] Enable goleak check

### DIFF
--- a/receiver/nginxreceiver/package_test.go
+++ b/receiver/nginxreceiver/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package nginxreceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/receiver/nginxreceiver/scraper_test.go
+++ b/receiver/nginxreceiver/scraper_test.go
@@ -24,6 +24,8 @@ import (
 
 func TestScraper(t *testing.T) {
 	nginxMock := newMockServer(t)
+	defer nginxMock.Close()
+
 	cfg := createDefaultConfig().(*Config)
 	cfg.Endpoint = nginxMock.URL + "/status"
 	require.NoError(t, component.ValidateConfig(cfg))
@@ -79,6 +81,7 @@ func TestScraperError(t *testing.T) {
 		_, err = sc.scrape(context.Background())
 		require.ErrorContains(t, err, "Bad status page")
 	})
+	nginxMock.Close()
 }
 
 func TestScraperFailedStart(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable `goleak` check for the NGINX receiver to help ensure no goroutines are being leaked. This is a test only change, a couple test servers were missing `Close` calls.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` check.