### PR TITLE
Add support for enabling compression on the mezmo exporter

### DIFF
--- a/.chloggen/mezmo-compression.yaml
+++ b/.chloggen/mezmo-compression.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mezmoexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for compressing requests in the Mezmo exporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32287]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/mezmoexporter/README.md
+++ b/exporter/mezmoexporter/README.md
@@ -31,7 +31,7 @@ that adds `hostname` detection support.
 specified, will default to `https://logs.mezmo.com/otel/ingest/rest`.
 - `ingest_key` (required): Ingestion key used to send log data to Mezmo.  See
 [Ingestion Keys](https://docs.mezmo.com/docs/ingestion-key) for more details.
-- `compression` (optional): Enables compression of requests.
+- `compression` (optional bool): Enables compression of requests, disabled by default. Set to `true` to enable.
 
 # Example:
 ## Simple Log Data
@@ -55,6 +55,7 @@ exporters:
   mezmo:
     ingest_url: "https://logs.mezmo.com/otel/ingest/rest"
     ingest_key: "00000000000000000000000000000000"
+    compression: true
 
 service:
   pipelines:

--- a/exporter/mezmoexporter/README.md
+++ b/exporter/mezmoexporter/README.md
@@ -27,10 +27,11 @@ that adds `hostname` detection support.
 
 # Configuration options:
 
-- `ingest_url` (optional): Specifies the URL to send ingested logs to.  If not 
+- `ingest_url` (optional): Specifies the URL to send ingested logs to.  If not
 specified, will default to `https://logs.mezmo.com/otel/ingest/rest`.
 - `ingest_key` (required): Ingestion key used to send log data to Mezmo.  See
 [Ingestion Keys](https://docs.mezmo.com/docs/ingestion-key) for more details.
+- `compression` (optional): Enables compression of requests.
 
 # Example:
 ## Simple Log Data

--- a/exporter/mezmoexporter/config.go
+++ b/exporter/mezmoexporter/config.go
@@ -42,6 +42,9 @@ type Config struct {
 
 	// Token is the authentication token provided by Mezmo.
 	IngestKey configopaque.String `mapstructure:"ingest_key"`
+
+	// Compression is the flag to enable/disable compression of the payload. Default is false.
+	Compression bool `mapstructure:"compression"`
 }
 
 // returns default http client settings


### PR DESCRIPTION

**Description:** <Describe what has changed.>
Add support for enabling compression on the mezmo exporter. This is implemented using a buffer pool to avoid gc overhead, and while I was at it I thought I might as well change the string building to also use the same pool.


**Link to tracking Issue:** 

Fixes #32284


**Testing:**

Unit test added

**Documentation:** 

New config property added to README.md
