### PR TITLE
[chore][receiver/apache] Enable goleak check

### DIFF
--- a/receiver/apachereceiver/package_test.go
+++ b/receiver/apachereceiver/package_test.go
@@ -1,0 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package apachereceiver
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -27,6 +27,8 @@ import (
 
 func TestScraper(t *testing.T) {
 	apacheMock := newMockServer(t)
+	defer func() { apacheMock.Close() }()
+
 	cfg := createDefaultConfig().(*Config)
 	cfg.Endpoint = fmt.Sprintf("%s%s", apacheMock.URL, "/server-status?auto")
 	require.NoError(t, component.ValidateConfig(cfg))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables `goleak` on the Apache receiver to help ensure no goroutines are leaking. This is a test only change, a test server wasn't properly being shutdown in a test.

**Link to tracking Issue:** <Issue number if applicable>
#30438

**Testing:** <Describe what testing was performed and which tests were added.>
All existing tests are passing, as well as added `goleak` checks.