### PR TITLE
[receiver/azuremonitor] Only use supported aggregations in queries to azure api

### DIFF
--- a/.chloggen/use-aggegration-in-queries.yaml
+++ b/.chloggen/use-aggegration-in-queries.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Only use supported aggregations for metrics when requesting azure api
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -383,7 +383,7 @@ func (s *azureScraper) getResourceMetricsValues(ctx context.Context, resourceID 
 
 			for _, metric := range result.Value {
 				if *metric.ErrorCode != "Success" {
-					errorMsg := fmt.Errorf("loading value for metric %v failed with error %v", metric.Name.Value, metric.ErrorMessage)
+					errorMsg := fmt.Errorf("loading value for metric %v failed with error %v", &metric.Name.Value, &metric.ErrorMessage)
 					s.settings.Logger.Error("failed to get Azure Metrics values data for metric", zap.Error(errorMsg))
 					continue
 				}

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -60,9 +60,9 @@ type azureResource struct {
 }
 
 type metricsCompositeKey struct {
-	dimensions  string // comma separated sorted dimensions
-	aggregation string
-	timeGrain   string
+	dimensions   string // comma separated sorted dimensions
+	aggregations string // comma separated sorted aggregations
+	timeGrain    string
 }
 
 type azureResourceMetrics struct {
@@ -314,7 +314,7 @@ func (s *azureScraper) getResourceMetricsDefinitions(ctx context.Context, resour
 				aggregationSlice = append(aggregationSlice, string(*aggregation))
 			}
 			sort.Strings(aggregationSlice)
-			compositeKey.aggregation = strings.Join(aggregationSlice, ",")
+			compositeKey.aggregations = strings.Join(aggregationSlice, ",")
 
 			if len(v.Dimensions) > 0 {
 				var dimensionsSlice []string
@@ -364,7 +364,7 @@ func (s *azureScraper) getResourceMetricsValues(ctx context.Context, resourceID 
 			opts := getResourceMetricsValuesRequestOptions(
 				metricsByGrain.metrics,
 				compositeKey.dimensions,
-				compositeKey.aggregation,
+				compositeKey.aggregations,
 				compositeKey.timeGrain,
 				start,
 				end,

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -255,6 +255,7 @@ func TestAzureScraperScrape(t *testing.T) {
 				clientMetricsValues:      metricsValuesClientMock,
 				mb:                       metadata.NewMetricsBuilder(metadata.DefaultMetricsBuilderConfig(), settings),
 				mutex:                    &sync.Mutex{},
+				settings:                 receivertest.NewNopCreateSettings().TelemetrySettings,
 			}
 			s.resources = map[string]*azureResource{}
 
@@ -460,8 +461,8 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 }
 
 func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientListResponse {
-	name1, name2, name3, name4, name5, name6, name7, dimension1, dimension2, dimensionValue := "metric1", "metric2",
-		"metric3", "metric4", "metric5", "metric6", "metric7", "dimension1", "dimension2", "dimension value"
+	name1, name2, name3, name4, name5, name6, name7, dimension1, dimension2, dimensionValue, success := "metric1", "metric2",
+		"metric3", "metric4", "metric5", "metric6", "metric7", "dimension1", "dimension2", "dimension value", "Success"
 	var unit1 armmonitor.Unit = "unit1"
 	var value1 float64 = 1
 
@@ -488,7 +489,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
-							ErrorCode: to.Ptr("Success"),
+							ErrorCode: &success,
 						},
 						{
 							Name: &armmonitor.LocalizableString{
@@ -508,7 +509,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
-							ErrorCode: to.Ptr("Success"),
+							ErrorCode: &success,
 						},
 					},
 				},
@@ -534,7 +535,27 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
-							ErrorCode: to.Ptr("Success"),
+							ErrorCode: &success,
+						},
+						{
+							Name: &armmonitor.LocalizableString{
+								Value: &name5,
+							},
+							Unit: &unit1,
+							Timeseries: []*armmonitor.TimeSeriesElement{
+								{
+									Data: []*armmonitor.MetricValue{
+										{
+											Average: &value1,
+											Count:   &value1,
+											Maximum: &value1,
+											Minimum: &value1,
+											Total:   &value1,
+										},
+									},
+								},
+							},
+							ErrorCode: to.Ptr("Error"),
 						},
 					},
 				},
@@ -562,7 +583,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
-							ErrorCode: to.Ptr("Success"),
+							ErrorCode: &success,
 						},
 					},
 				},
@@ -602,7 +623,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
-							ErrorCode: to.Ptr("Success"),
+							ErrorCode: &success,
 						},
 					},
 				},
@@ -636,7 +657,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
-							ErrorCode: to.Ptr("Success"),
+							ErrorCode: &success,
 						},
 					},
 				},
@@ -668,7 +689,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
-							ErrorCode: to.Ptr("Success"),
+							ErrorCode: &success,
 						},
 					},
 				},

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -5,6 +5,7 @@ package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-
 
 import (
 	"context"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -331,6 +332,9 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 		"/resourceGroups/group1/resourceId3": 0,
 	}
 
+	aggregations := to.SliceOfPtrs(armmonitor.AggregationTypeAverage, armmonitor.AggregationTypeCount,
+		armmonitor.AggregationTypeMaximum, armmonitor.AggregationTypeMinimum, armmonitor.AggregationTypeTotal)
+
 	pages := map[string][]armmonitor.MetricDefinitionsClientListResponse{
 		"/resourceGroups/group1/resourceId1": {
 			{
@@ -345,6 +349,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 									TimeGrain: &timeGrain1,
 								},
 							},
+							SupportedAggregationTypes: aggregations,
 						},
 						{
 							Name: &armmonitor.LocalizableString{
@@ -355,6 +360,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 									TimeGrain: &timeGrain1,
 								},
 							},
+							SupportedAggregationTypes: aggregations,
 						},
 						{
 							Name: &armmonitor.LocalizableString{
@@ -365,6 +371,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 									TimeGrain: &timeGrain1,
 								},
 							},
+							SupportedAggregationTypes: aggregations,
 						},
 					},
 				},
@@ -383,6 +390,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 									TimeGrain: &timeGrain1,
 								},
 							},
+							SupportedAggregationTypes: aggregations,
 						},
 						{
 							Name: &armmonitor.LocalizableString{
@@ -401,6 +409,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 									Value: &dimension2,
 								},
 							},
+							SupportedAggregationTypes: aggregations,
 						},
 						{
 							Name: &armmonitor.LocalizableString{
@@ -416,6 +425,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 									Value: &dimension1,
 								},
 							},
+							SupportedAggregationTypes: aggregations,
 						},
 					},
 				},
@@ -439,6 +449,7 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 									Value: &dimension1,
 								},
 							},
+							SupportedAggregationTypes: aggregations,
 						},
 					},
 				},
@@ -477,6 +488,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
+							ErrorCode: to.Ptr("Success"),
 						},
 						{
 							Name: &armmonitor.LocalizableString{
@@ -496,6 +508,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
+							ErrorCode: to.Ptr("Success"),
 						},
 					},
 				},
@@ -521,6 +534,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
+							ErrorCode: to.Ptr("Success"),
 						},
 					},
 				},
@@ -548,6 +562,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
+							ErrorCode: to.Ptr("Success"),
 						},
 					},
 				},
@@ -587,6 +602,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
+							ErrorCode: to.Ptr("Success"),
 						},
 					},
 				},
@@ -620,6 +636,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
+							ErrorCode: to.Ptr("Success"),
 						},
 					},
 				},
@@ -651,6 +668,7 @@ func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientLi
 									},
 								},
 							},
+							ErrorCode: to.Ptr("Success"),
 						},
 					},
 				},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
We had cases where certain metrics where not displayed because the Azure API returned with an InternalError due to unsupported aggegration types in the query. This PR adjusts the receiver to only use supported aggegrations for a specific metric in the query parameter. I have also added a check and error in case the api returned an error for a specific metric.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** 
Added a test case to the unit tests where erroneous responses will not be expected. Also tested new aggregation logic with querying metrics from Azure API for API Management Capacity metric (which previously failed with an InternalError). 

**Documentation:** <Describe the documentation added.>