### PR TITLE
[chore][Ping code owners on new issues] Fix output formatting

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -97,7 +97,7 @@ if [[ -n "${PING_LINES}" ]]; then
   #    to get the newlines to render correctly, using string formatting
   #    causes the newlines to be interpreted literally.
   echo -e "Pinging code owners:\n${PING_LINES}"
-  echo -e "Pinging code owners:\n${PING_LINES}\n%s" "${LABELS_COMMENT}"  \
+  echo -e "Pinging code owners:\n${PING_LINES}\n" "${LABELS_COMMENT}"  \
   | gh issue comment "${ISSUE}" -F -
 else
   echo "No code owners were found to ping"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I noticed the output of a recent comment made by the `github-actions` bot had an extra `%s` in its output when pinging code owners on new issues. This is unnecessary.

Example links:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32666#issuecomment-2074269815
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32723#issuecomment-2080146099