### PR TITLE
[chore][receiver/gitproviderreceiver] Enable goleak check in GitHub scraper

### DIFF
--- a/receiver/gitproviderreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/gitproviderreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -649,6 +649,7 @@ func TestGetContributors(t *testing.T) {
 			ghs.cfg.GitHubOrg = tc.org
 
 			server := httptest.NewServer(tc.server)
+			defer func() { server.Close() }()
 
 			client := github.NewClient(nil)
 			url, _ := url.Parse(server.URL + "/api-v3" + "/")

--- a/receiver/gitproviderreceiver/internal/scraper/githubscraper/package_test.go
+++ b/receiver/gitproviderreceiver/internal/scraper/githubscraper/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package githubscraper
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable `goleak` check in the `internal/scraper/githubscraper` package of the Git Provider receiver to help ensure no goroutines are being leaked. This is a test only change, a `Close` call was missing on a server in a test.

**Link to tracking Issue:** <Issue number if applicable>
#30438 

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` check.