### PR TITLE
add batcher config to splunkhec exporter

### DIFF
--- a/.chloggen/exporter-splunkhec-addbatcherconfig.yaml
+++ b/.chloggen/exporter-splunkhec-addbatcherconfig.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: exporter/splunkhec
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: add exporter batcher config in splunk hec exporter
+note: add experimental exporter batcher config in splunk hec exporter
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [32545]

--- a/.chloggen/exporter-splunkhec-addbatcherconfig.yaml
+++ b/.chloggen/exporter-splunkhec-addbatcherconfig.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: exporter/splunkhec
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: add experimental exporter batcher config in splunk hec exporter
+note: add experimental exporter batcher config
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [32545]

--- a/.chloggen/exporter-splunkhec-addbatcherconfig.yaml
+++ b/.chloggen/exporter-splunkhec-addbatcherconfig.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/splunkhec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add exporter batcher config in splunk hec exporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32545]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -66,7 +66,7 @@ The following configuration options can also be configured:
 - `telemetry/enabled` (default: false): Specifies whether to enable telemetry inside splunk hec exporter.
 - `telemetry/override_metrics_names` (default: empty map): Specifies the metrics name to overrides in splunk hec exporter.
 - `telemetry/extra_attributes` (default: empty map): Specifies the extra metrics attributes in splunk hec exporter.
-- `batcher`: Specifies batching configuration on the exporter. Information about the configuration can be found [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
+- `batcher`(Experimental): Specifies batching configuration on the exporter. This configuration is experimental and may change until the [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/8122) is resolved. Information about the configuration can be found [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
 
 In addition, this exporter offers queued retry which is enabled by default.
 Information about queued retry configuration parameters can be found

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -66,6 +66,7 @@ The following configuration options can also be configured:
 - `telemetry/enabled` (default: false): Specifies whether to enable telemetry inside splunk hec exporter.
 - `telemetry/override_metrics_names` (default: empty map): Specifies the metrics name to overrides in splunk hec exporter.
 - `telemetry/extra_attributes` (default: empty map): Specifies the extra metrics attributes in splunk hec exporter.
+- `batcher`: Specifies batching configuration on the exporter. Information about the configuration can be found [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
 
 In addition, this exporter offers queued retry which is enabled by default.
 Information about queued retry configuration parameters can be found

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -66,7 +66,7 @@ The following configuration options can also be configured:
 - `telemetry/enabled` (default: false): Specifies whether to enable telemetry inside splunk hec exporter.
 - `telemetry/override_metrics_names` (default: empty map): Specifies the metrics name to overrides in splunk hec exporter.
 - `telemetry/extra_attributes` (default: empty map): Specifies the extra metrics attributes in splunk hec exporter.
-- `batcher`(Experimental, disabled by default): Specifies batching configuration on the exporter. This configuration is experimental and may change until the [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/8122) is resolved. Information about the configuration can be found [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
+- `batcher`(Experimental, disabled by default): Specifies batching configuration on the exporter. Information about the configuration can be found [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
 
 In addition, this exporter offers queued retry which is enabled by default.
 Information about queued retry configuration parameters can be found

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -66,7 +66,7 @@ The following configuration options can also be configured:
 - `telemetry/enabled` (default: false): Specifies whether to enable telemetry inside splunk hec exporter.
 - `telemetry/override_metrics_names` (default: empty map): Specifies the metrics name to overrides in splunk hec exporter.
 - `telemetry/extra_attributes` (default: empty map): Specifies the extra metrics attributes in splunk hec exporter.
-- `batcher`(Experimental): Specifies batching configuration on the exporter. This configuration is experimental and may change until the [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/8122) is resolved. Information about the configuration can be found [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
+- `batcher`(Experimental, disabled by default): Specifies batching configuration on the exporter. This configuration is experimental and may change until the [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/8122) is resolved. Information about the configuration can be found [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md)
 
 In addition, this exporter offers queued retry which is enabled by default.
 Information about queued retry configuration parameters can be found

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
@@ -67,6 +68,7 @@ type Config struct {
 	confighttp.ClientConfig      `mapstructure:",squash"`
 	exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
+	BatcherConfig                exporterbatcher.Config `mapstructure:"batcher"`
 
 	// LogDataEnabled can be used to disable sending logs by the exporter.
 	LogDataEnabled bool `mapstructure:"log_data_enabled"`

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -68,7 +68,10 @@ type Config struct {
 	confighttp.ClientConfig      `mapstructure:",squash"`
 	exporterhelper.QueueSettings `mapstructure:"sending_queue"`
 	configretry.BackOffConfig    `mapstructure:"retry_on_failure"`
-	BatcherConfig                exporterbatcher.Config `mapstructure:"batcher"`
+
+	// Experimental: This configuration is at the early stage of development and may change without backward compatibility
+	// until https://github.com/open-telemetry/opentelemetry-collector/issues/8122 is resolved.
+	BatcherConfig exporterbatcher.Config `mapstructure:"batcher"`
 
 	// LogDataEnabled can be used to disable sending logs by the exporter.
 	LogDataEnabled bool `mapstructure:"log_data_enabled"`

--- a/exporter/splunkhecexporter/config_test.go
+++ b/exporter/splunkhecexporter/config_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter/internal/metadata"
@@ -89,6 +90,16 @@ func TestLoadConfig(t *testing.T) {
 					Enabled:      true,
 					NumConsumers: 2,
 					QueueSize:    10,
+				},
+				BatcherConfig: exporterbatcher.Config{
+					Enabled:      true,
+					FlushTimeout: time.Second,
+					MinSizeConfig: exporterbatcher.MinSizeConfig{
+						MinSizeItems: 1,
+					},
+					MaxSizeConfig: exporterbatcher.MaxSizeConfig{
+						MaxSizeItems: 10,
+					},
 				},
 				HecToOtelAttrs: splunk.HecToOtelAttrs{
 					Source:     "mysource",

--- a/exporter/splunkhecexporter/factory.go
+++ b/exporter/splunkhecexporter/factory.go
@@ -66,10 +66,7 @@ func getExporterOptions(cfg *Config, startFunc component.StartFunc, shutdownFunc
 		exporterhelper.WithQueue(cfg.QueueSettings),
 		exporterhelper.WithStart(startFunc),
 		exporterhelper.WithShutdown(shutdownFunc),
-	}
-
-	if cfg.BatcherConfig.Enabled {
-		options = append(options, exporterhelper.WithBatcher(cfg.BatcherConfig))
+		exporterhelper.WithBatcher(cfg.BatcherConfig),
 	}
 
 	return options

--- a/exporter/splunkhecexporter/testdata/config.yaml
+++ b/exporter/splunkhecexporter/testdata/config.yaml
@@ -26,6 +26,11 @@ splunk_hec/allsettings:
     initial_interval: 10s
     max_interval: 60s
     max_elapsed_time: 10m
+  batcher:
+    enabled: true
+    flush_timeout: 1s
+    min_size_items: 1
+    max_size_items: 10
   splunk_app_name: "OpenTelemetry-Collector Splunk Exporter"
   splunk_app_version: "v0.0.1"
   hec_metadata_to_otel_attrs:


### PR DESCRIPTION
**Description:** 
Add a new feature in splunk hec exporter
- utilitize batching framework https://github.com/open-telemetry/opentelemetry-collector/pull/9738 in splunk hec exporter
- adds batcher config in splunk hec exporter config and append it as exporter option if enabled

**Link to tracking Issue:**
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32545

**Testing:**
Added unit test for the config

**Documentation:**
Updated the README file