### PR TITLE
[chore][receiver/googlecloudspannerreceiver] Enable goleak checks

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/filter/package_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filter
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder_test.go
@@ -96,6 +96,7 @@ func TestFilterBuilder_BuildFilterByMetricPositiveTotalLimit(t *testing.T) {
 						assert.Equal(t, expectedLimit, f.TotalLimit())
 						assert.Equal(t, expectedLimit, f.LimitByTimestamp())
 					}
+					assert.NoError(t, f.Shutdown())
 				}
 			}
 		})
@@ -147,6 +148,7 @@ func TestFilterBuilder_HandleLowCardinalityGroups(t *testing.T) {
 					assert.Equal(t, expectedLimit, f.TotalLimit())
 					assert.Equal(t, expectedLimit, f.LimitByTimestamp())
 					assert.Equal(t, testCase.expectedRemainingTotalLimit, remainingTotalLimit)
+					assert.NoError(t, f.Shutdown())
 				}
 			}
 		})
@@ -200,6 +202,7 @@ func TestFilterBuilder_HandleHighCardinalityGroups(t *testing.T) {
 					assert.Equal(t, testCase.expectedHighCardinalityTotalLimit, f.TotalLimit())
 					assert.Equal(t, testCase.expectedHighCardinalityLimitByTimestamp, f.LimitByTimestamp())
 					assert.Equal(t, testCase.expectedRemainingTotalLimit, remainingTotalLimit)
+					assert.NoError(t, f.Shutdown())
 				}
 			}
 		})
@@ -234,6 +237,7 @@ func TestFilterBuilder_TestConstructFiltersForGroups(t *testing.T) {
 			assert.Equal(t, totalLimitPerMetric, f.TotalLimit())
 			assert.Equal(t, limitPerMetricByTimestamp, f.LimitByTimestamp())
 			assert.Equal(t, expectedRemainingTotalLimit, result)
+			assert.NoError(t, f.Shutdown())
 		}
 	}
 }

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/itemfilterfactory_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/itemfilterfactory_test.go
@@ -47,6 +47,7 @@ func TestNewItemFilterResolver(t *testing.T) {
 				require.Nil(t, factory)
 			} else {
 				require.NoError(t, err)
+				require.NoError(t, factory.Shutdown())
 			}
 		})
 	}

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/package_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/package_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package filterfactory
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// See https://github.com/census-instrumentation/opencensus-go/issues/1191 for more information on ignore.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/package_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/package_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package statsreader
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// See https://github.com/census-instrumentation/opencensus-go/issues/1191 for more information on ignore.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This is a test only change that enables `goleak` checks on some of the internal packages of the Google Cloud Spanner receiver to help ensure no goroutines are leaking. Some tests were missing shutdown calls so those have been added.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` checks.