### PR TITLE
[chore] [windowsperfcounters] Add alxbl as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -154,7 +154,7 @@ pkg/translator/prometheusremotewrite/                    @open-telemetry/collect
 pkg/translator/signalfx/                                 @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/translator/skywalking/                               @open-telemetry/collector-contrib-approvers @JaredTan95
 pkg/translator/zipkin/                                   @open-telemetry/collector-contrib-approvers @MovieStoreGuy @andrzej-stencel @crobert-1
-pkg/winperfcounters/                                     @open-telemetry/collector-contrib-approvers @dashpole @Mrod1598 @BinaryFissionGames
+pkg/winperfcounters/                                     @open-telemetry/collector-contrib-approvers @dashpole @Mrod1598 @BinaryFissionGames @alxbl
 
 processor/attributesprocessor/                           @open-telemetry/collector-contrib-approvers @boostchicken
 processor/cumulativetodeltaprocessor/                    @open-telemetry/collector-contrib-approvers @TylerHelmuth
@@ -273,7 +273,7 @@ receiver/vcenterreceiver/                                @open-telemetry/collect
 receiver/wavefrontreceiver/                              @open-telemetry/collector-contrib-approvers @samiura
 receiver/webhookeventreceiver/                           @open-telemetry/collector-contrib-approvers @atoulme @shalper2
 receiver/windowseventlogreceiver/                        @open-telemetry/collector-contrib-approvers @djaglowski @armstrmi @pjanotti
-receiver/windowsperfcountersreceiver/                    @open-telemetry/collector-contrib-approvers @dashpole
+receiver/windowsperfcountersreceiver/                    @open-telemetry/collector-contrib-approvers @dashpole @alxbl
 receiver/zipkinreceiver/                                 @open-telemetry/collector-contrib-approvers @MovieStoreGuy @andrzej-stencel @crobert-1
 receiver/zookeeperreceiver/                              @open-telemetry/collector-contrib-approvers @djaglowski
 

--- a/pkg/winperfcounters/metadata.yaml
+++ b/pkg/winperfcounters/metadata.yaml
@@ -1,3 +1,3 @@
 status:
   codeowners:
-    active: [dashpole, Mrod1598, BinaryFissionGames]
+    active: [dashpole, Mrod1598, BinaryFissionGames, alxbl]

--- a/receiver/windowsperfcountersreceiver/README.md
+++ b/receiver/windowsperfcountersreceiver/README.md
@@ -7,7 +7,7 @@
 | Unsupported Platforms | darwin, linux |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fwindowsperfcounters%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fwindowsperfcounters) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fwindowsperfcounters%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fwindowsperfcounters) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@dashpole](https://www.github.com/dashpole) \| Seeking more code owners! |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@dashpole](https://www.github.com/dashpole), [@alxbl](https://www.github.com/alxbl) \| Seeking more code owners! |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/windowsperfcountersreceiver/metadata.yaml
+++ b/receiver/windowsperfcountersreceiver/metadata.yaml
@@ -7,7 +7,7 @@ status:
     beta: [metrics]
   distributions: [contrib]
   codeowners:
-    active: [dashpole]
+    active: [dashpole, alxbl]
     seeking_new: true
   unsupported_platforms: [darwin, linux]
 


### PR DESCRIPTION
**Description:** 
Adding myself as a code owner for both `pkg/windowsperfcounters` and `receiver/windowsperfcounters` since we're currently working with those two a lot and will likely have more fixes/contributions coming in the next couple of months.

I wasn't sure about the `pkg`, so if there are objections to that, I can do it in a later PR.

**Link to tracking Issue:** Follow up on #32576
**Testing:** N/A
**Documentation:** N/A