### PR TITLE
[chore][CI/CD] Fix cloudflare receiver integration test

### DIFF
--- a/receiver/cloudflarereceiver/logs_integration_test.go
+++ b/receiver/cloudflarereceiver/logs_integration_test.go
@@ -39,7 +39,7 @@ var testPayloads = []string{
 	"multiple_log_payload",
 }
 
-func TestReceiverTLS(t *testing.T) {
+func TestReceiverTLSIntegration(t *testing.T) {
 	for _, payloadName := range testPayloads {
 		t.Run(payloadName, func(t *testing.T) {
 			testAddr := testutil.GetAvailableLocalAddress(t)
@@ -108,7 +108,7 @@ func TestReceiverTLS(t *testing.T) {
 
 			logs := sink.AllLogs()[0]
 
-			expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "processed", fmt.Sprintf("%s.json", payloadName)))
+			expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "processed", fmt.Sprintf("%s.yaml", payloadName)))
 			require.NoError(t, err)
 
 			require.NoError(t, plogtest.CompareLogs(expectedLogs, logs, plogtest.IgnoreObservedTimestamp()))


### PR DESCRIPTION
Fixed the expected file extension for golden metrics comparison in cloudflare receiver integration test to be .yaml, not .json.

Due to the undocumented behavior of the Integration test Make tasks only running tests containing the string 'Integration', this was broken when golden metrics were changed in test from JSON to YAML in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/20438. 


While the 'Integration' restriction is being addressed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32529, in case that gets caught up in review or this limitation is accidentally reintroduced I added 'Integration' to the name of the test, as well.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32532

**Testing:** Ran the test locally to confirm that the test runs successfully.