### PR TITLE
[receiver/vcenter] Adds extra resource attributes to relevant Resource Pools

### DIFF
--- a/.chloggen/fix_vcenter-cluster-attr-on-rpools.yaml
+++ b/.chloggen/fix_vcenter-cluster-attr-on-rpools.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds the `vcenter.cluster.name` resource attribute to resource pool with a ClusterComputeResource parent"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32535]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -32,6 +32,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: DC0_C0
         - key: vcenter.resource_pool.name
           value:
             stringValue: Resources

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -1,6 +1,9 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: vcenter.host.name
+          value:
+            stringValue: DC0_H0
         - key: vcenter.resource_pool.name
           value:
             stringValue: Resources

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -5109,6 +5109,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: vcenter.host.name
+          value:
+            stringValue: esxi-111.europe-southeast1.gve.goog
         - key: vcenter.resource_pool.inventory_path
           value:
             stringValue: /Datacenter/host/StandaloneHost/Resources

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -5057,6 +5057,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: Cluster
         - key: vcenter.resource_pool.inventory_path
           value:
             stringValue: /Datacenter/host/Cluster/Resources


### PR DESCRIPTION
**Description:** <Describe what has changed.>
`vcenter.cluster.name` attribute is added to all Resource Pool resources that belong to a Cluster. In addition, `vcenter.host.name` attribute is added to all Resource Pool resources that belong to a standalone Host.

This helps to keep attributes consistent between all resource types. Also, Cluster information can’t automatically be parsed from the inventory path attribute, as we don’t have the context of nested folders. So this allows for the ability to tell what Cluster a Resource Pool belongs to (if any).

**Link to tracking Issue:** <Issue number if applicable>
#32535 

**Testing:** <Describe what testing was performed and which tests were added.>
Unit/integration tests updated and tested. Local environment tested.

**Documentation:** <Describe the documentation added.>
N/A