### PR TITLE
[exporter/sapm] Change the logging channel to 'Error' for failed responses.

### DIFF
--- a/exporter/sapmexporter/exporter.go
+++ b/exporter/sapmexporter/exporter.go
@@ -109,7 +109,7 @@ func (se *sapmExporter) pushTraceData(ctx context.Context, td ptrace.Traces) err
 	ingestResponse, err := se.client.ExportWithAccessTokenAndGetResponse(ctx, batches, accessToken)
 	if se.config.LogDetailedResponse && ingestResponse != nil {
 		if ingestResponse.Err != nil {
-			se.logger.Debug("Failed to get response from trace ingest", zap.Error(ingestResponse.Err))
+			se.logger.Error("Failed to get response from trace ingest", zap.Error(ingestResponse.Err))
 		} else {
 			se.logger.Debug("Detailed response from ingest", zap.ByteString("response", ingestResponse.Body))
 		}


### PR DESCRIPTION
**Description:** Log level has been changed to Error from Debug for the failed responses

**Link to tracking Issue:** #32429

**Testing:** Check log messages

**Documentation:** not applicable 