### PR TITLE
[pkg/stanza] always register operator to DefaultRegistry. Double chec…

### DIFF
--- a/.chloggen/fix-jsonarrayparser.yaml
+++ b/.chloggen/fix-jsonarrayparser.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Always register operator to DefaultRegistry. Double check state in featuregate when unmarshal configuration."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32313]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/parser/jsonarray/config.go
+++ b/pkg/stanza/operator/parser/jsonarray/config.go
@@ -18,17 +18,16 @@ const (
 	headerDelimiter = ","
 )
 
-var jsonArrayParserFeatureGate = featuregate.GlobalRegistry().MustRegister(
+var _ = featuregate.GlobalRegistry().MustRegister(
 	"logs.jsonParserArray",
 	featuregate.StageAlpha,
+	featuregate.WithRegisterOperatorType(operatorType),
 	featuregate.WithRegisterDescription("When enabled, allows usage of `json_array_parser`."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30321"),
 )
 
 func init() {
-	if jsonArrayParserFeatureGate.IsEnabled() {
-		operator.Register(operatorType, func() operator.Builder { return NewConfig() })
-	}
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new json array parser config with default values

--- a/pkg/stanza/operator/parser/jsonarray/config_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/config_test.go
@@ -6,9 +6,12 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
+	"go.opentelemetry.io/collector/featuregate"
 )
 
 func TestConfig(t *testing.T) {
@@ -64,4 +67,17 @@ func TestConfig(t *testing.T) {
 			},
 		},
 	}.Run(t)
+}
+
+func TestLookup(t *testing.T) {
+	builder, ok := operator.DefaultRegistry.Lookup(operatorType)
+	assert.False(t, ok)
+	assert.Nil(t, builder)
+
+	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
+	assert.Nil(t, err)
+
+	builder2, ok2 := operator.DefaultRegistry.Lookup(operatorType)
+	assert.True(t, ok2)
+	assert.NotNil(t, builder2)
 }


### PR DESCRIPTION
*Description:** <Describe what has changed.>
bug:  collector launch fail with '--feature-gates=logs.jsonParserArray'

how to fix: 
1. `func init()`always register operator to `operator.DefaultRegistry`.
2. use `Gate.operatorType` double check operator state in `featuregate.globalRegistry` when unmarshal configuration. Because id and operatorType are not the same string. (id: "logs.jsonParserArray", operatorType: "json_array_parser")

depend on：https://github.com/open-telemetry/opentelemetry-collector/pull/9983
**Link to tracking Issue:** 
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32313