### PR TITLE
Agent should receive environment configuration from the supervisor

### DIFF
--- a/.chloggen/opamp_agent_inherits_env.yaml
+++ b/.chloggen/opamp_agent_inherits_env.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: When the OpAMP supervisor launches an agent, the agent inherits the environment from the supervisor.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32787]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -149,7 +149,9 @@ collector:
 ### Executing Collector
 
 The Supervisor starts and stops the Collector process as necessary. When
-run_as setting is provided, the Supervisor will execute the Collector
+it launches the collector, the collector will inherit the environment
+from the supervisor.
+When run_as setting is provided, the Supervisor will execute the Collector
 process as the specified user. This is highly recommended in situations
 when the Supervisor itself is running as root and it is desirable to
 drop the root privileges and run the Collector as a more restricted

--- a/cmd/opampsupervisor/supervisor/commander/commander.go
+++ b/cmd/opampsupervisor/supervisor/commander/commander.go
@@ -80,6 +80,7 @@ func (c *Commander) Start(ctx context.Context) error {
 	}
 
 	c.cmd = exec.CommandContext(ctx, c.cfg.Executable, c.args...) // #nosec G204
+	c.cmd.Env = os.Environ()  // The agent inherits the environment from the supervisor
 
 	// Capture standard output and standard error.
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/21072


### PR DESCRIPTION
**Description:** When spawning an agent, the supervisor copies over its own environment. This allows users to pass configuration to the agent+supervisor via environment variables.

r: @evan-bradley 