### PR TITLE
[chore][extension/remotetap] fix component name in README

### DIFF
--- a/extension/remotetapextension/README.md
+++ b/extension/remotetapextension/README.md
@@ -25,7 +25,7 @@ Example:
 ```yaml
 
 extensions:
-  remoteobserver:
+  remotetap:
 ```
 
 The full list of settings exposed for this exporter are documented [here](./config.go).


### PR DESCRIPTION
`remoteobserver` => `remotetap`

The type name `remoteObserverExtension` should also be changed for consistency @atoulme.