### PR TITLE
[chore][receiver/azureeventhub] Enable goleak check

### DIFF
--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -84,6 +84,8 @@ func (m *mockDataConsumer) consume(ctx context.Context, event *eventhub.Event) e
 }
 
 func TestEventhubHandler_Start(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	config := createDefaultConfig()
 	config.(*Config).Connection = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"
@@ -95,14 +97,16 @@ func TestEventhubHandler_Start(t *testing.T) {
 	}
 	ehHandler.hub = &mockHubWrapper{}
 
-	err := ehHandler.run(context.Background(), componenttest.NewNopHost())
+	err := ehHandler.run(ctx, componenttest.NewNopHost())
 	assert.NoError(t, err)
 
-	err = ehHandler.close(context.Background())
+	err = ehHandler.close(ctx)
 	assert.NoError(t, err)
 }
 
 func TestEventhubHandler_newMessageHandler(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	config := createDefaultConfig()
 	config.(*Config).Connection = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"
@@ -127,11 +131,11 @@ func TestEventhubHandler_newMessageHandler(t *testing.T) {
 	}
 	ehHandler.hub = &mockHubWrapper{}
 
-	err = ehHandler.run(context.Background(), componenttest.NewNopHost())
+	err = ehHandler.run(ctx, componenttest.NewNopHost())
 	assert.NoError(t, err)
 
 	now := time.Now()
-	err = ehHandler.newMessageHandler(context.Background(), &eventhub.Event{
+	err = ehHandler.newMessageHandler(ctx, &eventhub.Event{
 		Data:         []byte("hello"),
 		PartitionKey: nil,
 		Properties:   map[string]any{"foo": "bar"},

--- a/receiver/azureeventhubreceiver/go.mod
+++ b/receiver/azureeventhubreceiver/go.mod
@@ -21,6 +21,7 @@ require (
 	go.opentelemetry.io/collector/semconv v0.98.1-0.20240412014414-62f589864e3d
 	go.opentelemetry.io/otel/metric v1.25.0
 	go.opentelemetry.io/otel/trace v1.25.0
+	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
 

--- a/receiver/azureeventhubreceiver/package_test.go
+++ b/receiver/azureeventhubreceiver/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package azureeventhubreceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables `goleak` checks for the Azure Event Hub receiver to help ensure no goroutines are being leaked. This is a test only change, some goroutines were being detected as leaks simply because of the context.Background lifecycle. Using a cancel shows everything gets shutdown properly.

**Link to tracking Issue:** <Issue number if applicable>
#30438 

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` check.