### PR TITLE
[chore] Remove all direct usage of component.host.GetExporters

### DIFF
--- a/processor/routingprocessor/logs.go
+++ b/processor/routingprocessor/logs.go
@@ -5,6 +5,7 @@ package routingprocessor // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -66,8 +67,16 @@ func newLogProcessor(settings component.TelemetrySettings, config component.Conf
 	}, nil
 }
 
+type getExporters interface {
+	GetExporters() map[component.DataType]map[component.ID]component.Component
+}
+
 func (p *logProcessor) Start(_ context.Context, host component.Host) error {
-	err := p.router.registerExporters(host.GetExporters()[component.DataTypeLogs]) //nolint:staticcheck
+	ge, ok := host.(getExporters)
+	if !ok {
+		return fmt.Errorf("unable to get exporters")
+	}
+	err := p.router.registerExporters(ge.GetExporters()[component.DataTypeLogs])
 	if err != nil {
 		return err
 	}

--- a/processor/routingprocessor/metrics.go
+++ b/processor/routingprocessor/metrics.go
@@ -5,6 +5,7 @@ package routingprocessor // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -67,7 +68,11 @@ func newMetricProcessor(settings component.TelemetrySettings, config component.C
 }
 
 func (p *metricsProcessor) Start(_ context.Context, host component.Host) error {
-	err := p.router.registerExporters(host.GetExporters()[component.DataTypeMetrics]) //nolint:staticcheck
+	ge, ok := host.(getExporters)
+	if !ok {
+		return fmt.Errorf("unable to get exporters")
+	}
+	err := p.router.registerExporters(ge.GetExporters()[component.DataTypeMetrics])
 	if err != nil {
 		return err
 	}

--- a/processor/routingprocessor/traces.go
+++ b/processor/routingprocessor/traces.go
@@ -5,6 +5,7 @@ package routingprocessor // import "github.com/open-telemetry/opentelemetry-coll
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -68,7 +69,11 @@ func newTracesProcessor(settings component.TelemetrySettings, config component.C
 }
 
 func (p *tracesProcessor) Start(_ context.Context, host component.Host) error {
-	err := p.router.registerExporters(host.GetExporters()[component.DataTypeTraces]) //nolint:staticcheck
+	ge, ok := host.(getExporters)
+	if !ok {
+		return fmt.Errorf("unable to get exporters")
+	}
+	err := p.router.registerExporters(ge.GetExporters()[component.DataTypeTraces])
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:** 
Removes all direct use of the `component.Host.GetExporters` function so that it can be removed from the interface.

**Link to tracking Issue:** 
Works towards https://github.com/open-telemetry/opentelemetry-collector/issues/7370