### PR TITLE
[exporter/awsxray] make comma as invalid char for x-ray segment name

### DIFF
--- a/.chloggen/xrayexporter-segment-name-fix.yaml
+++ b/.chloggen/xrayexporter-segment-name-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: make comma`,` as invalid char for x-ray segment name
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32610]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -43,8 +43,10 @@ const (
 
 var (
 	// reInvalidSpanCharacters defines the invalid letters in a span name as per
-	// https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
-	reInvalidSpanCharacters = regexp.MustCompile(`[^ 0-9\p{L}N_.:/%&#=+,\-@]`)
+	// Allowed characters for X-Ray Segment Name:
+	// Unicode letters, numbers, and whitespace, and the following symbols: _, ., :, /, %, &, #, =, +, \, -, @
+	// Doc: https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html
+	reInvalidSpanCharacters = regexp.MustCompile(`[^ 0-9\p{L}N_.:/%&#=+\-@]`)
 )
 
 var (

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -399,9 +399,9 @@ func TestFixSegmentName(t *testing.T) {
 	validName := "EP @ test_15.testing-d\u00F6main.org#GO"
 	fixedName := fixSegmentName(validName)
 	assert.Equal(t, validName, fixedName)
-	invalidName := "<subDomain>.example.com"
+	invalidName := "<subDomain>.example.com,1413"
 	fixedName = fixSegmentName(invalidName)
-	assert.Equal(t, "subDomain.example.com", fixedName)
+	assert.Equal(t, "subDomain.example.com1413", fixedName)
 	fullyInvalidName := "<>"
 	fixedName = fixSegmentName(fullyInvalidName)
 	assert.Equal(t, defaultSegmentName, fixedName)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
X-Ray backend does not support Segment names that include the comma (`,`) character, according to the X-Ray documentation provided below. If users use OTel SDK to create Span names containing a comma, the X-Ray backend will reject these with the error response shown below. It appears that the regex previously implemented did not correctly exclude the comma as an invalid character when converting the span name to an X-Ray segment name. This update adjusts the span name validation regex to align with X-Ray's naming definitions.

```
"name": "MOBSTGSQLAWSV.wvinfo.org,1433",
"id": "399a73101ce890de",
ErrorCode: "InvalidName" Id: "399a73101ce890de" Message: "Invalid subsegment. ErrorCode: InvalidName, Cause: null } 
```

**Link to tracking Issue:** <Issue number if applicable>
n/a

**Testing:** 
unit test

**Documentation:** 
X-Ray public documentation noted that X-Ray Segment name should only contain Unicode letters, numbers, and whitespace, and the following symbols: _, ., :, /, %, &, #, =, +, \, -, @
* https://docs.aws.amazon.com/xray/latest/devguide/xray-api-segmentdocuments.html#api-segmentdocuments-fields