### PR TITLE
[pkg/stanza] Fix TimeParser unmarshaling

### DIFF
--- a/.chloggen/time_parser_take2.yaml
+++ b/.chloggen/time_parser_take2.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Unmarshaling now preserves the initial configuration.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32169]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -47,12 +47,13 @@ type TimeParser struct {
 
 // Unmarshal starting from default settings
 func (t *TimeParser) Unmarshal(component *confmap.Conf) error {
-	cfg := NewTimeParser()
-	err := component.Unmarshal(&cfg, confmap.WithIgnoreUnused())
+	err := component.Unmarshal(t, confmap.WithIgnoreUnused())
 	if err != nil {
 		return err
 	}
-	*t = cfg
+	if t.LayoutType == "" {
+		t.LayoutType = StrptimeKey
+	}
 	return nil
 }
 
@@ -69,10 +70,6 @@ func (t *TimeParser) Validate() error {
 
 	if t.Layout == "" && t.LayoutType != "native" {
 		return errors.NewError("missing required configuration parameter `layout`", "")
-	}
-
-	if t.LayoutType == "" {
-		t.LayoutType = StrptimeKey
 	}
 
 	switch t.LayoutType {

--- a/pkg/stanza/operator/helper/time_test.go
+++ b/pkg/stanza/operator/helper/time_test.go
@@ -9,7 +9,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/confmap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -571,6 +573,20 @@ func TestSetInvalidLocation(t *testing.T) {
 	err := tp.setLocation()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load location "+"not_a_location")
+}
+
+func TestUnmarshal(t *testing.T) {
+	conf := confmap.NewFromStringMap(map[string]any{
+		"location": "America/Shiprock",
+	})
+	tp := TimeParser{
+		Layout: "1/2/2006 15:04:05",
+	}
+
+	require.NoError(t, tp.Unmarshal(conf))
+	assert.Equal(t, "America/Shiprock", tp.Location)
+	assert.Equal(t, "strptime", tp.LayoutType)
+	assert.Equal(t, "1/2/2006 15:04:05", tp.Layout)
 }
 
 func TestUnmarshalTimeConfig(t *testing.T) {


### PR DESCRIPTION
**Description:**
Fix unmarshaling of TimeParser to conserve initial settings before unmarshaling.

**Link to tracking Issue:**
Fixes #32169

**Testing:**
Added the test from the issue.

For @mx-psi  I could not make it so we would apply https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31802#discussion_r1559849575 because `TimeParser` is reused on all operators, and therefore it becomes contentious to patch all over the place.