### PR TITLE
WIP: [translator/prometheusremotewrite] Expose PrometheusConverter type, with generated implementation

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -179,14 +179,15 @@ func (prwe *prwExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) er
 	case <-prwe.closeChan:
 		return errors.New("shutdown has been called")
 	default:
-
-		tsMap, err := prometheusremotewrite.FromMetrics(md, prwe.exporterSettings)
+		converter := prometheusremotewrite.NewPrometheusConverter()
+		err := converter.FromMetrics(md, prwe.exporterSettings)
+		timeSeries := converter.TimeSeries()
 		if err != nil {
 			prwe.telemetry.recordTranslationFailure(ctx)
-			prwe.settings.Logger.Debug("failed to translate metrics, exporting remaining metrics", zap.Error(err), zap.Int("translated", len(tsMap)))
+			prwe.settings.Logger.Debug("failed to translate metrics, exporting remaining metrics", zap.Error(err), zap.Int("translated", len(timeSeries)))
 		}
 
-		prwe.telemetry.recordTranslatedTimeSeries(ctx, len(tsMap))
+		prwe.telemetry.recordTranslatedTimeSeries(ctx, len(timeSeries))
 
 		var m []*prompb.MetricMetadata
 		if prwe.exporterSettings.SendMetadata {
@@ -194,7 +195,7 @@ func (prwe *prwExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) er
 		}
 
 		// Call export even if a conversion error, since there may be points that were successfully converted.
-		return prwe.handleExport(ctx, tsMap, m)
+		return prwe.handleExport(ctx, timeSeries, m)
 	}
 }
 
@@ -210,14 +211,14 @@ func validateAndSanitizeExternalLabels(cfg *Config) (map[string]string, error) {
 	return sanitizedLabels, nil
 }
 
-func (prwe *prwExporter) handleExport(ctx context.Context, tsMap map[string]*prompb.TimeSeries, m []*prompb.MetricMetadata) error {
+func (prwe *prwExporter) handleExport(ctx context.Context, timeSeries []prompb.TimeSeries, m []*prompb.MetricMetadata) error {
 	// There are no metrics to export, so return.
-	if len(tsMap) == 0 {
+	if len(timeSeries) == 0 {
 		return nil
 	}
 
 	// Calls the helper function to convert and batch the TsMap to the desired format
-	requests, err := batchTimeSeries(tsMap, prwe.maxBatchSizeBytes, m)
+	requests, err := batchTimeSeries(timeSeries, prwe.maxBatchSizeBytes, m)
 	if err != nil {
 		return err
 	}

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -338,9 +338,9 @@ func TestNoMetricsNoError(t *testing.T) {
 
 func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 	// First we will construct a TimeSeries array from the testutils package
-	testmap := make(map[string]*prompb.TimeSeries)
+	var timeSeries []prompb.TimeSeries
 	if ts != nil {
-		testmap["test"] = ts
+		timeSeries = append(timeSeries, *ts)
 	}
 
 	cfg := createDefaultConfig().(*Config)
@@ -369,7 +369,7 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 		return err
 	}
 
-	return prwe.handleExport(context.Background(), testmap, nil)
+	return prwe.handleExport(context.Background(), timeSeries, nil)
 }
 
 type mockPRWTelemetry struct {
@@ -944,19 +944,16 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 	})
 	require.NotNil(t, prwe.wal)
 
-	ts1 := &prompb.TimeSeries{
+	ts1 := prompb.TimeSeries{
 		Labels:  []prompb.Label{{Name: "ts1l1", Value: "ts1k1"}},
 		Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
 	}
-	ts2 := &prompb.TimeSeries{
+	ts2 := prompb.TimeSeries{
 		Labels:  []prompb.Label{{Name: "ts2l1", Value: "ts2k1"}},
 		Samples: []prompb.Sample{{Value: 2, Timestamp: 200}},
 	}
-	tsMap := map[string]*prompb.TimeSeries{
-		"timeseries1": ts1,
-		"timeseries2": ts2,
-	}
-	errs := prwe.handleExport(ctx, tsMap, nil)
+	timeSeries := []prompb.TimeSeries{ts1, ts2}
+	errs := prwe.handleExport(ctx, timeSeries, nil)
 	assert.NoError(t, errs)
 	// Shutdown after we've written to the WAL. This ensures that our
 	// exported data in-flight will flushed flushed to the WAL before exiting.
@@ -988,12 +985,12 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 		reqs = append(reqs, req)
 	}
 	assert.Equal(t, 1, len(reqs))
-	// We MUST have 2 time series as were passed into tsMap.
+	// We MUST have 2 time series as were passed into timeSeries.
 	gotFromWAL := reqs[0]
 	assert.Equal(t, 2, len(gotFromWAL.Timeseries))
 	want := &prompb.WriteRequest{
 		Timeseries: orderBySampleTimestamp([]prompb.TimeSeries{
-			*ts1, *ts2,
+			ts1, ts2,
 		}),
 	}
 

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -11,28 +11,28 @@ import (
 )
 
 // batchTimeSeries splits series into multiple batch write requests.
-func batchTimeSeries(tsMap map[string]*prompb.TimeSeries, maxBatchByteSize int, m []*prompb.MetricMetadata) ([]*prompb.WriteRequest, error) {
-	if len(tsMap) == 0 {
-		return nil, errors.New("invalid tsMap: cannot be empty map")
+func batchTimeSeries(timeSeries []prompb.TimeSeries, maxBatchByteSize int, m []*prompb.MetricMetadata) ([]*prompb.WriteRequest, error) {
+	if len(timeSeries) == 0 {
+		return nil, errors.New("invalid timeSeries: cannot be empty")
 	}
 
-	requests := make([]*prompb.WriteRequest, 0, len(tsMap)+len(m))
-	tsArray := make([]prompb.TimeSeries, 0, len(tsMap))
+	requests := make([]*prompb.WriteRequest, 0, len(timeSeries)+len(m))
+	tsArray := make([]prompb.TimeSeries, 0, len(timeSeries))
 	sizeOfCurrentBatch := 0
 
 	i := 0
-	for _, v := range tsMap {
-		sizeOfSeries := v.Size()
+	for _, ts := range timeSeries {
+		sizeOfSeries := ts.Size()
 
 		if sizeOfCurrentBatch+sizeOfSeries >= maxBatchByteSize {
 			wrapped := convertTimeseriesToRequest(tsArray)
 			requests = append(requests, wrapped)
 
-			tsArray = make([]prompb.TimeSeries, 0, len(tsMap)-i)
+			tsArray = make([]prompb.TimeSeries, 0, len(timeSeries)-i)
 			sizeOfCurrentBatch = 0
 		}
 
-		tsArray = append(tsArray, *v)
+		tsArray = append(tsArray, ts)
 		sizeOfCurrentBatch += sizeOfSeries
 		i++
 	}

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -21,34 +21,34 @@ func Test_batchTimeSeries(t *testing.T) {
 	ts1 := getTimeSeries(labels, sample1, sample2)
 	ts2 := getTimeSeries(labels, sample1, sample2, sample3)
 
-	tsMap1 := getTimeseriesMap([]*prompb.TimeSeries{})
-	tsMap2 := getTimeseriesMap([]*prompb.TimeSeries{ts1})
-	tsMap3 := getTimeseriesMap([]*prompb.TimeSeries{ts1, ts2})
+	timeSeries1 := []prompb.TimeSeries{}
+	timeSeries2 := []prompb.TimeSeries{*ts1}
+	timeSeries3 := []prompb.TimeSeries{*ts1, *ts2}
 
 	tests := []struct {
 		name                string
-		tsMap               map[string]*prompb.TimeSeries
+		timeSeries          []prompb.TimeSeries
 		maxBatchByteSize    int
 		numExpectedRequests int
 		returnErr           bool
 	}{
 		{
 			"no_timeseries",
-			tsMap1,
+			timeSeries1,
 			100,
 			-1,
 			true,
 		},
 		{
 			"normal_case",
-			tsMap2,
+			timeSeries2,
 			300,
 			1,
 			false,
 		},
 		{
 			"two_requests",
-			tsMap3,
+			timeSeries3,
 			300,
 			2,
 			false,
@@ -57,7 +57,7 @@ func Test_batchTimeSeries(t *testing.T) {
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			requests, err := batchTimeSeries(tt.tsMap, tt.maxBatchByteSize, nil)
+			requests, err := batchTimeSeries(tt.timeSeries, tt.maxBatchByteSize, nil)
 			if tt.returnErr {
 				assert.Error(t, err)
 				return

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -4,7 +4,6 @@
 package prometheusremotewriteexporter
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -382,12 +381,4 @@ func getQuantiles(bounds []float64, values []float64) pmetric.SummaryDataPointVa
 	}
 
 	return quantiles
-}
-
-func getTimeseriesMap(timeseries []*prompb.TimeSeries) map[string]*prompb.TimeSeries {
-	tsMap := make(map[string]*prompb.TimeSeries)
-	for i, v := range timeseries {
-		tsMap[fmt.Sprintf("%s%d", "timeseries_name", i)] = v
-	}
-	return tsMap
 }

--- a/pkg/translator/prometheusremotewrite/cmd/generate/main.go
+++ b/pkg/translator/prometheusremotewrite/cmd/generate/main.go
@@ -1,0 +1,81 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+)
+
+type context struct {
+	Name                    string
+	Package                 string
+	PackagePath             string
+	PbPackagePath           string
+	PbPackage               string
+	LabelType               string
+	SampleTimestampField    string
+	ExemplarTimestampField  string
+	HistogramTimestampField string
+	UnknownType             string
+	GaugeType               string
+	CounterType             string
+	HistogramType           string
+	SummaryType             string
+}
+
+func main() {
+	c := context{
+		Name:                    "Prometheus",
+		Package:                 "prometheusremotewrite",
+		PackagePath:             "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite",
+		PbPackagePath:           "github.com/prometheus/prometheus/prompb",
+		PbPackage:               "prompb",
+		LabelType:               "Label",
+		SampleTimestampField:    "Timestamp",
+		ExemplarTimestampField:  "Timestamp",
+		HistogramTimestampField: "Timestamp",
+		UnknownType:             "MetricMetadata_UNKNOWN",
+		GaugeType:               "MetricMetadata_GAUGE",
+		CounterType:             "MetricMetadata_COUNTER",
+		HistogramType:           "MetricMetadata_HISTOGRAM",
+		SummaryType:             "MetricMetadata_SUMMARY",
+	}
+
+	ms, err := filepath.Glob("templates/*.go.tmpl")
+	if err != nil {
+		panic(err)
+	}
+	for _, m := range ms {
+		t, err := template.ParseFiles(m)
+		if err != nil {
+			panic(err)
+		}
+
+		name, _, found := strings.Cut(filepath.Base(m), ".")
+		if !found {
+			panic(fmt.Errorf("invalid filename %q", m))
+		}
+		executeTemplate(t, name, c)
+	}
+}
+
+func executeTemplate(t *template.Template, name string, c context) {
+	f, err := os.Create(fmt.Sprintf("%s_generated.go", name))
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString("// Automatically generated file - do not edit!!\n\n"); err != nil {
+		panic(err)
+	}
+
+	if err := t.Execute(f, c); err != nil {
+		panic(err)
+	}
+}

--- a/pkg/translator/prometheusremotewrite/helper_generated.go
+++ b/pkg/translator/prometheusremotewrite/helper_generated.go
@@ -1,3 +1,5 @@
+// Automatically generated file - do not edit!!
+
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
@@ -109,11 +111,9 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 
 	// Calculate the maximum possible number of labels we could return so we can preallocate l
 	maxLabelCount := attributes.Len() + len(externalLabels) + len(extras)/2
-
 	if haveServiceName {
 		maxLabelCount++
 	}
-
 	if haveInstanceID {
 		maxLabelCount++
 	}
@@ -121,8 +121,6 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 	// map ensures no duplicate label name
 	l := make(map[string]string, maxLabelCount)
 
-	// Ensure attributes are sorted by key for consistent merging of keys which
-	// collide when sanitized.
 	labels := make([]prompb.Label, 0, maxLabelCount)
 	// XXX: Should we always drop service namespace/service name/service instance ID from the labels
 	// (as they get mapped to other Prometheus labels)?
@@ -132,6 +130,8 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 		}
 		return true
 	})
+	// Ensure attributes are sorted by key for consistent merging of keys which
+	// collide when sanitized.
 	sort.Stable(ByLabelName(labels))
 
 	for _, label := range labels {
@@ -205,7 +205,7 @@ func isValidAggregationTemporality(metric pmetric.Metric) bool {
 	return false
 }
 
-func (c *prometheusConverter) addHistogramDataPoints(dataPoints pmetric.HistogramDataPointSlice,
+func (c *PrometheusConverter) addHistogramDataPoints(dataPoints pmetric.HistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, baseName string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -388,7 +388,7 @@ func maxTimestamp(a, b pcommon.Timestamp) pcommon.Timestamp {
 	return b
 }
 
-func (c *prometheusConverter) addSummaryDataPoints(dataPoints pmetric.SummaryDataPointSlice, resource pcommon.Resource,
+func (c *PrometheusConverter) addSummaryDataPoints(dataPoints pmetric.SummaryDataPointSlice, resource pcommon.Resource,
 	settings Settings, baseName string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -461,7 +461,7 @@ func createLabels(name string, baseLabels []prompb.Label, extras ...string) []pr
 
 // getOrCreateTimeSeries returns the time series corresponding to the label set if existent, and false.
 // Otherwise it creates a new one and returns that, and true.
-func (c *prometheusConverter) getOrCreateTimeSeries(lbls []prompb.Label) (*prompb.TimeSeries, bool) {
+func (c *PrometheusConverter) getOrCreateTimeSeries(lbls []prompb.Label) (*prompb.TimeSeries, bool) {
 	h := timeSeriesSignature(lbls)
 	ts := c.unique[h]
 	if ts != nil {
@@ -497,7 +497,7 @@ func (c *prometheusConverter) getOrCreateTimeSeries(lbls []prompb.Label) (*promp
 // addTimeSeriesIfNeeded adds a corresponding time series if it doesn't already exist.
 // If the time series doesn't already exist, it gets added with startTimestamp for its value and timestamp for its timestamp,
 // both converted to milliseconds.
-func (c *prometheusConverter) addTimeSeriesIfNeeded(lbls []prompb.Label, startTimestamp pcommon.Timestamp, timestamp pcommon.Timestamp) {
+func (c *PrometheusConverter) addTimeSeriesIfNeeded(lbls []prompb.Label, startTimestamp pcommon.Timestamp, timestamp pcommon.Timestamp) {
 	ts, created := c.getOrCreateTimeSeries(lbls)
 	if created {
 		ts.Samples = []prompb.Sample{
@@ -511,8 +511,8 @@ func (c *prometheusConverter) addTimeSeriesIfNeeded(lbls []prompb.Label, startTi
 }
 
 // addResourceTargetInfo converts the resource to the target info metric.
-func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timestamp pcommon.Timestamp, converter *prometheusConverter) {
-	if settings.DisableTargetInfo || timestamp == 0 {
+func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timestamp pcommon.Timestamp, converter *PrometheusConverter) {
+if settings.DisableTargetInfo || timestamp == 0 {
 		return
 	}
 

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -106,7 +106,7 @@ func Test_isValidAggregationTemporality(t *testing.T) {
 	}
 }
 
-// TestPrometheusConverter_addSample verifies that prometheusConverter.addSample adds the sample to the correct time series.
+// TestPrometheusConverter_addSample verifies that PrometheusConverter.addSample adds the sample to the correct time series.
 func TestPrometheusConverter_addSample(t *testing.T) {
 	type testCase struct {
 		metric pmetric.Metric
@@ -115,7 +115,7 @@ func TestPrometheusConverter_addSample(t *testing.T) {
 	}
 
 	t.Run("empty_case", func(t *testing.T) {
-		converter := newPrometheusConverter()
+		converter := NewPrometheusConverter()
 		converter.addSample(nil, nil)
 		assert.Empty(t, converter.unique)
 		assert.Empty(t, converter.conflicts)
@@ -159,7 +159,7 @@ func TestPrometheusConverter_addSample(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 			converter.addSample(&tt.testCase[0].sample, tt.testCase[0].labels)
 			converter.addSample(&tt.testCase[1].sample, tt.testCase[1].labels)
 			assert.Exactly(t, tt.want, converter.unique)
@@ -382,7 +382,7 @@ func BenchmarkCreateAttributes(b *testing.B) {
 	}
 }
 
-// TestPrometheusConverter_addExemplars verifies that prometheusConverter.addExemplars adds exemplars correctly given bucket bounds data.
+// TestPrometheusConverter_addExemplars verifies that PrometheusConverter.addExemplars adds exemplars correctly given bucket bounds data.
 func TestPrometheusConverter_addExemplars(t *testing.T) {
 	ts1 := getTimeSeries(
 		getPromLabels(label11, value11, label12, value12),
@@ -439,7 +439,7 @@ func TestPrometheusConverter_addExemplars(t *testing.T) {
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			converter := &prometheusConverter{
+			converter := &PrometheusConverter{
 				unique: tt.orig,
 			}
 			converter.addExemplars(tt.dataPoint, tt.bucketBounds)
@@ -619,12 +619,12 @@ func TestAddResourceTargetInfo(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
 			addResourceTargetInfo(tc.resource, tc.settings, tc.timestamp, converter)
 
 			if len(tc.wantLabels) == 0 || tc.settings.DisableTargetInfo {
-				assert.Empty(t, converter.timeSeries())
+				assert.Empty(t, converter.TimeSeries())
 				return
 			}
 
@@ -764,7 +764,7 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
 			converter.addSummaryDataPoints(
 				metric.Summary().DataPoints(),
@@ -874,7 +874,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
 			converter.addHistogramDataPoints(
 				metric.Histogram().DataPoints(),
@@ -892,7 +892,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 }
 
 func TestPrometheusConverter_getOrCreateTimeSeries(t *testing.T) {
-	converter := newPrometheusConverter()
+	converter := NewPrometheusConverter()
 	lbls := []prompb.Label{
 		{
 			Name:  "key1",

--- a/pkg/translator/prometheusremotewrite/histograms_generated.go
+++ b/pkg/translator/prometheusremotewrite/histograms_generated.go
@@ -1,0 +1,198 @@
+// Automatically generated file - do not edit!!
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/prompb"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const defaultZeroThreshold = 1e-128
+
+func (c *PrometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
+	resource pcommon.Resource, settings Settings, baseName string) error {
+	for x := 0; x < dataPoints.Len(); x++ {
+		pt := dataPoints.At(x)
+		lbls := createAttributes(
+			resource,
+			pt.Attributes(),
+			settings.ExternalLabels,
+			nil,
+			true,
+			model.MetricNameLabel,
+			baseName,
+		)
+		ts, _ := c.getOrCreateTimeSeries(lbls)
+
+		histogram, err := exponentialToNativeHistogram(pt)
+		if err != nil {
+			return err
+		}
+		ts.Histograms = append(ts.Histograms, histogram)
+
+		exemplars := getPromExemplars[pmetric.ExponentialHistogramDataPoint](pt)
+		ts.Exemplars = append(ts.Exemplars, exemplars...)
+	}
+
+	return nil
+}
+
+// exponentialToNativeHistogram  translates OTel Exponential Histogram data point
+// to Prometheus Native Histogram.
+func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prompb.Histogram, error) {
+	scale := p.Scale()
+	if scale < -4 {
+		return prompb.Histogram{},
+			fmt.Errorf("cannot convert exponential to native histogram."+
+				" Scale must be >= -4, was %d", scale)
+	}
+
+	var scaleDown int32
+	if scale > 8 {
+		scaleDown = scale - 8
+		scale = 8
+	}
+
+	pSpans, pDeltas := convertBucketsLayout(p.Positive(), scaleDown)
+	nSpans, nDeltas := convertBucketsLayout(p.Negative(), scaleDown)
+
+	h := prompb.Histogram{
+		// The counter reset detection must be compatible with Prometheus to
+		// safely set ResetHint to NO. This is not ensured currently.
+		// Sending a sample that triggers counter reset but with ResetHint==NO
+		// would lead to Prometheus panic as it does not double check the hint.
+		// Thus we're explicitly saying UNKNOWN here, which is always safe.
+		// TODO: using created time stamp should be accurate, but we
+		// need to know here if it was used for the detection.
+		// Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28663#issuecomment-1810577303
+		// Counter reset detection in Prometheus: https://github.com/prometheus/prometheus/blob/f997c72f294c0f18ca13fa06d51889af04135195/tsdb/chunkenc/histogram.go#L232
+		ResetHint: prompb.Histogram_UNKNOWN,
+		Schema:    scale,
+
+		ZeroCount: &prompb.Histogram_ZeroCountInt{ZeroCountInt: p.ZeroCount()},
+		// TODO use zero_threshold, if set, see
+		// https://github.com/open-telemetry/opentelemetry-proto/pull/441
+		ZeroThreshold: defaultZeroThreshold,
+
+		PositiveSpans:  pSpans,
+		PositiveDeltas: pDeltas,
+		NegativeSpans:  nSpans,
+		NegativeDeltas: nDeltas,
+
+		Timestamp: convertTimeStamp(p.Timestamp()),
+	}
+
+	if p.Flags().NoRecordedValue() {
+		h.Sum = math.Float64frombits(value.StaleNaN)
+		h.Count = &prompb.Histogram_CountInt{CountInt: value.StaleNaN}
+	} else {
+		if p.HasSum() {
+			h.Sum = p.Sum()
+		}
+		h.Count = &prompb.Histogram_CountInt{CountInt: p.Count()}
+	}
+	return h, nil
+}
+
+// convertBucketsLayout translates OTel Exponential Histogram dense buckets
+// representation to Prometheus Native Histogram sparse bucket representation.
+//
+// The translation logic is taken from the client_golang `histogram.go#makeBuckets`
+// function, see `makeBuckets` https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go
+// The bucket indexes conversion was adjusted, since OTel exp. histogram bucket
+// index 0 corresponds to the range (1, base] while Prometheus bucket index 0
+// to the range (base 1].
+//
+// scaleDown is the factor by which the buckets are scaled down. In other words 2^scaleDown buckets will be merged into one.
+func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets, scaleDown int32) ([]prompb.BucketSpan, []int64) {
+	bucketCounts := buckets.BucketCounts()
+	if bucketCounts.Len() == 0 {
+		return nil, nil
+	}
+
+	var (
+		spans     []prompb.BucketSpan
+		deltas    []int64
+		count     int64
+		prevCount int64
+	)
+
+	appendDelta := func(count int64) {
+		spans[len(spans)-1].Length++
+		deltas = append(deltas, count-prevCount)
+		prevCount = count
+	}
+
+	// Let the compiler figure out that this is const during this function by
+	// moving it into a local variable.
+	numBuckets := bucketCounts.Len()
+
+	// The offset is scaled and adjusted by 1 as described above.
+	bucketIdx := buckets.Offset()>>scaleDown + 1
+	spans = append(spans, prompb.BucketSpan{
+		Offset: bucketIdx,
+		Length: 0,
+	})
+
+	for i := 0; i < numBuckets; i++ {
+		// The offset is scaled and adjusted by 1 as described above.
+		nextBucketIdx := (int32(i)+buckets.Offset())>>scaleDown + 1
+		if bucketIdx == nextBucketIdx { // We have not collected enough buckets to merge yet.
+			count += int64(bucketCounts.At(i))
+			continue
+		}
+		if count == 0 {
+			count = int64(bucketCounts.At(i))
+			continue
+		}
+
+		gap := nextBucketIdx - bucketIdx - 1
+		if gap > 2 {
+			// We have to create a new span, because we have found a gap
+			// of more than two buckets. The constant 2 is copied from the logic in
+			// https://github.com/prometheus/client_golang/blob/27f0506d6ebbb117b6b697d0552ee5be2502c5f2/prometheus/histogram.go#L1296
+			spans = append(spans, prompb.BucketSpan{
+				Offset: gap,
+				Length: 0,
+			})
+		} else {
+			// We have found a small gap (or no gap at all).
+			// Insert empty buckets as needed.
+			for j := int32(0); j < gap; j++ {
+				appendDelta(0)
+			}
+		}
+		appendDelta(count)
+		count = int64(bucketCounts.At(i))
+		bucketIdx = nextBucketIdx
+	}
+	// Need to use the last item's index. The offset is scaled and adjusted by 1 as described above.
+	gap := (int32(numBuckets)+buckets.Offset()-1)>>scaleDown + 1 - bucketIdx
+	if gap > 2 {
+		// We have to create a new span, because we have found a gap
+		// of more than two buckets. The constant 2 is copied from the logic in
+		// https://github.com/prometheus/client_golang/blob/27f0506d6ebbb117b6b697d0552ee5be2502c5f2/prometheus/histogram.go#L1296
+		spans = append(spans, prompb.BucketSpan{
+			Offset: gap,
+			Length: 0,
+		})
+	} else {
+		// We have found a small gap (or no gap at all).
+		// Insert empty buckets as needed.
+		for j := int32(0); j < gap; j++ {
+			appendDelta(0)
+		}
+	}
+	appendDelta(count)
+
+	return spans, deltas
+}

--- a/pkg/translator/prometheusremotewrite/histograms_test.go
+++ b/pkg/translator/prometheusremotewrite/histograms_test.go
@@ -738,7 +738,7 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
 
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 			require.NoError(t, converter.addExponentialHistogramDataPoints(
 				metric.ExponentialHistogram().DataPoints(),
 				pcommon.NewResource(),

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_generated.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_generated.go
@@ -1,3 +1,5 @@
+// Automatically generated file - do not edit!!
+
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"sort"
-	"strconv"
 
 	"github.com/prometheus/prometheus/prompb"
 	"go.opentelemetry.io/collector/pdata/pcommon"
@@ -26,34 +27,21 @@ type Settings struct {
 	SendMetadata        bool
 }
 
-// FromMetrics converts pmetric.Metrics to Prometheus remote write format.
-func FromMetrics(md pmetric.Metrics, settings Settings) (map[string]*prompb.TimeSeries, error) {
-	c := newPrometheusConverter()
-	errs := c.fromMetrics(md, settings)
-	tss := c.timeSeries()
-	out := make(map[string]*prompb.TimeSeries, len(tss))
-	for i := range tss {
-		out[strconv.Itoa(i)] = &tss[i]
-	}
-
-	return out, errs
-}
-
-// prometheusConverter converts from OTel write format to Prometheus write format.
-type prometheusConverter struct {
+// PrometheusConverter converts from OTel write format to Prometheus write format.
+type PrometheusConverter struct {
 	unique    map[uint64]*prompb.TimeSeries
 	conflicts map[uint64][]*prompb.TimeSeries
 }
 
-func newPrometheusConverter() *prometheusConverter {
-	return &prometheusConverter{
+func NewPrometheusConverter() *PrometheusConverter {
+	return &PrometheusConverter{
 		unique:    map[uint64]*prompb.TimeSeries{},
 		conflicts: map[uint64][]*prompb.TimeSeries{},
 	}
 }
 
-// fromMetrics converts pmetric.Metrics to Prometheus remote write format.
-func (c *prometheusConverter) fromMetrics(md pmetric.Metrics, settings Settings) (errs error) {
+// FromMetrics converts pmetric.Metrics to Prometheus remote write format.
+func (c *PrometheusConverter) FromMetrics(md pmetric.Metrics, settings Settings) (errs error) {
 	resourceMetricsSlice := md.ResourceMetrics()
 	for i := 0; i < resourceMetricsSlice.Len(); i++ {
 		resourceMetrics := resourceMetricsSlice.At(i)
@@ -128,26 +116,7 @@ func (c *prometheusConverter) fromMetrics(md pmetric.Metrics, settings Settings)
 		addResourceTargetInfo(resource, settings, mostRecentTimestamp, c)
 	}
 
-	return
-}
-
-// timeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
-func (c *prometheusConverter) timeSeries() []prompb.TimeSeries {
-	conflicts := 0
-	for _, ts := range c.conflicts {
-		conflicts += len(ts)
-	}
-	allTS := make([]prompb.TimeSeries, 0, len(c.unique)+conflicts)
-	for _, ts := range c.unique {
-		allTS = append(allTS, *ts)
-	}
-	for _, cTS := range c.conflicts {
-		for _, ts := range cTS {
-			allTS = append(allTS, *ts)
-		}
-	}
-
-	return allTS
+	return errs
 }
 
 func isSameMetric(ts *prompb.TimeSeries, lbls []prompb.Label) bool {
@@ -164,7 +133,7 @@ func isSameMetric(ts *prompb.TimeSeries, lbls []prompb.Label) bool {
 
 // addExemplars adds exemplars for the dataPoint. For each exemplar, if it can find a bucket bound corresponding to its value,
 // the exemplar is added to the bucket bound's time series, provided that the time series' has samples.
-func (c *prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
+func (c *PrometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
 	if len(bucketBounds) == 0 {
 		return
 	}
@@ -189,7 +158,7 @@ func (c *prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint,
 // If there is no corresponding TimeSeries already, it's created.
 // The corresponding TimeSeries is returned.
 // If either lbls is nil/empty or sample is nil, nothing is done.
-func (c *prometheusConverter) addSample(sample *prompb.Sample, lbls []prompb.Label) *prompb.TimeSeries {
+func (c *PrometheusConverter) addSample(sample *prompb.Sample, lbls []prompb.Label) *prompb.TimeSeries {
 	if sample == nil || len(lbls) == 0 {
 		// This shouldn't happen
 		return nil

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
@@ -72,9 +72,9 @@ func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
 											payload := createExportRequest(resourceAttributeCount, histogramCount, nonHistogramCount, labelsPerMetric, exemplarsPerSeries)
 
 											for i := 0; i < b.N; i++ {
-												converter := newPrometheusConverter()
-												require.NoError(b, converter.fromMetrics(payload.Metrics(), Settings{}))
-												require.NotNil(b, converter.timeSeries())
+												converter := NewPrometheusConverter()
+												require.NoError(b, converter.FromMetrics(payload.Metrics(), Settings{}))
+												require.NotNil(b, converter.TimeSeries())
 											}
 										})
 									}

--- a/pkg/translator/prometheusremotewrite/number_data_points_generated.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_generated.go
@@ -1,0 +1,98 @@
+// Automatically generated file - do not edit!!
+
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+
+import (
+	"math"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/value"
+	"github.com/prometheus/prometheus/prompb"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func (c *PrometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
+	resource pcommon.Resource, settings Settings, name string) {
+	for x := 0; x < dataPoints.Len(); x++ {
+		pt := dataPoints.At(x)
+		labels := createAttributes(
+			resource,
+			pt.Attributes(),
+			settings.ExternalLabels,
+			nil,
+			true,
+			model.MetricNameLabel,
+			name,
+		)
+		sample := &prompb.Sample{
+			// convert ns to ms
+			Timestamp: convertTimeStamp(pt.Timestamp()),
+		}
+		switch pt.ValueType() {
+		case pmetric.NumberDataPointValueTypeInt:
+			sample.Value = float64(pt.IntValue())
+		case pmetric.NumberDataPointValueTypeDouble:
+			sample.Value = pt.DoubleValue()
+		}
+		if pt.Flags().NoRecordedValue() {
+			sample.Value = math.Float64frombits(value.StaleNaN)
+		}
+		c.addSample(sample, labels)
+	}
+}
+
+func (c *PrometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
+	resource pcommon.Resource, metric pmetric.Metric, settings Settings, name string) {
+	for x := 0; x < dataPoints.Len(); x++ {
+		pt := dataPoints.At(x)
+		lbls := createAttributes(
+			resource,
+			pt.Attributes(),
+			settings.ExternalLabels,
+			nil,
+			true,
+			model.MetricNameLabel,
+			name,
+		)
+		sample := &prompb.Sample{
+			// convert ns to ms
+			Timestamp: convertTimeStamp(pt.Timestamp()),
+		}
+		switch pt.ValueType() {
+		case pmetric.NumberDataPointValueTypeInt:
+			sample.Value = float64(pt.IntValue())
+		case pmetric.NumberDataPointValueTypeDouble:
+			sample.Value = pt.DoubleValue()
+		}
+		if pt.Flags().NoRecordedValue() {
+			sample.Value = math.Float64frombits(value.StaleNaN)
+		}
+		ts := c.addSample(sample, lbls)
+		if ts != nil {
+			exemplars := getPromExemplars[pmetric.NumberDataPoint](pt)
+			ts.Exemplars = append(ts.Exemplars, exemplars...)
+		}
+
+		// add created time series if needed
+		if settings.ExportCreatedMetric && metric.Sum().IsMonotonic() {
+			startTimestamp := pt.StartTimestamp()
+			if startTimestamp == 0 {
+				return
+			}
+
+			createdLabels := make([]prompb.Label, len(lbls))
+			copy(createdLabels, lbls)
+			for i, l := range createdLabels {
+				if l.Name == model.MetricNameLabel {
+					createdLabels[i].Value = name + createdSuffix
+					break
+				}
+			}
+			c.addTimeSeriesIfNeeded(createdLabels, startTimestamp, pt.Timestamp())
+		}
+	}
+}

--- a/pkg/translator/prometheusremotewrite/number_data_points_test.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_test.go
@@ -14,7 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
+func TestPrometheusConverter_AddGaugeNumberDataPoints(t *testing.T) {
 	ts := uint64(time.Now().UnixNano())
 	tests := []struct {
 		name   string
@@ -50,7 +50,7 @@ func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
 			converter.addGaugeNumberDataPoints(
 				metric.Gauge().DataPoints(),
@@ -65,7 +65,7 @@ func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
 	}
 }
 
-func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
+func TestPrometheusConverter_AddSumNumberDataPoints(t *testing.T) {
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	tests := []struct {
 		name   string
@@ -224,7 +224,7 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
 			converter.addSumNumberDataPoints(
 				metric.Sum().DataPoints(),

--- a/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata_generated.go
+++ b/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata_generated.go
@@ -1,3 +1,5 @@
+// Automatically generated file - do not edit!!
+
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 

--- a/pkg/translator/prometheusremotewrite/prometheus.go
+++ b/pkg/translator/prometheusremotewrite/prometheus.go
@@ -1,0 +1,49 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//go:generate go run ./cmd/generate
+
+package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+
+import (
+	"strconv"
+
+	"github.com/prometheus/prometheus/prompb"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// TimeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
+func (c *PrometheusConverter) TimeSeries() []prompb.TimeSeries {
+	conflicts := 0
+	for _, ts := range c.conflicts {
+		conflicts += len(ts)
+	}
+	allTS := make([]prompb.TimeSeries, 0, len(c.unique)+conflicts)
+	for _, ts := range c.unique {
+		allTS = append(allTS, *ts)
+	}
+	for _, cTS := range c.conflicts {
+		for _, ts := range cTS {
+			allTS = append(allTS, *ts)
+		}
+	}
+
+	return allTS
+}
+
+// FromMetrics converts pmetric.Metrics to Prometheus remote write format.
+//
+// Deprecated: FromMetrics exists for historical compatibility and should not be used.
+// Use instead {{.Name}}.FromMetrics() and then {{.Name}}Converter.TimeSeries()
+// to obtain the Prometheus remote write format metrics.
+func FromMetrics(md pmetric.Metrics, settings Settings) (map[string]*prompb.TimeSeries, error) {
+	c := NewPrometheusConverter()
+	errs := c.FromMetrics(md, settings)
+	tss := c.TimeSeries()
+	out := make(map[string]*prompb.TimeSeries, len(tss))
+	for i := range tss {
+		out[strconv.Itoa(i)] = &tss[i]
+	}
+
+	return out, errs
+}

--- a/pkg/translator/prometheusremotewrite/templates/helper.go.tmpl
+++ b/pkg/translator/prometheusremotewrite/templates/helper.go.tmpl
@@ -1,0 +1,552 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package {{.Package}} // import "{{.PackagePath}}"
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+	"math"
+	"slices"
+	"sort"
+	"strconv"
+	"time"
+	"unicode/utf8"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/timestamp"
+	"github.com/prometheus/prometheus/model/value"
+	"{{.PbPackagePath}}"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+)
+
+const (
+	sumStr        = "_sum"
+	countStr      = "_count"
+	bucketStr     = "_bucket"
+	leStr         = "le"
+	quantileStr   = "quantile"
+	pInfStr       = "+Inf"
+	createdSuffix = "_created"
+	// maxExemplarRunes is the maximum number of UTF-8 exemplar characters
+	// according to the prometheus specification
+	// https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#exemplars
+	maxExemplarRunes = 128
+	// Trace and Span id keys are defined as part of the spec:
+	// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification%2Fmetrics%2Fdatamodel.md#exemplars-2
+	traceIDKey       = "trace_id"
+	spanIDKey        = "span_id"
+	infoType         = "info"
+	targetMetricName = "target_info"
+)
+
+type bucketBoundsData struct {
+	ts    *{{.PbPackage}}.TimeSeries
+	bound float64
+}
+
+// byBucketBoundsData enables the usage of sort.Sort() with a slice of bucket bounds
+type byBucketBoundsData []bucketBoundsData
+
+func (m byBucketBoundsData) Len() int           { return len(m) }
+func (m byBucketBoundsData) Less(i, j int) bool { return m[i].bound < m[j].bound }
+func (m byBucketBoundsData) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+
+// ByLabelName enables the usage of sort.Sort() with a slice of labels
+type ByLabelName []{{.PbPackage}}.{{.LabelType}}
+
+func (a ByLabelName) Len() int           { return len(a) }
+func (a ByLabelName) Less(i, j int) bool { return a[i].Name < a[j].Name }
+func (a ByLabelName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+// timeSeriesSignature returns a hashed label set signature.
+// The label slice should not contain duplicate label names; this method sorts the slice by label name before creating
+// the signature.
+// The algorithm is the same as in Prometheus' labels.StableHash function.
+func timeSeriesSignature(labels []{{.PbPackage}}.{{.LabelType}}) uint64 {
+	sort.Sort(ByLabelName(labels))
+
+	// Use xxhash.Sum64(b) for fast path as it's faster.
+	b := make([]byte, 0, 1024)
+	for i, v := range labels {
+		if len(b)+len(v.Name)+len(v.Value)+2 >= cap(b) {
+			// If labels entry is 1KB+ do not allocate whole entry.
+			h := xxhash.New()
+			_, _ = h.Write(b)
+			for _, v := range labels[i:] {
+				_, _ = h.WriteString(v.Name)
+				_, _ = h.Write(seps)
+				_, _ = h.WriteString(v.Value)
+				_, _ = h.Write(seps)
+			}
+			return h.Sum64()
+		}
+
+		b = append(b, v.Name...)
+		b = append(b, seps[0])
+		b = append(b, v.Value...)
+		b = append(b, seps[0])
+	}
+	return xxhash.Sum64(b)
+}
+
+var seps = []byte{'\xff'}
+
+// createAttributes creates a slice of Prometheus Labels with OTLP attributes and pairs of string values.
+// Unpaired string values are ignored. String pairs overwrite OTLP labels if collisions happen and
+// if logOnOverwrite is true, the overwrite is logged. Resulting label names are sanitized.
+func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externalLabels map[string]string,
+	ignoreAttrs []string, logOnOverwrite bool, extras ...string) []{{.PbPackage}}.{{.LabelType}} {
+	resourceAttrs := resource.Attributes()
+	serviceName, haveServiceName := resourceAttrs.Get(conventions.AttributeServiceName)
+	instance, haveInstanceID := resourceAttrs.Get(conventions.AttributeServiceInstanceID)
+
+	// Calculate the maximum possible number of labels we could return so we can preallocate l
+	maxLabelCount := attributes.Len() + len(externalLabels) + len(extras)/2
+	if haveServiceName {
+		maxLabelCount++
+	}
+	if haveInstanceID {
+		maxLabelCount++
+	}
+
+	// map ensures no duplicate label name
+	l := make(map[string]string, maxLabelCount)
+
+	labels := make([]{{.PbPackage}}.{{.LabelType}}, 0, maxLabelCount)
+	// XXX: Should we always drop service namespace/service name/service instance ID from the labels
+	// (as they get mapped to other Prometheus labels)?
+	attributes.Range(func(key string, value pcommon.Value) bool {
+		if !slices.Contains(ignoreAttrs, key) {
+			labels = append(labels, {{.PbPackage}}.{{.LabelType}}{Name: key, Value: value.AsString()})
+		}
+		return true
+	})
+	// Ensure attributes are sorted by key for consistent merging of keys which
+	// collide when sanitized.
+	sort.Stable(ByLabelName(labels))
+
+	for _, label := range labels {
+		var finalKey = prometheustranslator.NormalizeLabel(label.Name)
+		if existingValue, alreadyExists := l[finalKey]; alreadyExists {
+			l[finalKey] = existingValue + ";" + label.Value
+		} else {
+			l[finalKey] = label.Value
+		}
+	}
+
+	// Map service.name + service.namespace to job
+	if haveServiceName {
+		val := serviceName.AsString()
+		if serviceNamespace, ok := resourceAttrs.Get(conventions.AttributeServiceNamespace); ok {
+			val = fmt.Sprintf("%s/%s", serviceNamespace.AsString(), val)
+		}
+		l[model.JobLabel] = val
+	}
+	// Map service.instance.id to instance
+	if haveInstanceID {
+		l[model.InstanceLabel] = instance.AsString()
+	}
+	for key, value := range externalLabels {
+		// External labels have already been sanitized
+		if _, alreadyExists := l[key]; alreadyExists {
+			// Skip external labels if they are overridden by metric attributes
+			continue
+		}
+		l[key] = value
+	}
+
+	for i := 0; i < len(extras); i += 2 {
+		if i+1 >= len(extras) {
+			break
+		}
+		_, found := l[extras[i]]
+		if found && logOnOverwrite {
+			log.Println("label " + extras[i] + " is overwritten. Check if Prometheus reserved labels are used.")
+		}
+		// internal labels should be maintained
+		name := extras[i]
+		if !(len(name) > 4 && name[:2] == "__" && name[len(name)-2:] == "__") {
+			name = prometheustranslator.NormalizeLabel(name)
+		}
+		l[name] = extras[i+1]
+	}
+
+	labels = labels[:0]
+	for k, v := range l {
+		labels = append(labels, {{.PbPackage}}.{{.LabelType}}{Name: k, Value: v})
+	}
+
+	return labels
+}
+
+// isValidAggregationTemporality checks whether an OTel metric has a valid
+// aggregation temporality for conversion to a Prometheus metric.
+func isValidAggregationTemporality(metric pmetric.Metric) bool {
+	//exhaustive:enforce
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge, pmetric.MetricTypeSummary:
+		return true
+	case pmetric.MetricTypeSum:
+		return metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative
+	case pmetric.MetricTypeHistogram:
+		return metric.Histogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative
+	case pmetric.MetricTypeExponentialHistogram:
+		return metric.ExponentialHistogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative
+	}
+	return false
+}
+
+func (c *{{.Name}}Converter) addHistogramDataPoints(dataPoints pmetric.HistogramDataPointSlice,
+	resource pcommon.Resource, settings Settings, baseName string) {
+	for x := 0; x < dataPoints.Len(); x++ {
+		pt := dataPoints.At(x)
+		timestamp := convertTimeStamp(pt.Timestamp())
+		baseLabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nil, false)
+
+		// If the sum is unset, it indicates the _sum metric point should be
+		// omitted
+		if pt.HasSum() {
+			// treat sum as a sample in an individual TimeSeries
+			sum := &{{.PbPackage}}.Sample{
+				Value:     pt.Sum(),
+				{{.SampleTimestampField}}: timestamp,
+			}
+			if pt.Flags().NoRecordedValue() {
+				sum.Value = math.Float64frombits(value.StaleNaN)
+			}
+
+			sumlabels := createLabels(baseName+sumStr, baseLabels)
+			c.addSample(sum, sumlabels)
+
+		}
+
+		// treat count as a sample in an individual TimeSeries
+		count := &{{.PbPackage}}.Sample{
+			Value:     float64(pt.Count()),
+			{{.SampleTimestampField}}: timestamp,
+		}
+		if pt.Flags().NoRecordedValue() {
+			count.Value = math.Float64frombits(value.StaleNaN)
+		}
+
+		countlabels := createLabels(baseName+countStr, baseLabels)
+		c.addSample(count, countlabels)
+
+		// cumulative count for conversion to cumulative histogram
+		var cumulativeCount uint64
+
+		var bucketBounds []bucketBoundsData
+
+		// process each bound, based on histograms proto definition, # of buckets = # of explicit bounds + 1
+		for i := 0; i < pt.ExplicitBounds().Len() && i < pt.BucketCounts().Len(); i++ {
+			bound := pt.ExplicitBounds().At(i)
+			cumulativeCount += pt.BucketCounts().At(i)
+			bucket := &{{.PbPackage}}.Sample{
+				Value:     float64(cumulativeCount),
+				{{.SampleTimestampField}}: timestamp,
+			}
+			if pt.Flags().NoRecordedValue() {
+				bucket.Value = math.Float64frombits(value.StaleNaN)
+			}
+			boundStr := strconv.FormatFloat(bound, 'f', -1, 64)
+			labels := createLabels(baseName+bucketStr, baseLabels, leStr, boundStr)
+			ts := c.addSample(bucket, labels)
+
+			bucketBounds = append(bucketBounds, bucketBoundsData{ts: ts, bound: bound})
+		}
+		// add le=+Inf bucket
+		infBucket := &{{.PbPackage}}.Sample{
+			{{.SampleTimestampField}}: timestamp,
+		}
+		if pt.Flags().NoRecordedValue() {
+			infBucket.Value = math.Float64frombits(value.StaleNaN)
+		} else {
+			infBucket.Value = float64(pt.Count())
+		}
+		infLabels := createLabels(baseName+bucketStr, baseLabels, leStr, pInfStr)
+		ts := c.addSample(infBucket, infLabels)
+
+		bucketBounds = append(bucketBounds, bucketBoundsData{ts: ts, bound: math.Inf(1)})
+		c.addExemplars(pt, bucketBounds)
+
+		startTimestamp := pt.StartTimestamp()
+		if settings.ExportCreatedMetric && startTimestamp != 0 {
+			labels := createLabels(baseName+createdSuffix, baseLabels)
+			c.addTimeSeriesIfNeeded(labels, startTimestamp, pt.Timestamp())
+		}
+	}
+}
+
+type exemplarType interface {
+	pmetric.ExponentialHistogramDataPoint | pmetric.HistogramDataPoint | pmetric.NumberDataPoint
+	Exemplars() pmetric.ExemplarSlice
+}
+
+func getPromExemplars[T exemplarType](pt T) []{{.PbPackage}}.Exemplar {
+	promExemplars := make([]{{.PbPackage}}.Exemplar, 0, pt.Exemplars().Len())
+	for i := 0; i < pt.Exemplars().Len(); i++ {
+		exemplar := pt.Exemplars().At(i)
+		exemplarRunes := 0
+
+		promExemplar := {{.PbPackage}}.Exemplar{
+			Value:     exemplar.DoubleValue(),
+			{{.ExemplarTimestampField}}: timestamp.FromTime(exemplar.Timestamp().AsTime()),
+		}
+		if traceID := exemplar.TraceID(); !traceID.IsEmpty() {
+			val := hex.EncodeToString(traceID[:])
+			exemplarRunes += utf8.RuneCountInString(traceIDKey) + utf8.RuneCountInString(val)
+			promLabel := {{.PbPackage}}.{{.LabelType}}{
+				Name:  traceIDKey,
+				Value: val,
+			}
+			promExemplar.Labels = append(promExemplar.Labels, promLabel)
+		}
+		if spanID := exemplar.SpanID(); !spanID.IsEmpty() {
+			val := hex.EncodeToString(spanID[:])
+			exemplarRunes += utf8.RuneCountInString(spanIDKey) + utf8.RuneCountInString(val)
+			promLabel := {{.PbPackage}}.{{.LabelType}}{
+				Name:  spanIDKey,
+				Value: val,
+			}
+			promExemplar.Labels = append(promExemplar.Labels, promLabel)
+		}
+
+		attrs := exemplar.FilteredAttributes()
+		labelsFromAttributes := make([]{{.PbPackage}}.{{.LabelType}}, 0, attrs.Len())
+		attrs.Range(func(key string, value pcommon.Value) bool {
+			val := value.AsString()
+			exemplarRunes += utf8.RuneCountInString(key) + utf8.RuneCountInString(val)
+			promLabel := {{.PbPackage}}.{{.LabelType}}{
+				Name:  key,
+				Value: val,
+			}
+
+			labelsFromAttributes = append(labelsFromAttributes, promLabel)
+
+			return true
+		})
+		if exemplarRunes <= maxExemplarRunes {
+			// only append filtered attributes if it does not cause exemplar
+			// labels to exceed the max number of runes
+			promExemplar.Labels = append(promExemplar.Labels, labelsFromAttributes...)
+		}
+
+		promExemplars = append(promExemplars, promExemplar)
+	}
+
+	return promExemplars
+}
+
+// mostRecentTimestampInMetric returns the latest timestamp in a batch of metrics
+func mostRecentTimestampInMetric(metric pmetric.Metric) pcommon.Timestamp {
+	var ts pcommon.Timestamp
+	// handle individual metric based on type
+	//exhaustive:enforce
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge:
+		dataPoints := metric.Gauge().DataPoints()
+		for x := 0; x < dataPoints.Len(); x++ {
+			ts = maxTimestamp(ts, dataPoints.At(x).Timestamp())
+		}
+	case pmetric.MetricTypeSum:
+		dataPoints := metric.Sum().DataPoints()
+		for x := 0; x < dataPoints.Len(); x++ {
+			ts = maxTimestamp(ts, dataPoints.At(x).Timestamp())
+		}
+	case pmetric.MetricTypeHistogram:
+		dataPoints := metric.Histogram().DataPoints()
+		for x := 0; x < dataPoints.Len(); x++ {
+			ts = maxTimestamp(ts, dataPoints.At(x).Timestamp())
+		}
+	case pmetric.MetricTypeExponentialHistogram:
+		dataPoints := metric.ExponentialHistogram().DataPoints()
+		for x := 0; x < dataPoints.Len(); x++ {
+			ts = maxTimestamp(ts, dataPoints.At(x).Timestamp())
+		}
+	case pmetric.MetricTypeSummary:
+		dataPoints := metric.Summary().DataPoints()
+		for x := 0; x < dataPoints.Len(); x++ {
+			ts = maxTimestamp(ts, dataPoints.At(x).Timestamp())
+		}
+	}
+	return ts
+}
+
+func maxTimestamp(a, b pcommon.Timestamp) pcommon.Timestamp {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func (c *{{.Name}}Converter) addSummaryDataPoints(dataPoints pmetric.SummaryDataPointSlice, resource pcommon.Resource,
+	settings Settings, baseName string) {
+	for x := 0; x < dataPoints.Len(); x++ {
+		pt := dataPoints.At(x)
+		timestamp := convertTimeStamp(pt.Timestamp())
+		baseLabels := createAttributes(resource, pt.Attributes(), settings.ExternalLabels, nil, false)
+
+		// treat sum as a sample in an individual TimeSeries
+		sum := &{{.PbPackage}}.Sample{
+			Value:     pt.Sum(),
+			{{.SampleTimestampField}}: timestamp,
+		}
+		if pt.Flags().NoRecordedValue() {
+			sum.Value = math.Float64frombits(value.StaleNaN)
+		}
+		// sum and count of the summary should append suffix to baseName
+		sumlabels := createLabels(baseName+sumStr, baseLabels)
+		c.addSample(sum, sumlabels)
+
+		// treat count as a sample in an individual TimeSeries
+		count := &{{.PbPackage}}.Sample{
+			Value:     float64(pt.Count()),
+			{{.SampleTimestampField}}: timestamp,
+		}
+		if pt.Flags().NoRecordedValue() {
+			count.Value = math.Float64frombits(value.StaleNaN)
+		}
+		countlabels := createLabels(baseName+countStr, baseLabels)
+		c.addSample(count, countlabels)
+
+		// process each percentile/quantile
+		for i := 0; i < pt.QuantileValues().Len(); i++ {
+			qt := pt.QuantileValues().At(i)
+			quantile := &{{.PbPackage}}.Sample{
+				Value:     qt.Value(),
+				{{.SampleTimestampField}}: timestamp,
+			}
+			if pt.Flags().NoRecordedValue() {
+				quantile.Value = math.Float64frombits(value.StaleNaN)
+			}
+			percentileStr := strconv.FormatFloat(qt.Quantile(), 'f', -1, 64)
+			qtlabels := createLabels(baseName, baseLabels, quantileStr, percentileStr)
+			c.addSample(quantile, qtlabels)
+		}
+
+		startTimestamp := pt.StartTimestamp()
+		if settings.ExportCreatedMetric && startTimestamp != 0 {
+			createdLabels := createLabels(baseName+createdSuffix, baseLabels)
+			c.addTimeSeriesIfNeeded(createdLabels, startTimestamp, pt.Timestamp())
+		}
+	}
+}
+
+// createLabels returns a copy of baseLabels, adding to it the pair model.MetricNameLabel=name.
+// If extras are provided, corresponding label pairs are also added to the returned slice.
+// If extras is uneven length, the last (unpaired) extra will be ignored.
+func createLabels(name string, baseLabels []{{.PbPackage}}.{{.LabelType}}, extras ...string) []{{.PbPackage}}.{{.LabelType}} {
+	extraLabelCount := len(extras) / 2
+	labels := make([]{{.PbPackage}}.{{.LabelType}}, len(baseLabels), len(baseLabels)+extraLabelCount+1) // +1 for name
+	copy(labels, baseLabels)
+
+	n := len(extras)
+	n -= n % 2
+	for extrasIdx := 0; extrasIdx < n; extrasIdx += 2 {
+		labels = append(labels, {{.PbPackage}}.{{.LabelType}}{Name: extras[extrasIdx], Value: extras[extrasIdx+1]})
+	}
+
+	labels = append(labels, {{.PbPackage}}.{{.LabelType}}{Name: model.MetricNameLabel, Value: name})
+	return labels
+}
+
+// getOrCreateTimeSeries returns the time series corresponding to the label set if existent, and false.
+// Otherwise it creates a new one and returns that, and true.
+func (c *{{.Name}}Converter) getOrCreateTimeSeries(lbls []{{.PbPackage}}.{{.LabelType}}) (*{{.PbPackage}}.TimeSeries, bool) {
+	h := timeSeriesSignature(lbls)
+	ts := c.unique[h]
+	if ts != nil {
+		if isSameMetric(ts, lbls) {
+			// We already have this metric
+			return ts, false
+		}
+
+		// Look for a matching conflict
+		for _, cTS := range c.conflicts[h] {
+			if isSameMetric(cTS, lbls) {
+				// We already have this metric
+				return cTS, false
+			}
+		}
+
+		// New conflict
+		ts = &{{.PbPackage}}.TimeSeries{
+			Labels: lbls,
+		}
+		c.conflicts[h] = append(c.conflicts[h], ts)
+		return ts, true
+	}
+
+	// This metric is new
+	ts = &{{.PbPackage}}.TimeSeries{
+		Labels: lbls,
+	}
+	c.unique[h] = ts
+	return ts, true
+}
+
+// addTimeSeriesIfNeeded adds a corresponding time series if it doesn't already exist.
+// If the time series doesn't already exist, it gets added with startTimestamp for its value and timestamp for its timestamp,
+// both converted to milliseconds.
+func (c *{{.Name}}Converter) addTimeSeriesIfNeeded(lbls []{{.PbPackage}}.{{.LabelType}}, startTimestamp pcommon.Timestamp, timestamp pcommon.Timestamp) {
+	ts, created := c.getOrCreateTimeSeries(lbls)
+	if created {
+		ts.Samples = []{{.PbPackage}}.Sample{
+			{
+				// convert ns to ms
+				Value:     float64(convertTimeStamp(startTimestamp)),
+				{{.SampleTimestampField}}: convertTimeStamp(timestamp),
+			},
+		}
+	}
+}
+
+// addResourceTargetInfo converts the resource to the target info metric.
+func addResourceTargetInfo(resource pcommon.Resource, settings Settings, timestamp pcommon.Timestamp, converter *{{.Name}}Converter) {
+if settings.DisableTargetInfo || timestamp == 0 {
+		return
+	}
+
+	attributes := resource.Attributes()
+	identifyingAttrs := []string{
+		conventions.AttributeServiceNamespace,
+		conventions.AttributeServiceName,
+		conventions.AttributeServiceInstanceID,
+	}
+	nonIdentifyingAttrsCount := attributes.Len()
+	for _, a := range identifyingAttrs {
+		_, haveAttr := attributes.Get(a)
+		if haveAttr {
+			nonIdentifyingAttrsCount--
+		}
+	}
+	if nonIdentifyingAttrsCount == 0 {
+		// If we only have job + instance, then target_info isn't useful, so don't add it.
+		return
+	}
+
+	name := targetMetricName
+	if len(settings.Namespace) > 0 {
+		name = settings.Namespace + "_" + name
+	}
+
+	labels := createAttributes(resource, attributes, settings.ExternalLabels, identifyingAttrs, false, model.MetricNameLabel, name)
+	sample := &{{.PbPackage}}.Sample{
+		Value: float64(1),
+		// convert ns to ms
+		{{.SampleTimestampField}}: convertTimeStamp(timestamp),
+	}
+	converter.addSample(sample, labels)
+}
+
+// convertTimeStamp converts OTLP timestamp in ns to timestamp in ms
+func convertTimeStamp(timestamp pcommon.Timestamp) int64 {
+	return timestamp.AsTime().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+}

--- a/pkg/translator/prometheusremotewrite/templates/histograms.go.tmpl
+++ b/pkg/translator/prometheusremotewrite/templates/histograms.go.tmpl
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+package {{.Package}} // import "{{.PackagePath}}"
 
 import (
 	"fmt"
@@ -9,14 +9,14 @@ import (
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/value"
-	"github.com/prometheus/prometheus/prompb"
+	"{{.PbPackagePath}}"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 const defaultZeroThreshold = 1e-128
 
-func (c *prometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
+func (c *{{.Name}}Converter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, baseName string) error {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -46,10 +46,10 @@ func (c *prometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetr
 
 // exponentialToNativeHistogram  translates OTel Exponential Histogram data point
 // to Prometheus Native Histogram.
-func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prompb.Histogram, error) {
+func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) ({{.PbPackage}}.Histogram, error) {
 	scale := p.Scale()
 	if scale < -4 {
-		return prompb.Histogram{},
+		return {{.PbPackage}}.Histogram{},
 			fmt.Errorf("cannot convert exponential to native histogram."+
 				" Scale must be >= -4, was %d", scale)
 	}
@@ -63,7 +63,7 @@ func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prom
 	pSpans, pDeltas := convertBucketsLayout(p.Positive(), scaleDown)
 	nSpans, nDeltas := convertBucketsLayout(p.Negative(), scaleDown)
 
-	h := prompb.Histogram{
+	h := {{.PbPackage}}.Histogram{
 		// The counter reset detection must be compatible with Prometheus to
 		// safely set ResetHint to NO. This is not ensured currently.
 		// Sending a sample that triggers counter reset but with ResetHint==NO
@@ -73,10 +73,10 @@ func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prom
 		// need to know here if it was used for the detection.
 		// Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28663#issuecomment-1810577303
 		// Counter reset detection in Prometheus: https://github.com/prometheus/prometheus/blob/f997c72f294c0f18ca13fa06d51889af04135195/tsdb/chunkenc/histogram.go#L232
-		ResetHint: prompb.Histogram_UNKNOWN,
+		ResetHint: {{.PbPackage}}.Histogram_UNKNOWN,
 		Schema:    scale,
 
-		ZeroCount: &prompb.Histogram_ZeroCountInt{ZeroCountInt: p.ZeroCount()},
+		ZeroCount: &{{.PbPackage}}.Histogram_ZeroCountInt{ZeroCountInt: p.ZeroCount()},
 		// TODO use zero_threshold, if set, see
 		// https://github.com/open-telemetry/opentelemetry-proto/pull/441
 		ZeroThreshold: defaultZeroThreshold,
@@ -86,17 +86,17 @@ func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prom
 		NegativeSpans:  nSpans,
 		NegativeDeltas: nDeltas,
 
-		Timestamp: convertTimeStamp(p.Timestamp()),
+		{{.HistogramTimestampField}}: convertTimeStamp(p.Timestamp()),
 	}
 
 	if p.Flags().NoRecordedValue() {
 		h.Sum = math.Float64frombits(value.StaleNaN)
-		h.Count = &prompb.Histogram_CountInt{CountInt: value.StaleNaN}
+		h.Count = &{{.PbPackage}}.Histogram_CountInt{CountInt: value.StaleNaN}
 	} else {
 		if p.HasSum() {
 			h.Sum = p.Sum()
 		}
-		h.Count = &prompb.Histogram_CountInt{CountInt: p.Count()}
+		h.Count = &{{.PbPackage}}.Histogram_CountInt{CountInt: p.Count()}
 	}
 	return h, nil
 }
@@ -111,14 +111,14 @@ func exponentialToNativeHistogram(p pmetric.ExponentialHistogramDataPoint) (prom
 // to the range (base 1].
 //
 // scaleDown is the factor by which the buckets are scaled down. In other words 2^scaleDown buckets will be merged into one.
-func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets, scaleDown int32) ([]prompb.BucketSpan, []int64) {
+func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets, scaleDown int32) ([]{{.PbPackage}}.BucketSpan, []int64) {
 	bucketCounts := buckets.BucketCounts()
 	if bucketCounts.Len() == 0 {
 		return nil, nil
 	}
 
 	var (
-		spans     []prompb.BucketSpan
+		spans     []{{.PbPackage}}.BucketSpan
 		deltas    []int64
 		count     int64
 		prevCount int64
@@ -136,7 +136,7 @@ func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets, 
 
 	// The offset is scaled and adjusted by 1 as described above.
 	bucketIdx := buckets.Offset()>>scaleDown + 1
-	spans = append(spans, prompb.BucketSpan{
+	spans = append(spans, {{.PbPackage}}.BucketSpan{
 		Offset: bucketIdx,
 		Length: 0,
 	})
@@ -158,7 +158,7 @@ func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets, 
 			// We have to create a new span, because we have found a gap
 			// of more than two buckets. The constant 2 is copied from the logic in
 			// https://github.com/prometheus/client_golang/blob/27f0506d6ebbb117b6b697d0552ee5be2502c5f2/prometheus/histogram.go#L1296
-			spans = append(spans, prompb.BucketSpan{
+			spans = append(spans, {{.PbPackage}}.BucketSpan{
 				Offset: gap,
 				Length: 0,
 			})
@@ -179,7 +179,7 @@ func convertBucketsLayout(buckets pmetric.ExponentialHistogramDataPointBuckets, 
 		// We have to create a new span, because we have found a gap
 		// of more than two buckets. The constant 2 is copied from the logic in
 		// https://github.com/prometheus/client_golang/blob/27f0506d6ebbb117b6b697d0552ee5be2502c5f2/prometheus/histogram.go#L1296
-		spans = append(spans, prompb.BucketSpan{
+		spans = append(spans, {{.PbPackage}}.BucketSpan{
 			Offset: gap,
 			Length: 0,
 		})

--- a/pkg/translator/prometheusremotewrite/templates/metrics_to_prw.go.tmpl
+++ b/pkg/translator/prometheusremotewrite/templates/metrics_to_prw.go.tmpl
@@ -1,0 +1,168 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package {{.Package}} // import "{{.PackagePath}}"
+
+import (
+	"errors"
+	"fmt"
+	"sort"
+
+	"{{.PbPackagePath}}"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/multierr"
+
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+)
+
+type Settings struct {
+	Namespace           string
+	ExternalLabels      map[string]string
+	DisableTargetInfo   bool
+	ExportCreatedMetric bool
+	AddMetricSuffixes   bool
+	SendMetadata        bool
+}
+
+// {{.Name}}Converter converts from OTel write format to {{.Name}} write format.
+type {{.Name}}Converter struct {
+	unique    map[uint64]*{{.PbPackage}}.TimeSeries
+	conflicts map[uint64][]*{{.PbPackage}}.TimeSeries
+}
+
+func New{{.Name}}Converter() *{{.Name}}Converter {
+	return &{{.Name}}Converter{
+		unique:    map[uint64]*{{.PbPackage}}.TimeSeries{},
+		conflicts: map[uint64][]*{{.PbPackage}}.TimeSeries{},
+	}
+}
+
+// FromMetrics converts pmetric.Metrics to {{.Name}} remote write format.
+func (c *{{.Name}}Converter) FromMetrics(md pmetric.Metrics, settings Settings) (errs error) {
+	resourceMetricsSlice := md.ResourceMetrics()
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		resourceMetrics := resourceMetricsSlice.At(i)
+		resource := resourceMetrics.Resource()
+		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
+		// keep track of the most recent timestamp in the ResourceMetrics for
+		// use with the "target" info metric
+		var mostRecentTimestamp pcommon.Timestamp
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			metricSlice := scopeMetricsSlice.At(j).Metrics()
+
+			// TODO: decide if instrumentation library information should be exported as labels
+			for k := 0; k < metricSlice.Len(); k++ {
+				metric := metricSlice.At(k)
+				mostRecentTimestamp = maxTimestamp(mostRecentTimestamp, mostRecentTimestampInMetric(metric))
+
+				if !isValidAggregationTemporality(metric) {
+					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination for metric %q", metric.Name()))
+					continue
+				}
+
+				promName := prometheustranslator.BuildCompliantName(metric, settings.Namespace, settings.AddMetricSuffixes)
+
+				// handle individual metrics based on type
+				//exhaustive:enforce
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					dataPoints := metric.Gauge().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					c.addGaugeNumberDataPoints(dataPoints, resource, settings, promName)
+				case pmetric.MetricTypeSum:
+					dataPoints := metric.Sum().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					c.addSumNumberDataPoints(dataPoints, resource, metric, settings, promName)
+				case pmetric.MetricTypeHistogram:
+					dataPoints := metric.Histogram().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					c.addHistogramDataPoints(dataPoints, resource, settings, promName)
+				case pmetric.MetricTypeExponentialHistogram:
+					dataPoints := metric.ExponentialHistogram().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					errs = multierr.Append(errs, c.addExponentialHistogramDataPoints(
+						dataPoints,
+						resource,
+						settings,
+						promName,
+					))
+				case pmetric.MetricTypeSummary:
+					dataPoints := metric.Summary().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					c.addSummaryDataPoints(dataPoints, resource, settings, promName)
+				default:
+					errs = multierr.Append(errs, errors.New("unsupported metric type"))
+				}
+			}
+		}
+		addResourceTargetInfo(resource, settings, mostRecentTimestamp, c)
+	}
+
+	return errs
+}
+
+func isSameMetric(ts *{{.PbPackage}}.TimeSeries, lbls []{{.PbPackage}}.{{.LabelType}}) bool {
+	if len(ts.Labels) != len(lbls) {
+		return false
+	}
+	for i, l := range ts.Labels {
+		if l.Name != ts.Labels[i].Name || l.Value != ts.Labels[i].Value {
+			return false
+		}
+	}
+	return true
+}
+
+// addExemplars adds exemplars for the dataPoint. For each exemplar, if it can find a bucket bound corresponding to its value,
+// the exemplar is added to the bucket bound's time series, provided that the time series' has samples.
+func (c *{{.Name}}Converter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
+	if len(bucketBounds) == 0 {
+		return
+	}
+
+	exemplars := getPromExemplars(dataPoint)
+	if len(exemplars) == 0 {
+		return
+	}
+
+	sort.Sort(byBucketBoundsData(bucketBounds))
+	for _, exemplar := range exemplars {
+		for _, bound := range bucketBounds {
+			if len(bound.ts.Samples) > 0 && exemplar.Value <= bound.bound {
+				bound.ts.Exemplars = append(bound.ts.Exemplars, exemplar)
+				break
+			}
+		}
+	}
+}
+
+// addSample finds a TimeSeries that corresponds to lbls, and adds sample to it.
+// If there is no corresponding TimeSeries already, it's created.
+// The corresponding TimeSeries is returned.
+// If either lbls is nil/empty or sample is nil, nothing is done.
+func (c *{{.Name}}Converter) addSample(sample *{{.PbPackage}}.Sample, lbls []{{.PbPackage}}.{{.LabelType}}) *{{.PbPackage}}.TimeSeries {
+	if sample == nil || len(lbls) == 0 {
+		// This shouldn't happen
+		return nil
+	}
+
+	ts, _ := c.getOrCreateTimeSeries(lbls)
+	ts.Samples = append(ts.Samples, *sample)
+	return ts
+}

--- a/pkg/translator/prometheusremotewrite/templates/number_data_points.go.tmpl
+++ b/pkg/translator/prometheusremotewrite/templates/number_data_points.go.tmpl
@@ -1,19 +1,19 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+package {{.Package}} // import "{{.PackagePath}}"
 
 import (
 	"math"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/value"
-	"github.com/prometheus/prometheus/prompb"
+	"{{.PbPackagePath}}"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func (c *prometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
+func (c *{{.Name}}Converter) addGaugeNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
 	resource pcommon.Resource, settings Settings, name string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -26,9 +26,9 @@ func (c *prometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.Number
 			model.MetricNameLabel,
 			name,
 		)
-		sample := &prompb.Sample{
+		sample := &{{.PbPackage}}.Sample{
 			// convert ns to ms
-			Timestamp: convertTimeStamp(pt.Timestamp()),
+			{{.SampleTimestampField}}: convertTimeStamp(pt.Timestamp()),
 		}
 		switch pt.ValueType() {
 		case pmetric.NumberDataPointValueTypeInt:
@@ -43,7 +43,7 @@ func (c *prometheusConverter) addGaugeNumberDataPoints(dataPoints pmetric.Number
 	}
 }
 
-func (c *prometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
+func (c *{{.Name}}Converter) addSumNumberDataPoints(dataPoints pmetric.NumberDataPointSlice,
 	resource pcommon.Resource, metric pmetric.Metric, settings Settings, name string) {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)
@@ -56,9 +56,9 @@ func (c *prometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDa
 			model.MetricNameLabel,
 			name,
 		)
-		sample := &prompb.Sample{
+		sample := &{{.PbPackage}}.Sample{
 			// convert ns to ms
-			Timestamp: convertTimeStamp(pt.Timestamp()),
+			{{.SampleTimestampField}}: convertTimeStamp(pt.Timestamp()),
 		}
 		switch pt.ValueType() {
 		case pmetric.NumberDataPointValueTypeInt:
@@ -82,7 +82,7 @@ func (c *prometheusConverter) addSumNumberDataPoints(dataPoints pmetric.NumberDa
 				return
 			}
 
-			createdLabels := make([]prompb.Label, len(lbls))
+			createdLabels := make([]{{.PbPackage}}.{{.LabelType}}, len(lbls))
 			copy(createdLabels, lbls)
 			for i, l := range createdLabels {
 				if l.Name == model.MetricNameLabel {

--- a/pkg/translator/prometheusremotewrite/templates/otlp_to_openmetrics_metadata.go.tmpl
+++ b/pkg/translator/prometheusremotewrite/templates/otlp_to_openmetrics_metadata.go.tmpl
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package {{.Package}} // import "{{.PackagePath}}"
+
+import (
+	"{{.PbPackagePath}}"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+)
+
+func otelMetricTypeToPromMetricType(otelMetric pmetric.Metric) {{.PbPackage}}.MetricMetadata_MetricType {
+	switch otelMetric.Type() {
+	case pmetric.MetricTypeGauge:
+		return {{.PbPackage}}.{{.GaugeType}}
+	case pmetric.MetricTypeSum:
+		metricType := {{.PbPackage}}.{{.GaugeType}}
+		if otelMetric.Sum().IsMonotonic() {
+			metricType = {{.PbPackage}}.{{.CounterType}}
+		}
+		return metricType
+	case pmetric.MetricTypeHistogram:
+		return {{.PbPackage}}.{{.HistogramType}}
+	case pmetric.MetricTypeSummary:
+		return {{.PbPackage}}.{{.SummaryType}}
+	case pmetric.MetricTypeExponentialHistogram:
+		return {{.PbPackage}}.{{.HistogramType}}
+	}
+	return {{.PbPackage}}.{{.UnknownType}}
+}
+
+func OtelMetricsToMetadata(md pmetric.Metrics, addMetricSuffixes bool) []*{{.PbPackage}}.MetricMetadata {
+	resourceMetricsSlice := md.ResourceMetrics()
+
+	metadataLength := 0
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		scopeMetricsSlice := resourceMetricsSlice.At(i).ScopeMetrics()
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			metadataLength += scopeMetricsSlice.At(j).Metrics().Len()
+		}
+	}
+
+	var metadata = make([]*{{.PbPackage}}.MetricMetadata, 0, metadataLength)
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		resourceMetrics := resourceMetricsSlice.At(i)
+		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
+
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			scopeMetrics := scopeMetricsSlice.At(j)
+			for k := 0; k < scopeMetrics.Metrics().Len(); k++ {
+				metric := scopeMetrics.Metrics().At(k)
+				entry := {{.PbPackage}}.MetricMetadata{
+					Type:             otelMetricTypeToPromMetricType(metric),
+					MetricFamilyName: prometheustranslator.BuildCompliantName(metric, "", addMetricSuffixes),
+					Help:             metric.Description(),
+				}
+				metadata = append(metadata, &entry)
+			}
+		}
+	}
+
+	return metadata
+}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Expose the `PrometheusConverter` type from `pkg/translator/prometheusremotewrite` (previosly hidden behind the wrapping `FromMetrics` function), and generate the `PrometheusConverter.FromMetrics` implementation from templates. This approach lets Prometheus compatible systems such as Grafana Mimir, Thanos, Cortex etc. generate translation code for their own target format.

Also use the `PrometheusConverter` type from `exporter/prometheusremotewriteexporter`, to avoid the overhead of unnecessary translation in `prometheusremotewrite.FromMetrics`.

**Link to tracking Issue:** #32666

**Testing:** <Describe what testing was performed and which tests were added.>
I've benchmarked, the results are: TODO

**Documentation:** <Describe the documentation added.>