### PR TITLE
[chore][processor/resourcedetection] Fix README's config example

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -417,7 +417,8 @@ processors:
     override: false
     aks:
       resource_attributes:
-        k8s.cluster.name: true
+        k8s.cluster.name:
+          enabled: true
 ```
 
 Azure AKS cluster name is derived from the Azure Instance Metadata Service's (IMDS) infrastructure resource group field. This field contains the resource group and name of the cluster, separated by underscores. e.g: `MC_<resource group>_<cluster name>_<location>`.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The example config for enabling AKS's `k8s.cluster.name` metric was incorrect. This fixes it to be the correct format.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32258