### PR TITLE
[extension/oauth2clientauth] Enable dynamically reading ClientID and ClientSecret from command

### DIFF
--- a/.chloggen/extension-oauth2clientauth-cmd-values.yaml
+++ b/.chloggen/extension-oauth2clientauth-cmd-values.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/oauth2clientauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable dynamically retrieving ClientID and ClientSecret by executing commands
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32602]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Get the client ID and/or secret by executing the command specified in the ClientIDCmd (`client_id_cmd`) and ClientSecretCmd (`client_secret_cmd`) fields respectively as a list of strings.
+  - The command is executed every time the client issues a new token. This means that the corresponding value can change dynamically during the execution if the command output changes (e.g., retrieve value from a secret store).
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/extension/oauth2clientauthextension/README.md
+++ b/extension/oauth2clientauthextension/README.md
@@ -75,10 +75,16 @@ Following are the configuration fields
 - **client_id_file** - The file path to retrieve the client identifier issued to the client.
   The extension reads this file and updates the client ID used whenever it needs to issue a new token. This enables dynamically changing the client credentials by modifying the file contents when, for example, they need to rotate. <!-- Intended whitespace for compact new line -->  
   This setting takes precedence over `client_id`.
+- **client_id_cmd** - The command to retrieve the client identifier issued to the client. Expects a list of strings.
+  The extension executes the command and updates the client ID used whenever it needs to issue a new token. This enables dynamically changing the client credentials when the command returns a different output. For example, when they are retrieved from a secret store which rotates them. <!-- Intended whitespace for compact new line -->  
+  This setting takes precedence over `client_id_file` and `client_id`.
 - [**client_secret**](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) - The secret string associated with above identifier.
 - **client_secret_file** - The file path to retrieve the secret string associated with above identifier.
   The extension reads this file and updates the client secret used whenever it needs to issue a new token. This enables dynamically changing the client credentials by modifying the file contents when, for example, they need to rotate. <!-- Intended whitespace for compact new line -->  
   This setting takes precedence over `client_secret`.
+- **client_secret_cmd** - The command to retrieve the secret string associated with above identifier. Expects a list of strings.
+  The extension executes the command and updates the client secret used whenever it needs to issue a new token. This enables dynamically changing the client credentials when the command returns a different output. For example, when they are retrieved from a secret store which rotates them. <!-- Intended whitespace for compact new line -->  
+  This setting takes precedence over `client_secret_file` and `client_secret`.
 - [**endpoint_params**](https://github.com/golang/oauth2/blob/master/clientcredentials/clientcredentials.go#L44) - Additional parameters that are sent to the token endpoint.
 - [**scopes**](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) - **Optional** optional requested permissions associated for the client.
 - [**timeout**](https://golang.org/src/net/http/client.go#L90) -  **Optional** specifies the timeout on the underlying client to authorization server for fetching the tokens (initial and while refreshing).

--- a/extension/oauth2clientauthextension/clientcredentialsconfig.go
+++ b/extension/oauth2clientauthextension/clientcredentialsconfig.go
@@ -24,13 +24,11 @@ import (
 //
 // Example - Retrieve secret from file:
 //
-//	cfg := clientCredentialsConfig{
-//		Config: clientcredentials.Config{
-//			ClientID:     "clientId",
-//			...
-//		},
+//	cfg = newClientCredentialsConfig(&Config{
+//		ClientID: "clientID",
 //		ClientSecretFile: "/path/to/client/secret",
-//	}
+//		...,
+//	})
 type clientCredentialsConfig struct {
 	clientcredentials.Config
 
@@ -99,4 +97,18 @@ func (ts clientCredentialsTokenSource) Token() (*oauth2.Token, error) {
 		return nil, err
 	}
 	return cfg.TokenSource(ts.ctx).Token()
+}
+
+func newClientCredentialsConfig(cfg *Config) *clientCredentialsConfig {
+	return &clientCredentialsConfig{
+		Config: clientcredentials.Config{
+			ClientID:       cfg.ClientID,
+			ClientSecret:   string(cfg.ClientSecret),
+			TokenURL:       cfg.TokenURL,
+			Scopes:         cfg.Scopes,
+			EndpointParams: cfg.EndpointParams,
+		},
+		ClientIDFile:     cfg.ClientIDFile,
+		ClientSecretFile: cfg.ClientSecretFile,
+	}
 }

--- a/extension/oauth2clientauthextension/clientcredentialsconfig.go
+++ b/extension/oauth2clientauthextension/clientcredentialsconfig.go
@@ -60,14 +60,6 @@ func readCredentialsFile(path string) (string, error) {
 	return credential, nil
 }
 
-func getActualValue(value, filepath string) (string, error) {
-	if len(filepath) > 0 {
-		return readCredentialsFile(filepath)
-	}
-
-	return value, nil
-}
-
 // getClientID returns the actual client ID and abstracts the interface
 func (c *clientCredentialsConfig) getClientID() (string, error) {
 	return c.clientIDSource.getValue()
@@ -78,15 +70,14 @@ func (c *clientCredentialsConfig) getClientSecret() (string, error) {
 	return c.clientSecretSource.getValue()
 }
 
-// createConfig creates a proper clientcredentials.Config with values retrieved
-// from files, if the user has specified '*_file' values
+// createConfig creates a proper clientcredentials.Config with the actual config values
 func (c *clientCredentialsConfig) createConfig() (*clientcredentials.Config, error) {
-	clientID, err := getActualValue(c.ClientID, c.ClientIDFile)
+	clientID, err := c.getClientID()
 	if err != nil {
 		return nil, multierr.Combine(errNoClientIDProvided, err)
 	}
 
-	clientSecret, err := getActualValue(c.ClientSecret, c.ClientSecretFile)
+	clientSecret, err := c.getClientSecret()
 	if err != nil {
 		return nil, multierr.Combine(errNoClientSecretProvided, err)
 	}

--- a/extension/oauth2clientauthextension/clientcredentialsconfig.go
+++ b/extension/oauth2clientauthextension/clientcredentialsconfig.go
@@ -32,9 +32,6 @@ import (
 type clientCredentialsConfig struct {
 	clientcredentials.Config
 
-	ClientIDFile     string
-	ClientSecretFile string
-
 	clientIDSource     valueSource
 	clientSecretSource valueSource
 }
@@ -124,8 +121,6 @@ func newClientCredentialsConfig(cfg *Config) *clientCredentialsConfig {
 			Scopes:         cfg.Scopes,
 			EndpointParams: cfg.EndpointParams,
 		},
-		ClientIDFile:     cfg.ClientIDFile,
-		ClientSecretFile: cfg.ClientSecretFile,
 
 		clientIDSource:     clientIDSource,
 		clientSecretSource: clientSecretSource,

--- a/extension/oauth2clientauthextension/clientcredentialsconfig.go
+++ b/extension/oauth2clientauthextension/clientcredentialsconfig.go
@@ -5,9 +5,6 @@ package oauth2clientauthextension // import "github.com/open-telemetry/opentelem
 
 import (
 	"context"
-	"fmt"
-	"os"
-	"strings"
 
 	"go.uber.org/multierr"
 	"golang.org/x/oauth2"
@@ -43,19 +40,6 @@ type clientCredentialsTokenSource struct {
 
 // clientCredentialsTokenSource implements TokenSource
 var _ oauth2.TokenSource = (*clientCredentialsTokenSource)(nil)
-
-func readCredentialsFile(path string) (string, error) {
-	f, err := os.ReadFile(path)
-	if err != nil {
-		return "", fmt.Errorf("failed to read credentials file %q: %w", path, err)
-	}
-
-	credential := strings.TrimSpace(string(f))
-	if credential == "" {
-		return "", fmt.Errorf("empty credentials file %q", path)
-	}
-	return credential, nil
-}
 
 // getClientID returns the actual client ID and abstracts the interface
 func (c *clientCredentialsConfig) getClientID() (string, error) {

--- a/extension/oauth2clientauthextension/config.go
+++ b/extension/oauth2clientauthextension/config.go
@@ -29,12 +29,18 @@ type Config struct {
 	// ClientIDFile is the file path to read the application's ID from.
 	ClientIDFile string `mapstructure:"client_id_file"`
 
+	// ClientIDCmd contains the command to retrieve the ClientID
+	ClientIDCmd []string `mapstructure:"client_id_cmd"`
+
 	// ClientSecret is the application's secret.
 	// See https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1
 	ClientSecret configopaque.String `mapstructure:"client_secret"`
 
 	// ClientSecretFile is the file pathg to read the application's secret from.
 	ClientSecretFile string `mapstructure:"client_secret_file"`
+
+	// ClientSecretCmd contains the command to retrieve the ClientSecret
+	ClientSecretCmd []string `mapstructure:"client_secret_cmd"`
 
 	// EndpointParams specifies additional parameters for requests to the token endpoint.
 	EndpointParams url.Values `mapstructure:"endpoint_params"`
@@ -60,10 +66,10 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the extension configuration is valid
 func (cfg *Config) Validate() error {
-	if cfg.ClientID == "" && cfg.ClientIDFile == "" {
+	if cfg.ClientID == "" && cfg.ClientIDFile == "" && len(cfg.ClientIDCmd) == 0 {
 		return errNoClientIDProvided
 	}
-	if cfg.ClientSecret == "" && cfg.ClientSecretFile == "" {
+	if cfg.ClientSecret == "" && cfg.ClientSecretFile == "" && len(cfg.ClientSecretCmd) == 0 {
 		return errNoClientSecretProvided
 	}
 	if cfg.TokenURL == "" {

--- a/extension/oauth2clientauthextension/config_test.go
+++ b/extension/oauth2clientauthextension/config_test.go
@@ -69,6 +69,17 @@ func TestLoadConfig(t *testing.T) {
 			id:          component.NewIDWithName(metadata.Type, "missingsecret"),
 			expectedErr: errNoClientSecretProvided,
 		},
+		{
+			id: component.NewIDWithName(metadata.Type, "secretfromcommand"),
+			expected: &Config{
+				ClientID:        "someclientid",
+				ClientSecretCmd: []string{"cat", "/path/to/secret"},
+				EndpointParams:  url.Values{"audience": []string{"someaudience"}},
+				Scopes:          []string{"api.metrics"},
+				TokenURL:        "https://example.com/oauth2/default/v1/token",
+				Timeout:         time.Second,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -11,7 +11,6 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"golang.org/x/oauth2"
-	"golang.org/x/oauth2/clientcredentials"
 	"google.golang.org/grpc/credentials"
 	grpcOAuth "google.golang.org/grpc/credentials/oauth"
 )
@@ -45,18 +44,8 @@ func newClientAuthenticator(cfg *Config, logger *zap.Logger) (*clientAuthenticat
 	transport.TLSClientConfig = tlsCfg
 
 	return &clientAuthenticator{
-		clientCredentials: &clientCredentialsConfig{
-			Config: clientcredentials.Config{
-				ClientID:       cfg.ClientID,
-				ClientSecret:   string(cfg.ClientSecret),
-				TokenURL:       cfg.TokenURL,
-				Scopes:         cfg.Scopes,
-				EndpointParams: cfg.EndpointParams,
-			},
-			ClientIDFile:     cfg.ClientIDFile,
-			ClientSecretFile: cfg.ClientSecretFile,
-		},
-		logger: logger,
+		clientCredentials: newClientCredentialsConfig(cfg),
+		logger:            logger,
 		client: &http.Client{
 			Transport: transport,
 			Timeout:   cfg.Timeout,

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -110,6 +110,7 @@ func TestOAuthClientSettings(t *testing.T) {
 }
 
 func TestOAuthClientSettingsCredsConfig(t *testing.T) {
+	// test files for TLS testing
 	var (
 		testCredsFile        = "testdata/test-cred.txt"
 		testCredsEmptyFile   = "testdata/test-cred-empty.txt"
@@ -131,6 +132,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDFile: testCredsFile,
 				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testcreds",
@@ -144,6 +147,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:         "testclientid",
 				ClientSecretFile: testCredsFile,
+				TokenURL:         "https://example.com/v1/token",
+				Scopes:           []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testclientid",
@@ -157,6 +162,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDFile: testCredsEmptyFile,
 				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientIDProvided,
@@ -166,6 +173,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:         "testclientid",
 				ClientSecretFile: testCredsMissingFile,
+				TokenURL:         "https://example.com/v1/token",
+				Scopes:           []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientSecretProvided,
@@ -175,6 +184,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDCmd:  testCredsCmd,
 				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testcreds",
@@ -188,6 +199,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:        "testclientid",
 				ClientSecretCmd: testCredsCmd,
+				TokenURL:        "https://example.com/v1/token",
+				Scopes:          []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testclientid",
@@ -201,6 +214,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDCmd:  testCredsEmptyCmd,
 				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientIDProvided,
@@ -210,6 +225,8 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:        "testclientid",
 				ClientSecretCmd: testCredsErrorCmd,
+				TokenURL:        "https://example.com/v1/token",
+				Scopes:          []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientSecretProvided,
@@ -228,6 +245,13 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedClientConfig.ClientID, cfg.ClientID)
 			assert.Equal(t, test.expectedClientConfig.ClientSecret, cfg.ClientSecret)
+
+			// test tls settings
+			transport := rc.client.Transport.(*http.Transport)
+			tlsClientConfig := transport.TLSClientConfig
+			tlsTestSettingConfig, err := test.settings.TLSSetting.LoadTLSConfig(context.Background())
+			assert.NoError(t, err)
+			assert.Equal(t, tlsClientConfig.Certificates, tlsTestSettingConfig.Certificates)
 		})
 	}
 }

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -115,6 +115,9 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 		testCredsFile        = "testdata/test-cred.txt"
 		testCredsEmptyFile   = "testdata/test-cred-empty.txt"
 		testCredsMissingFile = "testdata/test-cred-missing.txt"
+		testCredsCmd         = []string{"cat", testCredsFile}
+		testCredsEmptyCmd    = []string{"cat", testCredsEmptyFile}
+		testCredsErrorCmd    = []string{"cat", testCredsMissingFile}
 	)
 
 	tests := []struct {
@@ -172,6 +175,58 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 				ClientSecretFile: testCredsMissingFile,
 				TokenURL:         "https://example.com/v1/token",
 				Scopes:           []string{"resource.read"},
+			},
+			shouldError:   true,
+			expectedError: &errNoClientSecretProvided,
+		},
+		{
+			name: "client_id_cmd",
+			settings: &Config{
+				ClientIDCmd:  testCredsCmd,
+				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			expectedClientConfig: &clientcredentials.Config{
+				ClientID:     "testcreds",
+				ClientSecret: "testsecret",
+			},
+			shouldError:   false,
+			expectedError: nil,
+		},
+		{
+			name: "client_secret_cmd",
+			settings: &Config{
+				ClientID:        "testclientid",
+				ClientSecretCmd: testCredsCmd,
+				TokenURL:        "https://example.com/v1/token",
+				Scopes:          []string{"resource.read"},
+			},
+			expectedClientConfig: &clientcredentials.Config{
+				ClientID:     "testclientid",
+				ClientSecret: "testcreds",
+			},
+			shouldError:   false,
+			expectedError: nil,
+		},
+		{
+			name: "empty_client_cmd",
+			settings: &Config{
+				ClientIDCmd:  testCredsEmptyCmd,
+				ClientSecret: "testsecret",
+				TokenURL:     "https://example.com/v1/token",
+				Scopes:       []string{"resource.read"},
+			},
+			shouldError:   true,
+			expectedError: &errNoClientIDProvided,
+		},
+		{
+			name: "error_client_creds_cmd",
+			settings: &Config{
+				ClientID:        "testclientid",
+				ClientSecretCmd: testCredsErrorCmd,
+				TokenURL:        "https://example.com/v1/token",
+				Scopes:          []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientSecretProvided,

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -110,7 +110,6 @@ func TestOAuthClientSettings(t *testing.T) {
 }
 
 func TestOAuthClientSettingsCredsConfig(t *testing.T) {
-	// test files for TLS testing
 	var (
 		testCredsFile        = "testdata/test-cred.txt"
 		testCredsEmptyFile   = "testdata/test-cred-empty.txt"
@@ -132,8 +131,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDFile: testCredsFile,
 				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
-				Scopes:       []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testcreds",
@@ -147,8 +144,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:         "testclientid",
 				ClientSecretFile: testCredsFile,
-				TokenURL:         "https://example.com/v1/token",
-				Scopes:           []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testclientid",
@@ -162,8 +157,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDFile: testCredsEmptyFile,
 				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
-				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientIDProvided,
@@ -173,8 +166,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:         "testclientid",
 				ClientSecretFile: testCredsMissingFile,
-				TokenURL:         "https://example.com/v1/token",
-				Scopes:           []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientSecretProvided,
@@ -184,8 +175,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDCmd:  testCredsCmd,
 				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
-				Scopes:       []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testcreds",
@@ -199,8 +188,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:        "testclientid",
 				ClientSecretCmd: testCredsCmd,
-				TokenURL:        "https://example.com/v1/token",
-				Scopes:          []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testclientid",
@@ -214,8 +201,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDCmd:  testCredsEmptyCmd,
 				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
-				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientIDProvided,
@@ -225,8 +210,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:        "testclientid",
 				ClientSecretCmd: testCredsErrorCmd,
-				TokenURL:        "https://example.com/v1/token",
-				Scopes:          []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientSecretProvided,
@@ -245,13 +228,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedClientConfig.ClientID, cfg.ClientID)
 			assert.Equal(t, test.expectedClientConfig.ClientSecret, cfg.ClientSecret)
-
-			// test tls settings
-			transport := rc.client.Transport.(*http.Transport)
-			tlsClientConfig := transport.TLSClientConfig
-			tlsTestSettingConfig, err := test.settings.TLSSetting.LoadTLSConfig(context.Background())
-			assert.NoError(t, err)
-			assert.Equal(t, tlsClientConfig.Certificates, tlsTestSettingConfig.Certificates)
 		})
 	}
 }

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -87,11 +87,15 @@ func TestOAuthClientSettings(t *testing.T) {
 				assert.Contains(t, err.Error(), test.expectedError)
 				return
 			}
+			// No errors expected since values are raw
+			clientID, _ := rc.clientCredentials.getClientID()
+			clientSecret, _ := rc.clientCredentials.getClientSecret()
+
 			assert.NoError(t, err)
 			assert.Equal(t, test.settings.Scopes, rc.clientCredentials.Scopes)
 			assert.Equal(t, test.settings.TokenURL, rc.clientCredentials.TokenURL)
-			assert.EqualValues(t, test.settings.ClientSecret, rc.clientCredentials.ClientSecret)
-			assert.Equal(t, test.settings.ClientID, rc.clientCredentials.ClientID)
+			assert.EqualValues(t, test.settings.ClientSecret, clientSecret)
+			assert.Equal(t, test.settings.ClientID, clientID)
 			assert.Equal(t, test.settings.Timeout, rc.client.Timeout)
 			assert.Equal(t, test.settings.EndpointParams, rc.clientCredentials.EndpointParams)
 

--- a/extension/oauth2clientauthextension/testdata/config.yaml
+++ b/extension/oauth2clientauthextension/testdata/config.yaml
@@ -34,3 +34,12 @@ oauth2client/missingurl:
   client_id: someclientid
   client_secret: someclientsecret
   scopes: ["api.metrics"]
+
+oauth2client/secretfromcommand:
+  client_id: someclientid
+  client_secret_cmd: ["cat", "/path/to/secret"]
+  token_url: https://example.com/oauth2/default/v1/token
+  endpoint_params:
+    audience: someaudience
+  scopes: ["api.metrics"]
+  timeout: 1s

--- a/extension/oauth2clientauthextension/value_sources.go
+++ b/extension/oauth2clientauthextension/value_sources.go
@@ -6,6 +6,7 @@ package oauth2clientauthextension // import "github.com/open-telemetry/opentelem
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 )
 
@@ -40,4 +41,31 @@ type fileSource struct {
 
 func (v fileSource) getValue() (string, error) {
 	return readCredentialsFile(v.path)
+}
+
+func executeCommand(cmdArgs ...string) (string, error) {
+	if len(cmdArgs) == 0 {
+		return "", fmt.Errorf("empty command provided")
+	}
+
+	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) // #nosec G204
+	outBytes, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	output := strings.TrimSpace(string(outBytes))
+	if output == "" {
+		return "", fmt.Errorf("command %q returned empty response", strings.Join(cmdArgs, " "))
+	}
+
+	return output, nil
+}
+
+type cmdGetter struct {
+	value []string
+}
+
+func (v cmdGetter) getValue() (string, error) {
+	return executeCommand(v.value...)
 }

--- a/extension/oauth2clientauthextension/value_sources.go
+++ b/extension/oauth2clientauthextension/value_sources.go
@@ -3,6 +3,12 @@
 
 package oauth2clientauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
 
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
 type valueSource interface {
 	getValue() (string, error)
 }
@@ -13,6 +19,19 @@ type rawSource struct {
 
 func (v rawSource) getValue() (string, error) {
 	return v.value, nil
+}
+
+func readCredentialsFile(path string) (string, error) {
+	f, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("failed to read credentials file %q: %w", path, err)
+	}
+
+	credential := strings.TrimSpace(string(f))
+	if credential == "" {
+		return "", fmt.Errorf("empty credentials file %q", path)
+	}
+	return credential, nil
 }
 
 type fileSource struct {

--- a/extension/oauth2clientauthextension/value_sources.go
+++ b/extension/oauth2clientauthextension/value_sources.go
@@ -62,10 +62,10 @@ func executeCommand(cmdArgs ...string) (string, error) {
 	return output, nil
 }
 
-type cmdGetter struct {
-	value []string
+type cmdSource struct {
+	cmd []string
 }
 
-func (v cmdGetter) getValue() (string, error) {
-	return executeCommand(v.value...)
+func (v cmdSource) getValue() (string, error) {
+	return executeCommand(v.cmd...)
 }

--- a/extension/oauth2clientauthextension/value_sources.go
+++ b/extension/oauth2clientauthextension/value_sources.go
@@ -51,7 +51,9 @@ func executeCommand(cmdArgs ...string) (string, error) {
 	cmd := exec.Command(cmdArgs[0], cmdArgs[1:]...) // #nosec G204
 	outBytes, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to execute command %q: %w",
+			strings.Join(cmdArgs, " "),
+			err)
 	}
 
 	output := strings.TrimSpace(string(outBytes))

--- a/extension/oauth2clientauthextension/value_sources.go
+++ b/extension/oauth2clientauthextension/value_sources.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2clientauthextension // import "github.com/open-telemetry/opentelemetry-collector-contrib/extension/oauth2clientauthextension"
+
+type valueSource interface {
+	getValue() (string, error)
+}
+
+type rawSource struct {
+	value string
+}
+
+func (v rawSource) getValue() (string, error) {
+	return v.value, nil
+}
+
+type fileSource struct {
+	path string
+}
+
+func (v fileSource) getValue() (string, error) {
+	return readCredentialsFile(v.path)
+}


### PR DESCRIPTION
**Description:**
This PR implements the feature described in detail in the issue linked below.

In a nutshell, it extends the `oauth2clientauth` extension to retrieve `ClientID` and/or `ClientSecret` by executing a command whenever a new token is needed for the OAuth flow.
As a result, the extension can use updated credentials (when the old ones expire and they get rotated for example) without the need to restart the OTEL collector, as long as the command returns a different output (e.g., fetch credentials from a secret store).

As part of this PR I also modify the design of the code which is responsible to get the actual client ID and secret values based on an old review comment. I have exposed the details in the tracking issue.

**Link to tracking Issue:** Closes #32602 

**Testing:**
* Unit testing: Extended the unit tests to ensure the functionality
* Tested in realistic environments both as a systemd service and a docker container (exporting data with the `otlphttp` exporter)
  The collectors export data to a service which sits behind and OIDC authentication proxy and the `oauth2clientauth` extension successfully retrieves the credentials from a secret store and authenticates against the service.

**Documentation:**
I have extended the extension's README file.