### PR TITLE
[chore] Remove usage of go.opentelemetry.io/otel/attribute.Sortable

### DIFF
--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -93,11 +93,10 @@ type Key struct {
 
 func NewKey(metricMetadata any, labels map[string]string) Key {
 	kvs := make([]attribute.KeyValue, 0, len(labels))
-	var sortable attribute.Sortable
 	for k, v := range labels {
 		kvs = append(kvs, attribute.String(k, v))
 	}
-	set := attribute.NewSetWithSortable(kvs, &sortable)
+	set := attribute.NewSet(kvs...)
 
 	dedupSortedLabels := set.Equivalent()
 	return Key{

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
@@ -606,7 +606,6 @@ func testStatsDMetric(
 ) statsDMetric {
 	if len(labelKeys) > 0 {
 		var kvs []attribute.KeyValue
-		var sortable attribute.Sortable
 		for n, k := range labelKeys {
 			kvs = append(kvs, attribute.String(k, labelValue[n]))
 		}
@@ -614,7 +613,7 @@ func testStatsDMetric(
 			description: statsDMetricDescription{
 				name:       name,
 				metricType: metricType,
-				attrs:      attribute.NewSetWithSortable(kvs, &sortable),
+				attrs:      attribute.NewSet(kvs...),
 			},
 			asFloat:    asFloat,
 			addition:   addition,
@@ -638,14 +637,13 @@ func testStatsDMetric(
 
 func testDescription(name string, metricType MetricType, keys []string, values []string) statsDMetricDescription {
 	var kvs []attribute.KeyValue
-	var sortable attribute.Sortable
 	for n, k := range keys {
 		kvs = append(kvs, attribute.String(k, values[n]))
 	}
 	return statsDMetricDescription{
 		name:       name,
 		metricType: metricType,
-		attrs:      attribute.NewSetWithSortable(kvs, &sortable),
+		attrs:      attribute.NewSet(kvs...),
 	}
 }
 


### PR DESCRIPTION
It's deprecated in the latest OTel go library and gives linter failures as reported in https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/8636462987/job/23676618353?pr=32301#step:8:766
