### PR TITLE
[chore] move actuated builds into separate workflow

### DIFF
--- a/.github/workflows/build-and-test-actuated.yml
+++ b/.github/workflows/build-and-test-actuated.yml
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   arm-unittest-matrix:
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     strategy:
       fail-fast: false
       matrix:
@@ -61,7 +62,7 @@ jobs:
       - name: Run Unit Tests
         run: make -j2 gotest GROUP=${{ matrix.group }}
   arm-unittest:
-    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Arm') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     runs-on: actuated-arm64-4cpu-4gb
     needs: [setup-environment, unittest-matrix]
     steps:

--- a/.github/workflows/build-and-test-actuated.yml
+++ b/.github/workflows/build-and-test-actuated.yml
@@ -1,0 +1,77 @@
+name: build-and-test
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+*'
+  merge_group:
+  pull_request:
+env:
+  TEST_RESULTS: testbed/tests/results/junit/results.xml
+  # Make sure to exit early if cache segment download times out after 2 minutes.
+  # We limit cache download as a whole to 5 minutes.
+  SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+  GOPROXY: https://goproxy1.cncf.selfactuated.dev,direct
+
+# Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  actuated-unittest-matrix:
+    strategy:
+      fail-fast: false
+      matrix:
+        group:
+          - receiver-0
+          - receiver-1
+          - receiver-2
+          - receiver-3
+          - processor
+          - exporter-0
+          - exporter-1
+          - exporter-2
+          - exporter-3
+          - extension
+          - connector
+          - internal
+          - pkg
+          - cmd-0
+          - cmd-1
+          - other
+    runs-on: actuated-arm64-4cpu-4gb
+    needs: [setup-environment]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.2"
+          cache: false
+      - name: Cache Go
+        id: go-cache
+        timeout-minutes: 5
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/bin
+            ~/go/pkg/mod
+          key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Run Unit Tests
+        run: make -j2 gotest GROUP=${{ matrix.group }}
+  actuated-unittest:
+    if: ${{ github.actor != 'dependabot[bot]' && always() }}
+    runs-on: ubuntu-latest
+    needs: [setup-environment, unittest-matrix]
+    steps:
+      - name: Print result
+        run: echo ${{ needs.actuated-unittest-matrix.result }}
+      - name: Interpret result
+        run: |
+          if [[ success == ${{ needs.actuated-unittest-matrix.result }} ]]
+          then
+            echo "All matrix jobs passed!"
+          else
+            echo "One or more matrix jobs failed."
+            false
+          fi

--- a/.github/workflows/build-and-test-actuated.yml
+++ b/.github/workflows/build-and-test-actuated.yml
@@ -1,4 +1,4 @@
-name: build-and-test
+name: build-and-test-arm
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/build-and-test-actuated.yml
+++ b/.github/workflows/build-and-test-actuated.yml
@@ -19,7 +19,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  actuated-unittest-matrix:
+  arm-unittest-matrix:
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +28,8 @@ jobs:
           - receiver-1
           - receiver-2
           - receiver-3
-          - processor
+          - processor-0
+          - processor-1
           - exporter-0
           - exporter-1
           - exporter-2
@@ -59,16 +60,16 @@ jobs:
           key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
       - name: Run Unit Tests
         run: make -j2 gotest GROUP=${{ matrix.group }}
-  actuated-unittest:
-    if: ${{ github.actor != 'dependabot[bot]' && always() }}
-    runs-on: ubuntu-latest
+  arm-unittest:
+    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Arm') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    runs-on: actuated-arm64-4cpu-4gb
     needs: [setup-environment, unittest-matrix]
     steps:
       - name: Print result
-        run: echo ${{ needs.actuated-unittest-matrix.result }}
+        run: echo ${{ needs.arm-unittest-matrix.result }}
       - name: Interpret result
         run: |
-          if [[ success == ${{ needs.actuated-unittest-matrix.result }} ]]
+          if [[ success == ${{ needs.arm-unittest-matrix.result }} ]]
           then
             echo "All matrix jobs passed!"
           else

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -251,10 +251,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ["1.22.2", "1.21.9"] # 1.20 is interpreted as 1.2 without quotes
-        runner: [ubuntu-latest, actuated-arm64-4cpu-4gb]
-        exclude:
-          - go-version: "1.21.9"
-            runner: actuated-arm64-4cpu-4gb
+        runner: [ubuntu-latest]
         group:
           - receiver-0
           - receiver-1
@@ -276,9 +273,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: [setup-environment]
     steps:
-      - if: startsWith( matrix.runner, 'actuated' )
-        run: |
-          echo "GOPROXY=https://goproxy1.cncf.selfactuated.dev,direct" >> "$GITHUB_ENV"
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:


### PR DESCRIPTION
As discussed in the 1-May-2024 SIG call, moving actuated builds to their own workflow file to make them not required.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32801