### PR TITLE
update otelcol versions to 0.98.0

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   name: otelcontribcol
   description: Local OpenTelemetry Collector Contrib binary, testing only.
   version: 0.98.0-dev
-  otelcol_version: 0.97.0
+  otelcol_version: 0.98.0
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.98.1-0.20240416174005-d0f15e2463f8

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -3,7 +3,7 @@ dist:
   name: oteltestbedcol
   description: OpenTelemetry Collector binary for testbed only tests.
   version: 0.98.0-dev
-  otelcol_version: 0.97.0
+  otelcol_version: 0.98.0
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/ballastextension v0.98.1-0.20240416174005-d0f15e2463f8


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Fix versioning mismatch

**Link to tracking Issue:** [32539](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32539)

**Testing:** ran `make genotelcontribcol` and `make genoteltestbedcol`