### PR TITLE
[receiver/filelog] Add test for fast-changing symlink

### DIFF
--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -388,7 +388,7 @@ func (g *fileLogGenerator) Generate() []receivertest.UniqueIDAttrVal {
 
 // TestSymlinkedLogs tests that the filelog receiver reading from a single
 // file that's actually a symlink to another file, while the symlink target
-// is changed frequently, reads all the logs from all the files ever targetted
+// is changed frequently, reads all the logs from all the files ever targeted
 // by that symlink.
 func TestSymlinkedLogs(t *testing.T) {
 	// Create 50 files with a predictable naming scheme, each containing


### PR DESCRIPTION
**Description:** 

This PR adds a test for the `filelog` receiver tracking a symlink that is updated periodically to point to a different log file.  The test asserts that all the logs from the various files the symlink points to over time are collected by the receiver.

**Related:**  https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32217