### PR TITLE
[DO NOT MERGE] Remove integration test naming requirement

### DIFF
--- a/Makefile.Common
+++ b/Makefile.Common
@@ -29,7 +29,7 @@ GOTEST_TIMEOUT?= 300s
 GOTEST_OPT?= -race -timeout $(GOTEST_TIMEOUT) -parallel 4 --tags=$(GO_BUILD_TAGS)
 GOTEST_INTEGRATION_OPT?= -race -timeout 360s -parallel 4
 GOTEST_OPT_WITH_COVERAGE = $(GOTEST_OPT) -coverprofile=coverage.txt -covermode=atomic
-GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS) -run=Integration
+GOTEST_OPT_WITH_INTEGRATION=$(GOTEST_INTEGRATION_OPT) -tags=integration,$(GO_BUILD_TAGS)
 GOTEST_OPT_WITH_INTEGRATION_COVERAGE=$(GOTEST_OPT_WITH_INTEGRATION) -coverprofile=integration-coverage.txt -covermode=atomic
 GOCMD?= go
 GOOS=$(shell $(GOCMD) env GOOS)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
While attempting to solve another bug I was running existing integration tests locally in the MongoDB Atlas receiver, and found that they were failing due to issues changes from more than a year ago. I did some investigation and found that it looks like the current options for running integration tests only run tests in integration files that contain `Integration` in their name. I'm posting this PR to try to confirm my understanding.

If I'm correct I'll file a bug.