### PR TITLE
WIP: prometheusremotewrite: Introduce pluggable conversion architecture

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -179,14 +179,15 @@ func (prwe *prwExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) er
 	case <-prwe.closeChan:
 		return errors.New("shutdown has been called")
 	default:
-
-		tsMap, err := prometheusremotewrite.FromMetrics(md, prwe.exporterSettings)
+		converter := prometheusremotewrite.NewPrometheusConverter()
+		err := converter.FromMetrics(md, prwe.exporterSettings)
+		timeSeries := converter.TimeSeries()
 		if err != nil {
 			prwe.telemetry.recordTranslationFailure(ctx)
-			prwe.settings.Logger.Debug("failed to translate metrics, exporting remaining metrics", zap.Error(err), zap.Int("translated", len(tsMap)))
+			prwe.settings.Logger.Debug("failed to translate metrics, exporting remaining metrics", zap.Error(err), zap.Int("translated", len(timeSeries)))
 		}
 
-		prwe.telemetry.recordTranslatedTimeSeries(ctx, len(tsMap))
+		prwe.telemetry.recordTranslatedTimeSeries(ctx, len(timeSeries))
 
 		var m []*prompb.MetricMetadata
 		if prwe.exporterSettings.SendMetadata {
@@ -194,7 +195,7 @@ func (prwe *prwExporter) PushMetrics(ctx context.Context, md pmetric.Metrics) er
 		}
 
 		// Call export even if a conversion error, since there may be points that were successfully converted.
-		return prwe.handleExport(ctx, tsMap, m)
+		return prwe.handleExport(ctx, timeSeries, m)
 	}
 }
 
@@ -210,14 +211,14 @@ func validateAndSanitizeExternalLabels(cfg *Config) (map[string]string, error) {
 	return sanitizedLabels, nil
 }
 
-func (prwe *prwExporter) handleExport(ctx context.Context, tsMap map[string]*prompb.TimeSeries, m []*prompb.MetricMetadata) error {
+func (prwe *prwExporter) handleExport(ctx context.Context, timeSeries []prompb.TimeSeries, m []*prompb.MetricMetadata) error {
 	// There are no metrics to export, so return.
-	if len(tsMap) == 0 {
+	if len(timeSeries) == 0 {
 		return nil
 	}
 
 	// Calls the helper function to convert and batch the TsMap to the desired format
-	requests, err := batchTimeSeries(tsMap, prwe.maxBatchSizeBytes, m)
+	requests, err := batchTimeSeries(timeSeries, prwe.maxBatchSizeBytes, m)
 	if err != nil {
 		return err
 	}

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -338,9 +338,9 @@ func TestNoMetricsNoError(t *testing.T) {
 
 func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 	// First we will construct a TimeSeries array from the testutils package
-	testmap := make(map[string]*prompb.TimeSeries)
+	var timeSeries []prompb.TimeSeries
 	if ts != nil {
-		testmap["test"] = ts
+		timeSeries = append(timeSeries, *ts)
 	}
 
 	cfg := createDefaultConfig().(*Config)
@@ -369,7 +369,7 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 		return err
 	}
 
-	return prwe.handleExport(context.Background(), testmap, nil)
+	return prwe.handleExport(context.Background(), timeSeries, nil)
 }
 
 type mockPRWTelemetry struct {
@@ -944,19 +944,16 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 	})
 	require.NotNil(t, prwe.wal)
 
-	ts1 := &prompb.TimeSeries{
+	ts1 := prompb.TimeSeries{
 		Labels:  []prompb.Label{{Name: "ts1l1", Value: "ts1k1"}},
 		Samples: []prompb.Sample{{Value: 1, Timestamp: 100}},
 	}
-	ts2 := &prompb.TimeSeries{
+	ts2 := prompb.TimeSeries{
 		Labels:  []prompb.Label{{Name: "ts2l1", Value: "ts2k1"}},
 		Samples: []prompb.Sample{{Value: 2, Timestamp: 200}},
 	}
-	tsMap := map[string]*prompb.TimeSeries{
-		"timeseries1": ts1,
-		"timeseries2": ts2,
-	}
-	errs := prwe.handleExport(ctx, tsMap, nil)
+	timeSeries := []prompb.TimeSeries{ts1, ts2}
+	errs := prwe.handleExport(ctx, timeSeries, nil)
 	assert.NoError(t, errs)
 	// Shutdown after we've written to the WAL. This ensures that our
 	// exported data in-flight will flushed flushed to the WAL before exiting.
@@ -988,12 +985,12 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 		reqs = append(reqs, req)
 	}
 	assert.Equal(t, 1, len(reqs))
-	// We MUST have 2 time series as were passed into tsMap.
+	// We MUST have 2 time series as were passed into timeSeries.
 	gotFromWAL := reqs[0]
 	assert.Equal(t, 2, len(gotFromWAL.Timeseries))
 	want := &prompb.WriteRequest{
 		Timeseries: orderBySampleTimestamp([]prompb.TimeSeries{
-			*ts1, *ts2,
+			ts1, ts2,
 		}),
 	}
 

--- a/exporter/prometheusremotewriteexporter/helper.go
+++ b/exporter/prometheusremotewriteexporter/helper.go
@@ -11,28 +11,28 @@ import (
 )
 
 // batchTimeSeries splits series into multiple batch write requests.
-func batchTimeSeries(tsMap map[string]*prompb.TimeSeries, maxBatchByteSize int, m []*prompb.MetricMetadata) ([]*prompb.WriteRequest, error) {
-	if len(tsMap) == 0 {
-		return nil, errors.New("invalid tsMap: cannot be empty map")
+func batchTimeSeries(timeSeries []prompb.TimeSeries, maxBatchByteSize int, m []*prompb.MetricMetadata) ([]*prompb.WriteRequest, error) {
+	if len(timeSeries) == 0 {
+		return nil, errors.New("invalid timeSeries: cannot be empty")
 	}
 
-	requests := make([]*prompb.WriteRequest, 0, len(tsMap)+len(m))
-	tsArray := make([]prompb.TimeSeries, 0, len(tsMap))
+	requests := make([]*prompb.WriteRequest, 0, len(timeSeries)+len(m))
+	tsArray := make([]prompb.TimeSeries, 0, len(timeSeries))
 	sizeOfCurrentBatch := 0
 
 	i := 0
-	for _, v := range tsMap {
-		sizeOfSeries := v.Size()
+	for _, ts := range timeSeries {
+		sizeOfSeries := ts.Size()
 
 		if sizeOfCurrentBatch+sizeOfSeries >= maxBatchByteSize {
 			wrapped := convertTimeseriesToRequest(tsArray)
 			requests = append(requests, wrapped)
 
-			tsArray = make([]prompb.TimeSeries, 0, len(tsMap)-i)
+			tsArray = make([]prompb.TimeSeries, 0, len(timeSeries)-i)
 			sizeOfCurrentBatch = 0
 		}
 
-		tsArray = append(tsArray, *v)
+		tsArray = append(tsArray, ts)
 		sizeOfCurrentBatch += sizeOfSeries
 		i++
 	}

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -21,34 +21,34 @@ func Test_batchTimeSeries(t *testing.T) {
 	ts1 := getTimeSeries(labels, sample1, sample2)
 	ts2 := getTimeSeries(labels, sample1, sample2, sample3)
 
-	tsMap1 := getTimeseriesMap([]*prompb.TimeSeries{})
-	tsMap2 := getTimeseriesMap([]*prompb.TimeSeries{ts1})
-	tsMap3 := getTimeseriesMap([]*prompb.TimeSeries{ts1, ts2})
+	timeSeries1 := []prompb.TimeSeries{}
+	timeSeries2 := []prompb.TimeSeries{*ts1}
+	timeSeries3 := []prompb.TimeSeries{*ts1, *ts2}
 
 	tests := []struct {
 		name                string
-		tsMap               map[string]*prompb.TimeSeries
+		timeSeries          []prompb.TimeSeries
 		maxBatchByteSize    int
 		numExpectedRequests int
 		returnErr           bool
 	}{
 		{
 			"no_timeseries",
-			tsMap1,
+			timeSeries1,
 			100,
 			-1,
 			true,
 		},
 		{
 			"normal_case",
-			tsMap2,
+			timeSeries2,
 			300,
 			1,
 			false,
 		},
 		{
 			"two_requests",
-			tsMap3,
+			timeSeries3,
 			300,
 			2,
 			false,
@@ -57,7 +57,7 @@ func Test_batchTimeSeries(t *testing.T) {
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			requests, err := batchTimeSeries(tt.tsMap, tt.maxBatchByteSize, nil)
+			requests, err := batchTimeSeries(tt.timeSeries, tt.maxBatchByteSize, nil)
 			if tt.returnErr {
 				assert.Error(t, err)
 				return

--- a/exporter/prometheusremotewriteexporter/testutil_test.go
+++ b/exporter/prometheusremotewriteexporter/testutil_test.go
@@ -4,7 +4,6 @@
 package prometheusremotewriteexporter
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
@@ -382,12 +381,4 @@ func getQuantiles(bounds []float64, values []float64) pmetric.SummaryDataPointVa
 	}
 
 	return quantiles
-}
-
-func getTimeseriesMap(timeseries []*prompb.TimeSeries) map[string]*prompb.TimeSeries {
-	tsMap := make(map[string]*prompb.TimeSeries)
-	for i, v := range timeseries {
-		tsMap[fmt.Sprintf("%s%d", "timeseries_name", i)] = v
-	}
-	return tsMap
 }

--- a/pkg/translator/prometheusremotewrite/common.go
+++ b/pkg/translator/prometheusremotewrite/common.go
@@ -1,0 +1,94 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
+
+import (
+	"errors"
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/multierr"
+
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+)
+
+// ConvertMetrics converts pmetric.Metrics to another metrics format via the converter.
+func ConvertMetrics(md pmetric.Metrics, settings Settings, converter MetricsConverter) (errs error) {
+	resourceMetricsSlice := md.ResourceMetrics()
+	for i := 0; i < resourceMetricsSlice.Len(); i++ {
+		resourceMetrics := resourceMetricsSlice.At(i)
+		resource := resourceMetrics.Resource()
+		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
+		// keep track of the most recent timestamp in the ResourceMetrics for
+		// use with the "target" info metric
+		var mostRecentTimestamp pcommon.Timestamp
+		for j := 0; j < scopeMetricsSlice.Len(); j++ {
+			metricSlice := scopeMetricsSlice.At(j).Metrics()
+
+			// TODO: decide if instrumentation library information should be exported as labels
+			for k := 0; k < metricSlice.Len(); k++ {
+				metric := metricSlice.At(k)
+				mostRecentTimestamp = maxTimestamp(mostRecentTimestamp, mostRecentTimestampInMetric(metric))
+
+				if !isValidAggregationTemporality(metric) {
+					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination for metric %q", metric.Name()))
+					continue
+				}
+
+				promName := prometheustranslator.BuildCompliantName(metric, settings.Namespace, settings.AddMetricSuffixes)
+
+				// handle individual metrics based on type
+				//exhaustive:enforce
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					dataPoints := metric.Gauge().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					errs = multierr.Append(errs, converter.AddGaugeNumberDataPoints(dataPoints, resource, settings, promName))
+				case pmetric.MetricTypeSum:
+					dataPoints := metric.Sum().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					errs = multierr.Append(errs, converter.AddSumNumberDataPoints(dataPoints, resource, metric, settings, promName))
+				case pmetric.MetricTypeHistogram:
+					dataPoints := metric.Histogram().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					errs = multierr.Append(errs, converter.AddHistogramDataPoints(dataPoints, resource, settings, promName))
+				case pmetric.MetricTypeExponentialHistogram:
+					dataPoints := metric.ExponentialHistogram().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					errs = multierr.Append(errs, converter.AddExponentialHistogramDataPoints(
+						dataPoints,
+						resource,
+						settings,
+						promName,
+					))
+				case pmetric.MetricTypeSummary:
+					dataPoints := metric.Summary().DataPoints()
+					if dataPoints.Len() == 0 {
+						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
+						break
+					}
+					errs = multierr.Append(errs, converter.AddSummaryDataPoints(dataPoints, resource, settings, promName))
+				default:
+					errs = multierr.Append(errs, errors.New("unsupported metric type"))
+				}
+			}
+		}
+		addResourceTargetInfo(resource, settings, mostRecentTimestamp, converter)
+	}
+
+	return
+}

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -106,8 +106,8 @@ func Test_isValidAggregationTemporality(t *testing.T) {
 	}
 }
 
-// TestPrometheusConverter_addSample verifies that prometheusConverter.addSample adds the sample to the correct time series.
-func TestPrometheusConverter_addSample(t *testing.T) {
+// TestPrometheusConverter_AddSample verifies that PrometheusConverter.AddSample adds the sample to the correct time series.
+func TestPrometheusConverter_AddSample(t *testing.T) {
 	type testCase struct {
 		metric pmetric.Metric
 		sample prompb.Sample
@@ -115,8 +115,8 @@ func TestPrometheusConverter_addSample(t *testing.T) {
 	}
 
 	t.Run("empty_case", func(t *testing.T) {
-		converter := newPrometheusConverter()
-		converter.addSample(nil, nil)
+		converter := NewPrometheusConverter()
+		converter.AddSample(nil, nil)
 		assert.Empty(t, converter.unique)
 		assert.Empty(t, converter.conflicts)
 	})
@@ -159,9 +159,9 @@ func TestPrometheusConverter_addSample(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			converter := newPrometheusConverter()
-			converter.addSample(&tt.testCase[0].sample, tt.testCase[0].labels)
-			converter.addSample(&tt.testCase[1].sample, tt.testCase[1].labels)
+			converter := NewPrometheusConverter()
+			converter.AddSample(&tt.testCase[0].sample, tt.testCase[0].labels)
+			converter.AddSample(&tt.testCase[1].sample, tt.testCase[1].labels)
 			assert.Exactly(t, tt.want, converter.unique)
 			assert.Empty(t, converter.conflicts)
 		})
@@ -382,8 +382,8 @@ func BenchmarkCreateAttributes(b *testing.B) {
 	}
 }
 
-// TestPrometheusConverter_addExemplars verifies that prometheusConverter.addExemplars adds exemplars correctly given bucket bounds data.
-func TestPrometheusConverter_addExemplars(t *testing.T) {
+// TestPrometheusConverter_AddExemplars verifies that PrometheusConverter.AddExemplars adds exemplars correctly given bucket bounds data.
+func TestPrometheusConverter_AddExemplars(t *testing.T) {
 	ts1 := getTimeSeries(
 		getPromLabels(label11, value11, label12, value12),
 		getSample(float64(intVal1), msTime1),
@@ -439,10 +439,10 @@ func TestPrometheusConverter_addExemplars(t *testing.T) {
 	// run tests
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			converter := &prometheusConverter{
+			converter := &PrometheusConverter{
 				unique: tt.orig,
 			}
-			converter.addExemplars(tt.dataPoint, tt.bucketBounds)
+			converter.AddExemplars(tt.dataPoint, tt.bucketBounds)
 			assert.Exactly(t, tt.want, converter.unique)
 		})
 	}
@@ -619,12 +619,12 @@ func TestAddResourceTargetInfo(t *testing.T) {
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
 			addResourceTargetInfo(tc.resource, tc.settings, tc.timestamp, converter)
 
 			if len(tc.wantLabels) == 0 || tc.settings.DisableTargetInfo {
-				assert.Empty(t, converter.timeSeries())
+				assert.Empty(t, converter.TimeSeries())
 				return
 			}
 
@@ -764,16 +764,16 @@ func TestPrometheusConverter_AddSummaryDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
-			converter.addSummaryDataPoints(
+			require.NoError(t, converter.AddSummaryDataPoints(
 				metric.Summary().DataPoints(),
 				pcommon.NewResource(),
 				Settings{
 					ExportCreatedMetric: true,
 				},
 				metric.Name(),
-			)
+			))
 
 			assert.Equal(t, tt.want(), converter.unique)
 			assert.Empty(t, converter.conflicts)
@@ -874,16 +874,16 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
-			converter.addHistogramDataPoints(
+			require.NoError(t, converter.AddHistogramDataPoints(
 				metric.Histogram().DataPoints(),
 				pcommon.NewResource(),
 				Settings{
 					ExportCreatedMetric: true,
 				},
 				metric.Name(),
-			)
+			))
 
 			assert.Equal(t, tt.want(), converter.unique)
 			assert.Empty(t, converter.conflicts)
@@ -892,7 +892,7 @@ func TestPrometheusConverter_AddHistogramDataPoints(t *testing.T) {
 }
 
 func TestPrometheusConverter_getOrCreateTimeSeries(t *testing.T) {
-	converter := newPrometheusConverter()
+	converter := NewPrometheusConverter()
 	lbls := []prompb.Label{
 		{
 			Name:  "key1",

--- a/pkg/translator/prometheusremotewrite/histograms.go
+++ b/pkg/translator/prometheusremotewrite/histograms.go
@@ -16,7 +16,7 @@ import (
 
 const defaultZeroThreshold = 1e-128
 
-func (c *prometheusConverter) addExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
+func (c *PrometheusConverter) AddExponentialHistogramDataPoints(dataPoints pmetric.ExponentialHistogramDataPointSlice,
 	resource pcommon.Resource, settings Settings, baseName string) error {
 	for x := 0; x < dataPoints.Len(); x++ {
 		pt := dataPoints.At(x)

--- a/pkg/translator/prometheusremotewrite/histograms_test.go
+++ b/pkg/translator/prometheusremotewrite/histograms_test.go
@@ -597,7 +597,7 @@ func validateNativeHistogramCount(t *testing.T, h prompb.Histogram) {
 	assert.Equal(t, want, actualCount, "native histogram count mismatch")
 }
 
-func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
+func TestPrometheusConverter_AddExponentialHistogramDataPoints(t *testing.T) {
 	tests := []struct {
 		name       string
 		metric     func() pmetric.Metric
@@ -738,8 +738,8 @@ func TestPrometheusConverter_addExponentialHistogramDataPoints(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
 
-			converter := newPrometheusConverter()
-			require.NoError(t, converter.addExponentialHistogramDataPoints(
+			converter := NewPrometheusConverter()
+			require.NoError(t, converter.AddExponentialHistogramDataPoints(
 				metric.ExponentialHistogram().DataPoints(),
 				pcommon.NewResource(),
 				Settings{},

--- a/pkg/translator/prometheusremotewrite/interface.go
+++ b/pkg/translator/prometheusremotewrite/interface.go
@@ -1,0 +1,26 @@
+package prometheusremotewrite
+
+import (
+	"github.com/prometheus/prometheus/prompb"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// MetricsConverter defines the interface for converters from OTel metrics.
+type MetricsConverter interface {
+	// AddSample adds a sample and returns the corresponding TimeSeries.
+	AddSample(*prompb.Sample, []prompb.Label) *prompb.TimeSeries
+	// AddExemplars adds exemplars.
+	AddExemplars(pmetric.HistogramDataPoint, []bucketBoundsData)
+	// AddGaugeNumberDataPoints adds Gauge metric data points.
+	AddGaugeNumberDataPoints(pmetric.NumberDataPointSlice, pcommon.Resource, Settings, string) error
+	// AddSumNumberDataPoints adds Sum metric data points.
+	AddSumNumberDataPoints(pmetric.NumberDataPointSlice, pcommon.Resource, pmetric.Metric, Settings, string) error
+	// AddSummaryDataPoints adds summary metric data points, each converted to len(QuantileValues) + 2 samples.
+	AddSummaryDataPoints(pmetric.SummaryDataPointSlice, pcommon.Resource, Settings, string) error
+	// AddHistogramDataPoints adds histogram metric data points, each converted to 2 + min(len(ExplicitBounds), len(BucketCount)) + 1 samples.
+	// It ignores extra buckets if len(ExplicitBounds) > len(BucketCounts).
+	AddHistogramDataPoints(pmetric.HistogramDataPointSlice, pcommon.Resource, Settings, string) error
+	// AddExponentialHistogramDataPoints adds exponential histogtram metric data points.
+	AddExponentialHistogramDataPoints(pmetric.ExponentialHistogramDataPointSlice, pcommon.Resource, Settings, string) error
+}

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw.go
@@ -4,17 +4,11 @@
 package prometheusremotewrite // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite"
 
 import (
-	"errors"
-	"fmt"
 	"sort"
 	"strconv"
 
 	"github.com/prometheus/prometheus/prompb"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"go.uber.org/multierr"
-
-	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
 )
 
 type Settings struct {
@@ -27,10 +21,14 @@ type Settings struct {
 }
 
 // FromMetrics converts pmetric.Metrics to Prometheus remote write format.
+//
+// Deprecated: FromMetrics exists for historical compatibility and should not be used.
+// Use instead PrometheusConverter.FromMetrics() and then PrometheusConverter.TimeSeries()
+// to obtain the Prometheus remote write format metrics.
 func FromMetrics(md pmetric.Metrics, settings Settings) (map[string]*prompb.TimeSeries, error) {
-	c := newPrometheusConverter()
-	errs := c.fromMetrics(md, settings)
-	tss := c.timeSeries()
+	c := NewPrometheusConverter()
+	errs := c.FromMetrics(md, settings)
+	tss := c.TimeSeries()
 	out := make(map[string]*prompb.TimeSeries, len(tss))
 	for i := range tss {
 		out[strconv.Itoa(i)] = &tss[i]
@@ -39,100 +37,26 @@ func FromMetrics(md pmetric.Metrics, settings Settings) (map[string]*prompb.Time
 	return out, errs
 }
 
-// prometheusConverter converts from OTel write format to Prometheus write format.
-type prometheusConverter struct {
+// PrometheusConverter converts from OTel write format to Prometheus write format.
+type PrometheusConverter struct {
 	unique    map[uint64]*prompb.TimeSeries
 	conflicts map[uint64][]*prompb.TimeSeries
 }
 
-func newPrometheusConverter() *prometheusConverter {
-	return &prometheusConverter{
+func NewPrometheusConverter() *PrometheusConverter {
+	return &PrometheusConverter{
 		unique:    map[uint64]*prompb.TimeSeries{},
 		conflicts: map[uint64][]*prompb.TimeSeries{},
 	}
 }
 
-// fromMetrics converts pmetric.Metrics to Prometheus remote write format.
-func (c *prometheusConverter) fromMetrics(md pmetric.Metrics, settings Settings) (errs error) {
-	resourceMetricsSlice := md.ResourceMetrics()
-	for i := 0; i < resourceMetricsSlice.Len(); i++ {
-		resourceMetrics := resourceMetricsSlice.At(i)
-		resource := resourceMetrics.Resource()
-		scopeMetricsSlice := resourceMetrics.ScopeMetrics()
-		// keep track of the most recent timestamp in the ResourceMetrics for
-		// use with the "target" info metric
-		var mostRecentTimestamp pcommon.Timestamp
-		for j := 0; j < scopeMetricsSlice.Len(); j++ {
-			metricSlice := scopeMetricsSlice.At(j).Metrics()
-
-			// TODO: decide if instrumentation library information should be exported as labels
-			for k := 0; k < metricSlice.Len(); k++ {
-				metric := metricSlice.At(k)
-				mostRecentTimestamp = maxTimestamp(mostRecentTimestamp, mostRecentTimestampInMetric(metric))
-
-				if !isValidAggregationTemporality(metric) {
-					errs = multierr.Append(errs, fmt.Errorf("invalid temporality and type combination for metric %q", metric.Name()))
-					continue
-				}
-
-				promName := prometheustranslator.BuildCompliantName(metric, settings.Namespace, settings.AddMetricSuffixes)
-
-				// handle individual metrics based on type
-				//exhaustive:enforce
-				switch metric.Type() {
-				case pmetric.MetricTypeGauge:
-					dataPoints := metric.Gauge().DataPoints()
-					if dataPoints.Len() == 0 {
-						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
-						break
-					}
-					c.addGaugeNumberDataPoints(dataPoints, resource, settings, promName)
-				case pmetric.MetricTypeSum:
-					dataPoints := metric.Sum().DataPoints()
-					if dataPoints.Len() == 0 {
-						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
-						break
-					}
-					c.addSumNumberDataPoints(dataPoints, resource, metric, settings, promName)
-				case pmetric.MetricTypeHistogram:
-					dataPoints := metric.Histogram().DataPoints()
-					if dataPoints.Len() == 0 {
-						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
-						break
-					}
-					c.addHistogramDataPoints(dataPoints, resource, settings, promName)
-				case pmetric.MetricTypeExponentialHistogram:
-					dataPoints := metric.ExponentialHistogram().DataPoints()
-					if dataPoints.Len() == 0 {
-						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
-						break
-					}
-					errs = multierr.Append(errs, c.addExponentialHistogramDataPoints(
-						dataPoints,
-						resource,
-						settings,
-						promName,
-					))
-				case pmetric.MetricTypeSummary:
-					dataPoints := metric.Summary().DataPoints()
-					if dataPoints.Len() == 0 {
-						errs = multierr.Append(errs, fmt.Errorf("empty data points. %s is dropped", metric.Name()))
-						break
-					}
-					c.addSummaryDataPoints(dataPoints, resource, settings, promName)
-				default:
-					errs = multierr.Append(errs, errors.New("unsupported metric type"))
-				}
-			}
-		}
-		addResourceTargetInfo(resource, settings, mostRecentTimestamp, c)
-	}
-
-	return
+// FromMetrics converts pmetric.Metrics to Prometheus remote write format.
+func (c *PrometheusConverter) FromMetrics(md pmetric.Metrics, settings Settings) error {
+	return ConvertMetrics(md, settings, c)
 }
 
-// timeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
-func (c *prometheusConverter) timeSeries() []prompb.TimeSeries {
+// TimeSeries returns a slice of the prompb.TimeSeries that were converted from OTel format.
+func (c *PrometheusConverter) TimeSeries() []prompb.TimeSeries {
 	conflicts := 0
 	for _, ts := range c.conflicts {
 		conflicts += len(ts)
@@ -162,9 +86,9 @@ func isSameMetric(ts *prompb.TimeSeries, lbls []prompb.Label) bool {
 	return true
 }
 
-// addExemplars adds exemplars for the dataPoint. For each exemplar, if it can find a bucket bound corresponding to its value,
+// AddExemplars adds exemplars for the dataPoint. For each exemplar, if it can find a bucket bound corresponding to its value,
 // the exemplar is added to the bucket bound's time series, provided that the time series' has samples.
-func (c *prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
+func (c *PrometheusConverter) AddExemplars(dataPoint pmetric.HistogramDataPoint, bucketBounds []bucketBoundsData) {
 	if len(bucketBounds) == 0 {
 		return
 	}
@@ -185,11 +109,11 @@ func (c *prometheusConverter) addExemplars(dataPoint pmetric.HistogramDataPoint,
 	}
 }
 
-// addSample finds a TimeSeries that corresponds to lbls, and adds sample to it.
+// AddSample finds a TimeSeries that corresponds to lbls, and adds sample to it.
 // If there is no corresponding TimeSeries already, it's created.
 // The corresponding TimeSeries is returned.
 // If either lbls is nil/empty or sample is nil, nothing is done.
-func (c *prometheusConverter) addSample(sample *prompb.Sample, lbls []prompb.Label) *prompb.TimeSeries {
+func (c *PrometheusConverter) AddSample(sample *prompb.Sample, lbls []prompb.Label) *prompb.TimeSeries {
 	if sample == nil || len(lbls) == 0 {
 		// This shouldn't happen
 		return nil

--- a/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
+++ b/pkg/translator/prometheusremotewrite/metrics_to_prw_test.go
@@ -72,9 +72,9 @@ func BenchmarkPrometheusConverter_FromMetrics(b *testing.B) {
 											payload := createExportRequest(resourceAttributeCount, histogramCount, nonHistogramCount, labelsPerMetric, exemplarsPerSeries)
 
 											for i := 0; i < b.N; i++ {
-												converter := newPrometheusConverter()
-												require.NoError(b, converter.fromMetrics(payload.Metrics(), Settings{}))
-												require.NotNil(b, converter.timeSeries())
+												converter := NewPrometheusConverter()
+												require.NoError(b, converter.FromMetrics(payload.Metrics(), Settings{}))
+												require.NotNil(b, converter.TimeSeries())
 											}
 										})
 									}

--- a/pkg/translator/prometheusremotewrite/number_data_points_test.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
-func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
+func TestPrometheusConverter_AddGaugeNumberDataPoints(t *testing.T) {
 	ts := uint64(time.Now().UnixNano())
 	tests := []struct {
 		name   string
@@ -50,14 +51,14 @@ func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
-			converter.addGaugeNumberDataPoints(
+			require.NoError(t, converter.AddGaugeNumberDataPoints(
 				metric.Gauge().DataPoints(),
 				pcommon.NewResource(),
 				Settings{},
 				metric.Name(),
-			)
+			))
 
 			assert.Equal(t, tt.want(), converter.unique)
 			assert.Empty(t, converter.conflicts)
@@ -65,7 +66,7 @@ func TestPrometheusConverter_addGaugeNumberDataPoints(t *testing.T) {
 	}
 }
 
-func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
+func TestPrometheusConverter_AddSumNumberDataPoints(t *testing.T) {
 	ts := pcommon.Timestamp(time.Now().UnixNano())
 	tests := []struct {
 		name   string
@@ -224,15 +225,15 @@ func TestPrometheusConverter_addSumNumberDataPoints(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			metric := tt.metric()
-			converter := newPrometheusConverter()
+			converter := NewPrometheusConverter()
 
-			converter.addSumNumberDataPoints(
+			require.NoError(t, converter.AddSumNumberDataPoints(
 				metric.Sum().DataPoints(),
 				pcommon.NewResource(),
 				metric,
 				Settings{ExportCreatedMetric: true},
 				metric.Name(),
-			)
+			))
 
 			assert.Equal(t, tt.want(), converter.unique)
 			assert.Empty(t, converter.conflicts)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Expose the `pkg/translator/prometheusremotewrite.prometheusConverter` type, as an implementation of new interface `pkg/translator/prometheusremotewrite.MetricsConverter`.

The purpose of the `MetricsConverter` interface is to facilitate converters for Prometheus compatible systems such as Grafana Mimir/Thanos/Cortex, with partially shared implementation (the `ConvertMetrics` and `addResourceTargetInfo` functions). The conversion methods for the different metric types are not shared, in order to achieve optimal performance.

**Link to tracking Issue:** #32666

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>