### PR TITLE
[chore][receiver/awsxray] Enable goleak checks

### DIFF
--- a/receiver/awsxrayreceiver/internal/udppoller/package_test.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package udppoller
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
@@ -291,6 +291,7 @@ func TestSocketReadIrrecoverableNetError(t *testing.T) {
 	}
 
 	p.Start(context.Background())
+	defer func() { assert.NoError(t, p.Close()) }()
 
 	assert.Eventuallyf(t, func() bool {
 		logs := recordedLogs.All()
@@ -328,6 +329,7 @@ func TestSocketReadTimeOutNetError(t *testing.T) {
 	}
 
 	p.Start(context.Background())
+	defer func() { assert.NoError(t, p.Close()) }()
 
 	assert.Eventuallyf(t, func() bool {
 		logs := recordedLogs.All()
@@ -363,6 +365,7 @@ func TestSocketGenericReadError(t *testing.T) {
 	}
 
 	p.Start(context.Background())
+	defer func() { assert.NoError(t, p.Close()) }()
 
 	assert.Eventuallyf(t, func() bool {
 		logs := recordedLogs.All()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Enable `goleak` checks in the `internal/udppoller` package of the AWS X-Ray receiver to help ensure no goroutines are being leaked. This is a test only change, simply adding a few missing `Close` calls.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests as well as added `goleak` checks are passing.