### PR TITLE
[statsdreceiver] add datadog_summary observer

### DIFF
--- a/.chloggen/statsd-datadog-summary.yaml
+++ b/.chloggen/statsd-datadog-summary.yaml
@@ -10,7 +10,7 @@ component: statsdreceiver
 note: "Add a new `datadog_summary` observer type to enable Datadog-style aggregations over StatsD histograms."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [32338]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/statsd-datadog-summary.yaml
+++ b/.chloggen/statsd-datadog-summary.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "enhancement"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add a new `datadog_summary` observer type to enable Datadog-style aggregations over StatsD histograms."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This enables matching how Datadog internally aggregates DogStatsD Histograms and Timings. 
+  The primary use-case for this observer is when you are additionally leveraging the datadogexporter to send the OTLP metrics on to Datadog,
+  but want to preserve prior behavior around metric namings and aggregations, e.g., to avoid
+  rewriting dashboards and monitors.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -39,9 +39,14 @@ The Following settings are optional:
 
 `"statsd_type"` specifies received Statsd data type. Possible values for this setting are `"timing"`, `"timer"`, `"histogram"` and `"distribution"`.
 
-`"observer_type"` specifies OTLP data type to convert to. We support `"gauge"`, `"summary"`, and `"histogram"`. For `"gauge"`, it does not perform any aggregation.
-For `"summary`, the statsD receiver will aggregate to one OTLP summary metric for one metric description (the same metric name with the same tags). It will send percentile 0, 10, 50, 90, 95, 100 to the downstream.  The `"histogram"` setting selects an [auto-scaling exponential histogram configured with only a maximum size](https://github.com/lightstep/go-expohisto#readme), as shown in the example below.
-TODO: Add a new option to use a smoothed summary like Prometheus: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3261 
+`"observer_type"` specifies OTLP data type to convert to. We support `"gauge"`, `"summary"`, `"datadog_summary"`, and `"histogram"`.
+
+* For `"gauge"`, it does not perform any aggregation.
+* For `"summary`, it aggregates to one OTLP summary metric for one metric description (the same metric name with the same tags). It will send percentile 0, 10, 50, 90, 95, 100 to the downstream.
+* For `"datadog_summary"`, the receiver will aggregate to a new set of metrics representing the `count`, `avg`, `median`, `max`, and `95percentile` aggregation values of the metric, named after the incoming metric description with the aggregation as a suffix, and with all tags applied. This best matches how Datadog internally aggregates DogStatsD Histograms and Timings. The primary use-case for this observer is when you are additionally leveraging the datadogexporter to send the OTLP metrics on to Datadog.
+* The `"histogram"` setting selects an [auto-scaling exponential histogram configured with only a maximum size](https://github.com/lightstep/go-expohisto#readme), as shown in the example below.
+
+TODO: Add a new option to use a smoothed summary like Prometheus: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3261
 
 Example:
 

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -54,7 +54,10 @@ func (c *Config) Validate() error {
 		}
 
 		switch eachMap.ObserverType {
-		case protocol.GaugeObserver, protocol.SummaryObserver, protocol.HistogramObserver:
+		case protocol.GaugeObserver,
+			protocol.SummaryObserver,
+			protocol.DatadogSummaryObserver,
+			protocol.HistogramObserver:
 			// do nothing
 		case protocol.DisableObserver:
 			fallthrough

--- a/receiver/statsdreceiver/go.mod
+++ b/receiver/statsdreceiver/go.mod
@@ -21,6 +21,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/exp v0.0.0-20231110203233-9a3e6036ecaa
 	gonum.org/v1/gonum v0.15.0
 )
 


### PR DESCRIPTION
**Description:**
this adds a new observer that produces a "summary" of histograms similar to how datadog does it. this is not a distinct metric type in datadog, but instead is a convention where a sum and multiple gauges are emitted for the incoming histogram. the sum tracks the total number of samples and the gauges track mean, median, sum, and p95 aggregations over the sample set.

the primary use-case for this observer is for cases where you are substituting the OpenTelemetry Collector in place of the Datadog Agent for DogStatsD ingest, but don't want to break existing dependencies on existing metrics that aggregate over histograms (i.e., don't want to be rewriting lots of dashboards and monitors.)

**Link to tracking Issue:** n/a

**Testing:** adds test coverage

**Documentation:** updates docs