### PR TITLE
[receiver/haproxy] fix reading more than 4096 bytes

### DIFF
--- a/.chloggen/haproxy_readall.yaml
+++ b/.chloggen/haproxy_readall.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: haproxyreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix reading stats larger than 4096 bytes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32652]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/haproxyreceiver/scraper.go
+++ b/receiver/haproxyreceiver/scraper.go
@@ -70,12 +70,10 @@ func (s *scraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 		if err != nil {
 			return pmetric.NewMetrics(), err
 		}
-		buf := make([]byte, 4096)
-		n, err := c.Read(buf)
+		buf, err := io.ReadAll(c)
 		if err != nil {
 			return pmetric.NewMetrics(), err
 		}
-		buf = buf[0:n]
 		records, err = s.readStats(buf)
 		if err != nil {
 			return pmetric.NewMetrics(), fmt.Errorf("error reading stats: %w", err)

--- a/receiver/haproxyreceiver/scraper_test.go
+++ b/receiver/haproxyreceiver/scraper_test.go
@@ -41,6 +41,7 @@ func Test_scraper_readStats(t *testing.T) {
 			require.NoError(t, err2)
 			_, err2 = c.Write(stats)
 			require.NoError(t, err2)
+			require.NoError(t, c.Close())
 		default:
 			require.Fail(t, fmt.Sprintf("invalid message: %v", data))
 		}


### PR DESCRIPTION
**Description:**
This makes sure to read the whole data when interacting over the socket with haproxy.

**Link to tracking Issue:**
Fixes #32652

**Testing:**
Tested manually.
