### PR TITLE
chore: [receiver/kafka] docs add example of connecting to kafka with sasl +tls

### DIFF
--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -107,8 +107,8 @@ receivers:
         username: "user"
         password: "secret"
         mechanism: "SCRAM-SHA-512"
-    tls:
-      insecure: false
+      tls:
+        insecure: false
 ```
 Example of header extraction:
 

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -89,6 +89,7 @@ The following settings can be optionally configured:
   - `extract_headers` (default = false): Allows user to attach header fields to resource attributes in otel piepline
   - `headers` (default = []): List of headers they'd like to extract from kafka record. 
   **Note: Matching pattern will be `exact`. Regexes are not supported as of now.** 
+
 Example:
 
 ```yaml
@@ -96,7 +97,19 @@ receivers:
   kafka:
     protocol_version: 2.0.0
 ```
+Example of connecting to kafka using sasl and TLS:
 
+```yaml
+receivers:
+  kafka:
+    auth:
+      sasl:
+        username: "user"
+        password: "secret"
+        mechanism: "SCRAM-SHA-512"
+    tls:
+      insecure: false
+```
 Example of header extraction:
 
 ```yaml


### PR DESCRIPTION
**Description:** 

Adding an example on how to connect to kafka that needs both tls and sasl config.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31931

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>