### PR TITLE
cmd/telemetrygen: Add headers to gRPC metadata for logs

### DIFF
--- a/.chloggen/telemetrygen-logs-grpc-metadata.yaml
+++ b/.chloggen/telemetrygen-logs-grpc-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add headers to gRPC metadata for logs
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: 32668
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/telemetrygen-logs-grpc-metadata.yaml
+++ b/.chloggen/telemetrygen-logs-grpc-metadata.yaml
@@ -10,7 +10,7 @@ component: telemetrygen
 note: Add headers to gRPC metadata for logs
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: 32668
+issues: [32668]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/telemetrygen/internal/common/config.go
+++ b/cmd/telemetrygen/internal/common/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	// OTLP config
 	CustomEndpoint      string
 	Insecure            bool
+	InsecureSkipVerify  bool
 	UseHTTP             bool
 	HTTPPath            string
 	Headers             KeyValue
@@ -120,6 +121,7 @@ func (c *Config) CommonFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&c.CustomEndpoint, "otlp-endpoint", "", "Destination endpoint for exporting logs, metrics and traces")
 	fs.BoolVar(&c.Insecure, "otlp-insecure", false, "Whether to enable client transport security for the exporter's grpc or http connection")
+	fs.BoolVar(&c.InsecureSkipVerify, "otlp-insecure-skip-verify", false, "Whether a client verifies the server's certificate chain and host name")
 	fs.BoolVar(&c.UseHTTP, "otlp-http", false, "Whether to use HTTP exporter rather than a gRPC one")
 
 	// custom headers

--- a/cmd/telemetrygen/internal/logs/exporter.go
+++ b/cmd/telemetrygen/internal/logs/exporter.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog/plogotlp"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/metadata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
 )
@@ -23,8 +24,6 @@ type exporter interface {
 }
 
 func newExporter(cfg *Config) (exporter, error) {
-
-	// Exporter with HTTP
 	if cfg.UseHTTP {
 		if cfg.Insecure {
 			return &httpClientExporter{
@@ -60,16 +59,22 @@ func newExporter(cfg *Config) (exporter, error) {
 			return nil, err
 		}
 	}
-	return &gRPCClientExporter{client: plogotlp.NewGRPCClient(clientConn)}, nil
+	return &gRPCClientExporter{client: plogotlp.NewGRPCClient(clientConn), cfg: cfg}, nil
 }
 
 type gRPCClientExporter struct {
 	client plogotlp.GRPCClient
+	cfg    *Config
 }
 
 func (e *gRPCClientExporter) export(logs plog.Logs) error {
+	md := metadata.New(map[string]string{})
+	for k, v := range e.cfg.Headers {
+		md.Set(k, v)
+	}
+	ctx := metadata.NewOutgoingContext(context.Background(), md)
 	req := plogotlp.NewExportRequestFromLogs(logs)
-	if _, err := e.client.Export(context.Background(), req); err != nil {
+	if _, err := e.client.Export(ctx, req); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**Description:** <Describe what has changed.>
So far, sending (HTTP) headers along with gRPC requests hasn't been possible.
For that reason, sending bearer tokens for authentication didn't work either.

This is fixed now.

Updated version of #30082
cc @mx-psi 