### PR TITLE
[receiver/azureeventhub] Fix memory leak on shutdown

### DIFF
--- a/.chloggen/goleak_azureeventhubrec_fix.yaml
+++ b/.chloggen/goleak_azureeventhubrec_fix.yaml
@@ -10,7 +10,7 @@ component: azureeventhubreceiver
 note: Fix memory leak on shutdown
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [32401]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/goleak_azureeventhubrec_fix.yaml
+++ b/.chloggen/goleak_azureeventhubrec_fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureeventhubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix memory leak on shutdown
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -53,12 +53,14 @@ type eventhubHandler struct {
 	dataConsumer dataConsumer
 	config       *Config
 	settings     receiver.CreateSettings
+	cancel       context.CancelFunc
 }
 
 // Implement eventHandler Interface
 var _ eventHandler = (*eventhubHandler)(nil)
 
 func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
+	ctx, h.cancel = context.WithCancel(ctx)
 
 	storageClient, err := adapter.GetStorageClient(ctx, host, h.config.StorageID, h.settings.ID)
 	if err != nil {
@@ -177,6 +179,10 @@ func (h *eventhubHandler) close(ctx context.Context) error {
 		}
 		h.hub = nil
 	}
+	if h.cancel != nil {
+		h.cancel()
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As explained [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30438#issuecomment-2057846085), components need to cancel all their work and background tasks before returning from `Shutdown`. My original [change for this component](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32364) to add `goleak` testing worked around the proper behavior. This PR fully addresses the `Shutdown` functionality to ensure the component behaves the way the spec requires.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
Tests are passing.