### PR TITLE
[chore][receiver/k8scluster] Fix config's indentation in README

### DIFF
--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -72,12 +72,12 @@ Example:
     auth_type: kubeConfig
     node_conditions_to_report: [Ready, MemoryPressure]
     allocatable_types_to_report: [cpu, memory]
-  metrics:
-    k8s.container.cpu_limit:
-      enabled: false
-  resource_attributes:
-    container.id:
-      enabled: false
+    metrics:
+      k8s.container.cpu_limit:
+        enabled: false
+    resource_attributes:
+      container.id:
+        enabled: false
 ```
 
 The full list of settings exposed for this receiver are documented [here](./config.go)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`metrics` and `resource_attributes` are configurable options within the `k8s_cluster` receiver. The indentation should properly reflect this.