### PR TITLE
[chore] Exclude Go 1.21 ARM CI from matrix

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -247,6 +247,9 @@ jobs:
       matrix:
         go-version: ["1.22.2", "1.21.9"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest, actuated-arm64-4cpu-4gb]
+        exclude:
+          - go-version: "1.21.9"
+            runner: actuated-arm64-4cpu-4gb
         group:
           - receiver-0
           - receiver-1


### PR DESCRIPTION
**Description:**
 Exclude running tests on Go 1.21 with ARM CI.

**Link to tracking Issue:**
#32447 