### PR TITLE
[.github] Add receiver-2 and receiver-3 groups to matrix for Windows unit tests

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -29,6 +29,8 @@ jobs:
         group:
           - receiver-0
           - receiver-1
+          - receiver-2
+          - receiver-3
           - processor
           - exporter
           - extension


### PR DESCRIPTION
**Description:** 

We missed adding these on #30901, causing #32508

**Link to tracking Issue:** Fixes #32508