### PR TITLE
[exporter/loadbalacing] Add support for new streamID routing

### DIFF
--- a/.chloggen/loadbalacingexporter-update-metric-routing-options.yaml
+++ b/.chloggen/loadbalacingexporter-update-metric-routing-options.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: loadbalancingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds a new streamID routingKey, which will route based on the datapoint ID. See updated README for details"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32513]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -1159,3 +1159,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/acke
 replace github.com/open-telemetry/opentelemetry-collector-contrib/connector/grafanacloudconnector => ../../connector/grafanacloudconnector
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/sumologicextension => ../../extension/sumologicextension
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ../../internal/exp/metrics

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -17,6 +17,15 @@ const (
 	svcRouting
 	metricNameRouting
 	resourceRouting
+	streamIDRouting
+)
+
+const (
+	svcRoutingStr        = "service"
+	traceIDRoutingStr    = "traceID"
+	metricNameRoutingStr = "metric"
+	resourceRoutingStr   = "resource"
+	streamIDRoutingStr   = "streamID"
 )
 
 // Config defines configuration for the exporter.

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -6,8 +6,11 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.29.6
 	github.com/aws/smithy-go v1.20.2
+	github.com/json-iterator/go v1.1.12
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.99.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.99.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.99.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/collector/component v0.99.0
@@ -23,6 +26,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.29.3
 	k8s.io/apimachinery v0.29.3
 	k8s.io/client-go v0.29.3
@@ -70,7 +74,6 @@ require (
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.4 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
@@ -152,7 +155,6 @@ require (
 	google.golang.org/grpc v1.63.2 // indirect
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
@@ -175,3 +177,7 @@ retract (
 replace cloud.google.com/go v0.65.0 => cloud.google.com/go v0.110.10
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.29.6
 	github.com/aws/smithy-go v1.20.2
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.99.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal v0.99.0
 	github.com/stretchr/testify v1.9.0
 	go.opencensus.io v0.24.0
@@ -43,7 +44,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.28.6 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
-	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
@@ -82,6 +83,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.99.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
@@ -161,6 +163,8 @@ require (
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal => ../../pkg/batchpersignal
 
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ../../internal/exp/metrics
+
 retract (
 	v0.76.2
 	v0.76.1
@@ -169,3 +173,5 @@ retract (
 
 // ambiguous import: found package cloud.google.com/go/compute/metadata in multiple modules
 replace cloud.google.com/go v0.65.0 => cloud.google.com/go v0.110.10
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil

--- a/exporter/loadbalancingexporter/go.sum
+++ b/exporter/loadbalancingexporter/go.sum
@@ -167,8 +167,10 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.99.0 h1:773dRpLIpySHFwejaGl8cPbyf1Q2jwhMOgJjDPSqQj0=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.99.0/go.mod h1:PXpmpyK6VWoq1zb5ltUZxqSEpuBpFsY5WmlInpNiDUI=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.99.0 h1:UasccXIsMcNGsGuyft5N7C1vvzRmQCYHWVXF7YBcY/I=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.99.0/go.mod h1:v9snZu986K9CFjBYeYMwYs2hyqfTiOgLZDw5qphiObI=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.99.0 h1:EEgERxtXvEIhtHtC7kWbRmfX5LWNIBQqx0RI70r1bfw=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.99.0/go.mod h1:5KimRKjmPn++ylvv00qpVnaInTejqcrrYlZ24pCiymQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/exporter/loadbalancingexporter/go.sum
+++ b/exporter/loadbalancingexporter/go.sum
@@ -33,8 +33,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
-github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
@@ -167,6 +167,8 @@ github.com/onsi/ginkgo/v2 v2.14.0 h1:vSmGj2Z5YPb9JwCWT6z6ihcUvDhuXLc3sJiqd3jMKAY
 github.com/onsi/ginkgo/v2 v2.14.0/go.mod h1:JkUdW7JkN0V6rFvsHcJ478egV3XH9NxpD27Hal/PhZw=
 github.com/onsi/gomega v1.30.0 h1:hvMK7xYz4D3HapigLTeGdId/NcfQx1VHMJc60ew99+8=
 github.com/onsi/gomega v1.30.0/go.mod h1:9sxs+SwGrKI0+PWe4Fxa9tFQQBG5xSsSbMXOI8PPpoQ=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.99.0 h1:773dRpLIpySHFwejaGl8cPbyf1Q2jwhMOgJjDPSqQj0=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.99.0/go.mod h1:PXpmpyK6VWoq1zb5ltUZxqSEpuBpFsY5WmlInpNiDUI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/exporter/loadbalancingexporter/helpers.go
+++ b/exporter/loadbalancingexporter/helpers.go
@@ -4,7 +4,6 @@
 package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter"
 
 import (
-	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
@@ -63,61 +62,4 @@ func mergeTraces(t1 ptrace.Traces, t2 ptrace.Traces) ptrace.Traces {
 	}
 
 	return mergedTraces
-}
-
-// mergeMetrics concatenates two pmetric.Metrics into a single pmetric.Metrics.
-func mergeMetrics(m1 pmetric.Metrics, m2 pmetric.Metrics) pmetric.Metrics {
-	mergedMetrics := pmetric.NewMetrics()
-
-	if m1.MetricCount() == 0 && m2.MetricCount() == 0 {
-		return mergedMetrics
-	}
-
-	// Iterate over the first metric and append metrics to the merged metrics
-	for i := 0; i < m1.ResourceMetrics().Len(); i++ {
-		rs := m1.ResourceMetrics().At(i)
-		newRS := mergedMetrics.ResourceMetrics().AppendEmpty()
-
-		rs.Resource().MoveTo(newRS.Resource())
-		newRS.SetSchemaUrl(rs.SchemaUrl())
-
-		for j := 0; j < rs.ScopeMetrics().Len(); j++ {
-			ils := rs.ScopeMetrics().At(j)
-
-			newILS := newRS.ScopeMetrics().AppendEmpty()
-			ils.Scope().MoveTo(newILS.Scope())
-			newILS.SetSchemaUrl(ils.SchemaUrl())
-
-			for k := 0; k < ils.Metrics().Len(); k++ {
-				metric := ils.Metrics().At(k)
-				newMetric := newILS.Metrics().AppendEmpty()
-				metric.MoveTo(newMetric)
-			}
-		}
-	}
-
-	// Iterate over the second metric and append metrics to the merged metrics
-	for i := 0; i < m2.ResourceMetrics().Len(); i++ {
-		rs := m2.ResourceMetrics().At(i)
-		newRS := mergedMetrics.ResourceMetrics().AppendEmpty()
-
-		rs.Resource().MoveTo(newRS.Resource())
-		newRS.SetSchemaUrl(rs.SchemaUrl())
-
-		for j := 0; j < rs.ScopeMetrics().Len(); j++ {
-			ils := rs.ScopeMetrics().At(j)
-
-			newILS := newRS.ScopeMetrics().AppendEmpty()
-			ils.Scope().MoveTo(newILS.Scope())
-			newILS.SetSchemaUrl(ils.SchemaUrl())
-
-			for k := 0; k < ils.Metrics().Len(); k++ {
-				metric := ils.Metrics().At(k)
-				newMetric := newILS.Metrics().AppendEmpty()
-				metric.MoveTo(newMetric)
-			}
-		}
-	}
-
-	return mergedMetrics
 }

--- a/exporter/loadbalancingexporter/helpers_test.go
+++ b/exporter/loadbalancingexporter/helpers_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 )
@@ -66,60 +65,6 @@ func TestMergeTraces(t *testing.T) {
 	require.Equal(t, expectedTraces, mergedTraces)
 }
 
-func TestMergeMetricsTwoEmpty(t *testing.T) {
-	expectedEmpty := pmetric.NewMetrics()
-	metric1 := pmetric.NewMetrics()
-	metric2 := pmetric.NewMetrics()
-
-	mergedMetrics := mergeMetrics(metric1, metric2)
-
-	require.Equal(t, expectedEmpty, mergedMetrics)
-}
-
-func TestMergeMetricsSingleEmpty(t *testing.T) {
-	expectedMetrics := simpleMetricsWithResource()
-
-	metric1 := pmetric.NewMetrics()
-	metric2 := simpleMetricsWithResource()
-
-	mergedMetrics := mergeMetrics(metric1, metric2)
-
-	require.Equal(t, expectedMetrics, mergedMetrics)
-}
-
-func TestMergeMetrics(t *testing.T) {
-	expectedMetrics := pmetric.NewMetrics()
-	expectedMetrics.ResourceMetrics().EnsureCapacity(3)
-	ametrics := expectedMetrics.ResourceMetrics().AppendEmpty()
-	ametrics.Resource().Attributes().PutStr(conventions.AttributeServiceName, "service-name-1")
-	ametrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("m1")
-	bmetrics := expectedMetrics.ResourceMetrics().AppendEmpty()
-	bmetrics.Resource().Attributes().PutStr(conventions.AttributeServiceName, "service-name-2")
-	bmetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("m1")
-	cmetrics := expectedMetrics.ResourceMetrics().AppendEmpty()
-	cmetrics.Resource().Attributes().PutStr(conventions.AttributeServiceName, "service-name-3")
-	cmetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("m2")
-
-	metric1 := pmetric.NewMetrics()
-	metric1.ResourceMetrics().EnsureCapacity(2)
-	m1ametrics := metric1.ResourceMetrics().AppendEmpty()
-	m1ametrics.Resource().Attributes().PutStr(conventions.AttributeServiceName, "service-name-1")
-	m1ametrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("m1")
-	m1bmetrics := metric1.ResourceMetrics().AppendEmpty()
-	m1bmetrics.Resource().Attributes().PutStr(conventions.AttributeServiceName, "service-name-2")
-	m1bmetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("m1")
-
-	metric2 := pmetric.NewMetrics()
-	metric2.ResourceMetrics().EnsureCapacity(1)
-	m2cmetrics := metric2.ResourceMetrics().AppendEmpty()
-	m2cmetrics.Resource().Attributes().PutStr(conventions.AttributeServiceName, "service-name-3")
-	m2cmetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetName("m2")
-
-	mergedMetrics := mergeMetrics(metric1, metric2)
-
-	require.Equal(t, expectedMetrics, mergedMetrics)
-}
-
 func benchMergeTraces(b *testing.B, tracesCount int) {
 	traces1 := ptrace.NewTraces()
 	traces2 := ptrace.NewTraces()
@@ -145,31 +90,4 @@ func BenchmarkMergeTraces_X500(b *testing.B) {
 
 func BenchmarkMergeTraces_X1000(b *testing.B) {
 	benchMergeTraces(b, 1000)
-}
-
-func benchMergeMetrics(b *testing.B, metricsCount int) {
-	metrics1 := pmetric.NewMetrics()
-	metrics2 := pmetric.NewMetrics()
-
-	for i := 0; i < metricsCount; i++ {
-		appendSimpleMetricWithID(metrics2.ResourceMetrics().AppendEmpty(), "metrics-2")
-	}
-
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		mergeMetrics(metrics1, metrics2)
-	}
-}
-
-func BenchmarkMergeMetrics_X100(b *testing.B) {
-	benchMergeMetrics(b, 100)
-}
-
-func BenchmarkMergeMetrics_X500(b *testing.B) {
-	benchMergeMetrics(b, 500)
-}
-
-func BenchmarkMergeMetrics_X1000(b *testing.B) {
-	benchMergeMetrics(b, 1000)
 }

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -7,8 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -18,17 +16,15 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/multierr"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 )
 
 var _ exporter.Metrics = (*metricExporterImp)(nil)
-
-type exporterMetrics map[*wrappedExporter]pmetric.Metrics
 
 type metricExporterImp struct {
 	loadBalancer *loadBalancer
@@ -52,13 +48,15 @@ func newMetricsExporter(params exporter.CreateSettings, cfg component.Config) (*
 	metricExporter := metricExporterImp{loadBalancer: lb, routingKey: svcRouting}
 
 	switch cfg.(*Config).RoutingKey {
-	case "service", "":
+	case svcRoutingStr, "":
 		// default case for empty routing key
 		metricExporter.routingKey = svcRouting
-	case "resource":
+	case resourceRoutingStr:
 		metricExporter.routingKey = resourceRouting
-	case "metric":
+	case metricNameRoutingStr:
 		metricExporter.routingKey = metricNameRouting
+	case streamIDRoutingStr:
+		metricExporter.routingKey = streamIDRouting
 	default:
 		return nil, fmt.Errorf("unsupported routing_key: %q", cfg.(*Config).RoutingKey)
 	}
@@ -82,52 +80,62 @@ func (e *metricExporterImp) Shutdown(ctx context.Context) error {
 }
 
 func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
-	batches := batchpersignal.SplitMetrics(md)
+	var batches map[string]pmetric.Metrics
 
-	exporterSegregatedMetrics := make(exporterMetrics)
-	endpoints := make(map[*wrappedExporter]string)
+	switch e.routingKey {
+	case svcRouting:
+		var err error
+		batches, err = splitMetricsByResourceServiceName(md)
+		if err != nil {
+			return err
+		}
+	case resourceRouting:
+		batches = splitMetricsByResourceID(md)
+	case metricNameRouting:
+		batches = splitMetricsByMetricName(md)
+	case streamIDRouting:
+		batches = splitMetricsByStreamID(md)
+	}
 
-	for _, batch := range batches {
-		routingIDs, err := routingIdentifiersFromMetrics(batch, e.routingKey)
+	// Now assign each batch to an exporter, and merge as we go
+	metricsByExporter := map[*wrappedExporter]pmetric.Metrics{}
+	exporterEndpoints := map[*wrappedExporter]string{}
+
+	for routingID, mds := range batches {
+		exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(routingID))
 		if err != nil {
 			return err
 		}
 
-		for rid := range routingIDs {
-			exp, endpoint, err := e.loadBalancer.exporterAndEndpoint([]byte(rid))
-			if err != nil {
-				return err
-			}
-
-			_, ok := exporterSegregatedMetrics[exp]
-			if !ok {
-				exp.consumeWG.Add(1)
-				exporterSegregatedMetrics[exp] = pmetric.NewMetrics()
-			}
-			exporterSegregatedMetrics[exp] = mergeMetrics(exporterSegregatedMetrics[exp], batch)
-
-			endpoints[exp] = endpoint
+		expMetrics, ok := metricsByExporter[exp]
+		if !ok {
+			exp.consumeWG.Add(1)
+			expMetrics = pmetric.NewMetrics()
+			metricsByExporter[exp] = expMetrics
+			exporterEndpoints[exp] = endpoint
 		}
+
+		metrics.Merge(expMetrics, mds)
 	}
 
 	var errs error
-
-	for exp, metrics := range exporterSegregatedMetrics {
+	for exp, mds := range metricsByExporter {
 		start := time.Now()
-		err := exp.ConsumeMetrics(ctx, metrics)
-		exp.consumeWG.Done()
+		err := exp.ConsumeMetrics(ctx, mds)
 		duration := time.Since(start)
+
+		exp.consumeWG.Done()
 		errs = multierr.Append(errs, err)
 
 		if err == nil {
 			_ = stats.RecordWithTags(
 				ctx,
-				[]tag.Mutator{tag.Upsert(endpointTagKey, endpoints[exp]), successTrueMutator},
+				[]tag.Mutator{tag.Upsert(endpointTagKey, exporterEndpoints[exp]), successTrueMutator},
 				mBackendLatency.M(duration.Milliseconds()))
 		} else {
 			_ = stats.RecordWithTags(
 				ctx,
-				[]tag.Mutator{tag.Upsert(endpointTagKey, endpoints[exp]), successFalseMutator},
+				[]tag.Mutator{tag.Upsert(endpointTagKey, exporterEndpoints[exp]), successFalseMutator},
 				mBackendLatency.M(duration.Milliseconds()))
 		}
 	}
@@ -135,90 +143,227 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 	return errs
 }
 
-func routingIdentifiersFromMetrics(mds pmetric.Metrics, key routingKey) (map[string]bool, error) {
-	ids := make(map[string]bool)
+func splitMetricsByResourceServiceName(md pmetric.Metrics) (map[string]pmetric.Metrics, error) {
+	results := map[string]pmetric.Metrics{}
 
-	// no need to test "empty labels"
-	// no need to test "empty resources"
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
 
-	rs := mds.ResourceMetrics()
-	if rs.Len() == 0 {
-		return nil, errors.New("empty resource metrics")
+		svc, ok := rm.Resource().Attributes().Get(conventions.AttributeServiceName)
+		if !ok {
+			return nil, errors.New("unable to get service name")
+		}
+
+		newMD := pmetric.NewMetrics()
+		rmClone := newMD.ResourceMetrics().AppendEmpty()
+		rm.CopyTo(rmClone)
+
+		key := svc.Str()
+		existing, ok := results[key]
+		if ok {
+			metrics.Merge(existing, newMD)
+		} else {
+			results[key] = newMD
+		}
 	}
 
-	ils := rs.At(0).ScopeMetrics()
-	if ils.Len() == 0 {
-		return nil, errors.New("empty scope metrics")
+	return results, nil
+}
+
+func splitMetricsByResourceID(md pmetric.Metrics) map[string]pmetric.Metrics {
+	results := map[string]pmetric.Metrics{}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+
+		newMD := pmetric.NewMetrics()
+		rmClone := newMD.ResourceMetrics().AppendEmpty()
+		rm.CopyTo(rmClone)
+
+		key := identity.OfResource(rm.Resource()).String()
+		existing, ok := results[key]
+		if ok {
+			metrics.Merge(existing, newMD)
+		} else {
+			results[key] = newMD
+		}
 	}
 
-	metrics := ils.At(0).Metrics()
-	if metrics.Len() == 0 {
-		return nil, errors.New("empty metrics")
-	}
+	return results
+}
 
-	for i := 0; i < rs.Len(); i++ {
-		resource := rs.At(i).Resource()
-		switch key {
-		default:
-		case svcRouting, traceIDRouting:
-			svc, ok := resource.Attributes().Get(conventions.AttributeServiceName)
-			if !ok {
-				return nil, errors.New("unable to get service name")
-			}
-			ids[svc.Str()] = true
-		case metricNameRouting:
-			sm := rs.At(i).ScopeMetrics()
-			for j := 0; j < sm.Len(); j++ {
-				metrics := sm.At(j).Metrics()
-				for k := 0; k < metrics.Len(); k++ {
-					md := metrics.At(k)
-					rKey := metricRoutingKey(md)
-					ids[rKey] = true
-				}
-			}
-		case resourceRouting:
-			sm := rs.At(i).ScopeMetrics()
-			for j := 0; j < sm.Len(); j++ {
-				metrics := sm.At(j).Metrics()
-				for k := 0; k < metrics.Len(); k++ {
-					md := metrics.At(k)
-					rKey := resourceRoutingKey(md, resource.Attributes())
-					ids[rKey] = true
+func splitMetricsByMetricName(md pmetric.Metrics) map[string]pmetric.Metrics {
+	results := map[string]pmetric.Metrics{}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+
+				newMD, mClone := cloneMetricWithoutType(rm, sm, m)
+				m.CopyTo(mClone)
+
+				key := m.Name()
+				existing, ok := results[key]
+				if ok {
+					metrics.Merge(existing, newMD)
+				} else {
+					results[key] = newMD
 				}
 			}
 		}
 	}
 
-	return ids, nil
-
+	return results
 }
 
-// maintain
-func sortedMapAttrs(attrs pcommon.Map) []string {
-	keys := make([]string, 0)
-	for k := range attrs.AsRaw() {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
+func splitMetricsByStreamID(md pmetric.Metrics) map[string]pmetric.Metrics {
+	results := map[string]pmetric.Metrics{}
 
-	attrsHash := make([]string, 0)
-	for _, k := range keys {
-		attrsHash = append(attrsHash, k)
-		if v, ok := attrs.Get(k); ok {
-			attrsHash = append(attrsHash, v.AsString())
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		res := rm.Resource()
+
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			scope := sm.Scope()
+
+			for k := 0; k < sm.Metrics().Len(); k++ {
+				m := sm.Metrics().At(k)
+				metricID := identity.OfResourceMetric(res, scope, m)
+
+				switch m.Type() {
+				case pmetric.MetricTypeGauge:
+					gauge := m.Gauge()
+
+					for l := 0; l < gauge.DataPoints().Len(); l++ {
+						dp := gauge.DataPoints().At(l)
+
+						newMD, mClone := cloneMetricWithoutType(rm, sm, m)
+						gaugeClone := mClone.SetEmptyGauge()
+
+						dpClone := gaugeClone.DataPoints().AppendEmpty()
+						dp.CopyTo(dpClone)
+
+						key := identity.OfStream(metricID, dp).String()
+						existing, ok := results[key]
+						if ok {
+							metrics.Merge(existing, newMD)
+						} else {
+							results[key] = newMD
+						}
+					}
+				case pmetric.MetricTypeSum:
+					sum := m.Sum()
+
+					for l := 0; l < sum.DataPoints().Len(); l++ {
+						dp := sum.DataPoints().At(l)
+
+						newMD, mClone := cloneMetricWithoutType(rm, sm, m)
+						sumClone := mClone.SetEmptySum()
+						sumClone.SetIsMonotonic(sum.IsMonotonic())
+						sumClone.SetAggregationTemporality(sum.AggregationTemporality())
+
+						dpClone := sumClone.DataPoints().AppendEmpty()
+						dp.CopyTo(dpClone)
+
+						key := identity.OfStream(metricID, dp).String()
+						existing, ok := results[key]
+						if ok {
+							metrics.Merge(existing, newMD)
+						} else {
+							results[key] = newMD
+						}
+					}
+				case pmetric.MetricTypeHistogram:
+					histogram := m.Histogram()
+
+					for l := 0; l < histogram.DataPoints().Len(); l++ {
+						dp := histogram.DataPoints().At(l)
+
+						newMD, mClone := cloneMetricWithoutType(rm, sm, m)
+						histogramClone := mClone.SetEmptyHistogram()
+						histogramClone.SetAggregationTemporality(histogram.AggregationTemporality())
+
+						dpClone := histogramClone.DataPoints().AppendEmpty()
+						dp.CopyTo(dpClone)
+
+						key := identity.OfStream(metricID, dp).String()
+						existing, ok := results[key]
+						if ok {
+							metrics.Merge(existing, newMD)
+						} else {
+							results[key] = newMD
+						}
+					}
+				case pmetric.MetricTypeExponentialHistogram:
+					expHistogram := m.ExponentialHistogram()
+
+					for l := 0; l < expHistogram.DataPoints().Len(); l++ {
+						dp := expHistogram.DataPoints().At(l)
+
+						newMD, mClone := cloneMetricWithoutType(rm, sm, m)
+						expHistogramClone := mClone.SetEmptyExponentialHistogram()
+						expHistogramClone.SetAggregationTemporality(expHistogram.AggregationTemporality())
+
+						dpClone := expHistogramClone.DataPoints().AppendEmpty()
+						dp.CopyTo(dpClone)
+
+						key := identity.OfStream(metricID, dp).String()
+						existing, ok := results[key]
+						if ok {
+							metrics.Merge(existing, newMD)
+						} else {
+							results[key] = newMD
+						}
+					}
+				case pmetric.MetricTypeSummary:
+					summary := m.Summary()
+
+					for l := 0; l < summary.DataPoints().Len(); l++ {
+						dp := summary.DataPoints().At(l)
+
+						newMD, mClone := cloneMetricWithoutType(rm, sm, m)
+						sumClone := mClone.SetEmptySummary()
+
+						dpClone := sumClone.DataPoints().AppendEmpty()
+						dp.CopyTo(dpClone)
+
+						key := identity.OfStream(metricID, dp).String()
+						existing, ok := results[key]
+						if ok {
+							metrics.Merge(existing, newMD)
+						} else {
+							results[key] = newMD
+						}
+					}
+				}
+			}
 		}
 	}
-	return attrsHash
+
+	return results
 }
 
-func resourceRoutingKey(md pmetric.Metric, attrs pcommon.Map) string {
-	attrsHash := sortedMapAttrs(attrs)
-	attrsHash = append(attrsHash, md.Name())
-	routingRef := strings.Join(attrsHash, "")
+func cloneMetricWithoutType(rm pmetric.ResourceMetrics, sm pmetric.ScopeMetrics, m pmetric.Metric) (md pmetric.Metrics, mClone pmetric.Metric) {
+	md = pmetric.NewMetrics()
 
-	return routingRef
-}
+	rmClone := md.ResourceMetrics().AppendEmpty()
+	rm.Resource().CopyTo(rmClone.Resource())
+	rmClone.SetSchemaUrl(rm.SchemaUrl())
 
-func metricRoutingKey(md pmetric.Metric) string {
-	return md.Name()
+	smClone := rmClone.ScopeMetrics().AppendEmpty()
+	sm.Scope().CopyTo(smClone.Scope())
+	smClone.SetSchemaUrl(sm.SchemaUrl())
+
+	mClone = smClone.Metrics().AppendEmpty()
+	mClone.SetName(m.Name())
+	mClone.SetDescription(m.Description())
+	mClone.SetUnit(m.Unit())
+
+	return md, mClone
 }

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/metric_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/metric_name/input.yaml
@@ -1,0 +1,77 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 945
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 1000
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/metric_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/metric_name/output.yaml
@@ -1,0 +1,51 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 945
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 1000
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_id/input.yaml
@@ -1,0 +1,55 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_id/output.yaml
@@ -1,0 +1,34 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_service_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_service_name/input.yaml
@@ -1,0 +1,55 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_service_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/resource_service_name/output.yaml
@@ -1,0 +1,34 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/stream_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/stream_id/input.yaml
@@ -1,0 +1,101 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/stream_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/single_endpoint/stream_id/output.yaml
@@ -1,0 +1,101 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/metric_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/metric_name/input.yaml
@@ -1,0 +1,99 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 945
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: third.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 945
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 1000
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: third.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 1000
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/metric_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/metric_name/output.yaml
@@ -1,0 +1,168 @@
+endpoint-1:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: third.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 945
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: third.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 1000
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+endpoint-2:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 444
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+endpoint-3:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 945
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 1000
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_id/input.yaml
@@ -1,0 +1,82 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: asdf
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 90
+                  asDouble: 666
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_id/output.yaml
@@ -1,0 +1,87 @@
+endpoint-1:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: asdf
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 90
+                    asDouble: 666
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+endpoint-2:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+endpoint-3:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/input.yaml
@@ -1,0 +1,82 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceB
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceC
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 90
+                  asDouble: 666
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/resource_service_name/output.yaml
@@ -1,0 +1,87 @@
+endpoint-1:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: serviceA
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: serviceB
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+endpoint-2:
+  resourceMetrics: []
+endpoint-3:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: serviceC
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 90
+                    asDouble: 666
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/stream_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/stream_id/input.yaml
@@ -1,0 +1,101 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc

--- a/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/stream_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/consume_metrics/triple_endpoint/stream_id/output.yaml
@@ -1,0 +1,123 @@
+endpoint-1:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 444
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 666
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+endpoint-2:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 666
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+endpoint-3:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 444
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_metric_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_metric_name/input.yaml
@@ -1,0 +1,77 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 945
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 945
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_metric_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_metric_name/output.yaml
@@ -1,0 +1,112 @@
+first.monotonic.sum:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+second.monotonic.sum:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 945
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 945
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_id/input.yaml
@@ -1,0 +1,55 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_id/output.yaml
@@ -1,0 +1,58 @@
+resource/99d9e3f8e25dd8f6:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+resource/561be85f9d0f9beb:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_service_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_service_name/input.yaml
@@ -1,0 +1,55 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceB
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_service_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_resource_service_name/output.yaml
@@ -1,0 +1,58 @@
+serviceA:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: serviceA
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+serviceB:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: serviceB
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_stream_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_stream_id/input.yaml
@@ -1,0 +1,101 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: first.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: second.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_stream_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/basic_stream_id/output.yaml
@@ -1,0 +1,209 @@
+stream/770305850f3632c4:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+stream/df3ac8f1f36e5836:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 444
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+stream/10f62caa42f23208:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+stream/a6cee13bcfa90742:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 666
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+stream/94a1b62d162da7e3:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: first.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 444
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+stream/33c7b4e4b72e9f19:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+stream/f1a737c32030b2ff:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: bar
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: second.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 666
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_metric_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_metric_name/input.yaml
@@ -1,0 +1,77 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 120
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 150
+                  asDouble: 945
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_metric_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_metric_name/output.yaml
@@ -1,0 +1,47 @@
+cumulative.monotonic.sum:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 444
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 120
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 150
+                    asDouble: 945
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_id/input.yaml
@@ -1,0 +1,55 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_id/output.yaml
@@ -1,0 +1,35 @@
+resource/99d9e3f8e25dd8f6:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_service_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_service_name/input.yaml
@@ -1,0 +1,55 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: service.name
+          value:
+            stringValue: serviceA
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_service_name/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_resource_service_name/output.yaml
@@ -1,0 +1,35 @@
+serviceA:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: service.name
+            value:
+              stringValue: serviceA
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_stream_id/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_stream_id/input.yaml
@@ -1,0 +1,119 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 444
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 60
+                  asDouble: 444
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 90
+                  asDouble: 555
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 70
+                  asDouble: 555
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 100
+                  asDouble: 666
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 666
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 110
+                  asDouble: 777
+                  attributes:
+                    - key: bbb
+                      value:
+                        stringValue: ccc

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_stream_id/output.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/duplicate_stream_id/output.yaml
@@ -1,0 +1,94 @@
+stream/c7006b564eec22c9:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 50
+                    asDouble: 333
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 60
+                    asDouble: 444
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 70
+                    asDouble: 555
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+                  - timeUnixNano: 80
+                    asDouble: 666
+                    attributes:
+                      - key: aaa
+                        value:
+                          stringValue: bbb
+stream/e2d32621d2dcda0f:
+  resourceMetrics:
+    - schemaUrl: https://test-res-schema.com/schema
+      resource:
+        attributes:
+          - key: resource_key
+            value:
+              stringValue: foo
+      scopeMetrics:
+        - schemaUrl: https://test-scope-schema.com/schema
+          scope:
+            name: MyTestInstrument
+            version: "1.2.3"
+            attributes:
+              - key: scope_key
+                value:
+                  stringValue: foo
+          metrics:
+            - name: cumulative.monotonic.sum
+              sum:
+                aggregationTemporality: 2
+                isMonotonic: true
+                dataPoints:
+                  - timeUnixNano: 80
+                    asDouble: 444
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+                  - timeUnixNano: 90
+                    asDouble: 555
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+                  - timeUnixNano: 100
+                    asDouble: 666
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc
+                  - timeUnixNano: 110
+                    asDouble: 777
+                    attributes:
+                      - key: bbb
+                        value:
+                          stringValue: ccc

--- a/exporter/loadbalancingexporter/testdata/metrics/split_metrics/missing_service_name/input.yaml
+++ b/exporter/loadbalancingexporter/testdata/metrics/split_metrics/missing_service_name/input.yaml
@@ -1,0 +1,28 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_label
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -49,9 +49,9 @@ func newTracesExporter(params exporter.CreateSettings, cfg component.Config) (*t
 	traceExporter := traceExporterImp{loadBalancer: lb, routingKey: traceIDRouting}
 
 	switch cfg.(*Config).RoutingKey {
-	case "service":
+	case svcRoutingStr:
 		traceExporter.routingKey = svcRouting
-	case "traceID", "":
+	case traceIDRoutingStr, "":
 	default:
 		return nil, fmt.Errorf("unsupported routing_key: %s", cfg.(*Config).RoutingKey)
 	}

--- a/go.mod
+++ b/go.mod
@@ -508,6 +508,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/datadog v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/docker v0.99.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.99.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/kafka v0.99.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1159,3 +1159,5 @@ replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/enco
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding/otlpencodingextension => ./extension/encoding/otlpencodingextension
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension => ./extension/ackextension
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics => ./internal/exp/metrics

--- a/internal/exp/metrics/metrics.go
+++ b/internal/exp/metrics/metrics.go
@@ -1,0 +1,120 @@
+package metrics
+
+import (
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/streams"
+)
+
+// Merge will merge the metrics data in mdB into mdA, then return mdA.
+// mdB will not be modified. The function will attempt to merge the data in mdB into
+// existing ResourceMetrics / ScopeMetrics / Metrics in mdA if possible. If they don't
+// exist, new entries will be created as needed.
+//
+// NOTE: Any "unnecessary" duplicate entries in mdA will *not* be combined. For example if
+// mdA contains two ResourcMetric entries with identical Resource values, they will not be
+// combined. If you wish to have this behavior, you could call this function twice:
+//
+//	cleanedMetrics := Merge(pmetric.NewMetrics(), mdA)
+//	Merge(cleanedMetrics, mdB)
+//
+// That said, this will do a large amount of memory copying
+func Merge(mdA pmetric.Metrics, mdB pmetric.Metrics) pmetric.Metrics {
+outer:
+	for i := 0; i < mdB.ResourceMetrics().Len(); i++ {
+		rmB := mdB.ResourceMetrics().At(i)
+		resourceIDB := identity.OfResource(rmB.Resource())
+
+		for j := 0; j < mdA.ResourceMetrics().Len(); j++ {
+			rmA := mdA.ResourceMetrics().At(j)
+			resourceIDA := identity.OfResource(rmA.Resource())
+
+			if resourceIDA == resourceIDB {
+				mergeResourceMetrics(resourceIDA, rmA, rmB)
+				continue outer
+			}
+		}
+
+		// We didn't find a match
+		// Add it to mdA
+		newRM := mdA.ResourceMetrics().AppendEmpty()
+		rmB.CopyTo(newRM)
+	}
+
+	return mdA
+}
+
+func mergeResourceMetrics(resourceID identity.Resource, rmA pmetric.ResourceMetrics, rmB pmetric.ResourceMetrics) pmetric.ResourceMetrics {
+outer:
+	for i := 0; i < rmB.ScopeMetrics().Len(); i++ {
+		smB := rmB.ScopeMetrics().At(i)
+		scopeIDB := identity.OfScope(resourceID, smB.Scope())
+
+		for j := 0; j < rmA.ScopeMetrics().Len(); j++ {
+			smA := rmA.ScopeMetrics().At(j)
+			scopeIDA := identity.OfScope(resourceID, smA.Scope())
+
+			if scopeIDA == scopeIDB {
+				mergeScopeMetrics(scopeIDA, smA, smB)
+				continue outer
+			}
+		}
+
+		// We didn't find a match
+		// Add it to rmA
+		newSM := rmA.ScopeMetrics().AppendEmpty()
+		smB.CopyTo(newSM)
+	}
+
+	return rmA
+}
+
+func mergeScopeMetrics(scopeID identity.Scope, smA pmetric.ScopeMetrics, smB pmetric.ScopeMetrics) pmetric.ScopeMetrics {
+outer:
+	for i := 0; i < smB.Metrics().Len(); i++ {
+		mB := smB.Metrics().At(i)
+		metricIDB := identity.OfMetric(scopeID, mB)
+
+		for j := 0; j < smA.Metrics().Len(); j++ {
+			mA := smA.Metrics().At(j)
+			metricIDA := identity.OfMetric(scopeID, mA)
+
+			if metricIDA == metricIDB {
+				switch mA.Type() {
+				case pmetric.MetricTypeGauge:
+					mergeDataPoints(mA.Gauge().DataPoints(), mB.Gauge().DataPoints())
+				case pmetric.MetricTypeSum:
+					mergeDataPoints(mA.Sum().DataPoints(), mB.Sum().DataPoints())
+				case pmetric.MetricTypeHistogram:
+					mergeDataPoints(mA.Histogram().DataPoints(), mB.Histogram().DataPoints())
+				case pmetric.MetricTypeExponentialHistogram:
+					mergeDataPoints(mA.ExponentialHistogram().DataPoints(), mB.ExponentialHistogram().DataPoints())
+				case pmetric.MetricTypeSummary:
+					mergeDataPoints(mA.Summary().DataPoints(), mB.Summary().DataPoints())
+				}
+
+				continue outer
+			}
+		}
+
+		// We didn't find a match
+		// Add it to smA
+		newM := smA.Metrics().AppendEmpty()
+		mB.CopyTo(newM)
+	}
+
+	return smA
+}
+
+func mergeDataPoints[DPS streams.DataPointSlice[DP], DP streams.DataPoint[DP]](dataPointsA DPS, dataPointsB DPS) DPS {
+	// Append all the datapoints from B to A
+	for i := 0; i < dataPointsB.Len(); i++ {
+		dpB := dataPointsB.At(i)
+
+		newDP := dataPointsA.AppendEmpty()
+		dpB.CopyTo(newDP)
+	}
+
+	return dataPointsA
+}

--- a/internal/exp/metrics/metrics_test.go
+++ b/internal/exp/metrics/metrics_test.go
@@ -1,0 +1,42 @@
+package metrics_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
+)
+
+func TestMergeMetrics(t *testing.T) {
+	t.Parallel()
+
+	testCases := []string{
+		"basic_merge",
+	}
+
+	for _, tc := range testCases {
+		testName := tc
+
+		t.Run(testName, func(t *testing.T) {
+			t.Parallel()
+
+			dir := filepath.Join("testdata", testName)
+
+			mdA, err := golden.ReadMetrics(filepath.Join(dir, "a.yaml"))
+			require.NoError(t, err)
+
+			mdB, err := golden.ReadMetrics(filepath.Join(dir, "b.yaml"))
+			require.NoError(t, err)
+
+			expectedOutput, err := golden.ReadMetrics(filepath.Join(dir, "output.yaml"))
+			require.NoError(t, err)
+
+			output := metrics.Merge(mdA, mdB)
+			require.NoError(t, pmetrictest.CompareMetrics(expectedOutput, output))
+		})
+	}
+}

--- a/internal/exp/metrics/streams/streams.go
+++ b/internal/exp/metrics/streams/streams.go
@@ -3,7 +3,11 @@
 
 package streams // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/streams"
 
-import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+import (
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+)
 
 // Sequence of streams that can be iterated upon
 type Seq[T any] func(yield func(identity.Stream, T) bool) bool
@@ -60,4 +64,16 @@ func (m HashMap[T]) Clear() {
 // the oldest, least active, etc.
 type Evictor interface {
 	Evict() identity.Stream
+}
+
+type DataPointSlice[DP DataPoint[DP]] interface {
+	Len() int
+	At(i int) DP
+	AppendEmpty() DP
+}
+
+type DataPoint[Self any] interface {
+	Timestamp() pcommon.Timestamp
+	Attributes() pcommon.Map
+	CopyTo(dest Self)
 }

--- a/internal/exp/metrics/testdata/basic_merge/a.yaml
+++ b/internal/exp/metrics/testdata/basic_merge/a.yaml
@@ -1,0 +1,28 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/internal/exp/metrics/testdata/basic_merge/b.yaml
+++ b/internal/exp/metrics/testdata/basic_merge/b.yaml
@@ -1,0 +1,120 @@
+resourceMetrics:
+  # The first entry is an identical resource metrics ID
+  # But different scope metrics ID
+  # And identical metric ID / stream data
+  # We should end up with a new scope metric entry
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: bar
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  # The next entry has a difference resource_key, but identical scope and metric ID / data
+  # We should end up with a new resource metric entry
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  # The next entry has identical resource and scope IDs
+  # But a different metric name / type
+  # We should get a new metric entry added to the original scope metric entry
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: delta.monotonic.sum
+            sum:
+              aggregationTemporality: 1
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  # The next entry has identical resource, scope, and metric IDs
+  # The metric datapoint should be added to the existing metric
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 80
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/internal/exp/metrics/testdata/basic_merge/output.yaml
+++ b/internal/exp/metrics/testdata/basic_merge/output.yaml
@@ -1,0 +1,92 @@
+resourceMetrics:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: foo
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+                - timeUnixNano: 80
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+          - name: delta.monotonic.sum
+            sum:
+              aggregationTemporality: 1
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: bar
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
+      attributes:
+        - key: resource_key
+          value:
+            stringValue: bar
+    scopeMetrics:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: "1.2.3"
+          attributes:
+            - key: scope_key
+              value:
+                stringValue: foo
+        metrics:
+          - name: cumulative.monotonic.sum
+            sum:
+              aggregationTemporality: 2
+              isMonotonic: true
+              dataPoints:
+                - timeUnixNano: 50
+                  asDouble: 333
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb


### PR DESCRIPTION
**Description:** This adds a new routing option for metrics: `streamID`. This routes datapoints based on their `streamID`. That's the unique hash of all it's attributes, plus the attributes and identifying information of its resource, scope, and metric data

Detailed change list:

* Created `const` string values for all the routingKey enums
  * To prevent fat-finger typos in code
* Refactored metricExporterImp::ConsumeMetrics()
  * Simplified the metrics splitting to be explicit functions, instead of doing generic splitting, and then flagging routing using a dict of bools
    *  If we had kept it as-is, I would have needed to further split by datapoint for `streamID` routing, but the other routingKey methods don't need that. And would just require more work in `MergeMetrics()`
* Added a new set of helper functions in `internal/exp/metrics`: `MergeMetrics()`
  * This will merge the metrics in mdB *into* mdA, trying to re-use resourceMetrics, scopeMetrics, and metric values as possible
    * This was a flaw in the previous `mergeMetrics()`
    * It would only append values, instead of trying to re-use existing resourceMetrics, scopeMetrics, and metric values
    * This meant that all downstream collectors would lose out on potentially lots of data deduplication, since there would be duplicate resourcMetrics, scopeMetrics, and metric instances

NOTE: The old `ConsumeMetrics()` used its own custom hashing function to create the key for `resource` routing. The new code uses `identity.OfResource()` from `internal/exp/metrics/identity`. The effect is the same, but the key will be different from before. So when a user updates to this code, the routing will be slightly different.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32513

**Testing:**

I added a new suite of tests for the splitting of metrics depending on the routingKey. I utilize `golden` so all input / output metric data can be declared in yaml, which is much easier to visually parse. Meaning we can have much more complicated / "real-life" data sets.

I updated the benchmarks to also test different numbers of resourceMetrics and scopeMetrics. So we can see how those affect routing times.

**Documentation:**

I updated the README to describe the new routingKey: `metricID`, and how it works