### PR TITLE
[chore] [pkg/stanza] fix new line issue on windows test

### DIFF
--- a/pkg/stanza/fileconsumer/internal/reader/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_test.go
@@ -6,7 +6,6 @@ package reader
 import (
 	"context"
 	"fmt"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -191,19 +190,10 @@ func TestFingerprintChangeSize(t *testing.T) {
 func TestFlushPeriodEOF(t *testing.T) {
 	tempDir := t.TempDir()
 	temp := filetest.OpenTemp(t, tempDir)
-
-	var lineBreak string
-	switch runtime.GOOS {
-	case "windows":
-		lineBreak = "\r\n"
-	default:
-		lineBreak = "\n"
-	}
 	// Create a long enough initial token, so the scanner can't read the whole file at once
 	aContentLength := 2 * 16 * 1024
 	content := []byte(strings.Repeat("a", aContentLength))
-	content = append(content, lineBreak...)
-	content = append(content, 'b')
+	content = append(content, '\n', 'b', '\n')
 	_, err := temp.WriteString(string(content))
 	require.NoError(t, err)
 

--- a/pkg/stanza/fileconsumer/internal/reader/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_test.go
@@ -6,6 +6,7 @@ package reader
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -190,11 +191,18 @@ func TestFingerprintChangeSize(t *testing.T) {
 func TestFlushPeriodEOF(t *testing.T) {
 	tempDir := t.TempDir()
 	temp := filetest.OpenTemp(t, tempDir)
+
+	var lineBreak string
+	switch runtime.GOOS {
+	case "windows":
+		lineBreak = "\r\n"
+	default:
+		lineBreak = "\n"
+	}
 	// Create a long enough initial token, so the scanner can't read the whole file at once
 	aContentLength := 2 * 16 * 1024
 	content := []byte(strings.Repeat("a", aContentLength))
-	newLine := fmt.Sprintln("")
-	content = append(content, newLine...)
+	content = append(content, lineBreak...)
 	content = append(content, 'b')
 	_, err := temp.WriteString(string(content))
 	require.NoError(t, err)

--- a/pkg/stanza/fileconsumer/internal/reader/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_test.go
@@ -193,7 +193,9 @@ func TestFlushPeriodEOF(t *testing.T) {
 	// Create a long enough initial token, so the scanner can't read the whole file at once
 	aContentLength := 2 * 16 * 1024
 	content := []byte(strings.Repeat("a", aContentLength))
-	content = append(content, '\n', 'b')
+	newLine := fmt.Sprintln("")
+	content = append(content, newLine...)
+	content = append(content, 'b')
 	_, err := temp.WriteString(string(content))
 	require.NoError(t, err)
 

--- a/pkg/stanza/fileconsumer/internal/reader/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_test.go
@@ -193,7 +193,7 @@ func TestFlushPeriodEOF(t *testing.T) {
 	// Create a long enough initial token, so the scanner can't read the whole file at once
 	aContentLength := 2 * 16 * 1024
 	content := []byte(strings.Repeat("a", aContentLength))
-	content = append(content, '\n', 'b', '\n')
+	content = append(content, '\n', 'b')
 	_, err := temp.WriteString(string(content))
 	require.NoError(t, err)
 

--- a/pkg/stanza/flush/flush.go
+++ b/pkg/stanza/flush/flush.go
@@ -52,7 +52,8 @@ func (s *State) Func(splitFunc bufio.SplitFunc, period time.Duration) bufio.Spli
 		}
 
 		// We're seeing new data so postpone the next flush
-		if len(data) > s.LastDataLength {
+		//if len(data) > s.LastDataLength {
+		if !atEOF {
 			s.LastDataChange = time.Now()
 			s.LastDataLength = len(data)
 			return 0, nil, nil

--- a/pkg/stanza/flush/flush.go
+++ b/pkg/stanza/flush/flush.go
@@ -52,8 +52,7 @@ func (s *State) Func(splitFunc bufio.SplitFunc, period time.Duration) bufio.Spli
 		}
 
 		// We're seeing new data so postpone the next flush
-		//if len(data) > s.LastDataLength {
-		if !atEOF {
+		if len(data) > s.LastDataLength && !atEOF {
 			s.LastDataChange = time.Now()
 			s.LastDataLength = len(data)
 			return 0, nil, nil


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fix for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32715.
In order to read the second token of the unit test we need to explicitly append a new line (`'\n'`) after it.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>