### PR TITLE
[processor/groupbytrace] Fix groupbytrace metrics contain duplicate prefix

### DIFF
--- a/.chloggen/fix_groupbytrace_contain_duplicate_prefix.yaml
+++ b/.chloggen/fix_groupbytrace_contain_duplicate_prefix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: groupbytraceprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix groupbytrace metrics contain duplicate prefix
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32698]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/groupbytraceprocessor/metrics.go
+++ b/processor/groupbytraceprocessor/metrics.go
@@ -13,14 +13,14 @@ import (
 )
 
 var (
-	mNumTracesConf      = stats.Int64("processor_groupbytrace_conf_num_traces", "Maximum number of traces to hold in the internal storage", stats.UnitDimensionless)
-	mNumEventsInQueue   = stats.Int64("processor_groupbytrace_num_events_in_queue", "Number of events currently in the queue", stats.UnitDimensionless)
-	mNumTracesInMemory  = stats.Int64("processor_groupbytrace_num_traces_in_memory", "Number of traces currently in the in-memory storage", stats.UnitDimensionless)
-	mTracesEvicted      = stats.Int64("processor_groupbytrace_traces_evicted", "Traces evicted from the internal buffer", stats.UnitDimensionless)
-	mReleasedSpans      = stats.Int64("processor_groupbytrace_spans_released", "Spans released to the next consumer", stats.UnitDimensionless)
-	mReleasedTraces     = stats.Int64("processor_groupbytrace_traces_released", "Traces released to the next consumer", stats.UnitDimensionless)
-	mIncompleteReleases = stats.Int64("processor_groupbytrace_incomplete_releases", "Releases that are suspected to have been incomplete", stats.UnitDimensionless)
-	mEventLatency       = stats.Int64("processor_groupbytrace_event_latency", "How long the queue events are taking to be processed", stats.UnitMilliseconds)
+	mNumTracesConf      = stats.Int64("conf_num_traces", "Maximum number of traces to hold in the internal storage", stats.UnitDimensionless)
+	mNumEventsInQueue   = stats.Int64("num_events_in_queue", "Number of events currently in the queue", stats.UnitDimensionless)
+	mNumTracesInMemory  = stats.Int64("num_traces_in_memory", "Number of traces currently in the in-memory storage", stats.UnitDimensionless)
+	mTracesEvicted      = stats.Int64("traces_evicted", "Traces evicted from the internal buffer", stats.UnitDimensionless)
+	mReleasedSpans      = stats.Int64("spans_released", "Spans released to the next consumer", stats.UnitDimensionless)
+	mReleasedTraces     = stats.Int64("traces_released", "Traces released to the next consumer", stats.UnitDimensionless)
+	mIncompleteReleases = stats.Int64("incomplete_releases", "Releases that are suspected to have been incomplete", stats.UnitDimensionless)
+	mEventLatency       = stats.Int64("event_latency", "How long the queue events are taking to be processed", stats.UnitMilliseconds)
 )
 
 // metricViews return the metrics views according to given telemetry level.


### PR DESCRIPTION
The actual metrics generated by groupbytrace have duplicate prefix `processor_groupbytrace`

error groupbytrace  metrics:
```
# HELP otelcol_processor_groupbytrace_processor_groupbytrace_incomplete_releases Releases that are suspected to have been incomplete
# TYPE otelcol_processor_groupbytrace_processor_groupbytrace_incomplete_releases counter
otelcol_processor_groupbytrace_processor_groupbytrace_incomplete_releases{service_instance_id="ac4299e2-8c43-47df-bdd6-90028fb39cd1",service_name="otelcontribcol",service_version="0.99.0-dev"} 0
# HELP otelcol_processor_groupbytrace_processor_groupbytrace_num_events_in_queue Number of events currently in the queue
# TYPE otelcol_processor_groupbytrace_processor_groupbytrace_num_events_in_queue gauge
otelcol_processor_groupbytrace_processor_groupbytrace_num_events_in_queue{service_instance_id="ac4299e2-8c43-47df-bdd6-90028fb39cd1",service_name="otelcontribcol",service_version="0.99.0-dev"} 0
# HELP otelcol_processor_groupbytrace_processor_groupbytrace_num_traces_in_memory Number of traces currently in the in-memory storage
# TYPE otelcol_processor_groupbytrace_processor_groupbytrace_num_traces_in_memory gauge
otelcol_processor_groupbytrace_processor_groupbytrace_num_traces_in_memory{service_instance_id="ac4299e2-8c43-47df-bdd6-90028fb39cd1",service_name="otelcontribcol",service_version="0.99.0-dev"} 0
# HELP otelcol_processor_groupbytrace_processor_groupbytrace_spans_released Spans released to the next consumer
# TYPE otelcol_processor_groupbytrace_processor_groupbytrace_spans_released counter
otelcol_processor_groupbytrace_processor_groupbytrace_spans_released{service_instance_id="ac4299e2-8c43-47df-bdd6-90028fb39cd1",service_name="otelcontribcol",service_version="0.99.0-dev"} 20
# HELP otelcol_processor_groupbytrace_processor_groupbytrace_traces_evicted Traces evicted from the internal buffer
# TYPE otelcol_processor_groupbytrace_processor_groupbytrace_traces_evicted counter
otelcol_processor_groupbytrace_processor_groupbytrace_traces_evicted{service_instance_id="ac4299e2-8c43-47df-bdd6-90028fb39cd1",service_name="otelcontribcol",service_version="0.99.0-dev"} 0
# HELP otelcol_processor_groupbytrace_processor_groupbytrace_traces_released Traces released to the next consumer
# TYPE otelcol_processor_groupbytrace_processor_groupbytrace_traces_released counter
otelcol_processor_groupbytrace_processor_groupbytrace_traces_released{service_instance_id="ac4299e2-8c43-47df-bdd6-90028fb39cd1",service_name="otelcontribcol",service_version="0.99.0-dev"} 10
```