### PR TITLE
[chore] correct remotetapprocessor/README.md

### DIFF
--- a/processor/remotetapprocessor/README.md
+++ b/processor/remotetapprocessor/README.md
@@ -24,8 +24,8 @@ any open WebSockets is rate limited by an adjustable amount.
 
 The WebSocket processor has two configurable fields: `port` and `limit`:
 
-- `port`: The port on which the WebSocket processor listens. Optional. Defaults
-  to `12001`.
+- `endpoint`: The endpoint on which the WebSocket processor listens. Optional. Defaults
+  to `0.0.0.0:12001`.
   The `component.UseLocalHostAsDefaultHost` feature gate changes this to localhost:12001. This will become the default in a future release.
 
 - `limit`: The rate limit over the WebSocket in messages per second. Can be a
@@ -35,6 +35,6 @@ Example configuration:
 
 ```yaml
 websocket:
-  port: 12001
+  endpoint: 0.0.0.0:12001
   limit: 1 # rate limit 1 msg/sec
 ```


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `websocket` configuration item is `endpoint`, and the default value is `0.0.0.0:12001`.
```go
// ServerConfig defines settings for creating an HTTP server.
type ServerConfig struct {
	// Endpoint configures the listening address for the server.
	Endpoint string `mapstructure:"endpoint"`
        ...
}
```

```go
func createDefaultConfig() component.Config {
	return &Config{
		ServerConfig: confighttp.ServerConfig{
			Endpoint: localhostgate.EndpointForPort(defaultPort),
		},
		Limit: 1,
	}
}
```