### PR TITLE
[chore][CONTRIBUTING.md] Add paragraph on linking issues in PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,21 @@ If you would like to contribute please read OpenTelemetry Collector [contributin
 guidelines](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md) before you begin your
 work.
 
-## Pull-request title
+## Pull-requests
+
+### Title guidelines
 
 The title for your pull-request should contain the component type and name in brackets, plus a short statement for your
 change. For instance:
 
     [processor/tailsampling] fix AND policy
+
+### Description guidelines
+
+When linking to an open issue, if your PR is meant to close said issue, please prefix your issue with one of the
+following keywords: `Resolves`, `Fixes`, or `Closes`. More information on this functionality (and more keyword options) can be found
+[here](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
+This will automatically close the issue once your PR has been merged.
 
 ## Changelog
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
GitHub has automation to [automatically close issues if they're prefixed with the right keyword](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword). It would be good to document this for users to make sure issues are closed when the PR is merged, and not left open.