### PR TITLE
feat (processor/k8sattributes): wait for synced when starting k8sattributes processor.

### DIFF
--- a/.chloggen/k8sattributes-block.yaml
+++ b/.chloggen/k8sattributes-block.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Block when starting util the metadata have been synced, to fix that some data couldn't be associated with metadata when the agent was just started.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/k8sattributes-block.yaml
+++ b/.chloggen/k8sattributes-block.yaml
@@ -10,7 +10,7 @@ component: processor/k8sattributes
 note: Block when starting util the metadata have been synced, to fix that some data couldn't be associated with metadata when the agent was just started.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [32556]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/k8sattributes-block.yaml
+++ b/.chloggen/k8sattributes-block.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: processor/k8sattributes
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Block when starting util the metadata have been synced, to fix that some data couldn't be associated with metadata when the agent was just started.
+note: Block when starting until the metadata have been synced, to fix that some data couldn't be associated with metadata when the agent was just started.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [32556]

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -198,6 +198,21 @@ the processor associates the received trace to the pod, based on the connection 
 }
 ```
 
+By default, the processor will be ready as soon as it starts, even no metadata has been fetched yet.
+If data is sent to this processor before the metadata is synced, there will be no metadata to enrich the data with.
+
+To wait for the metadata to be synced before the processor is ready, set the `wait_for_metadata` option to `true`.
+Then the processor will not be ready until the metadata has been synced.
+If a timeout is reached, the processor will fail to start and return an error, which will cause the collector to exit.
+The timeout defaults to 10s and can be configured with the `metadata_sync_timeout` option.
+
+example for setting the processor to wait for metadata to be synced before it is ready:
+
+```yaml
+wait_for_metadata: true
+wait_for_metadata_timeout: 10s
+```
+
 ## Extracting attributes from pod labels and annotations
 
 The k8sattributesprocessor can also set resource attributes from k8s labels and annotations of pods, namespaces and nodes.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -202,7 +202,7 @@ By default, the processor will be ready as soon as it starts, even if no metadat
 If data is sent to this processor before the metadata is synced, there will be no metadata to enrich the data with.
 
 To wait for the metadata to be synced before the processor is ready, set the `wait_for_metadata` option to `true`.
-Then the processor will not be ready until the metadata is fully synced. As a result, the start-up of the Collector tool will be blocked. If the metadata cannot be synced, the Collector tool will ultimately fail to start.
+Then the processor will not be ready until the metadata is fully synced. As a result, the start-up of the Collector will be blocked. If the metadata cannot be synced, the Collector will ultimately fail to start.
 If a timeout is reached, the processor will fail to start and return an error, which will cause the collector to exit.
 The timeout defaults to 10s and can be configured with the `metadata_sync_timeout` option.
 

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -198,11 +198,11 @@ the processor associates the received trace to the pod, based on the connection 
 }
 ```
 
-By default, the processor will be ready as soon as it starts, even no metadata has been fetched yet.
+By default, the processor will be ready as soon as it starts, even if no metadata has been fetched yet.
 If data is sent to this processor before the metadata is synced, there will be no metadata to enrich the data with.
 
 To wait for the metadata to be synced before the processor is ready, set the `wait_for_metadata` option to `true`.
-Then the processor will not be ready until the metadata has been synced.
+Then the processor will not be ready until the metadata is fully synced. As a result, the start-up of the Collector tool will be blocked. If the metadata cannot be synced, the Collector tool will ultimately fail to start.
 If a timeout is reached, the processor will fail to start and return an error, which will cause the collector to exit.
 The timeout defaults to 10s and can be configured with the `metadata_sync_timeout` option.
 

--- a/processor/k8sattributesprocessor/client_test.go
+++ b/processor/k8sattributesprocessor/client_test.go
@@ -70,10 +70,11 @@ func (f *fakeClient) GetNode(nodeName string) (*kube.Node, bool) {
 }
 
 // Start is a noop for FakeClient.
-func (f *fakeClient) Start() {
+func (f *fakeClient) Start() error {
 	if f.Informer != nil {
-		f.Informer.Run(f.StopCh)
+		go f.Informer.Run(f.StopCh)
 	}
+	return nil
 }
 
 // Stop is a noop for FakeClient.

--- a/processor/k8sattributesprocessor/client_test.go
+++ b/processor/k8sattributesprocessor/client_test.go
@@ -4,6 +4,8 @@
 package k8sattributesprocessor
 
 import (
+	"time"
+
 	"go.opentelemetry.io/collector/component"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -35,7 +37,7 @@ func selectors() (labels.Selector, fields.Selector) {
 }
 
 // newFakeClient instantiates a new FakeClient object and satisfies the ClientProvider type
-func newFakeClient(_ component.TelemetrySettings, _ k8sconfig.APIConfig, rules kube.ExtractionRules, filters kube.Filters, associations []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformerProvider, _ kube.InformerProviderNamespace, _ kube.InformerProviderReplicaSet) (kube.Client, error) {
+func newFakeClient(_ component.TelemetrySettings, _ k8sconfig.APIConfig, rules kube.ExtractionRules, filters kube.Filters, associations []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformerProvider, _ kube.InformerProviderNamespace, _ kube.InformerProviderReplicaSet, _ bool, _ time.Duration) (kube.Client, error) {
 	cs := fake.NewSimpleClientset()
 
 	ls, fs := selectors()

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -6,6 +6,7 @@ package k8sattributesprocessor // import "github.com/open-telemetry/opentelemetr
 import (
 	"fmt"
 	"regexp"
+	"time"
 
 	"go.opentelemetry.io/collector/featuregate"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -46,6 +47,12 @@ type Config struct {
 	// Exclude section allows to define names of pod that should be
 	// ignored while tagging.
 	Exclude ExcludeConfig `mapstructure:"exclude"`
+
+	// WaitForMetadata is a flag that determines if the processor should wait k8s metadata to be synced when starting.
+	WaitForMetadata bool `mapstructure:"wait_for_metadata"`
+
+	// WaitForMetadataTimeout is the maximum time the processor will wait for the k8s metadata to be synced.
+	WaitForMetadataTimeout time.Duration `mapstructure:"wait_for_metadata_timeout"`
 }
 
 func (cfg *Config) Validate() error {

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -6,6 +6,7 @@ package k8sattributesprocessor
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,6 +35,7 @@ func TestLoadConfig(t *testing.T) {
 				Extract: ExtractConfig{
 					Metadata: enabledAttributes(),
 				},
+				WaitForMetadataTimeout: 10 * time.Second,
 			},
 		},
 		{
@@ -105,6 +107,7 @@ func TestLoadConfig(t *testing.T) {
 						{Name: "jaeger-collector"},
 					},
 				},
+				WaitForMetadataTimeout: 10 * time.Second,
 			},
 		},
 		{
@@ -127,6 +130,7 @@ func TestLoadConfig(t *testing.T) {
 						{Name: "jaeger-collector"},
 					},
 				},
+				WaitForMetadataTimeout: 10 * time.Second,
 			},
 		},
 		{
@@ -149,6 +153,7 @@ func TestLoadConfig(t *testing.T) {
 						{Name: "jaeger-collector"},
 					},
 				},
+				WaitForMetadataTimeout: 10 * time.Second,
 			},
 		},
 		{

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -5,6 +5,7 @@ package k8sattributesprocessor // import "github.com/open-telemetry/opentelemetr
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
@@ -44,6 +45,7 @@ func createDefaultConfig() component.Config {
 		Extract: ExtractConfig{
 			Metadata: enabledAttributes(),
 		},
+		WaitForMetadataTimeout: 10 * time.Second,
 	}
 }
 
@@ -201,6 +203,11 @@ func createProcessorOpts(cfg component.Config) []option {
 	opts = append(opts, withExtractPodAssociations(oCfg.Association...))
 
 	opts = append(opts, withExcludes(oCfg.Exclude))
+
+	opts = append(opts, withWaitForMetadataTimeout(oCfg.WaitForMetadataTimeout))
+	if oCfg.WaitForMetadata {
+		opts = append(opts, withWaitForMetadata(true))
+	}
 
 	return opts
 }

--- a/processor/k8sattributesprocessor/generated_component_test.go
+++ b/processor/k8sattributesprocessor/generated_component_test.go
@@ -65,9 +65,9 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(&cfg))
 
-	for _, test := range tests {
-		t.Run(test.name+"-shutdown", func(t *testing.T) {
-			c, err := test.createFn(context.Background(), processortest.NewNopSettings(), cfg)
+	for _, tt := range tests {
+		t.Run(tt.name+"-shutdown", func(t *testing.T) {
+			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
 			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)

--- a/processor/k8sattributesprocessor/generated_component_test.go
+++ b/processor/k8sattributesprocessor/generated_component_test.go
@@ -65,47 +65,9 @@ func TestComponentLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(&cfg))
 
-	for _, tt := range tests {
-		t.Run(tt.name+"-shutdown", func(t *testing.T) {
-			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
-			require.NoError(t, err)
-			err = c.Shutdown(context.Background())
-			require.NoError(t, err)
-		})
-		t.Run(tt.name+"-lifecycle", func(t *testing.T) {
-			c, err := tt.createFn(context.Background(), processortest.NewNopSettings(), cfg)
-			require.NoError(t, err)
-			host := componenttest.NewNopHost()
-			err = c.Start(context.Background(), host)
-			require.NoError(t, err)
-			require.NotPanics(t, func() {
-				switch tt.name {
-				case "logs":
-					e, ok := c.(processor.Logs)
-					require.True(t, ok)
-					logs := generateLifecycleTestLogs()
-					if !e.Capabilities().MutatesData {
-						logs.MarkReadOnly()
-					}
-					err = e.ConsumeLogs(context.Background(), logs)
-				case "metrics":
-					e, ok := c.(processor.Metrics)
-					require.True(t, ok)
-					metrics := generateLifecycleTestMetrics()
-					if !e.Capabilities().MutatesData {
-						metrics.MarkReadOnly()
-					}
-					err = e.ConsumeMetrics(context.Background(), metrics)
-				case "traces":
-					e, ok := c.(processor.Traces)
-					require.True(t, ok)
-					traces := generateLifecycleTestTraces()
-					if !e.Capabilities().MutatesData {
-						traces.MarkReadOnly()
-					}
-					err = e.ConsumeTraces(context.Background(), traces)
-				}
-			})
+	for _, test := range tests {
+		t.Run(test.name+"-shutdown", func(t *testing.T) {
+			c, err := test.createFn(context.Background(), processortest.NewNopSettings(), cfg)
 			require.NoError(t, err)
 			err = c.Shutdown(context.Background())
 			require.NoError(t, err)

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -87,7 +87,20 @@ var rRegex = regexp.MustCompile(`^(.*)-[0-9a-zA-Z]+$`)
 var cronJobRegex = regexp.MustCompile(`^(.*)-[0-9]+$`)
 
 // New initializes a new k8s Client.
-func New(set component.TelemetrySettings, apiCfg k8sconfig.APIConfig, rules ExtractionRules, filters Filters, associations []Association, exclude Excludes, newClientSet APIClientsetProvider, newInformer InformerProvider, newNamespaceInformer InformerProviderNamespace, newReplicaSetInformer InformerProviderReplicaSet, waitForMetadata bool, waitForMetadataTimeout time.Duration) (Client, error) {
+func New(
+	set component.TelemetrySettings,
+	apiCfg k8sconfig.APIConfig,
+	rules ExtractionRules,
+	filters Filters,
+	associations []Association,
+	exclude Excludes,
+	newClientSet APIClientsetProvider,
+	newInformer InformerProvider,
+	newNamespaceInformer InformerProviderNamespace,
+	newReplicaSetInformer InformerProviderReplicaSet,
+	waitForMetadata bool,
+	waitForMetadataTimeout time.Duration,
+) (Client, error) {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(set)
 	if err != nil {
 		return nil, err

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -180,7 +180,7 @@ func TestClientStartStop(t *testing.T) {
 	done := make(chan struct{})
 	assert.False(t, fctr.HasStopped())
 	go func() {
-		c.Start()
+		assert.NoError(t, c.Start())
 		close(done)
 	}()
 	c.Stop()

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -143,29 +143,18 @@ func nodeAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 }
 
 func TestDefaultClientset(t *testing.T) {
-	c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, nil, nil, nil, nil)
+	c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, nil, nil, nil, nil, false, 10*time.Second)
 	assert.Error(t, err)
 	assert.Equal(t, "invalid authType for kubernetes: ", err.Error())
 	assert.Nil(t, c)
 
-	c, err = New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, nil, nil, nil)
+	c, err = New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{}, []Association{}, Excludes{}, newFakeAPIClientset, nil, nil, nil, false, 10*time.Second)
 	assert.NoError(t, err)
 	assert.NotNil(t, c)
 }
 
 func TestBadFilters(t *testing.T) {
-	c, err := New(
-		componenttest.NewNopTelemetrySettings(),
-		k8sconfig.APIConfig{},
-		ExtractionRules{},
-		Filters{Fields: []FieldFilter{{Op: selection.Exists}}},
-		[]Association{},
-		Excludes{},
-		newFakeAPIClientset,
-		NewFakeInformer,
-		NewFakeNamespaceInformer,
-		NewFakeReplicaSetInformer,
-	)
+	c, err := New(componenttest.NewNopTelemetrySettings(), k8sconfig.APIConfig{}, ExtractionRules{}, Filters{Fields: []FieldFilter{{Op: selection.Exists}}}, []Association{}, Excludes{}, newFakeAPIClientset, NewFakeInformer, NewFakeNamespaceInformer, NewFakeReplicaSetInformer, false, 10*time.Second)
 	assert.Error(t, err)
 	assert.Nil(t, c)
 }
@@ -201,7 +190,7 @@ func TestConstructorErrors(t *testing.T) {
 			gotAPIConfig = c
 			return nil, fmt.Errorf("error creating k8s client")
 		}
-		c, err := New(componenttest.NewNopTelemetrySettings(), apiCfg, er, ff, []Association{}, Excludes{}, clientProvider, NewFakeInformer, NewFakeNamespaceInformer, nil)
+		c, err := New(componenttest.NewNopTelemetrySettings(), apiCfg, er, ff, []Association{}, Excludes{}, clientProvider, NewFakeInformer, NewFakeNamespaceInformer, nil, false, 10*time.Second)
 		assert.Nil(t, c)
 		assert.Error(t, err)
 		assert.Equal(t, "error creating k8s client", err.Error())
@@ -1923,7 +1912,7 @@ func newTestClientWithRulesAndFilters(t *testing.T, f Filters) (*WatchClient, *o
 			},
 		},
 	}
-	c, err := New(set, k8sconfig.APIConfig{}, ExtractionRules{}, f, associations, exclude, newFakeAPIClientset, NewFakeInformer, NewFakeNamespaceInformer, NewFakeReplicaSetInformer)
+	c, err := New(set, k8sconfig.APIConfig{}, ExtractionRules{}, f, associations, exclude, newFakeAPIClientset, NewFakeInformer, NewFakeNamespaceInformer, NewFakeReplicaSetInformer, false, 10*time.Second)
 	require.NoError(t, err)
 	return c.(*WatchClient), logs
 }

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1973,5 +1973,4 @@ func TestWaitForMetadata(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/processor/k8sattributesprocessor/internal/kube/fake_informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/fake_informer.go
@@ -40,7 +40,7 @@ func (f *FakeInformer) AddEventHandler(handler cache.ResourceEventHandler) (cach
 }
 
 func (f *FakeInformer) AddEventHandlerWithResyncPeriod(_ cache.ResourceEventHandler, _ time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
+	return f, nil
 }
 
 func (f *FakeInformer) RemoveEventHandler(_ cache.ResourceEventHandlerRegistration) error {
@@ -165,7 +165,7 @@ func (f *NoOpInformer) AddEventHandler(handler cache.ResourceEventHandler) (cach
 }
 
 func (f *NoOpInformer) AddEventHandlerWithResyncPeriod(_ cache.ResourceEventHandler, _ time.Duration) (cache.ResourceEventHandlerRegistration, error) {
-	return nil, nil
+	return f, nil
 }
 
 func (f *NoOpInformer) RemoveEventHandler(_ cache.ResourceEventHandlerRegistration) error {

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -91,7 +91,7 @@ type Client interface {
 	GetPod(PodIdentifier) (*Pod, bool)
 	GetNamespace(string) (*Namespace, bool)
 	GetNode(string) (*Node, bool)
-	Start()
+	Start() error
 	Stop()
 }
 

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -96,7 +96,7 @@ type Client interface {
 }
 
 // ClientProvider defines a func type that returns a new Client.
-type ClientProvider func(component.TelemetrySettings, k8sconfig.APIConfig, ExtractionRules, Filters, []Association, Excludes, APIClientsetProvider, InformerProvider, InformerProviderNamespace, InformerProviderReplicaSet) (Client, error)
+type ClientProvider func(component.TelemetrySettings, k8sconfig.APIConfig, ExtractionRules, Filters, []Association, Excludes, APIClientsetProvider, InformerProvider, InformerProviderNamespace, InformerProviderReplicaSet, bool, time.Duration) (Client, error)
 
 // APIClientsetProvider defines a func type that initializes and return a new kubernetes
 // Clientset object.

--- a/processor/k8sattributesprocessor/internal/metadata/generated_resource_test.go
+++ b/processor/k8sattributesprocessor/internal/metadata/generated_resource_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestResourceBuilder(t *testing.T) {
-	for _, test := range []string{"default", "all_set", "none_set"} {
-		t.Run(test, func(t *testing.T) {
-			cfg := loadResourceAttributesConfig(t, test)
+	for _, tt := range []string{"default", "all_set", "none_set"} {
+		t.Run(tt, func(t *testing.T) {
+			cfg := loadResourceAttributesConfig(t, tt)
 			rb := NewResourceBuilder(cfg)
 			rb.SetContainerID("container.id-val")
 			rb.SetContainerImageName("container.image.name-val")
@@ -42,7 +42,7 @@ func TestResourceBuilder(t *testing.T) {
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
-			switch test {
+			switch tt {
 			case "default":
 				assert.Equal(t, 8, res.Attributes().Len())
 			case "all_set":
@@ -51,11 +51,11 @@ func TestResourceBuilder(t *testing.T) {
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
 			default:
-				assert.Failf(t, "unexpected test case: %s", test)
+				assert.Failf(t, "unexpected test case: %s", tt)
 			}
 
 			val, ok := res.Attributes().Get("container.id")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "container.id-val", val.Str())
 			}
@@ -65,7 +65,7 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "container.image.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("container.image.repo_digests")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, []any{"container.image.repo_digests-item1", "container.image.repo_digests-item2"}, val.Slice().AsRaw())
 			}
@@ -75,27 +75,27 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "container.image.tag-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.cluster.uid")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.cluster.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.container.name")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.container.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.cronjob.name")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.cronjob.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.daemonset.name")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.daemonset.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.daemonset.uid")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.daemonset.uid-val", val.Str())
 			}
@@ -105,17 +105,17 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "k8s.deployment.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.deployment.uid")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.deployment.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.job.name")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.job.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.job.uid")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.job.uid-val", val.Str())
 			}
@@ -130,17 +130,17 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "k8s.node.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.node.uid")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.node.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.pod.hostname")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.pod.hostname-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.pod.ip")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.pod.ip-val", val.Str())
 			}
@@ -160,22 +160,22 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "k8s.pod.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.replicaset.name")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.replicaset.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.replicaset.uid")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.replicaset.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.statefulset.name")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.statefulset.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.statefulset.uid")
-			assert.Equal(t, test == "all_set", ok)
+			assert.Equal(t, tt == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.statefulset.uid-val", val.Str())
 			}

--- a/processor/k8sattributesprocessor/internal/metadata/generated_resource_test.go
+++ b/processor/k8sattributesprocessor/internal/metadata/generated_resource_test.go
@@ -9,9 +9,9 @@ import (
 )
 
 func TestResourceBuilder(t *testing.T) {
-	for _, tt := range []string{"default", "all_set", "none_set"} {
-		t.Run(tt, func(t *testing.T) {
-			cfg := loadResourceAttributesConfig(t, tt)
+	for _, test := range []string{"default", "all_set", "none_set"} {
+		t.Run(test, func(t *testing.T) {
+			cfg := loadResourceAttributesConfig(t, test)
 			rb := NewResourceBuilder(cfg)
 			rb.SetContainerID("container.id-val")
 			rb.SetContainerImageName("container.image.name-val")
@@ -42,7 +42,7 @@ func TestResourceBuilder(t *testing.T) {
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
-			switch tt {
+			switch test {
 			case "default":
 				assert.Equal(t, 8, res.Attributes().Len())
 			case "all_set":
@@ -51,11 +51,11 @@ func TestResourceBuilder(t *testing.T) {
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
 			default:
-				assert.Failf(t, "unexpected test case: %s", tt)
+				assert.Failf(t, "unexpected test case: %s", test)
 			}
 
 			val, ok := res.Attributes().Get("container.id")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "container.id-val", val.Str())
 			}
@@ -65,7 +65,7 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "container.image.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("container.image.repo_digests")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, []any{"container.image.repo_digests-item1", "container.image.repo_digests-item2"}, val.Slice().AsRaw())
 			}
@@ -75,27 +75,27 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "container.image.tag-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.cluster.uid")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.cluster.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.container.name")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.container.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.cronjob.name")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.cronjob.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.daemonset.name")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.daemonset.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.daemonset.uid")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.daemonset.uid-val", val.Str())
 			}
@@ -105,17 +105,17 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "k8s.deployment.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.deployment.uid")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.deployment.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.job.name")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.job.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.job.uid")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.job.uid-val", val.Str())
 			}
@@ -130,17 +130,17 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "k8s.node.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.node.uid")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.node.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.pod.hostname")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.pod.hostname-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.pod.ip")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.pod.ip-val", val.Str())
 			}
@@ -160,22 +160,22 @@ func TestResourceBuilder(t *testing.T) {
 				assert.EqualValues(t, "k8s.pod.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.replicaset.name")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.replicaset.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.replicaset.uid")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.replicaset.uid-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.statefulset.name")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.statefulset.name-val", val.Str())
 			}
 			val, ok = res.Attributes().Get("k8s.statefulset.uid")
-			assert.Equal(t, tt == "all_set", ok)
+			assert.Equal(t, test == "all_set", ok)
 			if ok {
 				assert.EqualValues(t, "k8s.statefulset.uid-val", val.Str())
 			}

--- a/processor/k8sattributesprocessor/metadata.yaml
+++ b/processor/k8sattributesprocessor/metadata.yaml
@@ -114,6 +114,7 @@ resource_attributes:
 
 tests:
   config:
+  skip_lifecycle: true
   goleak:
     skip: true
 

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"time"
 
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"k8s.io/apimachinery/pkg/selection"
@@ -378,6 +379,22 @@ func withExcludes(podExclude ExcludeConfig) option {
 			ignoredNames.Pods = append(ignoredNames.Pods, kube.ExcludePods{Name: regexp.MustCompile(name.Name)})
 		}
 		p.podIgnore = ignoredNames
+		return nil
+	}
+}
+
+// withWaitForMetadata allows specifying whether to wait for pod metadata to be synced.
+func withWaitForMetadata(wait bool) option {
+	return func(p *kubernetesprocessor) error {
+		p.waitForMetadata = wait
+		return nil
+	}
+}
+
+// withWaitForMetadataTimeout allows specifying the timeout for waiting for pod metadata to be synced.
+func withWaitForMetadataTimeout(timeout time.Duration) option {
+	return func(p *kubernetesprocessor) error {
+		p.waitForMetadataTimeout = timeout
 		return nil
 	}
 }

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -73,7 +73,11 @@ func (kp *kubernetesprocessor) Start(_ context.Context, host component.Host) err
 		}
 	}
 	if !kp.passthroughMode {
-		go kp.kc.Start()
+		err := kp.kc.Start()
+		if err != nil {
+			kp.telemetrySettings.ReportStatus(component.NewFatalErrorEvent(err))
+			return nil
+		}
 	}
 	return nil
 }

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
@@ -27,17 +28,19 @@ const (
 )
 
 type kubernetesprocessor struct {
-	cfg               component.Config
-	options           []option
-	telemetrySettings component.TelemetrySettings
-	logger            *zap.Logger
-	apiConfig         k8sconfig.APIConfig
-	kc                kube.Client
-	passthroughMode   bool
-	rules             kube.ExtractionRules
-	filters           kube.Filters
-	podAssociations   []kube.Association
-	podIgnore         kube.Excludes
+	cfg                    component.Config
+	options                []option
+	telemetrySettings      component.TelemetrySettings
+	logger                 *zap.Logger
+	apiConfig              k8sconfig.APIConfig
+	kc                     kube.Client
+	passthroughMode        bool
+	rules                  kube.ExtractionRules
+	filters                kube.Filters
+	podAssociations        []kube.Association
+	podIgnore              kube.Excludes
+	waitForMetadata        bool
+	waitForMetadataTimeout time.Duration
 }
 
 func (kp *kubernetesprocessor) initKubeClient(set component.TelemetrySettings, kubeClient kube.ClientProvider) error {
@@ -45,7 +48,7 @@ func (kp *kubernetesprocessor) initKubeClient(set component.TelemetrySettings, k
 		kubeClient = kube.New
 	}
 	if !kp.passthroughMode {
-		kc, err := kubeClient(set, kp.apiConfig, kp.rules, kp.filters, kp.podAssociations, kp.podIgnore, nil, nil, nil, nil)
+		kc, err := kubeClient(set, kp.apiConfig, kp.rules, kp.filters, kp.podAssociations, kp.podIgnore, nil, nil, nil, nil, kp.waitForMetadata, kp.waitForMetadataTimeout)
 		if err != nil {
 			return err
 		}
@@ -60,7 +63,7 @@ func (kp *kubernetesprocessor) Start(_ context.Context, host component.Host) err
 	for _, opt := range allOptions {
 		if err := opt(kp); err != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
-			return nil
+			return err
 		}
 	}
 
@@ -69,14 +72,14 @@ func (kp *kubernetesprocessor) Start(_ context.Context, host component.Host) err
 		err := kp.initKubeClient(kp.telemetrySettings, kubeClientProvider)
 		if err != nil {
 			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
-			return nil
+			return err
 		}
 	}
 	if !kp.passthroughMode {
 		err := kp.kc.Start()
 		if err != nil {
-			kp.telemetrySettings.ReportStatus(component.NewFatalErrorEvent(err))
-			return nil
+			componentstatus.ReportStatus(host, componentstatus.NewFatalErrorEvent(err))
+			return err
 		}
 	}
 	return nil

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -266,7 +266,7 @@ func TestNewProcessor(t *testing.T) {
 }
 
 func TestProcessorBadClientProvider(t *testing.T) {
-	clientProvider := func(_ component.TelemetrySettings, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformerProvider, _ kube.InformerProviderNamespace, _ kube.InformerProviderReplicaSet) (kube.Client, error) {
+	clientProvider := func(_ component.TelemetrySettings, _ k8sconfig.APIConfig, _ kube.ExtractionRules, _ kube.Filters, _ []kube.Association, _ kube.Excludes, _ kube.APIClientsetProvider, _ kube.InformerProvider, _ kube.InformerProviderNamespace, _ kube.InformerProviderReplicaSet, _ bool, _ time.Duration) (kube.Client, error) {
 		return nil, fmt.Errorf("bad client error")
 	}
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

When starting `k8sattributes` processor, block until an initial synchronization has been completed. This solves #32556 

**Link to tracking Issue:** <Issue number if applicable>

fix #32556

**Testing:** <Describe what testing was performed and which tests were added.>

Tested in a cluster with constant high span traffic, no more spans with unassociated k8s metadata after adding this pr.

**Documentation:** <Describe the documentation added.>