### PR TITLE
[pkg/stanza] when the 'jsonArrayParserFeatureGate'  is disabled, the func 'Build'  returns an error

### DIFF
--- a/.chloggen/fix-jsonarrayparser-build.yaml
+++ b/.chloggen/fix-jsonarrayparser-build.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "When the `jsonArrayParserFeatureGate` is disabled, the func `Build` returns an error."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32313]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/fix-jsonarrayparser-build.yaml
+++ b/.chloggen/fix-jsonarrayparser-build.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: pkg/stanza
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "When the `jsonArrayParserFeatureGate` is disabled, the func `Build` returns an error."
+note: Fix race condition which prevented `jsonArrayParserFeatureGate` from working correctly.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [32313]

--- a/pkg/stanza/go.mod
+++ b/pkg/stanza/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/jpillora/backoff v1.0.0
 	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage v0.98.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.98.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.98.0
 	github.com/stretchr/testify v1.9.0
 	github.com/valyala/fastjson v1.6.4
@@ -77,6 +78,8 @@ replace github.com/googleapis/gnostic v0.5.6 => github.com/googleapis/gnostic v0
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage => ../../extension/storage
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
 retract (
 	v0.76.2

--- a/pkg/stanza/operator/parser/jsonarray/config.go
+++ b/pkg/stanza/operator/parser/jsonarray/config.go
@@ -3,6 +3,7 @@
 package jsonarray // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/jsonarray"
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/valyala/fastjson"
@@ -26,9 +27,7 @@ var jsonArrayParserFeatureGate = featuregate.GlobalRegistry().MustRegister(
 )
 
 func init() {
-	if jsonArrayParserFeatureGate.IsEnabled() {
-		operator.Register(operatorType, func() operator.Builder { return NewConfig() })
-	}
+	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 }
 
 // NewConfig creates a new json array parser config with default values
@@ -51,6 +50,10 @@ type Config struct {
 
 // Build will build a json array parser operator.
 func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+	if !jsonArrayParserFeatureGate.IsEnabled() {
+		return nil, fmt.Errorf("%s operator disabled", operatorType)
+	}
+
 	parserOperator, err := c.ParserConfig.Build(logger)
 	if err != nil {
 		return nil, err

--- a/pkg/stanza/operator/parser/jsonarray/config_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/config_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/featuregate"
 
+	commontestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
@@ -16,7 +16,7 @@ import (
 )
 
 func TestConfig(t *testing.T) {
-	// Manually adding operator to the Registry as its behind a feature gate
+	// Manually adding operator to the Registry as it's behind a feature gate
 	operator.Register(operatorType, func() operator.Builder { return NewConfig() })
 
 	operatortest.ConfigUnmarshalTests{
@@ -83,8 +83,7 @@ func TestBuildWithFeatureGate(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			if c.isFeatureGateEnable {
-				err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
-				require.Nil(t, err)
+				defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
 			}
 
 			buildFunc, ok := operator.Lookup(operatorType)

--- a/pkg/stanza/operator/parser/jsonarray/parser_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/parser_test.go
@@ -8,16 +8,15 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/featuregate"
 
+	commontestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func newTestParser(t *testing.T) *Parser {
-	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
-	require.Nil(t, err)
+	defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
 
 	cfg := NewConfigWithID("test")
 	op, err := cfg.Build(testutil.Logger(t))
@@ -26,12 +25,11 @@ func newTestParser(t *testing.T) *Parser {
 }
 
 func TestParserBuildFailure(t *testing.T) {
-	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
-	require.Nil(t, err)
+	defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
 
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err = cfg.Build(testutil.Logger(t))
+	_, err := cfg.Build(testutil.Logger(t))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -44,8 +42,7 @@ func TestParserInvalidType(t *testing.T) {
 }
 
 func TestParserByteFailureHeadersMismatch(t *testing.T) {
-	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
-	require.Nil(t, err)
+	defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
 
 	cfg := NewConfigWithID("test")
 	cfg.Header = "name,sev,msg"
@@ -58,8 +55,7 @@ func TestParserByteFailureHeadersMismatch(t *testing.T) {
 }
 
 func TestParserJarray(t *testing.T) {
-	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
-	require.Nil(t, err)
+	defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
 
 	cases := []struct {
 		name             string
@@ -281,6 +277,8 @@ func TestParserJarray(t *testing.T) {
 }
 
 func TestParserJarrayMultiline(t *testing.T) {
+	defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
+
 	cases := []struct {
 		name     string
 		input    string
@@ -387,6 +385,8 @@ dd","eeee"]`,
 }
 
 func TestBuildParserJarray(t *testing.T) {
+	defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
+
 	newBasicParser := func() *Config {
 		cfg := NewConfigWithID("test")
 		cfg.OutputIDs = []string{"test"}

--- a/pkg/stanza/operator/parser/jsonarray/parser_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -15,6 +16,9 @@ import (
 )
 
 func newTestParser(t *testing.T) *Parser {
+	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
+	require.Nil(t, err)
+
 	cfg := NewConfigWithID("test")
 	op, err := cfg.Build(testutil.Logger(t))
 	require.NoError(t, err)
@@ -22,9 +26,12 @@ func newTestParser(t *testing.T) *Parser {
 }
 
 func TestParserBuildFailure(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
+	require.Nil(t, err)
+
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	_, err = cfg.Build(testutil.Logger(t))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -37,6 +44,9 @@ func TestParserInvalidType(t *testing.T) {
 }
 
 func TestParserByteFailureHeadersMismatch(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
+	require.Nil(t, err)
+
 	cfg := NewConfigWithID("test")
 	cfg.Header = "name,sev,msg"
 	op, err := cfg.Build(testutil.Logger(t))
@@ -48,6 +58,9 @@ func TestParserByteFailureHeadersMismatch(t *testing.T) {
 }
 
 func TestParserJarray(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set("logs.jsonParserArray", true)
+	require.Nil(t, err)
+
 	cases := []struct {
 		name             string
 		configure        func(*Config)

--- a/processor/logstransformprocessor/go.mod
+++ b/processor/logstransformprocessor/go.mod
@@ -85,3 +85,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/azureeventhubreceiver/go.mod
+++ b/receiver/azureeventhubreceiver/go.mod
@@ -145,3 +145,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/share
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/azure => ../../pkg/translator/azure
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/filelogreceiver/go.mod
+++ b/receiver/filelogreceiver/go.mod
@@ -84,3 +84,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/journaldreceiver/go.mod
+++ b/receiver/journaldreceiver/go.mod
@@ -81,3 +81,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/namedpipereceiver/go.mod
+++ b/receiver/namedpipereceiver/go.mod
@@ -75,3 +75,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/otlpjsonfilereceiver/go.mod
+++ b/receiver/otlpjsonfilereceiver/go.mod
@@ -84,3 +84,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/sqlqueryreceiver/go.mod
+++ b/receiver/sqlqueryreceiver/go.mod
@@ -181,3 +181,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza => 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/sqlquery => ../../internal/sqlquery
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/syslogreceiver/go.mod
+++ b/receiver/syslogreceiver/go.mod
@@ -85,3 +85,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/tcplogreceiver/go.mod
+++ b/receiver/tcplogreceiver/go.mod
@@ -85,3 +85,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/udplogreceiver/go.mod
+++ b/receiver/udplogreceiver/go.mod
@@ -81,3 +81,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/windowseventlogreceiver/go.mod
+++ b/receiver/windowseventlogreceiver/go.mod
@@ -81,3 +81,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
bug: 
- collector launch fail with '--feature-gates=logs.jsonParserArray'

how to fix:
1. `func init()` always register operator to `operator.DefaultRegistry`.
2. when the `jsonArrayParserFeatureGate` is disabled, the func `Build` returns an error.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32313
