### PR TITLE
[chore] remove runner from cache key to make caching less costly

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -287,7 +287,7 @@ jobs:
           path: |
             ~/go/bin
             ~/go/pkg/mod
-          key: go-cache-${{ runner.os }}-${{ matrix.runner }}-${{ hashFiles('**/go.sum') }}
+          key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload


### PR DESCRIPTION
This may help with #29856 - reducing the key so the same cache is reused. This may impact builds if the runners for Actuated and Ubuntu have slightly different dependencies. We will need to run this PR a couple times to see if there's an impact.