### PR TITLE
[receiver/azureblob] Support service principal authentication for Azure Blob storage

### DIFF
--- a/.chloggen/azure-blob-service-principal-auth.yaml
+++ b/.chloggen/azure-blob-service-principal-auth.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureblobreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support service principal authentication for Blob storage
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/azure-blob-service-principal-auth.yaml
+++ b/.chloggen/azure-blob-service-principal-auth.yaml
@@ -10,7 +10,7 @@ component: azureblobreceiver
 note: Support service principal authentication for Blob storage
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [32705]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/configschema/go.mod
+++ b/cmd/configschema/go.mod
@@ -200,7 +200,7 @@ require (
 	github.com/Azure/azure-pipeline-go v0.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2 // indirect

--- a/cmd/configschema/go.sum
+++ b/cmd/configschema/go.sum
@@ -655,8 +655,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqb
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2 h1:FDif4R1+UUR+00q6wquyX90K7A8dN+R5E8GEadoP7sU=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2/go.mod h1:aiYBYui4BJ/BJCAIKs92XiPyQfTaBWqvHujDwKb6CBU=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 h1:sUFnFjzDUie80h24I7mrKtwCKgLY9L8h5Tp2x9+TWqk=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0/go.mod h1:52JbnQTp15qg5mRkMBHwp0j0ZFwHJ42Sx3zVV5RE9p0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0 h1:MxA59PGoCFb+vCwRQi3PhQEwHj4+r2dhuv9HG+vM7iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0/go.mod h1:uYt4CfhkJA9o0FN7jfE5minm/i4nUE4MjGUJkzB6Zs8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -264,7 +264,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -654,8 +654,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqb
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2 h1:FDif4R1+UUR+00q6wquyX90K7A8dN+R5E8GEadoP7sU=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2/go.mod h1:aiYBYui4BJ/BJCAIKs92XiPyQfTaBWqvHujDwKb6CBU=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 h1:sUFnFjzDUie80h24I7mrKtwCKgLY9L8h5Tp2x9+TWqk=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0/go.mod h1:52JbnQTp15qg5mRkMBHwp0j0ZFwHJ42Sx3zVV5RE9p0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0 h1:MxA59PGoCFb+vCwRQi3PhQEwHj4+r2dhuv9HG+vM7iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0/go.mod h1:uYt4CfhkJA9o0FN7jfE5minm/i4nUE4MjGUJkzB6Zs8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/go.mod
+++ b/go.mod
@@ -213,7 +213,7 @@ require (
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/network/armnetwork/v4 v4.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -655,8 +655,8 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqb
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2 h1:FDif4R1+UUR+00q6wquyX90K7A8dN+R5E8GEadoP7sU=
 github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2/go.mod h1:aiYBYui4BJ/BJCAIKs92XiPyQfTaBWqvHujDwKb6CBU=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 h1:sUFnFjzDUie80h24I7mrKtwCKgLY9L8h5Tp2x9+TWqk=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0/go.mod h1:52JbnQTp15qg5mRkMBHwp0j0ZFwHJ42Sx3zVV5RE9p0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0 h1:MxA59PGoCFb+vCwRQi3PhQEwHj4+r2dhuv9HG+vM7iM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v5 v5.5.0/go.mod h1:uYt4CfhkJA9o0FN7jfE5minm/i4nUE4MjGUJkzB6Zs8=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v2 v2.0.0 h1:PTFGRSlMKCQelWwxUyYVEUqseBJVemLyqWJjvMyt0do=

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -59,7 +59,6 @@ Using Service Principal for authentication:
 receivers:
   azureblob:
     auth: service_principal
-    subscription_id: "${subscription_id}"
     tenant_id: "${tenant_id}"
     client_id: "${client_id}"
     client_secret: "${env:CLIENT_SECRET}"

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -19,25 +19,53 @@ This receiver reads logs and trace data from [Azure Blob Storage](https://azure.
 
 The following settings are required:
 
-- `connection_string:` (no default): Azure Blob Storage connection key, which can be found in the Azure Blob Storage resource on the Azure Portal.
 - `event_hub:`
   `  endpoint:` (no default): Azure Event Hub endpoint triggering on the `Blob Create` event 
 
 The following settings can be optionally configured:
 
+- `auth` (default = connection_string): Specifies the used authentication method. Supported values are `connection_string`, `service_principal`.
+- `cloud` (default = "AzureCloud"): defines which Azure cloud to use when using the `service_principal` authentication method. Either `AzureCloud` or `AzureUSGovernment`
 - `logs:`
   `  container_name:` (default = "logs"): Name of the blob container with the logs
 - `traces:`
   `  container_name:` (default = "traces"): Name of the blob container with the traces
 
-Example:
+Authenticating using a connection string requires following additional settings:
+
+- `connection_string:` Azure Blob Storage connection key, which can be found in the Azure Blob Storage resource on the Azure Portal.
+
+Authenticating using service principal requires following additional settings:
+
+- `tenant_id`
+- `client_id`
+- `client_secret`
+
+### Example Configurations
+
+Using connection string for authentication:
 
 ```yaml
 receivers:
   azureblob:
     connection_string: DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net
     event_hub:
-      endpoint: Endpoint=sb://oteldata.servicebus.windows.net/;SharedAccessKeyName=otelhubbpollicy;SharedAccessKey=mPJVubIK5dJ6mLfZo1ucsdkLysLSQ6N7kddvsIcmoEs=;EntityPath=otellhub    
+      endpoint: Endpoint=sb://oteldata.servicebus.windows.net/;SharedAccessKeyName=otelhubbpollicy;SharedAccessKey=mPJVubIK5dJ6mLfZo1ucsdkLysLSQ6N7kddvsIcmoEs=;EntityPath=otellhub
+```
+
+Using Service Principal for authentication:
+
+```yaml
+receivers:
+  azureblob:
+    auth: service_principal
+    subscription_id: "${subscription_id}"
+    tenant_id: "${tenant_id}"
+    client_id: "${client_id}"
+    client_secret: "${env:CLIENT_SECRET}"
+    storage_account_url: https://accountName.blob.core.windows.net
+    event_hub:
+      endpoint: Endpoint=sb://oteldata.servicebus.windows.net/;SharedAccessKeyName=otelhubbpollicy;SharedAccessKey=mPJVubIK5dJ6mLfZo1ucsdkLysLSQ6N7kddvsIcmoEs=;EntityPath=otellhub
 ```
 
 The receiver subscribes [on the events](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-event-overview) published by Azure Blob Storage and handled by Azure Event Hub. When it receives `Blob Create` event, it reads the logs or traces from a corresponding blob and deletes it after processing.

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -35,7 +35,7 @@ Authenticating using a connection string requires configuration of the following
 
 - `connection_string:` Azure Blob Storage connection key, which can be found in the Azure Blob Storage resource on the Azure Portal.
 
-Authenticating using service principal requires following additional settings:
+Authenticating using service principal requires configuration of the following additional settings:
 
 - `tenant_id`
 - `client_id`

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -56,7 +56,7 @@ receivers:
       endpoint: Endpoint=sb://oteldata.servicebus.windows.net/;SharedAccessKeyName=otelhubbpollicy;SharedAccessKey=mPJVubIK5dJ6mLfZo1ucsdkLysLSQ6N7kddvsIcmoEs=;EntityPath=otellhub
 ```
 
-Using Service Principal for authentication:
+Using service principal for authentication:
 
 ```yaml
 receivers:

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -41,6 +41,8 @@ Authenticating using service principal requires following additional settings:
 - `client_id`
 - `client_secret`
 
+The service principal requires the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) role on the logs and traces containers.
+
 ### Example Configurations
 
 Using connection string for authentication:

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -44,7 +44,7 @@ Authenticating using service principal requires configuration of the following a
 
 The service principal method also requires the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) role on the logs and traces containers.
 
-### Example Configurations
+### Example configurations
 
 Using connection string for authentication:
 

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -42,7 +42,7 @@ Authenticating using service principal requires following additional settings:
 - `client_secret`
 - `storage_account_url`
 
-The service principal requires the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) role on the logs and traces containers.
+The service principal method also requires the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) role on the logs and traces containers.
 
 ### Example Configurations
 

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -40,6 +40,7 @@ Authenticating using service principal requires following additional settings:
 - `tenant_id`
 - `client_id`
 - `client_secret`
+- `storage_account_url`
 
 The service principal requires the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) role on the logs and traces containers.
 

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -37,10 +37,11 @@ Authenticating using a connection string requires configuration of the following
 
 Authenticating using service principal requires configuration of the following additional settings:
 
-- `tenant_id`
-- `client_id`
-- `client_secret`
-- `storage_account_url`
+- `service_principal:`
+  `  tenant_id`
+  `  client_id`
+  `  client_secret`
+- `storage_account_url:` Azure Storage Account url
 
 The service principal method also requires the [Storage Blob Data Contributor](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage#storage-blob-data-contributor) role on the logs and traces containers.
 
@@ -62,9 +63,10 @@ Using service principal for authentication:
 receivers:
   azureblob:
     auth: service_principal
-    tenant_id: "${tenant_id}"
-    client_id: "${client_id}"
-    client_secret: "${env:CLIENT_SECRET}"
+    service_principal:
+      tenant_id: "${tenant_id}"
+      client_id: "${client_id}"
+      client_secret: "${env:CLIENT_SECRET}"
     storage_account_url: https://accountName.blob.core.windows.net
     event_hub:
       endpoint: Endpoint=sb://oteldata.servicebus.windows.net/;SharedAccessKeyName=otelhubbpollicy;SharedAccessKey=mPJVubIK5dJ6mLfZo1ucsdkLysLSQ6N7kddvsIcmoEs=;EntityPath=otellhub

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -25,7 +25,7 @@ The following settings are required:
 The following settings can be optionally configured:
 
 - `auth` (default = connection_string): Specifies the used authentication method. Supported values are `connection_string`, `service_principal`.
-- `cloud` (default = "AzureCloud"): defines which Azure cloud to use when using the `service_principal` authentication method. Either `AzureCloud` or `AzureUSGovernment`
+- `cloud` (default = "AzureCloud"): Defines which Azure Cloud to use when using the `service_principal` authentication method. Value is either `AzureCloud` or `AzureUSGovernment`.
 - `logs:`
   `  container_name:` (default = "logs"): Name of the blob container with the logs
 - `traces:`

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -31,7 +31,7 @@ The following settings can be optionally configured:
 - `traces:`
   `  container_name:` (default = "traces"): Name of the blob container with the traces
 
-Authenticating using a connection string requires following additional settings:
+Authenticating using a connection string requires configuration of the following additional setting:
 
 - `connection_string:` Azure Blob Storage connection key, which can be found in the Azure Blob Storage resource on the Azure Portal.
 

--- a/receiver/azureblobreceiver/blobclient.go
+++ b/receiver/azureblobreceiver/blobclient.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"go.uber.org/zap"
 )
@@ -45,8 +46,20 @@ func (bc *azureBlobClient) readBlob(ctx context.Context, containerName string, b
 	return downloadedData, err
 }
 
-func newBlobClient(connectionString string, logger *zap.Logger) (*azureBlobClient, error) {
+func newBlobClientFromConnectionString(connectionString string, logger *zap.Logger) (*azureBlobClient, error) {
 	serviceClient, err := azblob.NewClientFromConnectionString(connectionString, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &azureBlobClient{
+		serviceClient,
+		logger,
+	}, nil
+}
+
+func newBlobClientFromCredential(storageAccountURL string, cred azcore.TokenCredential, logger *zap.Logger) (*azureBlobClient, error) {
+	serviceClient, err := azblob.NewClient(storageAccountURL, cred, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/azureblobreceiver/blobclient_test.go
+++ b/receiver/azureblobreceiver/blobclient_test.go
@@ -6,6 +6,8 @@ package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -14,19 +16,30 @@ import (
 const (
 	goodConnectionString = "DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net"
 	badConnectionString  = "DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=accountkey;EndpointSuffix=core.windows.net"
+
+	storageAccountURL = "https://accountName.blob.core.windows.net"
 )
 
-func TestNewBlobClient(t *testing.T) {
-	blobClient, err := newBlobClient(goodConnectionString, zaptest.NewLogger(t))
+func TestNewBlobClientFromConnectionString(t *testing.T) {
+	blobClient, err := newBlobClientFromConnectionString(goodConnectionString, zaptest.NewLogger(t))
 
 	require.NoError(t, err)
 	require.NotNil(t, blobClient)
 	assert.NotNil(t, blobClient.serviceClient)
 }
 
-func TestNewBlobClientError(t *testing.T) {
-	blobClient, err := newBlobClient(badConnectionString, zaptest.NewLogger(t))
+func TestNewBlobClientFromConnectionStringError(t *testing.T) {
+	blobClient, err := newBlobClientFromConnectionString(badConnectionString, zaptest.NewLogger(t))
 
 	assert.Error(t, err)
 	assert.Nil(t, blobClient)
+}
+
+func TestNewBlobClientFromCredentials(t *testing.T) {
+	var cred azcore.TokenCredential = (*azidentity.ClientSecretCredential)(nil)
+	blobClient, err := newBlobClientFromCredential(storageAccountURL, cred, zaptest.NewLogger(t))
+
+	require.NoError(t, err)
+	require.NotNil(t, blobClient)
+	assert.NotNil(t, blobClient.serviceClient)
 }

--- a/receiver/azureblobreceiver/config.go
+++ b/receiver/azureblobreceiver/config.go
@@ -3,10 +3,44 @@
 
 package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureblobreceiver"
 
+import (
+	"errors"
+	"fmt"
+
+	"go.uber.org/multierr"
+)
+
+const (
+	azureCloud           = "AzureCloud"
+	azureGovernmentCloud = "AzureUSGovernment"
+)
+
+var (
+	// Predefined error responses for configuration validation failures
+	errMissingTenantID          = errors.New(`"TenantID" is not specified in config`)
+	errMissingClientID          = errors.New(`"ClientID" is not specified in config`)
+	errMissingClientSecret      = errors.New(`"ClientSecret" is not specified in config`)
+	errMissingStorageAccountURL = errors.New(`"StorageAccountURL" is not specified in config`)
+	errMissingConnectionString  = errors.New(`"ConnectionString" is not specified in config`)
+	errInvalidCloud             = errors.New(`"Cloud" is invalid`)
+)
+
 type Config struct {
+	// Type of authentication to use
+	Authentication string `mapstructure:"auth"`
 	// Azure Blob Storage connection key,
 	// which can be found in the Azure Blob Storage resource on the Azure Portal. (no default)
 	ConnectionString string `mapstructure:"connection_string"`
+	// Storage Account URL, used with Service Principal authentication
+	StorageAccountURL string `mapstructure:"storage_account_url"`
+	// Tenant ID, used with Service Principal authentication
+	TenantID string `mapstructure:"tenant_id"`
+	// Client ID, used with Service Principal authentication
+	ClientID string `mapstructure:"client_id"`
+	// Client secret, used with Service Principal authentication
+	ClientSecret string `mapstructure:"client_secret"`
+	// Azure Cloud to authenticate against, used with Service Principal authentication
+	Cloud string `mapstructure:"cloud"`
 	// Configurations of Azure Event Hub triggering on the `Blob Create` event
 	EventHub EventHubConfig `mapstructure:"event_hub"`
 	// Logs related configurations
@@ -14,6 +48,11 @@ type Config struct {
 	// Traces related configurations
 	Traces TracesConfig `mapstructure:"traces"`
 }
+
+const (
+	servicePrincipal = "service_principal"
+	connectionString = "connection_string"
+)
 
 type EventHubConfig struct {
 	// Azure Event Hub endpoint triggering on the `Blob Create` event
@@ -28,4 +67,38 @@ type LogsConfig struct {
 type TracesConfig struct {
 	// Name of the blob container with the traces (default = "traces")
 	ContainerName string `mapstructure:"container_name"`
+}
+
+// Validate validates the configuration by checking for missing or invalid fields
+func (c Config) Validate() (err error) {
+	switch c.Authentication {
+	case servicePrincipal:
+		if c.TenantID == "" {
+			err = multierr.Append(err, errMissingTenantID)
+		}
+
+		if c.ClientID == "" {
+			err = multierr.Append(err, errMissingClientID)
+		}
+
+		if c.ClientSecret == "" {
+			err = multierr.Append(err, errMissingClientSecret)
+		}
+
+		if c.StorageAccountURL == "" {
+			err = multierr.Append(err, errMissingStorageAccountURL)
+		}
+
+		if c.Cloud != azureCloud && c.Cloud != azureGovernmentCloud {
+			err = multierr.Append(err, errInvalidCloud)
+		}
+	case connectionString:
+		if c.ConnectionString == "" {
+			err = multierr.Append(err, errMissingConnectionString)
+		}
+	default:
+		return fmt.Errorf("authentication %v is not supported. supported authentications include [%v,%v]", c.Authentication, servicePrincipal, connectionString)
+	}
+
+	return
 }

--- a/receiver/azureblobreceiver/config.go
+++ b/receiver/azureblobreceiver/config.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.uber.org/multierr"
 )
 
@@ -71,7 +72,7 @@ type ServicePrincipalConfig struct {
 	// Client ID, used with Service Principal authentication
 	ClientID string `mapstructure:"client_id"`
 	// Client secret, used with Service Principal authentication
-	ClientSecret string `mapstructure:"client_secret"`
+	ClientSecret configopaque.String `mapstructure:"client_secret"`
 }
 
 // Validate validates the configuration by checking for missing or invalid fields

--- a/receiver/azureblobreceiver/config.go
+++ b/receiver/azureblobreceiver/config.go
@@ -33,12 +33,8 @@ type Config struct {
 	ConnectionString string `mapstructure:"connection_string"`
 	// Storage Account URL, used with Service Principal authentication
 	StorageAccountURL string `mapstructure:"storage_account_url"`
-	// Tenant ID, used with Service Principal authentication
-	TenantID string `mapstructure:"tenant_id"`
-	// Client ID, used with Service Principal authentication
-	ClientID string `mapstructure:"client_id"`
-	// Client secret, used with Service Principal authentication
-	ClientSecret string `mapstructure:"client_secret"`
+	// Configuration for the Service Principal credentials
+	ServicePrincipal ServicePrincipalConfig `mapstructure:"service_principal"`
 	// Azure Cloud to authenticate against, used with Service Principal authentication
 	Cloud string `mapstructure:"cloud"`
 	// Configurations of Azure Event Hub triggering on the `Blob Create` event
@@ -69,19 +65,28 @@ type TracesConfig struct {
 	ContainerName string `mapstructure:"container_name"`
 }
 
+type ServicePrincipalConfig struct {
+	// Tenant ID, used with Service Principal authentication
+	TenantID string `mapstructure:"tenant_id"`
+	// Client ID, used with Service Principal authentication
+	ClientID string `mapstructure:"client_id"`
+	// Client secret, used with Service Principal authentication
+	ClientSecret string `mapstructure:"client_secret"`
+}
+
 // Validate validates the configuration by checking for missing or invalid fields
 func (c Config) Validate() (err error) {
 	switch c.Authentication {
 	case servicePrincipal:
-		if c.TenantID == "" {
+		if c.ServicePrincipal.TenantID == "" {
 			err = multierr.Append(err, errMissingTenantID)
 		}
 
-		if c.ClientID == "" {
+		if c.ServicePrincipal.ClientID == "" {
 			err = multierr.Append(err, errMissingClientID)
 		}
 
-		if c.ClientSecret == "" {
+		if c.ServicePrincipal.ClientSecret == "" {
 			err = multierr.Append(err, errMissingClientSecret)
 		}
 

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -30,16 +30,47 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, len(cfg.Receivers), 2)
 
 	receiver := cfg.Receivers[component.NewID(metadata.Type)]
-	assert.Equal(t, factory.CreateDefaultConfig(), receiver)
+	assert.NoError(t, componenttest.CheckConfigStruct(receiver))
+	assert.Equal(
+		t,
+		&Config{
+			Authentication:   connectionString,
+			ConnectionString: goodConnectionString,
+			Logs:             LogsConfig{ContainerName: logsContainerName},
+			Traces:           TracesConfig{ContainerName: tracesContainerName},
+			Cloud:            defaultCloud,
+		},
+		receiver)
 
 	receiver = cfg.Receivers[component.NewIDWithName(metadata.Type, "2")].(*Config)
 	assert.NoError(t, componenttest.CheckConfigStruct(receiver))
 	assert.Equal(
 		t,
 		&Config{
-			ConnectionString: goodConnectionString,
-			Logs:             LogsConfig{ContainerName: logsContainerName},
-			Traces:           TracesConfig{ContainerName: tracesContainerName},
+			Authentication:    servicePrincipal,
+			TenantID:          "mock-tenant-id",
+			ClientID:          "mock-client-id",
+			ClientSecret:      "mock-client-secret",
+			StorageAccountURL: "https://accountName.blob.core.windows.net",
+			Logs:              LogsConfig{ContainerName: logsContainerName},
+			Traces:            TracesConfig{ContainerName: tracesContainerName},
+			Cloud:             defaultCloud,
 		},
 		receiver)
+}
+
+func TestMissingConnectionString(t *testing.T) {
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	err := component.ValidateConfig(cfg)
+	assert.EqualError(t, err, `"ConnectionString" is not specified in config`)
+}
+
+func TestMissingServicePrincipalCredentials(t *testing.T) {
+	var err error
+	factory := NewFactory()
+	cfg := factory.CreateDefaultConfig()
+	cfg.(*Config).Authentication = servicePrincipal
+	err = component.ValidateConfig(cfg)
+	assert.EqualError(t, err, `"TenantID" is not specified in config; "ClientID" is not specified in config; "ClientSecret" is not specified in config; "StorageAccountURL" is not specified in config`)
 }

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -34,7 +34,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(
 		t,
 		&Config{
-			Authentication:   connectionString,
+			Authentication:   ConnectionStringAuth,
 			ConnectionString: goodConnectionString,
 			Logs:             LogsConfig{ContainerName: logsContainerName},
 			Traces:           TracesConfig{ContainerName: tracesContainerName},
@@ -47,7 +47,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(
 		t,
 		&Config{
-			Authentication: servicePrincipal,
+			Authentication: ServicePrincipalAuth,
 			ServicePrincipal: ServicePrincipalConfig{
 				TenantID:     "mock-tenant-id",
 				ClientID:     "mock-client-id",
@@ -72,7 +72,7 @@ func TestMissingServicePrincipalCredentials(t *testing.T) {
 	var err error
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	cfg.(*Config).Authentication = servicePrincipal
+	cfg.(*Config).Authentication = ServicePrincipalAuth
 	err = component.ValidateConfig(cfg)
 	assert.EqualError(t, err, `"TenantID" is not specified in config; "ClientID" is not specified in config; "ClientSecret" is not specified in config; "StorageAccountURL" is not specified in config`)
 }

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -48,9 +48,11 @@ func TestLoadConfig(t *testing.T) {
 		t,
 		&Config{
 			Authentication:    servicePrincipal,
-			TenantID:          "mock-tenant-id",
-			ClientID:          "mock-client-id",
-			ClientSecret:      "mock-client-secret",
+			ServicePrincipal:  ServicePrincipalConfig{
+				TenantID:          "mock-tenant-id",
+				ClientID:          "mock-client-id",
+				ClientSecret:      "mock-client-secret",
+			},
 			StorageAccountURL: "https://accountName.blob.core.windows.net",
 			Logs:              LogsConfig{ContainerName: logsContainerName},
 			Traces:            TracesConfig{ContainerName: tracesContainerName},

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -47,11 +47,11 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(
 		t,
 		&Config{
-			Authentication:    servicePrincipal,
-			ServicePrincipal:  ServicePrincipalConfig{
-				TenantID:          "mock-tenant-id",
-				ClientID:          "mock-client-id",
-				ClientSecret:      "mock-client-secret",
+			Authentication: servicePrincipal,
+			ServicePrincipal: ServicePrincipalConfig{
+				TenantID:     "mock-tenant-id",
+				ClientID:     "mock-client-id",
+				ClientSecret: "mock-client-secret",
 			},
 			StorageAccountURL: "https://accountName.blob.core.windows.net",
 			Logs:              LogsConfig{ContainerName: logsContainerName},

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -6,7 +6,9 @@ package azureblobreceiver // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"context"
 	"errors"
+	"fmt"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
@@ -19,6 +21,7 @@ import (
 const (
 	logsContainerName   = "logs"
 	tracesContainerName = "traces"
+	defaultCloud        = azureCloud
 )
 
 var (
@@ -44,8 +47,10 @@ func NewFactory() receiver.Factory {
 
 func (f *blobReceiverFactory) createDefaultConfig() component.Config {
 	return &Config{
-		Logs:   LogsConfig{ContainerName: logsContainerName},
-		Traces: TracesConfig{ContainerName: tracesContainerName},
+		Logs:           LogsConfig{ContainerName: logsContainerName},
+		Traces:         TracesConfig{ContainerName: tracesContainerName},
+		Authentication: connectionString,
+		Cloud:          defaultCloud,
 	}
 }
 
@@ -118,9 +123,26 @@ func (f *blobReceiverFactory) getReceiver(
 }
 
 func (f *blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logger) (blobEventHandler, error) {
-	bc, err := newBlobClient(cfg.ConnectionString, logger)
-	if err != nil {
-		return nil, err
+	var bc blobClient
+	var err error
+
+	switch cfg.Authentication {
+	case connectionString:
+		bc, err = newBlobClientFromConnectionString(cfg.ConnectionString, logger)
+		if err != nil {
+			return nil, err
+		}
+	case servicePrincipal:
+		cred, err := azidentity.NewClientSecretCredential(cfg.TenantID, cfg.ClientID, cfg.ClientSecret, nil)
+		if err != nil {
+			return nil, err
+		}
+		bc, err = newBlobClientFromCredential(cfg.StorageAccountURL, cred, logger)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unknown authentication %v", cfg.Authentication)
 	}
 
 	return newBlobEventHandler(cfg.EventHub.EndPoint, cfg.Logs.ContainerName, cfg.Traces.ContainerName, bc, logger),

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -133,7 +133,7 @@ func (f *blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logge
 			return nil, err
 		}
 	case servicePrincipal:
-		cred, err := azidentity.NewClientSecretCredential(cfg.TenantID, cfg.ClientID, cfg.ClientSecret, nil)
+		cred, err := azidentity.NewClientSecretCredential(cfg.ServicePrincipal.TenantID, cfg.ServicePrincipal.ClientID, cfg.ServicePrincipal.ClientSecret, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -49,7 +49,7 @@ func (f *blobReceiverFactory) createDefaultConfig() component.Config {
 	return &Config{
 		Logs:           LogsConfig{ContainerName: logsContainerName},
 		Traces:         TracesConfig{ContainerName: tracesContainerName},
-		Authentication: connectionString,
+		Authentication: ConnectionStringAuth,
 		Cloud:          defaultCloud,
 	}
 }
@@ -127,12 +127,12 @@ func (f *blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logge
 	var err error
 
 	switch cfg.Authentication {
-	case connectionString:
+	case ConnectionStringAuth:
 		bc, err = newBlobClientFromConnectionString(cfg.ConnectionString, logger)
 		if err != nil {
 			return nil, err
 		}
-	case servicePrincipal:
+	case ServicePrincipalAuth:
 		cred, err := azidentity.NewClientSecretCredential(cfg.ServicePrincipal.TenantID, cfg.ServicePrincipal.ClientID, string(cfg.ServicePrincipal.ClientSecret), nil)
 		if err != nil {
 			return nil, err

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -133,7 +133,7 @@ func (f *blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logge
 			return nil, err
 		}
 	case servicePrincipal:
-		cred, err := azidentity.NewClientSecretCredential(cfg.ServicePrincipal.TenantID, cfg.ServicePrincipal.ClientID, cfg.ServicePrincipal.ClientSecret, nil)
+		cred, err := azidentity.NewClientSecretCredential(cfg.ServicePrincipal.TenantID, cfg.ServicePrincipal.ClientID, string(cfg.ServicePrincipal.ClientSecret), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -21,7 +21,7 @@ import (
 const (
 	logsContainerName   = "logs"
 	tracesContainerName = "traces"
-	defaultCloud        = azureCloud
+	defaultCloud        = AzureCloudType
 )
 
 var (

--- a/receiver/azureblobreceiver/factory_test.go
+++ b/receiver/azureblobreceiver/factory_test.go
@@ -56,6 +56,7 @@ func TestTracesAndLogsReceiversAreSame(t *testing.T) {
 
 func getConfig() component.Config {
 	return &Config{
+		Authentication:   "connection_string",
 		ConnectionString: goodConnectionString,
 		Logs:             LogsConfig{ContainerName: logsContainerName},
 		Traces:           TracesConfig{ContainerName: tracesContainerName},

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -4,6 +4,8 @@ go 1.21.0
 
 require (
 	github.com/Azure/azure-event-hubs-go/v3 v3.6.2
+	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1
+	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.100.0
 	github.com/stretchr/testify v1.9.0
@@ -16,14 +18,14 @@ require (
 	go.opentelemetry.io/otel/metric v1.26.0
 	go.opentelemetry.io/otel/trace v1.26.0
 	go.uber.org/goleak v1.3.0
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 )
 
 require (
 	github.com/Azure/azure-amqp-common-go/v4 v4.2.0 // indirect
 	github.com/Azure/azure-sdk-for-go v65.0.0+incompatible // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 // indirect
 	github.com/Azure/go-amqp v1.0.2 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.28 // indirect
@@ -33,6 +35,7 @@ require (
 	github.com/Azure/go-autorest/autorest/validation v0.3.1 // indirect
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
+	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
@@ -44,6 +47,7 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1 // indirect
@@ -54,12 +58,14 @@ require (
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
 	github.com/knadh/koanf/v2 v2.1.1 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20210106213030-5aafc221ea8c // indirect
 	github.com/prometheus/client_golang v1.19.0 // indirect

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.100.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.100.1-0.20240509190532-c555005fcc80
+	go.opentelemetry.io/collector/config/configopaque v1.7.0
 	go.opentelemetry.io/collector/confmap v0.100.1-0.20240509190532-c555005fcc80
 	go.opentelemetry.io/collector/consumer v0.100.1-0.20240509190532-c555005fcc80
 	go.opentelemetry.io/collector/otelcol v0.100.1-0.20240509190532-c555005fcc80
@@ -113,7 +114,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.26.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.26.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.2.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.22.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
 	golang.org/x/net v0.24.0 // indirect

--- a/receiver/azureblobreceiver/go.mod
+++ b/receiver/azureblobreceiver/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.100.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.100.1-0.20240509190532-c555005fcc80
-	go.opentelemetry.io/collector/config/configopaque v1.7.0
+	go.opentelemetry.io/collector/config/configopaque v1.7.1-0.20240509190532-c555005fcc80
 	go.opentelemetry.io/collector/confmap v0.100.1-0.20240509190532-c555005fcc80
 	go.opentelemetry.io/collector/consumer v0.100.1-0.20240509190532-c555005fcc80
 	go.opentelemetry.io/collector/otelcol v0.100.1-0.20240509190532-c555005fcc80

--- a/receiver/azureblobreceiver/go.sum
+++ b/receiver/azureblobreceiver/go.sum
@@ -216,8 +216,8 @@ go.opentelemetry.io/collector/component v0.100.1-0.20240509190532-c555005fcc80 h
 go.opentelemetry.io/collector/component v0.100.1-0.20240509190532-c555005fcc80/go.mod h1:irNXb5UL1qDLrg62hagSoAJ4Bx0ZflrZMos/wm9MH+0=
 go.opentelemetry.io/collector/config/confignet v0.100.0 h1:SW8IMK+9GwFa1cNZdXw6wMkbCsqUaRtj0fgP8/yG6oI=
 go.opentelemetry.io/collector/config/confignet v0.100.0/go.mod h1:3naWoPss70RhDHhYjGACi7xh4NcVRvs9itzIRVWyu1k=
-go.opentelemetry.io/collector/config/configopaque v1.7.0 h1:nZh5Hb1ofq9xP1wHLSt4obM85pRTccSeAjV0NbrJeTc=
-go.opentelemetry.io/collector/config/configopaque v1.7.0/go.mod h1:vxoDKYYYUF/arrdQJxmfhlgkcsb0DpdzC9KPFP97uuE=
+go.opentelemetry.io/collector/config/configopaque v1.7.1-0.20240509190532-c555005fcc80 h1:PP6i1UYSGExbAM+GIMgUzklqOHuEwh+TBCCgN5AQXtI=
+go.opentelemetry.io/collector/config/configopaque v1.7.1-0.20240509190532-c555005fcc80/go.mod h1:vxoDKYYYUF/arrdQJxmfhlgkcsb0DpdzC9KPFP97uuE=
 go.opentelemetry.io/collector/config/configretry v0.100.0 h1:jEswHFjNokqJ0U2iYSzUlDy8N6A6D+zaoHM9t1TB6yw=
 go.opentelemetry.io/collector/config/configretry v0.100.0/go.mod h1:uRdmPeCkrW9Zsadh2WEbQ1AGXGYJ02vCfmmT+0g69nY=
 go.opentelemetry.io/collector/config/configtelemetry v0.100.1-0.20240509190532-c555005fcc80 h1:zaH9hn7ZqcBq95tC1Gbh521x+ijp+rm+12YqqCT2KZo=

--- a/receiver/azureblobreceiver/go.sum
+++ b/receiver/azureblobreceiver/go.sum
@@ -7,10 +7,10 @@ github.com/Azure/azure-sdk-for-go v65.0.0+incompatible h1:HzKLt3kIwMm4KeJYTdx9Eb
 github.com/Azure/azure-sdk-for-go v65.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1 h1:E+OJmp2tPvt1W+amx48v1eqbjDYsgN+RzP4q16yV5eM=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.11.1/go.mod h1:a6xsAQUZg+VsS3TJ05SRp524Hs4pZ/AeFSr5ENf0Yjo=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1 h1:sO0/P7g68FrryJzljemN+6GTssUXdANk6aJ7T1ZxnsQ=
-github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.1/go.mod h1:h8hyGFDsU5HMivxiS2iYFZsgDbU9OnnJ163x5UGVKYo=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2 h1:LqbJ/WzJUwBf8UiaSzgX7aMclParm9/5Vgp+TY51uBQ=
-github.com/Azure/azure-sdk-for-go/sdk/internal v1.5.2/go.mod h1:yInRyqWXAuaPrgI7p70+lDDgh3mlBohis29jGMISnmc=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2 h1:FDif4R1+UUR+00q6wquyX90K7A8dN+R5E8GEadoP7sU=
+github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.5.2/go.mod h1:aiYBYui4BJ/BJCAIKs92XiPyQfTaBWqvHujDwKb6CBU=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0 h1:sUFnFjzDUie80h24I7mrKtwCKgLY9L8h5Tp2x9+TWqk=
+github.com/Azure/azure-sdk-for-go/sdk/internal v1.6.0/go.mod h1:52JbnQTp15qg5mRkMBHwp0j0ZFwHJ42Sx3zVV5RE9p0=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0 h1:AifHbc4mg0x9zW52WOpKbsHaDKuRhlI7TVl47thgQ70=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.5.0/go.mod h1:T5RfihdXtBDxt1Ch2wobif3TvzTdumDy29kahv6AV9A=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.3.2 h1:YUUxeiOWgdAQE3pXt2H7QXzZs0q8UBjgRbl56qo8GYM=
@@ -41,8 +41,8 @@ github.com/Azure/go-autorest/logger v0.2.1 h1:IG7i4p/mDa2Ce4TRyAO8IHnVhAVF3RFU+Z
 github.com/Azure/go-autorest/logger v0.2.1/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUMfuitfgcfuo=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1 h1:DzHpqpoJVaCgOUdVHxE8QB52S6NiVdDQvGlny1qvPqA=
-github.com/AzureAD/microsoft-authentication-library-for-go v1.2.1/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=
+github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2/go.mod h1:wP83P5OoQ5p6ip3ScPr0BAq0BvuPAvacpEuSzyouqAI=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -84,8 +84,8 @@ github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzw
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
-github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
+github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
+github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
@@ -346,6 +346,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.11.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/receiver/azureblobreceiver/go.sum
+++ b/receiver/azureblobreceiver/go.sum
@@ -216,6 +216,8 @@ go.opentelemetry.io/collector/component v0.100.1-0.20240509190532-c555005fcc80 h
 go.opentelemetry.io/collector/component v0.100.1-0.20240509190532-c555005fcc80/go.mod h1:irNXb5UL1qDLrg62hagSoAJ4Bx0ZflrZMos/wm9MH+0=
 go.opentelemetry.io/collector/config/confignet v0.100.0 h1:SW8IMK+9GwFa1cNZdXw6wMkbCsqUaRtj0fgP8/yG6oI=
 go.opentelemetry.io/collector/config/confignet v0.100.0/go.mod h1:3naWoPss70RhDHhYjGACi7xh4NcVRvs9itzIRVWyu1k=
+go.opentelemetry.io/collector/config/configopaque v1.7.0 h1:nZh5Hb1ofq9xP1wHLSt4obM85pRTccSeAjV0NbrJeTc=
+go.opentelemetry.io/collector/config/configopaque v1.7.0/go.mod h1:vxoDKYYYUF/arrdQJxmfhlgkcsb0DpdzC9KPFP97uuE=
 go.opentelemetry.io/collector/config/configretry v0.100.0 h1:jEswHFjNokqJ0U2iYSzUlDy8N6A6D+zaoHM9t1TB6yw=
 go.opentelemetry.io/collector/config/configretry v0.100.0/go.mod h1:uRdmPeCkrW9Zsadh2WEbQ1AGXGYJ02vCfmmT+0g69nY=
 go.opentelemetry.io/collector/config/configtelemetry v0.100.1-0.20240509190532-c555005fcc80 h1:zaH9hn7ZqcBq95tC1Gbh521x+ijp+rm+12YqqCT2KZo=

--- a/receiver/azureblobreceiver/testdata/config.yaml
+++ b/receiver/azureblobreceiver/testdata/config.yaml
@@ -1,7 +1,12 @@
 receivers:
   azureblob:
-  azureblob/2:
     connection_string: DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net
+  azureblob/2:
+    auth: service_principal
+    tenant_id: mock-tenant-id
+    client_id: mock-client-id
+    client_secret: mock-client-secret
+    storage_account_url: https://accountName.blob.core.windows.net
     logs:
       container_name: logs
     traces:

--- a/receiver/azureblobreceiver/testdata/config.yaml
+++ b/receiver/azureblobreceiver/testdata/config.yaml
@@ -3,9 +3,10 @@ receivers:
     connection_string: DefaultEndpointsProtocol=https;AccountName=accountName;AccountKey=+idLkHYcL0MUWIKYHm2j4Q==;EndpointSuffix=core.windows.net
   azureblob/2:
     auth: service_principal
-    tenant_id: mock-tenant-id
-    client_id: mock-client-id
-    client_secret: mock-client-secret
+    service_principal:
+      tenant_id: mock-tenant-id
+      client_id: mock-client-id
+      client_secret: mock-client-secret
     storage_account_url: https://accountName.blob.core.windows.net
     logs:
       container_name: logs


### PR DESCRIPTION
**Description:**
Added support for authenticating to Blob storage via a Service Principal.
The default authentication method is still connection string to ensure backwards compatibility.

**Link to tracking Issue:** #32705 

**Testing:** 
Extended the unit tests for the blob client and the config

**Documentation:** 
Added information and examples to README
