### PR TITLE
[chore][receiver/filestats] Fix broken link in README

### DIFF
--- a/receiver/filestatsreceiver/README.md
+++ b/receiver/filestatsreceiver/README.md
@@ -19,4 +19,4 @@ The File Stats receiver collects metrics from files specified with a glob patter
 - `collection_interval` (default = `1m`): The interval at which metrics are emitted by this receiver.
 - `initial_delay` (default = `1s`): defines how long this receiver waits before starting.
 
-See [documentation.md] for a list of the metrics collected.
+See [documentation.md](./documentation.md) for a list of the metrics collected.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The format for the link to the `documentation.md` file was incorrect, this fixes it to properly link to the file.