### PR TITLE
[pkg/pdatatest/plogtest] Add an option to ignore log timestamp

### DIFF
--- a/.chloggen/plogtest-ignore-timestamp.yaml
+++ b/.chloggen/plogtest-ignore-timestamp.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/pdatatest/plogtest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add an option to ignore log timestamp
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32540]
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/pdatatest/plogtest/logs_test.go
+++ b/pkg/pdatatest/plogtest/logs_test.go
@@ -134,6 +134,14 @@ func TestCompareLogs(t *testing.T) {
 			withoutOptions: errors.New(`resource "map[]": scope "collector": log record "map[]": observed timestamp doesn't match expected: 11651379494838206465, actual: 11651379494838206464`),
 			withOptions:    nil,
 		},
+		{
+			name: "ignore-timestamp",
+			compareOptions: []CompareLogsOption{
+				IgnoreTimestamp(),
+			},
+			withoutOptions: errors.New(`resource "map[]": scope "collector": log record "map[]": timestamp doesn't match expected: 11651379494838206465, actual: 11651379494838206464`),
+			withOptions:    nil,
+		},
 	}
 
 	for _, tc := range tcs {

--- a/pkg/pdatatest/plogtest/options.go
+++ b/pkg/pdatatest/plogtest/options.go
@@ -49,6 +49,27 @@ func (opt ignoreResourceAttributeValue) maskLogsResourceAttributeValue(metrics p
 	}
 }
 
+func IgnoreTimestamp() CompareLogsOption {
+	return compareLogsOptionFunc(func(expected, actual plog.Logs) {
+		now := pcommon.NewTimestampFromTime(time.Now())
+		maskTimestamp(expected, now)
+		maskTimestamp(actual, now)
+	})
+}
+
+func maskTimestamp(logs plog.Logs, ts pcommon.Timestamp) {
+	rls := logs.ResourceLogs()
+	for i := 0; i < logs.ResourceLogs().Len(); i++ {
+		sls := rls.At(i).ScopeLogs()
+		for j := 0; j < sls.Len(); j++ {
+			lrs := sls.At(j).LogRecords()
+			for k := 0; k < lrs.Len(); k++ {
+				lrs.At(k).SetTimestamp(ts)
+			}
+		}
+	}
+}
+
 func IgnoreObservedTimestamp() CompareLogsOption {
 	return compareLogsOptionFunc(func(expected, actual plog.Logs) {
 		now := pcommon.NewTimestampFromTime(time.Now())

--- a/pkg/pdatatest/plogtest/testdata/ignore-timestamp/actual.yaml
+++ b/pkg/pdatatest/plogtest/testdata/ignore-timestamp/actual.yaml
@@ -1,0 +1,18 @@
+resourceLogs:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - logRecords:
+          - body:
+              stringValue: test
+            flags: 1
+            observedTimeUnixNano: "11651379494838206464"
+            severityNumber: 9
+            severityText: TEST
+            spanId: ""
+            timeUnixNano: "11651379494838206464"
+            traceId: ""
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: collector
+          version: v0.1.0

--- a/pkg/pdatatest/plogtest/testdata/ignore-timestamp/expected.yaml
+++ b/pkg/pdatatest/plogtest/testdata/ignore-timestamp/expected.yaml
@@ -1,0 +1,18 @@
+resourceLogs:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - logRecords:
+          - body:
+              stringValue: test
+            flags: 1
+            observedTimeUnixNano: "11651379494838206464"
+            severityNumber: 9
+            severityText: TEST
+            spanId: ""
+            timeUnixNano: "11651379494838206465"
+            traceId: ""
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: collector
+          version: v0.1.0


### PR DESCRIPTION
We have an option to ignore observed timestamp, but sometimes it's needed to ignore timestamp as well
