### PR TITLE
[chore][receiver/mongodbatlas] Fix broken paths in integration tests

### DIFF
--- a/receiver/mongodbatlasreceiver/alerts_integration_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_integration_test.go
@@ -110,6 +110,7 @@ func TestAlertsReceiver(t *testing.T) {
 }
 
 func TestAlertsReceiverTLS(t *testing.T) {
+	t.Skip("Cert files are invalid. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32543")
 	for _, payloadName := range testPayloads {
 		t.Run(payloadName, func(t *testing.T) {
 			testAddr := testutil.GetAvailableLocalAddress(t)

--- a/receiver/mongodbatlasreceiver/alerts_integration_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_integration_test.go
@@ -37,8 +37,8 @@ import (
 )
 
 var testPayloads = []string{
-	"metric-threshold-closed.yaml",
-	"new-primary.yaml",
+	"metric-threshold-closed",
+	"new-primary",
 }
 
 const (
@@ -77,7 +77,7 @@ func TestAlertsReceiver(t *testing.T) {
 				require.NoError(t, recv.Shutdown(context.Background()))
 			}()
 
-			payload, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", payloadName))
+			payload, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", payloadName+".json"))
 			require.NoError(t, err)
 
 			req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:%s", testPort), bytes.NewBuffer(payload))
@@ -101,7 +101,7 @@ func TestAlertsReceiver(t *testing.T) {
 
 			logs := sink.AllLogs()[0]
 
-			expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "alerts", "golden", payloadName))
+			expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "alerts", "golden", payloadName+".yaml"))
 			require.NoError(t, err)
 
 			require.NoError(t, plogtest.CompareLogs(expectedLogs, logs, plogtest.IgnoreObservedTimestamp()))
@@ -147,7 +147,7 @@ func TestAlertsReceiverTLS(t *testing.T) {
 				require.NoError(t, recv.Shutdown(context.Background()))
 			}()
 
-			payload, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", payloadName))
+			payload, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", payloadName+".json"))
 			require.NoError(t, err)
 
 			req, err := http.NewRequest("POST", fmt.Sprintf("https://localhost:%s", testPort), bytes.NewBuffer(payload))
@@ -187,7 +187,7 @@ func TestAtlasPoll(t *testing.T) {
 
 	alerts := []mongodbatlas.Alert{}
 	for _, pl := range testPayloads {
-		payloadFile, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", pl))
+		payloadFile, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", pl+".json"))
 		require.NoError(t, err)
 
 		alert := mongodbatlas.Alert{}
@@ -243,7 +243,7 @@ func TestAtlasPoll(t *testing.T) {
 	require.NoError(t, err)
 
 	logs := sink.AllLogs()[0]
-	expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "alerts", "golden", "retrieved-logs.json"))
+	expectedLogs, err := golden.ReadLogs(filepath.Join("testdata", "alerts", "golden", "retrieved-logs.yaml"))
 	require.NoError(t, err)
 	require.NoError(t, plogtest.CompareLogs(expectedLogs, logs, plogtest.IgnoreObservedTimestamp()))
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This fixes 2/3 failing integration tests in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32543. The last failing test `TestAlertsReceiverTLS` needs to be skipped for now, as its cert files are invalid and need to be re-generated.

All three of these tests are currently being skipped, but will run again when #32529 is merged.

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32529
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32543

**Testing:** <Describe what testing was performed and which tests were added.>
Two tests are passing again locally.