### PR TITLE
[receiver/awscloudwatch] allow named groups with no stream spec

### DIFF
--- a/.chloggen/aws-cw-receiver-full-named-loggroups.yaml
+++ b/.chloggen/aws-cw-receiver-full-named-loggroups.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awscloudwatchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The receiver now supports extracting data from named loggroups without requiring filters for log streams. This was already advertised as feature, but ignored during initialization.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32345]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -110,6 +110,9 @@ func newLogsReceiver(cfg *Config, logger *zap.Logger, consumer consumer.Logs) *l
 		if len(sc.Names) > 0 {
 			groups = append(groups, &streamNames{group: logGroupName, names: sc.Names})
 		}
+		if len(sc.Prefixes) == 0 && len(sc.Names) == 0 {
+			groups = append(groups, &streamNames{group: logGroupName})
+		}
 	}
 
 	// safeguard from using both


### PR DESCRIPTION
**Description:** Allow receiving named loggroups without stream filtering as indicated by a given example linked in the README

**Link to tracking Issue:** #32345

**Testing:** Adds additional unit test for this specific config case.

**Documentation:** None, implementation matches the given docs/example which was not the case before