### PR TITLE
[exporter/loadbalancing] Change config fields to use snake_case

### DIFF
--- a/.chloggen/loadbalancing-exporter-fix-conig-field-name.yaml
+++ b/.chloggen/loadbalancing-exporter-fix-conig-field-name.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/loadbalancing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change AWS Cloud map resolver config fields from camelCase to snake_case.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32331]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The snake_case is required in OTel Collector config fields. It used to be enforced by tests in cmd/oteltestbedcol,
+  but we had to disable them. Now, the tests are going to be enforced on every component independently. 
+  Hence, the camelCase config fields recently added with the new AWS Cloud Map resolver has to be fixed.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -192,9 +192,9 @@ exporters:
         # except the endpoint
         timeout: 3s
     resolver:
-      awsCloudMap:
+      aws_cloud_map:
         namespace: aws-namespace
-        serviceName: aws-otel-col-service-name
+        service_name: aws-otel-col-service-name
         interval: 30s
 
 service:

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -55,7 +55,7 @@ The `loadbalancingexporter` will, irrespective of the chosen resolver (`static`,
 Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using the processor.
 
 * The `otlp` property configures the template used for building the OTLP exporter. Refer to the OTLP Exporter documentation for information on which options are available. Note that the `endpoint` property should not be set and will be overridden by this exporter with the backend endpoint.
-* The `resolver` accepts a `static` node, a `dns`, a `k8s` service or `awsCloudMap`. If all four are specified, an `errMultipleResolversProvided` error will be thrown.
+* The `resolver` accepts a `static` node, a `dns`, a `k8s` service or `aws_cloud_map`. If all four are specified, an `errMultipleResolversProvided` error will be thrown.
 * The `hostname` property inside a `dns` node specifies the hostname to query in order to obtain the list of IP addresses.
 * The `dns` node also accepts the following optional properties:
   * `hostname` DNS hostname to resolve.
@@ -66,13 +66,13 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `service` Kubernetes service to resolve, e.g. `lb-svc.lb-ns`. If no namespace is specified, an attempt will be made to infer the namespace for this collector, and if this fails it will fall back to the `default` namespace.
   * `ports` port to be used for exporting the traces to the addresses resolved from `service`. If `ports` is not specified, the default port 4317 is used. When multiple ports are specified, two backends are added to the load balancer as if they were at different pods.
   * `timeout` resolver timeout in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `1s` will be used.
-* The `awsCloudMap` node accepts the following properties:
+* The `aws_cloud_map` node accepts the following properties:
   * `namespace` The CloudMap namespace where the service is register, e.g. `cloudmap`. If no `namespace` is specified, this will fail to start the Load Balancer exporter.
-  * `serviceName` The name of the service that you specified when you registered the instance, e.g. `otelcollectors`.  If no `serviceName` is specified, this will fail to start the Load Balancer exporter.
+  * `service_name` The name of the service that you specified when you registered the instance, e.g. `otelcollectors`.  If no `serviceName` is specified, this will fail to start the Load Balancer exporter.
   * `interval` resolver interval in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `30s` will be used.
   * `timeout` resolver timeout in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `5s` will be used.
   * `port` port to be used for exporting the traces to the addresses resolved from `service`. By default, the port is set in Cloud Map, but can be be overridden with a static value in this config
-  * `healthStatus` filter in AWS Cloud Map, you can specify the health status of the instances that you want to discover. The healthStatus filter is optional and allows you to query based on the health status of the instances. 
+  * `health_status` filter in AWS Cloud Map, you can specify the health status of the instances that you want to discover. The healthStatus filter is optional and allows you to query based on the health status of the instances. 
     * Available values are 
       * `HEALTHY`: Only return instances that are healthy.
       * `UNHEALTHY`: Only return instances that are unhealthy.

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -68,7 +68,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `timeout` resolver timeout in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `1s` will be used.
 * The `aws_cloud_map` node accepts the following properties:
   * `namespace` The CloudMap namespace where the service is register, e.g. `cloudmap`. If no `namespace` is specified, this will fail to start the Load Balancer exporter.
-  * `service_name` The name of the service that you specified when you registered the instance, e.g. `otelcollectors`.  If no `serviceName` is specified, this will fail to start the Load Balancer exporter.
+  * `service_name` The name of the service that you specified when you registered the instance, e.g. `otelcollectors`.  If no `service_name` is specified, this will fail to start the Load Balancer exporter.
   * `interval` resolver interval in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `30s` will be used.
   * `timeout` resolver timeout in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `5s` will be used.
   * `port` port to be used for exporting the traces to the addresses resolved from `service`. By default, the port is set in Cloud Map, but can be be overridden with a static value in this config

--- a/exporter/loadbalancingexporter/README.md
+++ b/exporter/loadbalancingexporter/README.md
@@ -72,7 +72,7 @@ Refer to [config.yaml](./testdata/config.yaml) for detailed examples on using th
   * `interval` resolver interval in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `30s` will be used.
   * `timeout` resolver timeout in go-Duration format, e.g. `5s`, `1d`, `30m`. If not specified, `5s` will be used.
   * `port` port to be used for exporting the traces to the addresses resolved from `service`. By default, the port is set in Cloud Map, but can be be overridden with a static value in this config
-  * `health_status` filter in AWS Cloud Map, you can specify the health status of the instances that you want to discover. The healthStatus filter is optional and allows you to query based on the health status of the instances. 
+  * `health_status` filter in AWS Cloud Map, you can specify the health status of the instances that you want to discover. The health_status filter is optional and allows you to query based on the health status of the instances. 
     * Available values are 
       * `HEALTHY`: Only return instances that are healthy.
       * `UNHEALTHY`: Only return instances that are unhealthy.

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -36,7 +36,7 @@ type ResolverSettings struct {
 	Static      *StaticResolver      `mapstructure:"static"`
 	DNS         *DNSResolver         `mapstructure:"dns"`
 	K8sSvc      *K8sSvcResolver      `mapstructure:"k8s"`
-	AWSCloudMap *AWSCloudMapResolver `mapstructure:"awsCloudMap"`
+	AWSCloudMap *AWSCloudMapResolver `mapstructure:"aws_cloud_map"`
 }
 
 // StaticResolver defines the configuration for the resolver providing a fixed list of backends
@@ -61,8 +61,8 @@ type K8sSvcResolver struct {
 
 type AWSCloudMapResolver struct {
 	NamespaceName string                   `mapstructure:"namespace"`
-	ServiceName   string                   `mapstructure:"serviceName"`
-	HealthStatus  types.HealthStatusFilter `mapstructure:"healthStatus"`
+	ServiceName   string                   `mapstructure:"service_name"`
+	HealthStatus  types.HealthStatusFilter `mapstructure:"health_status"`
 	Interval      time.Duration            `mapstructure:"interval"`
 	Timeout       time.Duration            `mapstructure:"timeout"`
 	Port          *uint16                  `mapstructure:"port"`

--- a/exporter/loadbalancingexporter/loadbalancer.go
+++ b/exporter/loadbalancingexporter/loadbalancer.go
@@ -92,7 +92,7 @@ func newLoadBalancer(params exporter.CreateSettings, cfg component.Config, facto
 	}
 
 	if oCfg.Resolver.AWSCloudMap != nil {
-		awsCloudMapLogger := params.Logger.With(zap.String("resolver", "awsCloudMap"))
+		awsCloudMapLogger := params.Logger.With(zap.String("resolver", "aws_cloud_map"))
 		var err error
 		res, err = newCloudMapResolver(awsCloudMapLogger, &oCfg.Resolver.AWSCloudMap.NamespaceName, &oCfg.Resolver.AWSCloudMap.ServiceName, oCfg.Resolver.AWSCloudMap.Port, &oCfg.Resolver.AWSCloudMap.HealthStatus, oCfg.Resolver.AWSCloudMap.Interval, oCfg.Resolver.AWSCloudMap.Timeout)
 		if err != nil {

--- a/exporter/loadbalancingexporter/resolver_aws_cloudmap.go
+++ b/exporter/loadbalancingexporter/resolver_aws_cloudmap.go
@@ -27,7 +27,7 @@ const (
 
 var (
 	errNoNamespace   = errors.New("no Cloud Map namespace specified to resolve the backends")
-	errNoServiceName = errors.New("no Cloud Map serviceName specified to resolve the backends")
+	errNoServiceName = errors.New("no Cloud Map service_name specified to resolve the backends")
 
 	awsResolverMutator = tag.Upsert(tag.MustNewKey("resolver"), "aws")
 
@@ -115,10 +115,10 @@ func (r *cloudMapResolver) start(ctx context.Context) error {
 	go r.periodicallyResolve()
 
 	r.logger.Info("AWS CloudMap resolver started",
-		zap.Stringp("serviceName", r.serviceName),
+		zap.Stringp("service_name", r.serviceName),
 		zap.Stringp("namespaceName", r.namespaceName),
 		zap.Uint16p("port", r.port),
-		zap.String("healthStatus", string(*r.healthStatus)),
+		zap.String("health_status", string(*r.healthStatus)),
 		zap.Duration("interval", r.resInterval), zap.Duration("timeout", r.resTimeout))
 	return nil
 }

--- a/exporter/loadbalancingexporter/testdata/config.yaml
+++ b/exporter/loadbalancingexporter/testdata/config.yaml
@@ -34,7 +34,7 @@ loadbalancing/4:
 
   # how to get the list of backends: DNS
   resolver:
-    awsCloudMap:
+    aws_cloud_map:
       namespace: cloudmap-1
-      serviceName: service-1
+      service_name: service-1
       port: 4319


### PR DESCRIPTION
Change AWS Cloud map resolver config fields from camelCase to snake_case.

The snake_case is required in OTel Collector config fields. It used to be enforced by tests in cmd/oteltestbedcol, but we had to disable them some time ago. Now, the tests are going to be enforced on every component independently. Hence, the camelCase config fields recently added with the new AWS Cloud Map resolver has to be fixed.
