### PR TITLE
[connector/exceptions] Always add span name as a dimension in the output metrics and log records

### DIFF
--- a/.chloggen/add-span-name-dimension-by-default.yaml
+++ b/.chloggen/add-span-name-dimension-by-default.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exceptionsconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make span name a default dimension for ouput metrics and log records.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32162]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/add-span-name-dimension-by-default.yaml
+++ b/.chloggen/add-span-name-dimension-by-default.yaml
@@ -1,5 +1,3 @@
-# Use this changelog template to create an entry for release notes.
-
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
 change_type: enhancement
 

--- a/connector/exceptionsconnector/README.md
+++ b/connector/exceptionsconnector/README.md
@@ -28,6 +28,7 @@ Generate metrics and logs from recorded [application exceptions](https://github.
 
 Each **metric** and **log** will have _at least_ the following dimensions:
 - Service name
+- Span name
 - Span kind
 - Status code
 

--- a/connector/exceptionsconnector/connector.go
+++ b/connector/exceptionsconnector/connector.go
@@ -15,6 +15,7 @@ const (
 	exceptionStacktraceKey = conventions.AttributeExceptionStacktrace
 	// TODO(marctc): formalize these constants in the OpenTelemetry specification.
 	spanKindKey   = "span.kind"   // OpenTelemetry non-standard constant.
+	spanNameKey   = "span.name"   // OpenTelemetry non-standard constant.
 	statusCodeKey = "status.code" // OpenTelemetry non-standard constant.
 	eventNameExc  = "exception"   // OpenTelemetry non-standard constant.
 )

--- a/connector/exceptionsconnector/connector_logs.go
+++ b/connector/exceptionsconnector/connector_logs.go
@@ -106,6 +106,7 @@ func (c *logsConnector) attrToLogRecord(sl plog.ScopeLogs, serviceName string, s
 	spanAttrs.CopyTo(logRecord.Attributes())
 
 	// Add common attributes to the log record.
+	logRecord.Attributes().PutStr(spanNameKey, span.Name())
 	logRecord.Attributes().PutStr(spanKindKey, traceutil.SpanKindStr(span.Kind()))
 	logRecord.Attributes().PutStr(statusCodeKey, traceutil.StatusCodeStr(span.Status().Code()))
 	logRecord.Attributes().PutStr(serviceNameKey, serviceName)

--- a/connector/exceptionsconnector/connector_metrics.go
+++ b/connector/exceptionsconnector/connector_metrics.go
@@ -160,6 +160,7 @@ func buildDimensionKVs(dimensions []dimension, serviceName string, span ptrace.S
 	dims := pcommon.NewMap()
 	dims.EnsureCapacity(3 + len(dimensions))
 	dims.PutStr(serviceNameKey, serviceName)
+	dims.PutStr(spanNameKey, span.Name())
 	dims.PutStr(spanKindKey, traceutil.SpanKindStr(span.Kind()))
 	dims.PutStr(statusCodeKey, traceutil.StatusCodeStr(span.Status().Code()))
 	for _, d := range dimensions {

--- a/connector/exceptionsconnector/connector_metrics_test.go
+++ b/connector/exceptionsconnector/connector_metrics_test.go
@@ -25,6 +25,7 @@ import (
 // metricID represents the minimum attributes that uniquely identifies a metric in our tests.
 type metricID struct {
 	service    string
+	spanName   string
 	kind       string
 	statusCode string
 }
@@ -196,6 +197,8 @@ func verifyMetricLabels(dp metricDataPoint, t testing.TB, seenMetricIDs map[metr
 		switch k {
 		case serviceNameKey:
 			mID.service = v.Str()
+		case spanNameKey:
+			mID.spanName = v.Str()
 		case spanKindKey:
 			mID.kind = v.Str()
 		case statusCodeKey:

--- a/connector/exceptionsconnector/connector_test.go
+++ b/connector/exceptionsconnector/connector_test.go
@@ -32,6 +32,7 @@ type serviceSpans struct {
 }
 
 type span struct {
+	name       string
 	kind       ptrace.SpanKind
 	statusCode ptrace.StatusCode
 }
@@ -49,10 +50,12 @@ func buildSampleTrace() ptrace.Traces {
 			serviceName: "service-a",
 			spans: []span{
 				{
+					name:       "svc-a-ep1",
 					kind:       ptrace.SpanKindServer,
 					statusCode: ptrace.StatusCodeError,
 				},
 				{
+					name:       "svc-a-ep2",
 					kind:       ptrace.SpanKindClient,
 					statusCode: ptrace.StatusCodeError,
 				},
@@ -63,6 +66,7 @@ func buildSampleTrace() ptrace.Traces {
 			serviceName: "service-b",
 			spans: []span{
 				{
+					name:       "svc-b-ep1",
 					kind:       ptrace.SpanKindServer,
 					statusCode: ptrace.StatusCodeError,
 				},
@@ -85,6 +89,7 @@ func initServiceSpans(serviceSpans serviceSpans, spans ptrace.ResourceSpans) {
 
 func initSpan(span span, s ptrace.Span) {
 	s.SetKind(span.kind)
+	s.SetName(span.name)
 	s.Status().SetCode(span.statusCode)
 	now := time.Now()
 	s.SetStartTimestamp(pcommon.NewTimestampFromTime(now))

--- a/connector/exceptionsconnector/testdata/config.yaml
+++ b/connector/exceptionsconnector/testdata/config.yaml
@@ -8,6 +8,7 @@ exceptions/full:
   # - span.name
   # - span.kind
   # - status.code
+  # - exception.stacktrace (Only for log records)
   dimensions:
     - name: exception.type
     - name: exception.message

--- a/connector/exceptionsconnector/testdata/logs.yml
+++ b/connector/exceptionsconnector/testdata/logs.yml
@@ -23,6 +23,9 @@ resourceLogs:
               - key: arrayAttrName
                 value:
                   arrayValue: {}
+              - key: span.name
+                value:
+                  stringValue: svc-a-ep1
               - key: span.kind
                 value:
                   stringValue: SPAN_KIND_SERVER
@@ -67,6 +70,9 @@ resourceLogs:
               - key: arrayAttrName
                 value:
                   arrayValue: {}
+              - key: span.name
+                value:
+                  stringValue: svc-a-ep2
               - key: span.kind
                 value:
                   stringValue: SPAN_KIND_CLIENT
@@ -115,6 +121,9 @@ resourceLogs:
               - key: arrayAttrName
                 value:
                   arrayValue: {}
+              - key: span.name
+                value:
+                  stringValue: svc-b-ep1
               - key: span.kind
                 value:
                   stringValue: SPAN_KIND_SERVER


### PR DESCRIPTION

**Description:** 
This change adds span.name as one of the default fields attached to the output logs and metrics.
This can help isolate the root cause of problems to specific endpoints within a service.

**Link to tracking Issue:** 
32162

**Testing:** 
- Unit Test Updated and Passed.
- Verified by label by sending the metrics to the prometheus exporter.
- Verified that logs output has span.name by sending the output to Splunk HEC exporter

**Documentation:** 
Updated README.md and Changelog file