### PR TITLE
[receiver/k8scluster] Fix container state metadata

### DIFF
--- a/.chloggen/containermeta.yaml
+++ b/.chloggen/containermeta.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix container state metadata
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32676]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -55,6 +55,7 @@ func Transform(pod *corev1.Pod) *corev1.Pod {
 			ContainerID:          cs.ContainerID,
 			RestartCount:         cs.RestartCount,
 			Ready:                cs.Ready,
+			State:                cs.State,
 			LastTerminationState: cs.LastTerminationState,
 		})
 	}

--- a/receiver/k8sclusterreceiver/internal/pod/pods_test.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods_test.go
@@ -348,6 +348,7 @@ func podWithOwnerReference(kind string) *corev1.Pod {
 }
 
 func TestTransform(t *testing.T) {
+	containerState := corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: v1.Now()}}
 	originalPod := &corev1.Pod{
 		ObjectMeta: v1.ObjectMeta{
 			Name:      "my-pod",
@@ -429,7 +430,7 @@ func TestTransform(t *testing.T) {
 					ContainerID:  "abc12345",
 					RestartCount: 2,
 					Ready:        true,
-					State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: v1.Now()}},
+					State:        containerState,
 				},
 			},
 		},
@@ -470,6 +471,7 @@ func TestTransform(t *testing.T) {
 					ContainerID:  "abc12345",
 					RestartCount: 2,
 					Ready:        true,
+					State:        containerState,
 				},
 			},
 		},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
The [transform](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/internal/pod/pods.go#L37) function is stripping out the container state which is needed in the container [GetMetadata](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/k8sclusterreceiver/internal/container/containers.go#L96)  

This PR adds the state field back.

**Link to tracking Issue:** <Issue number if applicable>
This PR fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32676

**Testing:** <Describe what testing was performed and which tests were added.>
Unit test and manual validation 

**Documentation:** <Describe the documentation added.>