### PR TITLE
[connector/countconnector] Handle non-string attributes

### DIFF
--- a/.chloggen/lkwronski.issue-30314-count-connector.yaml
+++ b/.chloggen/lkwronski.issue-30314-count-connector.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: connector/count 
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix handling of non-string attributes in the count connector
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30314]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/countconnector/README.md
+++ b/connector/countconnector/README.md
@@ -100,7 +100,7 @@ connectors:
 If attributes are specified for custom metrics, a separate count will be generated for each unique
 set of attribute values. Each count will be emitted as a data point on the same metric.
 
-Optionally, include a `default_value` for an attribute, to count data that does not contain the attribute.
+Optionally, include a `default_value` for an attribute, to count data that does not contain the attribute. The `default_value` value can be of type string, integer, or float.
 
 ```yaml
 receivers:

--- a/connector/countconnector/config.go
+++ b/connector/countconnector/config.go
@@ -48,7 +48,7 @@ type MetricInfo struct {
 
 type AttributeConfig struct {
 	Key          string `mapstructure:"key"`
-	DefaultValue string `mapstructure:"default_value"`
+	DefaultValue any    `mapstructure:"default_value"`
 }
 
 func (c *Config) Validate() error {

--- a/connector/countconnector/config_test.go
+++ b/connector/countconnector/config_test.go
@@ -323,6 +323,53 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "default_values",
+			expect: &Config{
+				Spans: map[string]MetricInfo{
+					defaultMetricNameSpans: {
+						Description: defaultMetricDescSpans,
+					},
+				},
+				SpanEvents: map[string]MetricInfo{
+					defaultMetricNameSpanEvents: {
+						Description: defaultMetricDescSpanEvents,
+					},
+				},
+				Metrics: map[string]MetricInfo{
+					defaultMetricNameMetrics: {
+						Description: defaultMetricDescMetrics,
+					},
+				},
+				DataPoints: map[string]MetricInfo{
+					defaultMetricNameDataPoints: {
+						Description: defaultMetricDescDataPoints,
+					},
+				},
+				Logs: map[string]MetricInfo{
+					"my.logrecord.count": {
+						Description: "My log record count with default values.",
+					},
+					"limited.logrecord.count": {
+						Description: "Limited log record count.",
+						Attributes: []AttributeConfig{
+							{
+								Key:          "env",
+								DefaultValue: "local",
+							},
+							{
+								Key:          "http_code",
+								DefaultValue: int(200),
+							},
+							{
+								Key:          "request_success",
+								DefaultValue: float64(0.85),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/connector/countconnector/connector_test.go
+++ b/connector/countconnector/connector_test.go
@@ -450,6 +450,40 @@ func TestMetricsToMetrics(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "int_attribute_value",
+			cfg: &Config{
+				DataPoints: map[string]MetricInfo{
+					"datapoint.count.by_attr": {
+						Description: "Data point count by int attribute",
+						Attributes: []AttributeConfig{
+							{
+								Key: "datapoint.int",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "default_int_attribute_value",
+			cfg: &Config{
+				DataPoints: map[string]MetricInfo{
+					"datapoint.count.by_attr": {
+						Description: "Data point count by default int attribute",
+						Attributes: []AttributeConfig{
+							{
+								Key: "datapoint.int",
+							},
+							{
+								Key:          "datapoint.optional_int",
+								DefaultValue: 10,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range testCases {

--- a/connector/countconnector/testdata/config.yaml
+++ b/connector/countconnector/testdata/config.yaml
@@ -165,3 +165,16 @@
           - key: env
           - key: component
             default_value: other
+  count/default_values:
+    logs:
+      my.logrecord.count:
+        description: My log record count with default values.
+      limited.logrecord.count:
+        description: Limited log record count.
+        attributes:
+          - key: env
+            default_value: "local"
+          - key: http_code
+            default_value: 200
+          - key: request_success
+            default_value: 0.85

--- a/connector/countconnector/testdata/metrics/default_int_attribute_value.yaml
+++ b/connector/countconnector/testdata/metrics/default_int_attribute_value.yaml
@@ -1,0 +1,52 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: resource.int
+          value:
+            intValue: 1
+        - key: resource.optional_int
+          value:
+            intValue: 2
+    scopeMetrics:
+      - metrics:
+          - description: Data point count by default int attribute
+            name: datapoint.count.by_attr
+            sum:
+              aggregationTemporality: 1
+              dataPoints:                     
+                - asInt: "1"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4   
+                - asInt: "5"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4  
+                - asInt: "6"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 2 
+                - asInt: "6"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 10 
+                  timeUnixNano: "1678391923821179000"
+              isMonotonic: true
+        scope:
+          name: otelcol/countconnector

--- a/connector/countconnector/testdata/metrics/input.yaml
+++ b/connector/countconnector/testdata/metrics/input.yaml
@@ -451,6 +451,231 @@ resourceMetrics:
         scope: {}
   - resource:
       attributes:
+        - key: resource.int
+          value:
+            intValue: 1
+        - key: resource.optional_int
+          value:
+            intValue: 2
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "123"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 2
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asInt: "456"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asInt: "789"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asInt: "0"
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+            name: gauge-int
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: 1.23
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 2
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asDouble: 4.56
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asDouble: 7.89
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asDouble: 0
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+            name: gauge-double
+            unit: "1"
+          - name: counter-int
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "123"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 2
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asInt: "456"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asInt: "789"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asInt: "0"
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+              isMonotonic: true
+            unit: "1"
+          - name: counter-double
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 1.23
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 2
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asDouble: 4.56
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asDouble: 4.56
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+                - asDouble: 0
+                  startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+              isMonotonic: true
+            unit: "1"
+          - histogram:
+              aggregationTemporality: 2
+              dataPoints:
+                - attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 2
+                  count: "1"
+                  startTimeUnixNano: "1581452772000000321"
+                  sum: 15
+                  timeUnixNano: "1581452773000000789"
+                - attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4
+                  count: "2"
+                  startTimeUnixNano: "1581452772000000321"
+                  sum: 30
+                  timeUnixNano: "1581452773000000789"
+                - attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                  count: "3"
+                  startTimeUnixNano: "1581452772000000321"
+                  sum: 45
+                  timeUnixNano: "1581452773000000789"
+                - startTimeUnixNano: "1581452772000000321"
+                  sum: 0
+                  timeUnixNano: "1581452773000000789"
+            name: double-histogram
+            unit: "1"
+          - name: double-summary
+            summary:
+              dataPoints:
+                - attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 2
+                  count: "1"
+                  startTimeUnixNano: "1581452772000000321"
+                  sum: 15
+                  timeUnixNano: "1581452773000000789"
+                - attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                    - key: datapoint.optional_int
+                      value:
+                        intValue: 4
+                  count: "2"
+                  startTimeUnixNano: "1581452772000000321"
+                  sum: 30
+                  timeUnixNano: "1581452773000000789"
+                - attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                  count: "3"
+                  startTimeUnixNano: "1581452772000000321"
+                  sum: 45
+                  timeUnixNano: "1581452773000000789"
+                - startTimeUnixNano: "1581452772000000321"
+                  timeUnixNano: "1581452773000000789"
+            unit: "1"
+        scope: {}      
+  - resource:
+      attributes:
         - key: resource.required
           value:
             stringValue: notfoo

--- a/connector/countconnector/testdata/metrics/int_attribute_value.yaml
+++ b/connector/countconnector/testdata/metrics/int_attribute_value.yaml
@@ -1,0 +1,31 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: resource.int
+          value:
+            intValue: 1
+        - key: resource.optional_int
+          value:
+            intValue: 2
+    scopeMetrics:
+      - metrics:
+          - description: Data point count by int attribute
+            name: datapoint.count.by_attr
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "11"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 1
+                  timeUnixNano: "1678391923821179000"
+                - asInt: "7"
+                  attributes:
+                    - key: datapoint.int
+                      value:
+                        intValue: 10
+                  timeUnixNano: "1678391923821179000"
+              isMonotonic: true
+        scope:
+          name: otelcol/countconnector

--- a/connector/countconnector/testdata/metrics/multiple_conditions.yaml
+++ b/connector/countconnector/testdata/metrics/multiple_conditions.yaml
@@ -101,3 +101,23 @@ resourceMetrics:
               isMonotonic: true
         scope:
           name: otelcol/countconnector
+  - resource:
+      attributes:
+        - key: resource.int
+          value:
+            intValue: 1
+        - key: resource.optional_int
+          value:
+            intValue: 2
+    scopeMetrics:
+      - metrics:
+          - description: Metric count if ...
+            name: metric.count.if
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  timeUnixNano: "1678391923819487000"
+              isMonotonic: true
+        scope:
+          name: otelcol/countconnector

--- a/connector/countconnector/testdata/metrics/multiple_metrics.yaml
+++ b/connector/countconnector/testdata/metrics/multiple_metrics.yaml
@@ -165,3 +165,39 @@ resourceMetrics:
               isMonotonic: true
         scope:
           name: otelcol/countconnector
+  - resource:
+      attributes:
+        - key: resource.int
+          value:
+            intValue: 1
+        - key: resource.optional_int
+          value:
+            intValue: 2
+    scopeMetrics:
+      - metrics:
+          - description: All metrics count
+            name: metric.count.all
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "6"
+                  timeUnixNano: "1678391923820480000"
+              isMonotonic: true
+          - description: Metric count if ...
+            name: metric.count.if
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "1"
+                  timeUnixNano: "1678391923820480000"
+              isMonotonic: true
+          - description: All data points count
+            name: datapoint.count.all
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "24"
+                  timeUnixNano: "1678391923820480000"
+              isMonotonic: true
+        scope:
+          name: otelcol/countconnector

--- a/connector/countconnector/testdata/metrics/zero_conditions.yaml
+++ b/connector/countconnector/testdata/metrics/zero_conditions.yaml
@@ -101,3 +101,31 @@ resourceMetrics:
               isMonotonic: true
         scope:
           name: otelcol/countconnector
+  - resource:
+      attributes:
+        - key: resource.int
+          value:
+            intValue: 1
+        - key: resource.optional_int
+          value:
+            intValue: 2
+    scopeMetrics:
+      - metrics:
+          - description: The number of metrics observed.
+            name: metric.count
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "6"
+                  timeUnixNano: "1678391923815929000"
+              isMonotonic: true
+          - description: The number of data points observed.
+            name: metric.datapoint.count
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - asInt: "24"
+                  timeUnixNano: "1678391923815929000"
+              isMonotonic: true
+        scope:
+          name: otelcol/countconnector


### PR DESCRIPTION
**Description:** 

Adding support for non string attributes in the count connector. I started working based on https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30314#issuecomment-1889535313, but it doesn't work. When I try to add the type constaint:

```
type Number interface {
	int64 | float64
}

type AttributeConfig struct {
	Key               string  `mapstructure:"key"`
	DefaultValue      Number  `mapstructure:"default_value"`
}
```
This causes the following error:
```
 cannot use type Number outside a type constraint: interface contains type constraints
```

My idea was to introduce new fields `DefaultIntValue` and `DefaultFloatValue` to handle number types, let me know if this makes sense, if so, I will add documentation and finalize this PR.


**Link to tracking Issue:** Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30314.

**Testing:** Added unit test

**Documentation:** TODO