### PR TITLE
[chore][receiver/mongodb] Update metric supported versions

### DIFF
--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -69,10 +69,6 @@ The full list of settings exposed for this receiver are documented [here](./conf
 The following metric are available with versions:
 
 - `mongodb.extent.count` < 4.4 with mmapv1 storage engine
-- `mongodb.session.count` >= 3.0 with wiredTiger storage engine
-- `mongodb.cache.operations` >= 3.0 with wiredTiger storage engine
-- `mongodb.connection.count` with attribute `active` is available >= 4.0
-- `mongodb.index.access.count` >= 4.0
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The MongoDB receiver currently only supports v4 and v5 of MongoDB. The metrics in the given section don't need to be included anymore as they're available for all supported versions of MongoDB.