### PR TITLE
[chore][receiver/googlecloudpubsubreceiver/internal] Enable goleak check

### DIFF
--- a/receiver/googlecloudpubsubreceiver/go.mod
+++ b/receiver/googlecloudpubsubreceiver/go.mod
@@ -17,6 +17,7 @@ require (
 	go.opentelemetry.io/collector/receiver v0.98.0
 	go.opentelemetry.io/otel/metric v1.25.0
 	go.opentelemetry.io/otel/trace v1.25.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/api v0.172.0

--- a/receiver/googlecloudpubsubreceiver/internal/handler_test.go
+++ b/receiver/googlecloudpubsubreceiver/internal/handler_test.go
@@ -19,14 +19,16 @@ import (
 )
 
 func TestCancelStream(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	srv := pstest.NewServer()
 	defer srv.Close()
 
 	var copts []option.ClientOption
 	var dialOpts []grpc.DialOption
-	conn, err := grpc.Dial(srv.Addr, append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))...)
+	conn, err := grpc.DialContext(ctx, srv.Addr, append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))...)
 	assert.NoError(t, err)
+	defer func() { assert.NoError(t, conn.Close()) }()
 	copts = append(copts, option.WithGRPCConn(conn))
 	_, err = srv.GServer.CreateTopic(ctx, &pubsubpb.Topic{
 		Name: "projects/my-project/topics/otlp",
@@ -42,7 +44,7 @@ func TestCancelStream(t *testing.T) {
 	client, err := pubsub.NewSubscriberClient(ctx, copts...)
 	assert.NoError(t, err)
 
-	handler, err := NewHandler(context.Background(), zaptest.NewLogger(t), client, "client-id", "projects/my-project/subscriptions/otlp",
+	handler, err := NewHandler(ctx, zaptest.NewLogger(t), client, "client-id", "projects/my-project/subscriptions/otlp",
 		func(context.Context, *pubsubpb.ReceivedMessage) error {
 			return nil
 		})

--- a/receiver/googlecloudpubsubreceiver/internal/handler_test.go
+++ b/receiver/googlecloudpubsubreceiver/internal/handler_test.go
@@ -26,7 +26,7 @@ func TestCancelStream(t *testing.T) {
 
 	var copts []option.ClientOption
 	var dialOpts []grpc.DialOption
-	conn, err := grpc.DialContext(ctx, srv.Addr, append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))...)
+	conn, err := grpc.NewClient(srv.Addr, append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))...)
 	assert.NoError(t, err)
 	defer func() { assert.NoError(t, conn.Close()) }()
 	copts = append(copts, option.WithGRPCConn(conn))

--- a/receiver/googlecloudpubsubreceiver/internal/package_test.go
+++ b/receiver/googlecloudpubsubreceiver/internal/package_test.go
@@ -1,0 +1,15 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+// See https://github.com/census-instrumentation/opencensus-go/issues/1191 for more information on ignore.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"))
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable `goleak` checks inside the `internal` package of the Google Cloud PubSub receiver to help ensure no goroutines are leaking. This is a test only change, some closes/cancels were missing. Also, we need to pass a context to the grpc dial functionality, so switch from`Dial` -> `DialContext`. `Dial` is a wrapper for `DialContext` passing in `context.Background()`.

**Link to tracking Issue:** <Issue number if applicable>
#30438 

**Testing:** <Describe what testing was performed and which tests were added.>
Existing tests are passing, as well as added `goleak` check.