### PR TITLE
Fix invalid syntax in filterprocessor OTTL example

### DIFF
--- a/processor/filterprocessor/README.md
+++ b/processor/filterprocessor/README.md
@@ -105,7 +105,7 @@ processors:
     error_mode: ignore
     metrics:
       datapoint:
-        - metric.name == "k8s.pod.phase" && value_int == 4
+        - metric.name == "k8s.pod.phase" and value_int == 4
 ```
 
 #### Dropping non-HTTP spans


### PR DESCRIPTION
**Description:** 
`and` is the right syntax - this tripped someone up on slack https://cloud-native.slack.com/archives/C01N6P7KR6W/p1714160735816669?thread_ts=1714160659.983649&cid=C01N6P7KR6W