### PR TITLE
[chore][receiver/sqlserver] Fix newlines when testing on Windows

### DIFF
--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -6,19 +6,17 @@ package sqlserverreceiver
 import (
 	"os"
 	"path"
-	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestQueryIODBWithoutInstanceName(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Test is failing on Windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32519")
-	}
-
-	expected, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithoutInstanceName.txt"))
+	expected_bytes, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithoutInstanceName.txt"))
 	require.NoError(t, err)
+	// Replace all will fix newlines when testing on Windows
+	expected := strings.ReplaceAll(string(expected_bytes[:]), "\r\n", "\n")
 
 	actual := getSQLServerDatabaseIOQuery("")
 
@@ -26,12 +24,10 @@ func TestQueryIODBWithoutInstanceName(t *testing.T) {
 }
 
 func TestQueryIODBWithInstanceName(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Test is failing on Windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32519")
-	}
-
-	expected, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithInstanceName.txt"))
+	expected_bytes, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithInstanceName.txt"))
 	require.NoError(t, err)
+	// Replace all will fix newlines when testing on Windows
+	expected := strings.ReplaceAll(string(expected_bytes[:]), "\r\n", "\n")
 
 	actual := getSQLServerDatabaseIOQuery("instanceName")
 

--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -20,7 +20,7 @@ func TestQueryIODBWithoutInstanceName(t *testing.T) {
 
 	actual := getSQLServerDatabaseIOQuery("")
 
-	require.Equal(t, string(expected), actual)
+	require.Equal(t, expected, actual)
 }
 
 func TestQueryIODBWithInstanceName(t *testing.T) {
@@ -31,5 +31,5 @@ func TestQueryIODBWithInstanceName(t *testing.T) {
 
 	actual := getSQLServerDatabaseIOQuery("instanceName")
 
-	require.Equal(t, string(expected), actual)
+	require.Equal(t, expected, actual)
 }

--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -13,10 +13,10 @@ import (
 )
 
 func TestQueryIODBWithoutInstanceName(t *testing.T) {
-	expected_bytes, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithoutInstanceName.txt"))
+	expectedBytes, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithoutInstanceName.txt"))
 	require.NoError(t, err)
 	// Replace all will fix newlines when testing on Windows
-	expected := strings.ReplaceAll(string(expected_bytes[:]), "\r\n", "\n")
+	expected := strings.ReplaceAll(string(expectedBytes), "\r\n", "\n")
 
 	actual := getSQLServerDatabaseIOQuery("")
 
@@ -24,10 +24,10 @@ func TestQueryIODBWithoutInstanceName(t *testing.T) {
 }
 
 func TestQueryIODBWithInstanceName(t *testing.T) {
-	expected_bytes, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithInstanceName.txt"))
+	expectedBytes, err := os.ReadFile(path.Join("./testdata", "databaseIOQueryWithInstanceName.txt"))
 	require.NoError(t, err)
 	// Replace all will fix newlines when testing on Windows
-	expected := strings.ReplaceAll(string(expected_bytes[:]), "\r\n", "\n")
+	expected := strings.ReplaceAll(string(expectedBytes), "\r\n", "\n")
 
 	actual := getSQLServerDatabaseIOQuery("instanceName")
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Tests were failing on Windows because when the expected results were loaded from a file, the newlines were `\r\n` instead of `\n`. This replaces the unexpected characters for testing.

This is a test only change, and re-enables the tests that were being skipped.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32519