### PR TITLE
[receiver/vcenter] Fixes `vcenter.vm.disk.throughput` metric

### DIFF
--- a/.chloggen/fix_vcenter-vm-add-disk-metric.yaml
+++ b/.chloggen/fix_vcenter-vm-add-disk-metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds functionality for `vcenter.vm.disk.throughput` while also changing to a gauge."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32772]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -329,16 +329,19 @@ The highest reported total latency (device and kernel times) over an interval of
 
 ### vcenter.vm.disk.throughput
 
-The throughput of the virtual machine's disk.
+Average number of kilobytes read from or written to the virtual disk each second.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By/sec | Sum | Int | Cumulative | false |
+As measured over the most recent 20s interval. Requires Performance Level 2.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {KiBy/s} | Gauge | Int |
 
 #### Attributes
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
+| direction | The direction of disk latency. | Str: ``read``, ``write`` |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.disk.usage

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -194,7 +194,7 @@ func TestMetricsBuilder(t *testing.T) {
 
 			defaultMetricsCount++
 			allMetricsCount++
-			mb.RecordVcenterVMDiskThroughputDataPoint(ts, 1, "object_name-val")
+			mb.RecordVcenterVMDiskThroughputDataPoint(ts, 1, AttributeDiskDirectionRead, "object_name-val")
 
 			defaultMetricsCount++
 			allMetricsCount++
@@ -704,18 +704,19 @@ func TestMetricsBuilder(t *testing.T) {
 				case "vcenter.vm.disk.throughput":
 					assert.False(t, validatedMetrics["vcenter.vm.disk.throughput"], "Found a duplicate in the metrics slice: vcenter.vm.disk.throughput")
 					validatedMetrics["vcenter.vm.disk.throughput"] = true
-					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
-					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "The throughput of the virtual machine's disk.", ms.At(i).Description())
-					assert.Equal(t, "By/sec", ms.At(i).Unit())
-					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
-					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())
-					dp := ms.At(i).Sum().DataPoints().At(0)
+					assert.Equal(t, pmetric.MetricTypeGauge, ms.At(i).Type())
+					assert.Equal(t, 1, ms.At(i).Gauge().DataPoints().Len())
+					assert.Equal(t, "Average number of kilobytes read from or written to the virtual disk each second.", ms.At(i).Description())
+					assert.Equal(t, "{KiBy/s}", ms.At(i).Unit())
+					dp := ms.At(i).Gauge().DataPoints().At(0)
 					assert.Equal(t, start, dp.StartTimestamp())
 					assert.Equal(t, ts, dp.Timestamp())
 					assert.Equal(t, pmetric.NumberDataPointValueTypeInt, dp.ValueType())
 					assert.Equal(t, int64(1), dp.IntValue())
-					attrVal, ok := dp.Attributes().Get("object")
+					attrVal, ok := dp.Attributes().Get("direction")
+					assert.True(t, ok)
+					assert.EqualValues(t, "read", attrVal.Str())
+					attrVal, ok = dp.Attributes().Get("object")
 					assert.True(t, ok)
 					assert.EqualValues(t, "object_name-val", attrVal.Str())
 				case "vcenter.vm.disk.usage":

--- a/receiver/vcenterreceiver/internal/mockserver/responses/vm-performance-counters.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/vm-performance-counters.xml
@@ -10,6 +10,34 @@
                 </sampleInfo>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
+                        <counterId>173</counterId>
+                        <instance>scsi0:0</instance>
+                    </id>
+                    <value>10</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>173</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>10</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>174</counterId>
+                        <instance>scsi0:0</instance>
+                    </id>
+                    <value>110</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>174</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>110</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
                         <counterId>176</counterId>
                         <instance>scsi0:0</instance>
                     </id>
@@ -248,6 +276,34 @@
                 </sampleInfo>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
+                        <counterId>173</counterId>
+                        <instance>scsi0:0</instance>
+                    </id>
+                    <value>9</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>173</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>9</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>174</counterId>
+                        <instance>scsi0:0</instance>
+                    </id>
+                    <value>91</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>174</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>91</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
                         <counterId>176</counterId>
                         <instance>scsi0:0</instance>
                     </id>
@@ -484,6 +540,34 @@
                     <timestamp>2022-05-17T14:39:20Z</timestamp>
                     <interval>20</interval>
                 </sampleInfo>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>173</counterId>
+                        <instance>scsi0:0</instance>
+                    </id>
+                    <value>8</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>173</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>8</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>174</counterId>
+                        <instance>scsi0:0</instance>
+                    </id>
+                    <value>81</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>174</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>81</value>
+                </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>176</counterId>

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -382,13 +382,12 @@ metrics:
     attributes: [object_name]
   vcenter.vm.disk.throughput:
     enabled: true
-    description: The throughput of the virtual machine's disk.
-    unit: By/sec
-    sum:
-      monotonic: false
+    description: Average number of kilobytes read from or written to the virtual disk each second.
+    unit: "{KiBy/s}"
+    gauge:
       value_type: int
-      aggregation_temporality: cumulative
-    attributes: [object_name]
+    attributes: [disk_direction, object_name]
+    extended_documentation: As measured over the most recent 20s interval. Requires Performance Level 2.
   vcenter.vm.network.throughput:
     enabled: true
     description: The amount of data that was transmitted or received over the network of the virtual machine.

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -171,6 +171,8 @@ var vmPerfMetricList = []string{
 	"disk.maxTotalLatency.latest",
 	"virtualDisk.totalWriteLatency.average",
 	"virtualDisk.totalReadLatency.average",
+	"virtualDisk.read.average",
+	"virtualDisk.write.average",
 }
 
 func (v *vcenterMetricScraper) recordVMPerformanceMetrics(entityMetric *performance.EntityMetric) {
@@ -201,6 +203,10 @@ func (v *vcenterMetricScraper) recordVMPerformanceMetrics(entityMetric *performa
 				v.mb.RecordVcenterVMDiskLatencyAvgDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite, metadata.AttributeDiskTypeVirtual, val.Instance)
 			case "disk.maxTotalLatency.latest":
 				v.mb.RecordVcenterVMDiskLatencyMaxDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, val.Instance)
+			case "virtualDisk.read.average":
+				v.mb.RecordVcenterVMDiskThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionRead, val.Instance)
+			case "virtualDisk.write.average":
+				v.mb.RecordVcenterVMDiskThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeDiskDirectionWrite, val.Instance)
 			}
 		}
 	}

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -5265,6 +5265,51 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             name: vcenter.vm.disk.latency.max
             unit: ms
+          - description: Average number of kilobytes read from or written to the virtual disk each second.
+            name: vcenter.vm.disk.throughput
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "10"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "110"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "110"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+            unit: '{KiBy/s}'
           - description: The amount of storage space used by the virtual machine.
             name: vcenter.vm.disk.usage
             sum:
@@ -5725,6 +5770,51 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             name: vcenter.vm.disk.latency.max
             unit: ms
+          - description: Average number of kilobytes read from or written to the virtual disk each second.
+            name: vcenter.vm.disk.throughput
+            gauge:
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "91"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "91"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+            unit: '{KiBy/s}'
           - description: The amount of storage space used by the virtual machine.
             name: vcenter.vm.disk.usage
             sum:
@@ -6182,6 +6272,51 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             name: vcenter.vm.disk.latency.max
             unit: ms
+          - description: Average number of kilobytes read from or written to the virtual disk each second.
+            name: vcenter.vm.disk.throughput
+            gauge:
+              dataPoints:
+                - asInt: "8"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "8"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "81"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "81"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+            unit: '{KiBy/s}'
           - description: The amount of storage space used by the virtual machine.
             name: vcenter.vm.disk.usage
             sum:

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -5241,6 +5241,51 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             name: vcenter.vm.disk.latency.max
             unit: ms
+          - description: Average number of kilobytes read from or written to the virtual disk each second.
+            name: vcenter.vm.disk.throughput
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "10"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "110"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "110"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+            unit: '{KiBy/s}'
           - description: The amount of storage space used by the virtual machine.
             name: vcenter.vm.disk.usage
             sum:
@@ -5684,6 +5729,51 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             name: vcenter.vm.disk.latency.max
             unit: ms
+          - description: Average number of kilobytes read from or written to the virtual disk each second.
+            name: vcenter.vm.disk.throughput
+            gauge:
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "91"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "91"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+            unit: '{KiBy/s}'
           - description: The amount of storage space used by the virtual machine.
             name: vcenter.vm.disk.usage
             sum:
@@ -6130,6 +6220,51 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             name: vcenter.vm.disk.latency.max
             unit: ms
+          - description: Average number of kilobytes read from or written to the virtual disk each second.
+            name: vcenter.vm.disk.throughput
+            gauge:
+              dataPoints:
+                - asInt: "8"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "8"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "81"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "81"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: scsi0:0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+            unit: '{KiBy/s}'
           - description: The amount of storage space used by the virtual machine.
             name: vcenter.vm.disk.usage
             sum:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adds missing functionality for `vcenter.vm.disk.throughput` metric on VM resources.
Also changes the metric from a Sum to a Gauge.

**Link to tracking Issue:** <Issue number if applicable>
#32772 

**Testing:** <Describe what testing was performed and which tests were added.>
Unit/integration tests updated and tested. Local environment tested.

**Documentation:** <Describe the documentation added.>
New documentation generated based on the metadata.