### PR TITLE
[chore][CI/CD] Upgrade golang 1.22 version for unittest-matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -242,7 +242,7 @@ jobs:
   unittest-matrix:
     strategy:
       matrix:
-        go-version: ["1.22.0", "1.21.9"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["1.22.2", "1.21.9"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest, actuated-arm64-4cpu-4gb]
         group:
           - receiver-0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Version 1.22.0 of golang only has a darwin OS build of arm architecture available from `actions/setup-go` and `actions/go-versions`, so hopefully upgrading to use 1.22.2 will help tests pass.

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32286

**Testing:** <Describe what testing was performed and which tests were added.>
None yet, but hopefully from this CI/CD run of `build-and-test/unittest-matrix` we can confirm if the updated go version resolves this issue for arm testing.

Run shows `1.22.2` got picked up successfully:
```
Setup go version spec 1.22.2
...
Attempting to download 1.22.2...
...
matching 1.22.2...
Acquiring 1.22.2 from https://github.com/actions/go-versions/releases/download/1.22.2-8[54](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/8622703577/job/23634936527?pr=32288#step:6:55)8848001/go-1.22.2-linux-arm64.tar.gz
...
Extracting Go...
```