### PR TITLE
[receiver/vcenter] Adds Warning Log For Cluster Resource Attributes for Datastore Resource

### DIFF
--- a/.chloggen/fix_vcenter-datastore-attr-warning.yaml
+++ b/.chloggen/fix_vcenter-datastore-attr-warning.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds `vcenter.cluster.name` attributes warning log related to Datastore resource"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32674]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -53,6 +53,7 @@ func newVmwareVcenterScraper(
 	settings receiver.CreateSettings,
 ) *vcenterMetricScraper {
 	client := newVcenterClient(config)
+	logger.Warn("[WARNING] `vcenter.cluster.name`: this attribute will be removed from the Datastore resource starting in release v0.101.0")
 	return &vcenterMetricScraper{
 		client:           client,
 		config:           config,


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adds warning log about the `vcenter.cluster.name` resource attribute from all Datastore resources.

This [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32687) follows up after a v0.100.0 release, and will fully resolve the problem for the v.0.101.0 release

**Link to tracking Issue:** <Issue number if applicable>
#32674 

**Testing:** <Describe what testing was performed and which tests were added.>
Manual Testing for new one time Log

**Documentation:** <Describe the documentation added.>
None needed