### PR TITLE
[chore] remove use of metadata in extension

### DIFF
--- a/extension/oidcauthextension/extension.go
+++ b/extension/oidcauthextension/extension.go
@@ -72,8 +72,13 @@ func (e *oidcExtension) start(context.Context, component.Host) error {
 
 // authenticate checks whether the given context contains valid auth data. Successfully authenticated calls will always return a nil error and a context with the auth data.
 func (e *oidcExtension) authenticate(ctx context.Context, headers map[string][]string) (context.Context, error) {
-	metadata := client.NewMetadata(headers)
-	authHeaders := metadata.Get(e.cfg.Attribute)
+	var authHeaders []string
+	for k, v := range headers {
+		if strings.EqualFold(k, e.cfg.Attribute) {
+			authHeaders = v
+			break
+		}
+	}
 	if len(authHeaders) == 0 {
 		return ctx, errNotAuthenticated
 	}


### PR DESCRIPTION
It's just used to retrieve a header value.