### PR TITLE
[chore] Add @carsonip as a codeowner for elasticsearchexporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,7 +51,7 @@ exporter/clickhouseexporter/                             @open-telemetry/collect
 exporter/coralogixexporter/                              @open-telemetry/collector-contrib-approvers @povilasv @matej-g
 exporter/datadogexporter/                                @open-telemetry/collector-contrib-approvers @mx-psi @dineshg13 @liustanley @songy23 @mackjmr
 exporter/datasetexporter/                                @open-telemetry/collector-contrib-approvers @atoulme @martin-majlis-s1 @zdaratom-s1 @tomaz-s1
-exporter/elasticsearchexporter/                          @open-telemetry/collector-contrib-approvers @JaredTan95 @ycombinator
+exporter/elasticsearchexporter/                          @open-telemetry/collector-contrib-approvers @JaredTan95 @ycombinator @carsonip
 exporter/fileexporter/                                   @open-telemetry/collector-contrib-approvers @atingchen
 exporter/googlecloudexporter/                            @open-telemetry/collector-contrib-approvers @aabmass @dashpole @jsuereth @punya @damemi @psx95
 exporter/googlecloudpubsubexporter/                      @open-telemetry/collector-contrib-approvers @alexvanboxel

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: traces, logs   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Felasticsearch%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Felasticsearch) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Felasticsearch%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Felasticsearch) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@JaredTan95](https://www.github.com/JaredTan95), [@ycombinator](https://www.github.com/ycombinator) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@JaredTan95](https://www.github.com/JaredTan95), [@ycombinator](https://www.github.com/ycombinator), [@carsonip](https://www.github.com/carsonip) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -7,7 +7,7 @@ status:
     beta: [traces, logs]
   distributions: [contrib]
   codeowners:
-    active: [JaredTan95, ycombinator]
+    active: [JaredTan95, ycombinator, carsonip]
 
 tests:
   config:


### PR DESCRIPTION
**Description:**

This PR proposes adding @carsonip as a codeowner for the elasticsearch exporter component, being an employee of Elastic and also meeting the codeowner requirements:

- Be a member of the OpenTelemetry organization.
    - https://github.com/orgs/open-telemetry/people?query=carsonip
- (Code Owner Discretion) It is best to have resolved an issue related to the component, contributed directly to the component, and/or review component PRs. How much interaction with the component is required before becoming a Code Owner is up to any existing Code Owners. 
    - #32221 
    - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32585
    - https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32359

cc @JaredTan95 @ycombinator the existing codeowners of elasticsearchexporter