### PR TITLE
[chore] Fix Splunk integration test by simplifying the run and using an older Splunk build

### DIFF
--- a/exporter/splunkhecexporter/testdata/integration_tests_config.yaml
+++ b/exporter/splunkhecexporter/testdata/integration_tests_config.yaml
@@ -1,20 +1,11 @@
-# SPLUNK DATA
-SPLUNK_IMAGE : "splunk/splunk:9.1"
-HOST : "non"
-
-#credentials:
-USER : "admin"
-PASSWORD : "helloworld"
-
-# ports
-UI_PORT: "8000"
-HEC_PORT: "8088"
-MANAGEMENT_PORT: "8089"
-
-# indexes
-EVENT_INDEX : "sck-otel"
-METRIC_INDEX: "sck-metrics"
-TRACE_INDEX: "sck-traces"
-
-# hec tokens
-HEC_TOKEN : "00000000-0000-0000-0000-000000000000"
+HOST: localhost
+USER: admin
+PASSWORD: helloworld
+UI_PORT: "62025"
+HEC_PORT: "62023"
+MANAGEMENT_PORT: "62024"
+EVENT_INDEX: sck-otel
+METRIC_INDEX: sck-metrics
+TRACE_INDEX: sck-traces
+HEC_TOKEN: 00000000-0000-0000-0000-000000000000
+SPLUNK_IMAGE: splunk/splunk:9.1.2

--- a/exporter/splunkhecexporter/testdata/splunk.yaml
+++ b/exporter/splunkhecexporter/testdata/splunk.yaml
@@ -1,0 +1,28 @@
+splunk:
+  hec:
+    enable: True
+    ssl: True
+    port: 8088
+    token: 00000000-0000-0000-0000-000000000000
+  conf:
+    indexes:
+      directory: /opt/splunk/etc/apps/search/local
+      content:
+        sck-otel:
+          coldPath: $SPLUNK_DB/sck-otel/colddb
+          datatype: event
+          homePath: $SPLUNK_DB/sck-otel/db
+          maxTotalDataSizeMB: 512000
+          thawedPath: $SPLUNK_DB/sck-otel/thaweddb
+        sck-metrics:
+          coldPath: $SPLUNK_DB/sck-metrics/colddb
+          datatype: metric
+          homePath: $SPLUNK_DB/sck-metrics/db
+          maxTotalDataSizeMB: 512000
+          thawedPath: $SPLUNK_DB/sck-metrics/thaweddb
+        sck-traces:
+          coldPath: $SPLUNK_DB/sck-traces/colddb
+          datatype: event
+          homePath: $SPLUNK_DB/sck-traces/db
+          maxTotalDataSizeMB: 512000
+          thawedPath: $SPLUNK_DB/sck-traces/thaweddb


### PR DESCRIPTION
**Description:**
Use splunk.yaml to run the container and set it up at once.
Use 9.1.2 as latest version is affected by https://github.com/splunk/splunk-ansible/pull/819.

**Link to tracking Issue:**
Fixes #32534
