### PR TITLE
[chore][receiver/sqlserver] Skip tests failing on Windows

### DIFF
--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -6,12 +6,17 @@ package sqlserverreceiver
 import (
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestQueryIODBWithoutInstanceName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Test is failing on Windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32519")
+	}
+
 	expected, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithoutInstanceName.txt"))
 	require.NoError(t, err)
 
@@ -21,6 +26,10 @@ func TestQueryIODBWithoutInstanceName(t *testing.T) {
 }
 
 func TestQueryIODBWithInstanceName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Test is failing on Windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32519")
+	}
+
 	expected, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithInstanceName.txt"))
 	require.NoError(t, err)
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
These tests were added as a part of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31915, functionality that has not yet been enabled in the collector. This means this code is not currently used, so the tests can be safely skipped on Windows for now, until they can be fixed as a part of the larger work going on in the receiver.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32519
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32518
