### PR TITLE
[breaking][pkg/stanza] Pass TelemetrySettings to Build of Builder interface

### DIFF
--- a/.chloggen/pass_telemetry_settings_to_stanza_ops.yaml
+++ b/.chloggen/pass_telemetry_settings_to_stanza_ops.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Pass TelemetrySettings to the Build method of the Builder interface
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32662, 31256]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The reason for this breaking change is to pass in the component.TelemetrySettings
+  so as to use them later in various ways:
+    - be able to report state statistics and telemetry in general
+    - be able to switch from SugaredLogger to Logger
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/pkg/stanza/adapter/benchmark_test.go
+++ b/pkg/stanza/adapter/benchmark_test.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -164,8 +163,8 @@ type BenchOpConfig struct {
 }
 
 // Build will build a noop operator.
-func (c BenchOpConfig) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c BenchOpConfig) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -57,7 +57,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 		pipe, err := pipeline.Config{
 			Operators:     operators,
 			DefaultOutput: emitter,
-		}.Build(params.Logger.Sugar())
+		}.Build(&params.TelemetrySettings)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -26,13 +26,14 @@ import (
 func createNoopReceiver(nextConsumer consumer.Logs) (*receiver, error) {
 	emitter := helper.NewLogEmitter(zap.NewNop().Sugar())
 
+	set := componenttest.NewNopTelemetrySettings()
 	pipe, err := pipeline.Config{
 		Operators: []operator.Config{
 			{
 				Builder: noop.NewConfig(),
 			},
 		},
-	}.Build(zap.NewNop().Sugar())
+	}.Build(&set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/adapter/mocks_test.go
+++ b/pkg/stanza/adapter/mocks_test.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/collector/component"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -41,8 +40,8 @@ func NewUnstartableConfig() operator.Config {
 }
 
 // Build will build an unstartable operator
-func (c *UnstartableConfig) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	o, _ := c.OutputConfig.Build(logger)
+func (c *UnstartableConfig) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	o, _ := c.OutputConfig.Build(set)
 	return &UnstartableOperator{OutputOperator: o}, nil
 }
 

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -139,10 +139,11 @@ func BenchmarkReadLine(b *testing.B) {
 		require.NoError(b, emitter.Stop())
 	}()
 
+	set := componenttest.NewNopTelemetrySettings()
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,
-	}.Build(zap.NewNop().Sugar())
+	}.Build(&set)
 	require.NoError(b, err)
 
 	// Populate the file that will be consumed
@@ -205,10 +206,11 @@ func BenchmarkParseAndMap(b *testing.B) {
 		require.NoError(b, emitter.Stop())
 	}()
 
+	set := componenttest.NewNopTelemetrySettings()
 	pipe, err := pipeline.Config{
 		Operators:     operatorCfgs,
 		DefaultOutput: emitter,
-	}.Build(zap.NewNop().Sugar())
+	}.Build(&set)
 	require.NoError(b, err)
 
 	// Populate the file that will be consumed

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
@@ -191,7 +192,8 @@ func BenchmarkFileInput(b *testing.B) {
 				}
 				return nil
 			}
-			op, err := cfg.Build(testutil.Logger(b), callback)
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set, callback)
 			require.NoError(b, err)
 
 			b.ResetTimer()

--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -10,8 +10,8 @@ import (
 	"runtime"
 	"time"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
-	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
@@ -89,11 +89,11 @@ type HeaderConfig struct {
 }
 
 // Deprecated [v0.97.0] Use Build and WithSplitFunc option instead
-func (c Config) BuildWithSplitFunc(logger *zap.SugaredLogger, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
-	return c.Build(logger, emit, WithSplitFunc(splitFunc))
+func (c Config) BuildWithSplitFunc(set *component.TelemetrySettings, emit emit.Callback, splitFunc bufio.SplitFunc) (*Manager, error) {
+	return c.Build(set, emit, WithSplitFunc(splitFunc))
 }
 
-func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback, opts ...Option) (*Manager, error) {
+func (c Config) Build(set *component.TelemetrySettings, emit emit.Callback, opts ...Option) (*Manager, error) {
 	if err := c.validate(); err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback, opts ...Opt
 	}
 
 	readerFactory := reader.Factory{
-		SugaredLogger:     logger.With("component", "fileconsumer"),
+		SugaredLogger:     set.Logger.Sugar().With("component", "fileconsumer"),
 		FromBeginning:     startAtBeginning,
 		FingerprintSize:   int(c.FingerprintSize),
 		InitialBufferSize: scanner.DefaultBufferSize,
@@ -165,12 +165,12 @@ func (c Config) Build(logger *zap.SugaredLogger, emit emit.Callback, opts ...Opt
 
 	var t tracker.Tracker
 	if o.noTracking {
-		t = tracker.NewNoStateTracker(logger.With("component", "fileconsumer"), c.MaxConcurrentFiles/2)
+		t = tracker.NewNoStateTracker(set.Logger.Sugar().With("component", "fileconsumer"), c.MaxConcurrentFiles/2)
 	} else {
-		t = tracker.NewFileTracker(logger.With("component", "fileconsumer"), c.MaxConcurrentFiles/2)
+		t = tracker.NewFileTracker(set.Logger.Sugar().With("component", "fileconsumer"), c.MaxConcurrentFiles/2)
 	}
 	return &Manager{
-		SugaredLogger: logger.With("component", "fileconsumer"),
+		SugaredLogger: set.Logger.Sugar().With("component", "fileconsumer"),
 		readerFactory: readerFactory,
 		fileMatcher:   fileMatcher,
 		pollInterval:  c.PollInterval,

--- a/pkg/stanza/fileconsumer/config_test.go
+++ b/pkg/stanza/fileconsumer/config_test.go
@@ -11,8 +11,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/featuregate"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/emittest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/fingerprint"
@@ -22,7 +23,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestNewConfig(t *testing.T) {
@@ -629,7 +629,8 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			input, err := cfg.Build(testutil.Logger(t), emittest.Nop)
+			set := componenttest.NewNopTelemetrySettings()
+			input, err := cfg.Build(&set, emittest.Nop)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -708,7 +709,8 @@ func TestBuildWithSplitFunc(t *testing.T) {
 				return len(data), data, nil
 			}
 
-			input, err := cfg.BuildWithSplitFunc(testutil.Logger(t), emittest.Nop, splitNone)
+			set := componenttest.NewNopTelemetrySettings()
+			input, err := cfg.BuildWithSplitFunc(&set, emittest.Nop, splitNone)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -795,7 +797,8 @@ func TestBuildWithHeader(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			input, err := cfg.Build(testutil.Logger(t), emittest.Nop)
+			set := componenttest.NewNopTelemetrySettings()
+			input, err := cfg.Build(&set, emittest.Nop)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return
@@ -848,6 +851,6 @@ func newMockOperatorConfig(cfg *Config) *mockOperatorConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *mockOperatorConfig) Build(*zap.SugaredLogger) (operator.Operator, error) {
+func (h *mockOperatorConfig) Build(_ *component.TelemetrySettings) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/fileconsumer/internal/header/config.go
+++ b/pkg/stanza/fileconsumer/internal/header/config.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
@@ -39,7 +40,7 @@ func NewConfig(matchRegex string, metadataOperators []operator.Config, enc encod
 	p, err := pipeline.Config{
 		Operators:     metadataOperators,
 		DefaultOutput: newPipelineOutput(nopLogger),
-	}.Build(nopLogger)
+	}.Build(&component.TelemetrySettings{Logger: nopLogger.Desugar()})
 
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipelines: %w", err)

--- a/pkg/stanza/fileconsumer/internal/header/reader.go
+++ b/pkg/stanza/fileconsumer/internal/header/reader.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 	"go.uber.org/zap"
 
@@ -31,7 +32,7 @@ func NewReader(logger *zap.SugaredLogger, cfg Config) (*Reader, error) {
 	r.pipeline, err = pipeline.Config{
 		Operators:     cfg.metadataOperators,
 		DefaultOutput: r.output,
-	}.Build(logger)
+	}.Build(&component.TelemetrySettings{Logger: logger.Desugar()})
 	if err != nil {
 		return nil, fmt.Errorf("failed to build pipeline: %w", err)
 	}

--- a/pkg/stanza/fileconsumer/internal/header/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/header/reader_test.go
@@ -82,6 +82,6 @@ func TestSkipUnmatchedHeaderLine(t *testing.T) {
 }
 
 func TestNewReaderErr(t *testing.T) {
-	_, err := NewReader(nil, Config{})
+	_, err := NewReader(zaptest.NewLogger(t).Sugar(), Config{})
 	assert.Error(t, err)
 }

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/emittest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func testManager(t *testing.T, cfg *Config, opts ...Option) (*Manager, *emittest.Sink) {
@@ -18,7 +18,8 @@ func testManager(t *testing.T, cfg *Config, opts ...Option) (*Manager, *emittest
 }
 
 func testManagerWithSink(t *testing.T, cfg *Config, sink *emittest.Sink, opts ...Option) *Manager {
-	input, err := cfg.Build(testutil.Logger(t), sink.Callback, opts...)
+	set := componenttest.NewNopTelemetrySettings()
+	input, err := cfg.Build(&set, sink.Callback, opts...)
 	require.NoError(t, err)
 	t.Cleanup(func() { input.tracker.ClosePreviousFiles() })
 	return input

--- a/pkg/stanza/operator/config.go
+++ b/pkg/stanza/operator/config.go
@@ -7,8 +7,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
-	"go.uber.org/zap"
 )
 
 // Config is the configuration of an operator
@@ -25,7 +25,7 @@ func NewConfig(b Builder) Config {
 type Builder interface {
 	ID() string
 	Type() string
-	Build(*zap.SugaredLogger) (Operator, error)
+	Build(*component.TelemetrySettings) (Operator, error)
 	SetID(string)
 }
 

--- a/pkg/stanza/operator/config_test.go
+++ b/pkg/stanza/operator/config_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -18,7 +18,7 @@ type FakeBuilder struct {
 	Array        []string `json:"array" yaml:"array"`
 }
 
-func (f *FakeBuilder) Build(_ *zap.SugaredLogger) (Operator, error) {
+func (f *FakeBuilder) Build(_ *component.TelemetrySettings) (Operator, error) {
 	return nil, nil
 }
 func (f *FakeBuilder) ID() string     { return "operator" }

--- a/pkg/stanza/operator/helper/helper_test.go
+++ b/pkg/stanza/operator/helper/helper_test.go
@@ -3,7 +3,7 @@
 package helper
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
@@ -35,6 +35,6 @@ func newHelpersConfig() *helpersConfig {
 
 // This function is impelmented for compatibility with operatortest
 // but is not meant to be used directly
-func (h *helpersConfig) Build(*zap.SugaredLogger) (operator.Operator, error) {
+func (h *helpersConfig) Build(_ *component.TelemetrySettings) (operator.Operator, error) {
 	panic("not impelemented")
 }

--- a/pkg/stanza/operator/helper/input.go
+++ b/pkg/stanza/operator/helper/input.go
@@ -6,7 +6,7 @@ package helper // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"context"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
@@ -29,8 +29,8 @@ type InputConfig struct {
 }
 
 // Build will build a base producer.
-func (c InputConfig) Build(logger *zap.SugaredLogger) (InputOperator, error) {
-	writerOperator, err := c.WriterConfig.Build(logger)
+func (c InputConfig) Build(set *component.TelemetrySettings) (InputOperator, error) {
+	writerOperator, err := c.WriterConfig.Build(set)
 	if err != nil {
 		return InputOperator{}, errors.WithDetails(err, "operator_id", c.ID())
 	}

--- a/pkg/stanza/operator/helper/input_test.go
+++ b/pkg/stanza/operator/helper/input_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -20,7 +21,8 @@ func TestInputConfigMissingBase(t *testing.T) {
 		},
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing required `type` field.")
 }
@@ -35,7 +37,8 @@ func TestInputConfigMissingOutput(t *testing.T) {
 		},
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.NoError(t, err)
 }
 
@@ -50,7 +53,8 @@ func TestInputConfigValid(t *testing.T) {
 		},
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.NoError(t, err)
 }
 

--- a/pkg/stanza/operator/helper/operator.go
+++ b/pkg/stanza/operator/helper/operator.go
@@ -4,6 +4,7 @@
 package helper // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
@@ -43,7 +44,7 @@ func (c BasicConfig) Type() string {
 }
 
 // Build will build a basic operator.
-func (c BasicConfig) Build(logger *zap.SugaredLogger) (BasicOperator, error) {
+func (c BasicConfig) Build(set *component.TelemetrySettings) (BasicOperator, error) {
 	if c.OperatorType == "" {
 		return BasicOperator{}, errors.NewError(
 			"missing required `type` field.",
@@ -52,7 +53,7 @@ func (c BasicConfig) Build(logger *zap.SugaredLogger) (BasicOperator, error) {
 		)
 	}
 
-	if logger == nil {
+	if set.Logger == nil {
 		return BasicOperator{}, errors.NewError(
 			"operator build context is missing a logger.",
 			"this is an unexpected internal error",
@@ -64,7 +65,7 @@ func (c BasicConfig) Build(logger *zap.SugaredLogger) (BasicOperator, error) {
 	operator := BasicOperator{
 		OperatorID:    c.ID(),
 		OperatorType:  c.Type(),
-		SugaredLogger: logger.With("operator_id", c.ID(), "operator_type", c.Type()),
+		SugaredLogger: set.Logger.Sugar().With("operator_id", c.ID(), "operator_type", c.Type()),
 	}
 
 	return operator, nil

--- a/pkg/stanza/operator/helper/operator_test.go
+++ b/pkg/stanza/operator/helper/operator_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -33,7 +34,8 @@ func TestBasicConfigBuildWithoutID(t *testing.T) {
 		OperatorType: "test-type",
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.NoError(t, err)
 }
 
@@ -42,7 +44,8 @@ func TestBasicConfigBuildWithoutType(t *testing.T) {
 		OperatorID: "test-id",
 	}
 
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing required `type` field.")
 }
@@ -53,7 +56,9 @@ func TestBasicConfigBuildMissingLogger(t *testing.T) {
 		OperatorType: "test-type",
 	}
 
-	_, err := config.Build(nil)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = nil
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "operator build context is missing a logger.")
 }
@@ -64,7 +69,8 @@ func TestBasicConfigBuildValid(t *testing.T) {
 		OperatorType: "test-type",
 	}
 
-	operator, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	operator, err := config.Build(&set)
 	require.NoError(t, err)
 	require.Equal(t, "test-id", operator.OperatorID)
 	require.Equal(t, "test-type", operator.OperatorType)

--- a/pkg/stanza/operator/helper/output.go
+++ b/pkg/stanza/operator/helper/output.go
@@ -4,7 +4,7 @@
 package helper // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -23,8 +23,8 @@ type OutputConfig struct {
 }
 
 // Build will build an output operator.
-func (c OutputConfig) Build(logger *zap.SugaredLogger) (OutputOperator, error) {
-	basicOperator, err := c.BasicConfig.Build(logger)
+func (c OutputConfig) Build(set *component.TelemetrySettings) (OutputOperator, error) {
+	basicOperator, err := c.BasicConfig.Build(set)
 	if err != nil {
 		return OutputOperator{}, err
 	}

--- a/pkg/stanza/operator/helper/output_test.go
+++ b/pkg/stanza/operator/helper/output_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -14,7 +15,8 @@ import (
 
 func TestOutputConfigMissingBase(t *testing.T) {
 	config := OutputConfig{}
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing required `type` field.")
 }
@@ -26,7 +28,8 @@ func TestOutputConfigBuildValid(t *testing.T) {
 			OperatorType: "test-type",
 		},
 	}
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.NoError(t, err)
 }
 

--- a/pkg/stanza/operator/helper/parser.go
+++ b/pkg/stanza/operator/helper/parser.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
@@ -35,8 +35,8 @@ type ParserConfig struct {
 }
 
 // Build will build a parser operator.
-func (c ParserConfig) Build(logger *zap.SugaredLogger) (ParserOperator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c ParserConfig) Build(set *component.TelemetrySettings) (ParserOperator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return ParserOperator{}, err
 	}
@@ -60,7 +60,7 @@ func (c ParserConfig) Build(logger *zap.SugaredLogger) (ParserOperator, error) {
 	}
 
 	if c.SeverityConfig != nil {
-		severityParser, err := c.SeverityConfig.Build(logger)
+		severityParser, err := c.SeverityConfig.Build(set)
 		if err != nil {
 			return ParserOperator{}, err
 		}

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap/zaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -21,7 +22,8 @@ import (
 
 func TestParserConfigMissingBase(t *testing.T) {
 	config := ParserConfig{}
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing required `type` field.")
 }
@@ -35,7 +37,8 @@ func TestParserConfigInvalidTimeParser(t *testing.T) {
 		LayoutType: "strptime",
 	}
 
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing required configuration parameter `layout`")
 }
@@ -47,7 +50,8 @@ func TestParserConfigBodyCollision(t *testing.T) {
 	b := entry.NewAttributeField("message")
 	cfg.BodyField = &b
 
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "`parse_to: body` not allowed when `body` is configured")
 }
@@ -87,7 +91,8 @@ func TestParserConfigBuildValid(t *testing.T) {
 		ParseFrom: scopeNameField,
 	}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	require.NotNil(t, op.TimeParser)
@@ -627,7 +632,8 @@ func TestParserFields(t *testing.T) {
 			cfg := NewParserConfig("test-id", "test-type")
 			tc.cfgMod(&cfg)
 
-			parser, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			parser, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			e := tc.input()

--- a/pkg/stanza/operator/helper/severity_builder.go
+++ b/pkg/stanza/operator/helper/severity_builder.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"strings"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 )
@@ -118,7 +118,7 @@ type SeverityConfig struct {
 }
 
 // Build builds a SeverityParser from a SeverityConfig
-func (c *SeverityConfig) Build(_ *zap.SugaredLogger) (SeverityParser, error) {
+func (c *SeverityConfig) Build(_ *component.TelemetrySettings) (SeverityParser, error) {
 	operatorMapping := getBuiltinMapping(c.Preset)
 
 	for severity, unknown := range c.Mapping {

--- a/pkg/stanza/operator/helper/severity_test.go
+++ b/pkg/stanza/operator/helper/severity_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 type severityTestCase struct {
@@ -512,7 +512,8 @@ func (tc severityTestCase) run(parseFrom entry.Field) func(*testing.T) {
 			OverwriteText: tc.overwriteText,
 		}
 
-		severityParser, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		severityParser, err := cfg.Build(&set)
 		if tc.buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return
@@ -564,7 +565,8 @@ func TestBuildCustomMapping(t *testing.T) {
 		Mapping:   allTheThingsMap,
 	}
 
-	severityParser, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	severityParser, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	for k, v := range expected {

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/expr-lang/expr/vm"
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -30,8 +31,8 @@ type TransformerConfig struct {
 }
 
 // Build will build a transformer operator.
-func (c TransformerConfig) Build(logger *zap.SugaredLogger) (TransformerOperator, error) {
-	writerOperator, err := c.WriterConfig.Build(logger)
+func (c TransformerConfig) Build(set *component.TelemetrySettings) (TransformerOperator, error) {
+	writerOperator, err := c.WriterConfig.Build(set)
 	if err != nil {
 		return TransformerOperator{}, errors.WithDetails(err, "operator_id", c.ID())
 	}

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"
@@ -22,27 +23,31 @@ import (
 func TestTransformerConfigMissingBase(t *testing.T) {
 	cfg := NewTransformerConfig("test", "")
 	cfg.OutputIDs = []string{"test-output"}
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing required `type` field.")
 }
 
 func TestTransformerConfigMissingOutput(t *testing.T) {
 	cfg := NewTransformerConfig("test", "test")
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.NoError(t, err)
 }
 
 func TestTransformerConfigValid(t *testing.T) {
 	cfg := NewTransformerConfig("test", "test")
 	cfg.OutputIDs = []string{"test-output"}
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.NoError(t, err)
 }
 
 func TestTransformerOnErrorDefault(t *testing.T) {
 	cfg := NewTransformerConfig("test-id", "test-type")
-	transformer, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	transformer, err := cfg.Build(&set)
 	require.NoError(t, err)
 	require.Equal(t, SendOnError, transformer.OnError)
 }
@@ -50,14 +55,16 @@ func TestTransformerOnErrorDefault(t *testing.T) {
 func TestTransformerOnErrorInvalid(t *testing.T) {
 	cfg := NewTransformerConfig("test", "test")
 	cfg.OnError = "invalid"
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "operator config has an invalid `on_error` field.")
 }
 
 func TestTransformerOperatorCanProcess(t *testing.T) {
 	cfg := NewTransformerConfig("test", "test")
-	transformer, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	transformer, err := cfg.Build(&set)
 	require.NoError(t, err)
 	require.True(t, transformer.CanProcess())
 }
@@ -317,7 +324,8 @@ func TestTransformerIf(t *testing.T) {
 			cfg := NewTransformerConfig("test", "test")
 			cfg.IfExpr = tc.ifExpr
 
-			transformer, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			transformer, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -342,7 +350,8 @@ func TestTransformerIf(t *testing.T) {
 	t.Run("InvalidIfExpr", func(t *testing.T) {
 		cfg := NewTransformerConfig("test", "test")
 		cfg.IfExpr = "'nonbool'"
-		_, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := cfg.Build(&set)
 		require.Error(t, err)
 	})
 }

--- a/pkg/stanza/operator/helper/writer.go
+++ b/pkg/stanza/operator/helper/writer.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -27,8 +27,8 @@ type WriterConfig struct {
 }
 
 // Build will build a writer operator from the config.
-func (c WriterConfig) Build(logger *zap.SugaredLogger) (WriterOperator, error) {
-	basicOperator, err := c.BasicConfig.Build(logger)
+func (c WriterConfig) Build(set *component.TelemetrySettings) (WriterOperator, error) {
+	basicOperator, err := c.BasicConfig.Build(set)
 	if err != nil {
 		return WriterOperator{}, err
 	}

--- a/pkg/stanza/operator/helper/writer_test.go
+++ b/pkg/stanza/operator/helper/writer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -23,7 +24,8 @@ func TestWriterConfigMissingOutput(t *testing.T) {
 			OperatorType: "testtype",
 		},
 	}
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.NoError(t, err)
 }
 
@@ -34,7 +36,8 @@ func TestWriterConfigValidBuild(t *testing.T) {
 			OperatorType: "testtype",
 		},
 	}
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.NoError(t, err)
 }
 

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -4,7 +4,7 @@
 package file // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/file"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer"
@@ -38,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a file input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		toBody:        toBody,
 	}
 
-	input.fileConsumer, err = c.Config.Build(logger, input.emit)
+	input.fileConsumer, err = c.Config.Build(set, input.emit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/file/config_test.go
+++ b/pkg/stanza/operator/input/file/config_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -537,7 +538,8 @@ func TestBuild(t *testing.T) {
 			cfg := basicConfig()
 			tc.modifyBaseConfig(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			tc.errorRequirement(t, err)
 			if err != nil {
 				return

--- a/pkg/stanza/operator/input/file/util_test.go
+++ b/pkg/stanza/operator/input/file/util_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -34,7 +35,8 @@ func newTestFileOperator(t *testing.T, cfgMod func(*Config)) (*Input, chan *entr
 	if cfgMod != nil {
 		cfgMod(cfg)
 	}
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	err = op.SetOutputs([]operator.Operator{fakeOutput})

--- a/pkg/stanza/operator/input/generate/config.go
+++ b/pkg/stanza/operator/input/generate/config.go
@@ -4,7 +4,7 @@
 package generate // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/generate"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -33,8 +33,8 @@ type Config struct {
 }
 
 // Build will build a generate input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/generate/input_test.go
+++ b/pkg/stanza/operator/input/generate/input_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -21,7 +22,8 @@ func TestInputGenerate(t *testing.T) {
 		Body: "test message",
 	}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/input/journald/config_linux.go
+++ b/pkg/stanza/operator/input/journald/config_linux.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	jsoniter "github.com/json-iterator/go"
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
@@ -26,8 +26,8 @@ func init() {
 }
 
 // Build will build a journald input operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/journald/config_nonlinux.go
+++ b/pkg/stanza/operator/input/journald/config_nonlinux.go
@@ -8,11 +8,11 @@ package journald // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"errors"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-func (c Config) Build(_ *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(_ *component.TelemetrySettings) (operator.Operator, error) {
 	return nil, errors.New("journald input operator is only supported on linux")
 }

--- a/pkg/stanza/operator/input/journald/input_test.go
+++ b/pkg/stanza/operator/input/journald/input_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -55,7 +56,8 @@ func TestInputJournald(t *testing.T) {
 	cfg := NewConfigWithID("my_journald_input")
 	cfg.OutputIDs = []string{"output"}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	mockOutput := testutil.NewMockOperator("output")
@@ -233,7 +235,8 @@ func TestInputJournaldError(t *testing.T) {
 	cfg := NewConfigWithID("my_journald_input")
 	cfg.OutputIDs = []string{"output"}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	mockOutput := testutil.NewMockOperator("output")

--- a/pkg/stanza/operator/input/namedpipe/config_linux.go
+++ b/pkg/stanza/operator/input/namedpipe/config_linux.go
@@ -8,7 +8,7 @@ package namedpipe // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -19,8 +19,8 @@ func init() {
 }
 
 // Build will build a namedpipe input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/namedpipe/input_nonlinux.go
+++ b/pkg/stanza/operator/input/namedpipe/input_nonlinux.go
@@ -8,11 +8,11 @@ package namedpipe // import "github.com/open-telemetry/opentelemetry-collector-c
 import (
 	"errors"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
 
-func (c *Config) Build(_ *zap.SugaredLogger) (operator.Operator, error) {
+func (c *Config) Build(_ *component.TelemetrySettings) (operator.Operator, error) {
 	return nil, errors.New("namedpipe input operator is only supported on linux")
 }

--- a/pkg/stanza/operator/input/namedpipe/input_test.go
+++ b/pkg/stanza/operator/input/namedpipe/input_test.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"golang.org/x/sys/unix"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -41,7 +41,8 @@ func TestCreatePipe(t *testing.T) {
 	conf.Path = filename(t)
 	conf.Permissions = 0666
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := conf.Build(&set)
 	require.NoError(t, err)
 
 	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
@@ -69,7 +70,8 @@ func TestCreatePipeFailsWithFile(t *testing.T) {
 		require.NoError(t, pipe.Close())
 	}()
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := conf.Build(&set)
 	require.NoError(t, err)
 
 	require.Error(t, op.Start(testutil.NewUnscopedMockPersister()))
@@ -83,7 +85,8 @@ func TestCreatePipeAlreadyExists(t *testing.T) {
 
 	require.NoError(t, unix.Mkfifo(conf.Path, conf.Permissions))
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := conf.Build(&set)
 	require.NoError(t, err)
 
 	require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
@@ -99,7 +102,8 @@ func TestPipeWrites(t *testing.T) {
 	conf.Permissions = 0666
 	conf.OutputIDs = []string{fake.ID()}
 
-	op, err := conf.Build(zaptest.NewLogger(t).Sugar())
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := conf.Build(&set)
 	require.NoError(t, err)
 	ops := []operator.Operator{op, fake}
 

--- a/pkg/stanza/operator/input/stdin/config.go
+++ b/pkg/stanza/operator/input/stdin/config.go
@@ -6,7 +6,7 @@ package stdin // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"os"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -31,8 +31,8 @@ type Config struct {
 }
 
 // Build will build a stdin input operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/stdin/input_test.go
+++ b/pkg/stanza/operator/input/stdin/input_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -17,7 +18,8 @@ func TestStdin(t *testing.T) {
 	cfg := NewConfig("")
 	cfg.OutputIDs = []string{"fake"}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/input/syslog/config.go
+++ b/pkg/stanza/operator/input/syslog/config.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -41,8 +41,8 @@ type Config struct {
 	UDP                *udp.BaseConfig `mapstructure:"udp"`
 }
 
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputBase, err := c.InputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputBase, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 	syslogParserCfg.BaseConfig = c.BaseConfig
 	syslogParserCfg.SetID(inputBase.ID() + "_internal_parser")
 	syslogParserCfg.OutputIDs = c.OutputIDs
-	syslogParser, err := syslogParserCfg.Build(logger)
+	syslogParser, err := syslogParserCfg.Build(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve syslog config: %w", err)
 	}
@@ -65,7 +65,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 			tcpInputCfg.SplitFuncBuilder = OctetSplitFuncBuilder
 		}
 
-		tcpInput, err := tcpInputCfg.Build(logger)
+		tcpInput, err := tcpInputCfg.Build(set)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve tcp config: %w", err)
 		}
@@ -93,7 +93,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 			return nil, errors.New("octet_counting and non_transparent_framing is not compatible with UDP")
 		}
 
-		udpInput, err := udpInputCfg.Build(logger)
+		udpInput, err := udpInputCfg.Build(set)
 		if err != nil {
 			return nil, fmt.Errorf("failed to resolve udp config: %w", err)
 		}

--- a/pkg/stanza/operator/input/syslog/input_test.go
+++ b/pkg/stanza/operator/input/syslog/input_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -137,7 +138,8 @@ func TestInput(t *testing.T) {
 }
 
 func InputTest(t *testing.T, tc syslog.Case, cfg *Config, rsrc map[string]any, attr map[string]any) {
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)
@@ -211,7 +213,8 @@ func TestSyslogIDs(t *testing.T) {
 
 	t.Run("TCP", func(t *testing.T) {
 		cfg := NewConfigWithTCP(basicConfig())
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 		syslogInputOp := op.(*Input)
 		require.Equal(t, "test_syslog_internal_tcp", syslogInputOp.tcp.ID())
@@ -222,7 +225,8 @@ func TestSyslogIDs(t *testing.T) {
 	})
 	t.Run("UDP", func(t *testing.T) {
 		cfg := NewConfigWithUDP(basicConfig())
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 		syslogInputOp := op.(*Input)
 		require.Equal(t, "test_syslog_internal_udp", syslogInputOp.udp.ID())

--- a/pkg/stanza/operator/input/tcp/config.go
+++ b/pkg/stanza/operator/input/tcp/config.go
@@ -11,8 +11,8 @@ import (
 	"time"
 
 	"github.com/jpillora/backoff"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configtls"
-	"go.uber.org/zap"
 	"golang.org/x/text/encoding"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
@@ -80,8 +80,8 @@ func (c Config) defaultSplitFuncBuilder(enc encoding.Encoding) (bufio.SplitFunc,
 }
 
 // Build will build a tcp input operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/tcp/input_test.go
+++ b/pkg/stanza/operator/input/tcp/input_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtls"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -78,7 +79,8 @@ func tcpInputTest(input []byte, expected []string) func(t *testing.T) {
 		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = ":0"
 
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -127,7 +129,8 @@ func tcpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -213,7 +216,8 @@ func tlsInputTest(input []byte, expected []string) func(t *testing.T) {
 			},
 		}
 
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -343,7 +347,8 @@ func TestBuild(t *testing.T) {
 			cfg.ListenAddress = tc.inputBody.ListenAddress
 			cfg.MaxLogSize = tc.inputBody.MaxLogSize
 			cfg.TLS = tc.inputBody.TLS
-			_, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			_, err := cfg.Build(&set)
 			if tc.expectErr {
 				require.Error(t, err)
 				return
@@ -388,7 +393,8 @@ func TestFailToBind(t *testing.T) {
 	var startTCP = func(int) (*Input, error) {
 		cfg := NewConfigWithID("test_id")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 		mockOutput := testutil.Operator{}
 		tcpInput := op.(*Input)
@@ -415,7 +421,8 @@ func BenchmarkTCPInput(b *testing.B) {
 	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
-	op, err := cfg.Build(testutil.Logger(b))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(b, err)
 
 	fakeOutput := testutil.NewFakeOutput(b)

--- a/pkg/stanza/operator/input/udp/config.go
+++ b/pkg/stanza/operator/input/udp/config.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"sync"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/decode"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -75,8 +75,8 @@ type BaseConfig struct {
 }
 
 // Build will build a udp input operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/input/udp/input_test.go
+++ b/pkg/stanza/operator/input/udp/input_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -20,7 +21,8 @@ import (
 
 func udpInputTest(input []byte, expected []string, cfg *Config) func(t *testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -71,7 +73,8 @@ func udpInputAttributesTest(input []byte, expected []string) func(t *testing.T) 
 		cfg.ListenAddress = ":0"
 		cfg.AddAttributes = true
 
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -179,7 +182,8 @@ func TestFailToBind(t *testing.T) {
 		cfg := NewConfigWithID("test_input")
 		cfg.ListenAddress = net.JoinHostPort(ip, strconv.Itoa(port))
 
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 
 		mockOutput := testutil.Operator{}
@@ -211,7 +215,8 @@ func BenchmarkUDPInput(b *testing.B) {
 	cfg := NewConfigWithID("test_id")
 	cfg.ListenAddress = ":0"
 
-	op, err := cfg.Build(testutil.Logger(b))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(b, err)
 
 	fakeOutput := testutil.NewFakeOutput(b)

--- a/pkg/stanza/operator/input/windows/config_windows.go
+++ b/pkg/stanza/operator/input/windows/config_windows.go
@@ -8,7 +8,7 @@ package windows // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 )
@@ -18,8 +18,8 @@ func init() {
 }
 
 // Build will build a windows event log operator.
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	inputOperator, err := c.InputConfig.Build(logger)
+func (c *Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	inputOperator, err := c.InputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/drop/config.go
+++ b/pkg/stanza/operator/output/drop/config.go
@@ -4,7 +4,7 @@
 package drop // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/output/drop"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -29,8 +29,8 @@ type Config struct {
 }
 
 // Build will build a drop output operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	outputOperator, err := c.OutputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	outputOperator, err := c.OutputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/drop/output_test.go
+++ b/pkg/stanza/operator/output/drop/output_test.go
@@ -8,28 +8,32 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestBuildValid(t *testing.T) {
 	cfg := NewConfig("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	require.IsType(t, &Output{}, op)
 }
 
 func TestBuildIvalid(t *testing.T) {
 	cfg := NewConfig("test")
-	_, err := cfg.Build(nil)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = nil
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build context is missing a logger")
 }
 
 func TestProcess(t *testing.T) {
 	cfg := NewConfig("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	entry := entry.New()

--- a/pkg/stanza/operator/output/file/config.go
+++ b/pkg/stanza/operator/output/file/config.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"html/template"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -35,8 +35,8 @@ type Config struct {
 }
 
 // Build will build a file output operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	outputOperator, err := c.OutputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	outputOperator, err := c.OutputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/stdout/config.go
+++ b/pkg/stanza/operator/output/stdout/config.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"os"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -36,8 +36,8 @@ type Config struct {
 }
 
 // Build will build a stdout operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	outputOperator, err := c.OutputConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	outputOperator, err := c.OutputConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/output/stdout/output_test.go
+++ b/pkg/stanza/operator/output/stdout/output_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestOperator(t *testing.T) {
@@ -27,7 +27,8 @@ func TestOperator(t *testing.T) {
 		},
 	}
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	var buf bytes.Buffer

--- a/pkg/stanza/operator/parser/csv/config.go
+++ b/pkg/stanza/operator/parser/csv/config.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -44,8 +44,8 @@ type Config struct {
 }
 
 // Build will build a csv parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/csv/parser_test.go
+++ b/pkg/stanza/operator/parser/csv/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -19,7 +20,8 @@ var testHeader = "name,sev,msg"
 func newTestParser(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -28,7 +30,8 @@ func newTestParserIgnoreQuotes(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	cfg.IgnoreQuotes = true
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -36,7 +39,8 @@ func newTestParserIgnoreQuotes(t *testing.T) *Parser {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -46,7 +50,8 @@ func TestParserBuildFailureLazyIgnoreQuotes(t *testing.T) {
 	cfg.Header = testHeader
 	cfg.LazyQuotes = true
 	cfg.IgnoreQuotes = true
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.ErrorContains(t, err, "only one of 'ignore_quotes' or 'lazy_quotes' can be true")
 }
@@ -55,7 +60,8 @@ func TestParserBuildFailureInvalidDelimiter(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Header = testHeader
 	cfg.FieldDelimiter = ";;"
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid 'delimiter': ';;'")
 }
@@ -64,7 +70,8 @@ func TestParserBuildFailureBadHeaderConfig(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Header = "testheader"
 	cfg.HeaderAttribute = "testheader"
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "only one header parameter can be set: 'header' or 'header_attribute'")
 }
@@ -793,7 +800,8 @@ func TestParserCSV(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return
@@ -1037,7 +1045,8 @@ cc""",dddd,eeee`,
 			cfg.OutputIDs = []string{"fake"}
 			cfg.Header = "A,B,C,D,E"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -1059,7 +1068,8 @@ func TestParserCSVInvalidJSONInput(t *testing.T) {
 		cfg.OutputIDs = []string{"fake"}
 		cfg.Header = testHeader
 
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 
 		fake := testutil.NewFakeOutput(t)
@@ -1084,21 +1094,24 @@ func TestBuildParserCSV(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.NoError(t, err)
 	})
 
 	t.Run("MissingHeaderField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = ""
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 	})
 
 	t.Run("InvalidHeaderFieldMissingDelimiter", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name"
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing field delimiter in header")
 	})
@@ -1106,7 +1119,8 @@ func TestBuildParserCSV(t *testing.T) {
 	t.Run("InvalidHeaderFieldWrongDelimiter", func(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name;position;number"
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 	})
 
@@ -1114,7 +1128,8 @@ func TestBuildParserCSV(t *testing.T) {
 		c := newBasicParser()
 		c.Header = "name,position,number"
 		c.FieldDelimiter = ":"
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "missing field delimiter in header")
 	})

--- a/pkg/stanza/operator/parser/json/config.go
+++ b/pkg/stanza/operator/parser/json/config.go
@@ -5,7 +5,7 @@ package json // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	jsoniter "github.com/json-iterator/go"
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -35,8 +35,8 @@ type Config struct {
 }
 
 // Build will build a JSON parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/json/parser_test.go
+++ b/pkg/stanza/operator/parser/json/parser_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -18,14 +19,16 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := config.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }
 
 func TestConfigBuild(t *testing.T) {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := config.Build(&set)
 	require.NoError(t, err)
 	require.IsType(t, &Parser{}, op)
 }
@@ -33,7 +36,8 @@ func TestConfigBuild(t *testing.T) {
 func TestConfigBuildFailure(t *testing.T) {
 	config := NewConfigWithID("test")
 	config.OnError = "invalid_on_error"
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -143,7 +147,8 @@ func TestParser(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/parser/jsonarray/config.go
+++ b/pkg/stanza/operator/parser/jsonarray/config.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 
 	"github.com/valyala/fastjson"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -49,12 +49,12 @@ type Config struct {
 }
 
 // Build will build a json array parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
 	if !jsonArrayParserFeatureGate.IsEnabled() {
 		return nil, fmt.Errorf("%s operator disabled", operatorType)
 	}
 
-	parserOperator, err := c.ParserConfig.Build(logger)
+	parserOperator, err := c.ParserConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/jsonarray/config_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/config_test.go
@@ -7,12 +7,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	commontestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestConfig(t *testing.T) {
@@ -89,7 +89,8 @@ func TestBuildWithFeatureGate(t *testing.T) {
 			buildFunc, ok := operator.Lookup(operatorType)
 			require.True(t, ok)
 
-			_, err := buildFunc().Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			_, err := buildFunc().Build(&set)
 			if err != nil {
 				require.Contains(t, err.Error(), c.onErr)
 			}

--- a/pkg/stanza/operator/parser/jsonarray/parser_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	commontestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
@@ -19,7 +20,8 @@ func newTestParser(t *testing.T) *Parser {
 	defer commontestutil.SetFeatureGateForTest(t, jsonArrayParserFeatureGate, true)()
 
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -29,7 +31,8 @@ func TestParserBuildFailure(t *testing.T) {
 
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -46,7 +49,8 @@ func TestParserByteFailureHeadersMismatch(t *testing.T) {
 
 	cfg := NewConfigWithID("test")
 	cfg.Header = "name,sev,msg"
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	parser := op.(*Parser)
 	_, err = parser.parse("[\"stanza\",\"INFO\",\"started agent\", 42, true]")
@@ -247,7 +251,8 @@ func TestParserJarray(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return
@@ -368,7 +373,8 @@ dd","eeee"]`,
 			cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField()}
 			cfg.OutputIDs = []string{"fake"}
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -395,7 +401,8 @@ func TestBuildParserJarray(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/stanza/operator/parser/keyvalue/config.go
+++ b/pkg/stanza/operator/parser/keyvalue/config.go
@@ -6,7 +6,7 @@ package keyvalue // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"errors"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -40,8 +40,8 @@ type Config struct {
 }
 
 // Build will build a key value parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/keyvalue/parser_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/parser_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -18,7 +19,8 @@ import (
 
 func newTestParser(t *testing.T) *Parser {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := config.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -31,7 +33,8 @@ func TestInit(t *testing.T) {
 
 func TestConfigBuild(t *testing.T) {
 	config := NewConfigWithID("test")
-	op, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := config.Build(&set)
 	require.NoError(t, err)
 	require.IsType(t, &Parser{}, op)
 }
@@ -39,7 +42,8 @@ func TestConfigBuild(t *testing.T) {
 func TestConfigBuildFailure(t *testing.T) {
 	config := NewConfigWithID("test")
 	config.OnError = "invalid_on_error"
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -133,7 +137,8 @@ func TestBuild(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := tc.input
-			_, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			_, err := cfg.Build(&set)
 			if tc.expectErr {
 				require.Error(t, err)
 				return
@@ -695,7 +700,8 @@ key=value`,
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if tc.expectBuildErr {
 				require.Error(t, err)
 				return

--- a/pkg/stanza/operator/parser/regex/config.go
+++ b/pkg/stanza/operator/parser/regex/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"go.opentelemetry.io/collector/component"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
@@ -44,8 +45,8 @@ type Config struct {
 }
 
 // Build will build a regex parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +80,11 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 
 	if c.Cache.Size > 0 {
 		op.cache = newMemoryCache(c.Cache.Size, 0)
-		logger.Debugf("configured %s with memory cache of size %d", op.ID(), op.cache.maxSize())
+		set.Logger.Debug(
+			"configured memory cache",
+			zap.String("operator_id", op.ID()),
+			zap.Uint16("size", op.cache.maxSize()),
+		)
 	}
 
 	return op, nil

--- a/pkg/stanza/operator/parser/regex/parser_test.go
+++ b/pkg/stanza/operator/parser/regex/parser_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -24,7 +25,8 @@ func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
 	if cacheSize > 0 {
 		cfg.Cache.Size = cacheSize
 	}
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -32,7 +34,8 @@ func newTestParser(t *testing.T, regex string, cacheSize uint16) *Parser {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -135,7 +138,8 @@ func TestParserRegex(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			tc.configure(cfg)
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			defer func() {
@@ -167,28 +171,32 @@ func TestBuildParserRegex(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.NoError(t, err)
 	})
 
 	t.Run("MissingRegexField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = ""
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 	})
 
 	t.Run("InvalidRegexField", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = "())()"
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 	})
 
 	t.Run("NoNamedGroups", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = ".*"
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no named capture groups")
 	})
@@ -196,7 +204,8 @@ func TestBuildParserRegex(t *testing.T) {
 	t.Run("NoNamedGroups", func(t *testing.T) {
 		c := newBasicParser()
 		c.Regex = "(.*)"
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "no named capture groups")
 	})
@@ -231,7 +240,8 @@ func newTestBenchParser(t *testing.T, cacheSize uint16) *Parser {
 	cfg.Regex = benchParsePattern
 	cfg.Cache.Size = cacheSize
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }

--- a/pkg/stanza/operator/parser/scope/config.go
+++ b/pkg/stanza/operator/parser/scope/config.go
@@ -4,7 +4,7 @@
 package scope // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/scope"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -36,8 +36,8 @@ type Config struct {
 }
 
 // Build will build a logger name parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/scope/parser_test.go
+++ b/pkg/stanza/operator/parser/scope/parser_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 const testScopeName = "my.logger"
@@ -92,7 +92,8 @@ func TestScopeNameParser(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			parser, err := tc.config.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			parser, err := tc.config.Build(&set)
 			require.NoError(t, err)
 
 			err = parser.Process(context.Background(), tc.input)

--- a/pkg/stanza/operator/parser/severity/config.go
+++ b/pkg/stanza/operator/parser/severity/config.go
@@ -4,7 +4,7 @@
 package severity // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/severity"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -36,13 +36,13 @@ type Config struct {
 }
 
 // Build will build a severity parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}
 
-	severityParser, err := c.SeverityConfig.Build(logger)
+	severityParser, err := c.SeverityConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/severity/parser_test.go
+++ b/pkg/stanza/operator/parser/severity/parser_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -222,7 +223,8 @@ func TestSeverityParser(t *testing.T) {
 
 func runSeverityParseTest(cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected entry.Severity) func(*testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return

--- a/pkg/stanza/operator/parser/syslog/config.go
+++ b/pkg/stanza/operator/parser/syslog/config.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -58,7 +58,7 @@ type BaseConfig struct {
 }
 
 // Build will build a JSON parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
 	if c.ParserConfig.TimeParser == nil {
 		parseFromField := entry.NewAttributeField("timestamp")
 		c.ParserConfig.TimeParser = &helper.TimeParser{
@@ -67,7 +67,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
 		}
 	}
 
-	parserOperator, err := c.ParserConfig.Build(logger)
+	parserOperator, err := c.ParserConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestUnmarshal(t *testing.T) {
@@ -126,7 +126,8 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestParserMissingProtocol(t *testing.T) {
-	_, err := NewConfig().Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := NewConfig().Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "missing field 'protocol'")
 }
@@ -213,7 +214,8 @@ func TestRFC6587ConfigOptions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			_, err := tc.cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			_, err := tc.cfg.Build(&set)
 			if tc.errContents != "" {
 				require.ErrorContains(t, err, tc.errContents)
 			} else {
@@ -228,7 +230,8 @@ func TestParserInvalidLocation(t *testing.T) {
 	config.Location = "not_a_location"
 	config.Protocol = RFC3164
 
-	_, err := config.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := config.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to load location "+config.Location)
 }

--- a/pkg/stanza/operator/parser/syslog/parser_test.go
+++ b/pkg/stanza/operator/parser/syslog/parser_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -27,7 +28,8 @@ func TestParser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			op, err := tc.Config.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := tc.Config.Build(&set)
 			require.NoError(t, err)
 
 			fake := testutil.NewFakeOutput(t)
@@ -57,7 +59,8 @@ func TestSyslogParseRFC5424_SDNameTooLong(t *testing.T) {
 
 	body := `<86>1 2015-08-05T21:58:59.693Z 192.168.2.132 SecureAuth0 23108 ID52020 [verylongsdnamethatisgreaterthan32bytes@12345 UserHostAddress="192.168.2.132"] my message`
 
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)
@@ -82,14 +85,16 @@ func TestSyslogProtocolConfig(t *testing.T) {
 	for _, proto := range []string{"RFC5424", "rfc5424", "RFC3164", "rfc3164"} {
 		cfg := basicConfig()
 		cfg.Protocol = proto
-		_, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := cfg.Build(&set)
 		require.NoError(t, err)
 	}
 
 	for _, proto := range []string{"RFC5424a", "rfc5424b", "RFC3164c", "rfc3164d"} {
 		cfg := basicConfig()
 		cfg.Protocol = proto
-		_, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := cfg.Build(&set)
 		require.Error(t, err)
 	}
 }

--- a/pkg/stanza/operator/parser/time/config.go
+++ b/pkg/stanza/operator/parser/time/config.go
@@ -4,8 +4,8 @@
 package time // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/time"
 
 import (
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/confmap"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -41,8 +41,8 @@ func (c *Config) Unmarshal(component *confmap.Conf) error {
 }
 
 // Build will build a time parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/time/parser_test.go
+++ b/pkg/stanza/operator/parser/time/parser_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -63,7 +64,8 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building time_parser operator")
 				return
@@ -121,7 +123,8 @@ func TestProcess(t *testing.T) {
 				require.NoError(t, err)
 				return
 			}
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if err != nil {
 				require.NoError(t, err)
 				return
@@ -501,7 +504,8 @@ func runTimeParseTest(t *testing.T, cfg *Config, ent *entry.Entry, buildErr bool
 
 func runLossyTimeParseTest(_ *testing.T, cfg *Config, ent *entry.Entry, buildErr bool, parseErr bool, expected time.Time, maxLoss time.Duration) func(*testing.T) {
 	return func(t *testing.T) {
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		if buildErr {
 			require.Error(t, err, "expected error when configuring operator")
 			return

--- a/pkg/stanza/operator/parser/trace/config.go
+++ b/pkg/stanza/operator/parser/trace/config.go
@@ -4,7 +4,7 @@
 package trace // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/trace"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -36,8 +36,8 @@ type Config struct {
 }
 
 // Build will build a trace parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/trace/parser_test.go
+++ b/pkg/stanza/operator/parser/trace/parser_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func TestInit(t *testing.T) {
@@ -22,7 +22,8 @@ func TestInit(t *testing.T) {
 }
 func TestDefaultParser(t *testing.T) {
 	traceParserConfig := NewConfig()
-	_, err := traceParserConfig.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := traceParserConfig.Build(&set)
 	require.NoError(t, err)
 }
 
@@ -83,7 +84,8 @@ func TestBuild(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg, err := tc.input()
 			require.NoError(t, err, "expected nil error when running test cases input func")
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if tc.expectErr {
 				require.Error(t, err, "expected error while building trace_parser operator")
 				return
@@ -109,7 +111,8 @@ func TestProcess(t *testing.T) {
 			"no-op",
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
-				return cfg.Build(testutil.Logger(t))
+				set := componenttest.NewNopTelemetrySettings()
+				return cfg.Build(&set)
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -128,7 +131,8 @@ func TestProcess(t *testing.T) {
 				cfg.SpanID.ParseFrom = &spanFrom
 				cfg.TraceID.ParseFrom = &traceFrom
 				cfg.TraceFlags.ParseFrom = &flagsFrom
-				return cfg.Build(testutil.Logger(t))
+				set := componenttest.NewNopTelemetrySettings()
+				return cfg.Build(&set)
 			},
 			&entry.Entry{
 				Body: map[string]any{
@@ -258,7 +262,8 @@ func TestTraceParserParse(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			traceParserConfig := NewConfigWithID("")
-			_, _ = traceParserConfig.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			_, _ = traceParserConfig.Build(&set)
 			e := entry.New()
 			e.Body = tc.inputRecord
 			err := traceParserConfig.Parse(e)

--- a/pkg/stanza/operator/parser/uri/config.go
+++ b/pkg/stanza/operator/parser/uri/config.go
@@ -4,7 +4,7 @@
 package uri // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/uri"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -34,8 +34,8 @@ type Config struct {
 }
 
 // Build will build a uri parser operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	parserOperator, err := c.ParserConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	parserOperator, err := c.ParserConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/parser/uri/parser_test.go
+++ b/pkg/stanza/operator/parser/uri/parser_test.go
@@ -9,15 +9,16 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
 )
 
 func newTestParser(t *testing.T) *Parser {
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	return op.(*Parser)
 }
@@ -31,7 +32,8 @@ func TestInit(t *testing.T) {
 func TestParserBuildFailure(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OnError = "invalid_on_error"
-	_, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "invalid `on_error` field")
 }
@@ -68,7 +70,8 @@ func TestProcess(t *testing.T) {
 			"default",
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
-				return cfg.Build(testutil.Logger(t))
+				set := componenttest.NewNopTelemetrySettings()
+				return cfg.Build(&set)
 			},
 			&entry.Entry{
 				Body: "https://google.com:443/path?user=dev",
@@ -94,7 +97,8 @@ func TestProcess(t *testing.T) {
 				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
 				cfg.ParseTo = entry.RootableField{Field: entry.NewBodyField("url2")}
-				return cfg.Build(testutil.Logger(t))
+				set := componenttest.NewNopTelemetrySettings()
+				return cfg.Build(&set)
 			},
 			&entry.Entry{
 				Body: map[string]any{
@@ -123,7 +127,8 @@ func TestProcess(t *testing.T) {
 			func() (operator.Operator, error) {
 				cfg := NewConfigWithID("test_id")
 				cfg.ParseFrom = entry.NewBodyField("url")
-				return cfg.Build(testutil.Logger(t))
+				set := componenttest.NewNopTelemetrySettings()
+				return cfg.Build(&set)
 			},
 			&entry.Entry{
 				Body: map[string]any{
@@ -490,7 +495,8 @@ func TestBuildParserURL(t *testing.T) {
 
 	t.Run("BasicConfig", func(t *testing.T) {
 		c := newBasicParser()
-		_, err := c.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		_, err := c.Build(&set)
 		require.NoError(t, err)
 	})
 }

--- a/pkg/stanza/operator/transformer/add/config.go
+++ b/pkg/stanza/operator/transformer/add/config.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -40,8 +40,8 @@ type Config struct {
 }
 
 // Build will build an add operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/add/transformer_test.go
+++ b/pkg/stanza/operator/transformer/add/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -340,7 +341,8 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			add := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/assignkeys/config.go
+++ b/pkg/stanza/operator/transformer/assignkeys/config.go
@@ -5,8 +5,8 @@ package assignkeys // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"fmt"
 
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -48,8 +48,8 @@ type Config struct {
 }
 
 // Build will build an assign_keys operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/assignkeys/transformer_test.go
+++ b/pkg/stanza/operator/transformer/assignkeys/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -129,7 +130,8 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if tc.expectErr && err != nil {
 				require.Error(t, err)
 				return

--- a/pkg/stanza/operator/transformer/copy/config.go
+++ b/pkg/stanza/operator/transformer/copy/config.go
@@ -6,7 +6,7 @@ package copy // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -39,8 +39,8 @@ type Config struct {
 }
 
 // Build will build a copy operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/copy/transformer_test.go
+++ b/pkg/stanza/operator/transformer/copy/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -287,7 +288,8 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			cp := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/filter/config.go
+++ b/pkg/stanza/operator/transformer/filter/config.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"math/big"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -46,8 +46,8 @@ type Config struct {
 }
 
 // Build will build a filter operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformer, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformer, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/filter/transformer_test.go
+++ b/pkg/stanza/operator/transformer/filter/transformer_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -179,7 +180,8 @@ func TestTransformer(t *testing.T) {
 			cfg := NewConfigWithID("test")
 			cfg.Expression = tc.expression
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			filtered := true
@@ -204,7 +206,8 @@ func TestFilterDropRatio(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.Expression = `body.message == "test_message"`
 	cfg.DropRatio = 0.5
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	processedEntries := 0

--- a/pkg/stanza/operator/transformer/flatten/config.go
+++ b/pkg/stanza/operator/transformer/flatten/config.go
@@ -6,7 +6,7 @@ package flatten // import "github.com/open-telemetry/opentelemetry-collector-con
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -38,8 +38,8 @@ type Config struct {
 }
 
 // Build will build a Flatten operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/flatten/transformer_test.go
+++ b/pkg/stanza/operator/transformer/flatten/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -319,7 +320,8 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			if tc.expectErr && err != nil {
 				require.Error(t, err)
 				t.SkipNow()

--- a/pkg/stanza/operator/transformer/move/config.go
+++ b/pkg/stanza/operator/transformer/move/config.go
@@ -6,7 +6,7 @@ package move // import "github.com/open-telemetry/opentelemetry-collector-contri
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -39,8 +39,8 @@ type Config struct {
 }
 
 // Build will build a Move operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/move/transformer_test.go
+++ b/pkg/stanza/operator/transformer/move/transformer_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -502,7 +503,8 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			move := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/noop/config.go
+++ b/pkg/stanza/operator/transformer/noop/config.go
@@ -4,7 +4,7 @@
 package noop // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/noop"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -34,8 +34,8 @@ type Config struct {
 }
 
 // Build will build a noop operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/noop/config_test.go
+++ b/pkg/stanza/operator/transformer/noop/config_test.go
@@ -7,20 +7,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 func TestBuildValid(t *testing.T) {
 	cfg := NewConfigWithID("test")
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	require.IsType(t, &Transformer{}, op)
 }
 
 func TestBuildInvalid(t *testing.T) {
 	cfg := NewConfigWithID("test")
-	_, err := cfg.Build(nil)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = nil
+	_, err := cfg.Build(&set)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "build context is missing a logger")
 }

--- a/pkg/stanza/operator/transformer/noop/transformer_test.go
+++ b/pkg/stanza/operator/transformer/noop/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -17,7 +18,8 @@ import (
 func TestProcess(t *testing.T) {
 	cfg := NewConfigWithID("test")
 	cfg.OutputIDs = []string{"fake"}
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	fake := testutil.NewFakeOutput(t)

--- a/pkg/stanza/operator/transformer/recombine/config.go
+++ b/pkg/stanza/operator/transformer/recombine/config.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/expr-lang/expr/vm"
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -62,8 +62,8 @@ type Config struct {
 }
 
 // Build creates a new Transformer from a config
-func (c *Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformer, err := c.TransformerConfig.Build(logger)
+func (c *Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformer, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build transformer config: %w", err)
 	}

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -670,7 +671,8 @@ func TestTransformer(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			op, err := tc.config.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := tc.config.Build(&set)
 			require.NoError(t, err)
 			require.NoError(t, op.Start(testutil.NewUnscopedMockPersister()))
 			defer func() { require.NoError(t, op.Stop()) }()
@@ -699,7 +701,8 @@ func TestTransformer(t *testing.T) {
 		cfg.CombineField = entry.NewBodyField()
 		cfg.IsFirstEntry = MatchAll
 		cfg.OutputIDs = []string{"fake"}
-		op, err := cfg.Build(testutil.Logger(t))
+		set := componenttest.NewNopTelemetrySettings()
+		op, err := cfg.Build(&set)
 		require.NoError(t, err)
 		recombine := op.(*Transformer)
 
@@ -735,7 +738,8 @@ func BenchmarkRecombine(b *testing.B) {
 	cfg.IsFirstEntry = "body startsWith 'log-0'"
 	cfg.OutputIDs = []string{"fake"}
 	cfg.SourceIdentifier = entry.NewAttributeField("file.path")
-	op, err := cfg.Build(testutil.Logger(b))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(b, err)
 	recombine := op.(*Transformer)
 
@@ -778,7 +782,8 @@ func BenchmarkRecombineLimitTrigger(b *testing.B) {
 	cfg.IsFirstEntry = "body == 'start'"
 	cfg.MaxLogSize = 6
 	cfg.OutputIDs = []string{"fake"}
-	op, err := cfg.Build(testutil.Logger(b))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(b, err)
 	recombine := op.(*Transformer)
 
@@ -820,7 +825,8 @@ func TestTimeout(t *testing.T) {
 	cfg.IsFirstEntry = MatchAll
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 
@@ -863,7 +869,8 @@ func TestTimeoutWhenAggregationKeepHappen(t *testing.T) {
 	cfg.CombineWith = ""
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 
@@ -916,7 +923,8 @@ func TestSourceBatchDelete(t *testing.T) {
 	cfg.OutputIDs = []string{"fake"}
 	cfg.ForceFlushTimeout = 100 * time.Millisecond
 	cfg.MaxLogSize = 6
-	op, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	op, err := cfg.Build(&set)
 	require.NoError(t, err)
 	recombine := op.(*Transformer)
 

--- a/pkg/stanza/operator/transformer/remove/config.go
+++ b/pkg/stanza/operator/transformer/remove/config.go
@@ -6,7 +6,7 @@ package remove // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -39,8 +39,8 @@ type Config struct {
 }
 
 // Build will build a Remove operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/remove/transformer_test.go
+++ b/pkg/stanza/operator/transformer/remove/transformer_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -252,7 +253,8 @@ func TestProcessAndBuild(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			remove := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/retain/config.go
+++ b/pkg/stanza/operator/transformer/retain/config.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -39,8 +39,8 @@ type Config struct {
 }
 
 // Build will build a retain operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/retain/transformer_test.go
+++ b/pkg/stanza/operator/transformer/retain/transformer_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -384,7 +385,8 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.op
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "drop"
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			retain := op.(*Transformer)

--- a/pkg/stanza/operator/transformer/router/config.go
+++ b/pkg/stanza/operator/transformer/router/config.go
@@ -6,7 +6,7 @@ package router // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -45,8 +45,8 @@ type RouteConfig struct {
 }
 
 // Build will build a router operator from the supplied configuration
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	basicOperator, err := c.BasicConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	basicOperator, err := c.BasicConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/router/transformer_test.go
+++ b/pkg/stanza/operator/transformer/router/transformer_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -183,7 +184,8 @@ func TestTransformer(t *testing.T) {
 			cfg.Routes = tc.routes
 			cfg.Default = tc.defaultOutput
 
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			results := map[string]int{}

--- a/pkg/stanza/operator/transformer/unquote/config.go
+++ b/pkg/stanza/operator/transformer/unquote/config.go
@@ -4,7 +4,7 @@
 package unquote // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/transformer/unquote"
 
 import (
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -36,8 +36,8 @@ type Config struct {
 }
 
 // Build will build an unquote operator.
-func (c Config) Build(logger *zap.SugaredLogger) (operator.Operator, error) {
-	transformerOperator, err := c.TransformerConfig.Build(logger)
+func (c Config) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	transformerOperator, err := c.TransformerConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/transformer/unquote/transformer_test.go
+++ b/pkg/stanza/operator/transformer/unquote/transformer_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -194,7 +195,8 @@ func TestBuildAndProcess(t *testing.T) {
 			cfg := tc.cfg
 			cfg.OutputIDs = []string{"fake"}
 			cfg.OnError = "send"
-			op, err := cfg.Build(testutil.Logger(t))
+			set := componenttest.NewNopTelemetrySettings()
+			op, err := cfg.Build(&set)
 			require.NoError(t, err)
 
 			unqouteOp := op.(*Transformer)

--- a/pkg/stanza/pipeline/config.go
+++ b/pkg/stanza/pipeline/config.go
@@ -6,7 +6,7 @@ package pipeline // import "github.com/open-telemetry/opentelemetry-collector-co
 import (
 	"fmt"
 
-	"go.uber.org/zap"
+	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -19,8 +19,8 @@ type Config struct {
 }
 
 // Build will build a pipeline from the config.
-func (c Config) Build(logger *zap.SugaredLogger) (*DirectedPipeline, error) {
-	if logger == nil {
+func (c Config) Build(set *component.TelemetrySettings) (*DirectedPipeline, error) {
+	if set.Logger == nil {
 		return nil, errors.NewError("logger must be provided", "")
 	}
 	if c.Operators == nil {
@@ -35,7 +35,7 @@ func (c Config) Build(logger *zap.SugaredLogger) (*DirectedPipeline, error) {
 
 	ops := make([]operator.Operator, 0, len(c.Operators))
 	for _, opCfg := range c.Operators {
-		op, err := opCfg.Build(logger)
+		op, err := opCfg.Build(set)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/stanza/pipeline/config_test.go
+++ b/pkg/stanza/pipeline/config_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/json"
@@ -25,7 +26,8 @@ func TestBuildPipelineSuccess(t *testing.T) {
 		},
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	pipe, err := cfg.Build(&set)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(pipe.Operators()))
 }
@@ -39,7 +41,9 @@ func TestBuildPipelineNoLogger(t *testing.T) {
 		},
 	}
 
-	pipe, err := cfg.Build(nil)
+	set := componenttest.NewNopTelemetrySettings()
+	set.Logger = nil
+	pipe, err := cfg.Build(&set)
 	require.EqualError(t, err, "logger must be provided")
 	require.Nil(t, pipe)
 }
@@ -47,7 +51,8 @@ func TestBuildPipelineNoLogger(t *testing.T) {
 func TestBuildPipelineNilOperators(t *testing.T) {
 	cfg := Config{}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	pipe, err := cfg.Build(&set)
 	require.EqualError(t, err, "operators must be specified")
 	require.Nil(t, pipe)
 }
@@ -57,7 +62,8 @@ func TestBuildPipelineEmptyOperators(t *testing.T) {
 		Operators: []operator.Config{},
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	pipe, err := cfg.Build(&set)
 	require.EqualError(t, err, "empty pipeline not allowed")
 	require.Nil(t, pipe)
 }
@@ -75,7 +81,8 @@ func TestBuildAPipelineDefaultOperator(t *testing.T) {
 		DefaultOutput: testutil.NewFakeOutput(t),
 	}
 
-	pipe, err := cfg.Build(testutil.Logger(t))
+	set := componenttest.NewNopTelemetrySettings()
+	pipe, err := cfg.Build(&set)
 	require.NoError(t, err)
 
 	ops := pipe.Operators()
@@ -356,10 +363,11 @@ func TestUpdateOutputIDs(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run("UpdateOutputIDs/"+tc.name, func(t *testing.T) {
+			set := componenttest.NewNopTelemetrySettings()
 			pipeline, err := Config{
 				Operators:     tc.ops(),
 				DefaultOutput: tc.defaultOut,
-			}.Build(testutil.Logger(t))
+			}.Build(&set)
 			require.NoError(t, err)
 			ops := pipeline.Operators()
 

--- a/processor/logstransformprocessor/factory.go
+++ b/processor/logstransformprocessor/factory.go
@@ -47,5 +47,5 @@ func createLogsProcessor(
 		return nil, errors.New("no operators were configured for this logs transform processor")
 	}
 
-	return newProcessor(pCfg, nextConsumer, set.Logger)
+	return newProcessor(pCfg, nextConsumer, &set.TelemetrySettings)
 }

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -36,9 +36,9 @@ type logsTransformProcessor struct {
 	shutdownFns   []component.ShutdownFunc
 }
 
-func newProcessor(config *Config, nextConsumer consumer.Logs, logger *zap.Logger) (*logsTransformProcessor, error) {
+func newProcessor(config *Config, nextConsumer consumer.Logs, set *component.TelemetrySettings) (*logsTransformProcessor, error) {
 	p := &logsTransformProcessor{
-		logger:   logger,
+		logger:   set.Logger,
 		config:   config,
 		consumer: nextConsumer,
 	}
@@ -49,7 +49,7 @@ func newProcessor(config *Config, nextConsumer consumer.Logs, logger *zap.Logger
 	pipe, err := pipeline.Config{
 		Operators:     baseCfg.Operators,
 		DefaultOutput: p.emitter,
-	}.Build(p.logger.Sugar())
+	}.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/processor/processortest"
-	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/plogtest"
@@ -225,8 +225,8 @@ type laggyOperatorConfig struct {
 	helper.WriterConfig
 }
 
-func (l *laggyOperatorConfig) Build(s *zap.SugaredLogger) (operator.Operator, error) {
-	wo, err := l.WriterConfig.Build(s)
+func (l *laggyOperatorConfig) Build(set *component.TelemetrySettings) (operator.Operator, error) {
+	wo, err := l.WriterConfig.Build(set)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/otlpjsonfilereceiver/file.go
+++ b/receiver/otlpjsonfilereceiver/file.go
@@ -78,7 +78,7 @@ func createLogsReceiver(_ context.Context, settings receiver.CreateSettings, con
 	if cfg.ReplayFile {
 		opts = append(opts, fileconsumer.WithNoTracking())
 	}
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(&settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartLogsOp(ctx)
 		var l plog.Logs
 		l, err = logsUnmarshaler.UnmarshalLogs(token)
@@ -115,7 +115,7 @@ func createMetricsReceiver(_ context.Context, settings receiver.CreateSettings, 
 	if cfg.ReplayFile {
 		opts = append(opts, fileconsumer.WithNoTracking())
 	}
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(&settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartMetricsOp(ctx)
 		var m pmetric.Metrics
 		m, err = metricsUnmarshaler.UnmarshalMetrics(token)
@@ -151,7 +151,7 @@ func createTracesReceiver(_ context.Context, settings receiver.CreateSettings, c
 	if cfg.ReplayFile {
 		opts = append(opts, fileconsumer.WithNoTracking())
 	}
-	input, err := cfg.Config.Build(settings.Logger.Sugar(), func(ctx context.Context, token []byte, _ map[string]any) error {
+	input, err := cfg.Config.Build(&settings.TelemetrySettings, func(ctx context.Context, token []byte, _ map[string]any) error {
 		ctx = obsrecv.StartTracesOp(ctx)
 		var t ptrace.Traces
 		t, err = tracesUnmarshaler.UnmarshalTraces(token)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR resumes the work from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31618.

The goal is to pass in the `component.TelemetrySettings` so as to use them later in various ways:
1) report the filelog's state stats: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31544
2) switch from `SugaredLogger` to `Logger`: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32177


More about the breaking change decision at https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31618#discussion_r1514999048.

**Link to tracking Issue:** <Issue number if applicable> https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31256

**Testing:** <Describe what testing was performed and which tests were added.> Testing suite got updated.

#### Manual Testing

1.
```yaml
receivers:
  filelog:
    start_at: end
    include:
    - /var/log/busybox/refactroring_test.log
    operators:
      - id: addon
        type: add
        field: attributes.extra
        value: my-val
exporters:
  debug:
    verbosity: detailed
service:
  pipelines:
    logs:
      receivers: [filelog]
      exporters: [debug]
      processors: []
```
2. `./bin/otelcontribcol_linux_amd64 --config ~/otelcol/config.yaml`
3. `echo 'some line' >> /var/log/busybox/refactroring_test.log`
4.
```console
2024-04-24T09:29:17.104+0300	info	LogsExporter	{"kind": "exporter", "data_type": "logs", "name": "debug", "resource logs": 1, "log records": 1}
2024-04-24T09:29:17.104+0300	info	ResourceLog #0
Resource SchemaURL: 
ScopeLogs #0
ScopeLogs SchemaURL: 
InstrumentationScope  
LogRecord #0
ObservedTimestamp: 2024-04-24 06:29:17.005433317 +0000 UTC
Timestamp: 1970-01-01 00:00:00 +0000 UTC
SeverityText: 
SeverityNumber: Unspecified(0)
Body: Str(some line)
Attributes:
     -> extra: Str(my-val)
     -> log.file.name: Str(1.log)
Trace ID: 
Span ID: 
Flags: 0
	{"kind": "exporter", "data_type": "logs", "name": "debug"}
```

**Documentation:** <Describe the documentation added.> TBA.