### PR TITLE
[receiver/vcenter] Remove vcenter.cluster.name resource attribute from standalone Host resources

### DIFF
--- a/.chloggen/fix_vcenter-modify-host-resource-attrs.yaml
+++ b/.chloggen/fix_vcenter-modify-host-resource-attrs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove the `vcenter.cluster.name` resource attribute from Host resources if the Host is standalone (no cluster)"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32548]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -241,7 +241,9 @@ func (v *vcenterMetricScraper) collectHost(
 	v.recordHostPerformanceMetrics(ctx, hwSum, errs)
 	rb := v.mb.NewResourceBuilder()
 	rb.SetVcenterHostName(host.Name())
-	rb.SetVcenterClusterName(compute.Name())
+	if compute.Reference().Type == "ClusterComputeResource" {
+		rb.SetVcenterClusterName(compute.Name())
+	}
 	v.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 }
 

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -66,9 +66,6 @@ resourceMetrics:
         - key: vcenter.host.name
           value:
             stringValue: DC0_H0
-        - key: vcenter.cluster.name
-          value:
-            stringValue: DC0_H0
     scopeMetrics:
       - metrics:
           - description: The amount of CPU used by the host.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
vcenter.cluster.name attribute is removed from all Host resources that have a ComputeResource parent (vs. a ClusterComputeResource) parent.

This helps to not cause confusion by making standalone hosts look like clustered hosts.

**Link to tracking Issue:** <Issue number if applicable>
#32548 

**Testing:** <Describe what testing was performed and which tests were added.>
Unit/integration tests updated and tested. Local environment tested.

**Documentation:** <Describe the documentation added.>
N/A