### PR TITLE
[chore][pkg/stanza/fileconsumer] Fix test on Windows

### DIFF
--- a/pkg/stanza/fileconsumer/matcher/internal/filter/exclude_test.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/filter/exclude_test.go
@@ -6,6 +6,7 @@ package filter
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -21,8 +22,9 @@ func TestExcludeOlderThanFilter(t *testing.T) {
 		fileMTimes       []time.Time
 		excludeOlderThan time.Duration
 
-		expect      []string
-		expectedErr string
+		expect             []string
+		expectedErr        string
+		expectedWindowsErr string
 	}{
 		"no_files": {
 			files:            []string{},
@@ -61,8 +63,9 @@ func TestExcludeOlderThanFilter(t *testing.T) {
 			fileMTimes:       []time.Time{twoHoursAgo, {}},
 			excludeOlderThan: 3 * time.Hour,
 
-			expect:      []string{"a.log"},
-			expectedErr: "b.log: no such file or directory",
+			expect:             []string{"a.log"},
+			expectedErr:        "b.log: no such file or directory",
+			expectedWindowsErr: "b.log: The system cannot find the file specified.",
 		},
 	}
 
@@ -92,7 +95,11 @@ func TestExcludeOlderThanFilter(t *testing.T) {
 			f := ExcludeOlderThan(tc.excludeOlderThan)
 			result, err := f.apply(items)
 			if tc.expectedErr != "" {
-				require.ErrorContains(t, err, tc.expectedErr)
+				if runtime.GOOS == "windows" {
+					require.ErrorContains(t, err, tc.expectedWindowsErr)
+				} else {
+					require.ErrorContains(t, err, tc.expectedErr)
+				}
 			} else {
 				require.NoError(t, err)
 			}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Test error message:
```
Error:      	Error "CreateFile C:\\Users\\RUNNER~1\\AppData\\Local\\Temp\\TestExcludeOlderThanFilterfile_not_present318488423\\001\\b.log: The system cannot find the file specified." does not contain "b.log: no such file or directory"
```
This is simply saying the error message on Windows doesn't contain the expected error message. However, we can tell from the output that the test is working as intended. This updates the test to use the proper error message on Windows to determine if it's successful.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32464

**Testing:** <Describe what testing was performed and which tests were added.>
I've added the `Run Windows` label to confirm this is working as intended.