### PR TITLE
[chore][cmd/telemetrygen] Fix deprecated method usage

### DIFF
--- a/cmd/telemetrygen/internal/logs/exporter.go
+++ b/cmd/telemetrygen/internal/logs/exporter.go
@@ -22,7 +22,7 @@ type exporter interface {
 	export(plog.Logs) error
 }
 
-func newExporter(ctx context.Context, cfg *Config) (exporter, error) {
+func newExporter(cfg *Config) (exporter, error) {
 
 	// Exporter with HTTP
 	if cfg.UseHTTP {

--- a/cmd/telemetrygen/internal/logs/exporter.go
+++ b/cmd/telemetrygen/internal/logs/exporter.go
@@ -46,7 +46,7 @@ func newExporter(ctx context.Context, cfg *Config) (exporter, error) {
 	var err error
 	var clientConn *grpc.ClientConn
 	if cfg.Insecure {
-		clientConn, err = grpc.DialContext(ctx, cfg.Endpoint(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+		clientConn, err = grpc.NewClient(cfg.Endpoint(), grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +55,7 @@ func newExporter(ctx context.Context, cfg *Config) (exporter, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS credentials: %w", err)
 		}
-		clientConn, err = grpc.DialContext(ctx, cfg.Endpoint(), grpc.WithTransportCredentials(creds))
+		clientConn, err = grpc.NewClient(cfg.Endpoint(), grpc.WithTransportCredentials(creds))
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/telemetrygen/internal/logs/logs.go
+++ b/cmd/telemetrygen/internal/logs/logs.go
@@ -4,7 +4,6 @@
 package logs
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -26,7 +25,7 @@ func Start(cfg *Config) error {
 		return err
 	}
 
-	e, err := newExporter(context.Background(), cfg)
+	e, err := newExporter(cfg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`grpc.DialContext` has been deprecated in favor of `grpc.NewClient`. The only difference relevant to our usage is that the context is no longer passed in. I investigated, and the context being cancelled and exiting the running sub-goroutine is [handled internally](https://github.com/grpc/grpc-go/blob/d32e66ce27447a0a217464a36fdd3935801c0453/clientconn.go#L135) in an equivalent way to how we were using `grpc.DialContext`, so there shouldn't be any impact here.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #32297