### PR TITLE
[receiver/vcenter] Adds Suspended VM Counts to `vcenter.cluster.vm.count`

### DIFF
--- a/.chloggen/fix_vcenter-cluster-vm-count-metric.yaml
+++ b/.chloggen/fix_vcenter-cluster-vm-count-metric.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Updates the `vcenter.cluster.vm.count` metric to also report suspended VM counts"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32803]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -68,7 +68,7 @@ The memory that is currently used by the cluster.
 
 ### vcenter.cluster.vm.count
 
-the number of virtual machines in the cluster.
+The number of virtual machines in the cluster.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -78,7 +78,7 @@ the number of virtual machines in the cluster.
 
 | Name | Description | Values |
 | ---- | ----------- | ------ |
-| power_state | Whether the virtual machines are powered on or off. | Str: ``on``, ``off`` |
+| power_state | The current power state of the virtual machine. | Str: ``on``, ``off``, ``suspended`` |
 
 ### vcenter.datastore.disk.usage
 

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -123,6 +123,7 @@ const (
 	_ AttributeVMCountPowerState = iota
 	AttributeVMCountPowerStateOn
 	AttributeVMCountPowerStateOff
+	AttributeVMCountPowerStateSuspended
 )
 
 // String returns the string representation of the AttributeVMCountPowerState.
@@ -132,14 +133,17 @@ func (av AttributeVMCountPowerState) String() string {
 		return "on"
 	case AttributeVMCountPowerStateOff:
 		return "off"
+	case AttributeVMCountPowerStateSuspended:
+		return "suspended"
 	}
 	return ""
 }
 
 // MapAttributeVMCountPowerState is a helper map of string to AttributeVMCountPowerState attribute value.
 var MapAttributeVMCountPowerState = map[string]AttributeVMCountPowerState{
-	"on":  AttributeVMCountPowerStateOn,
-	"off": AttributeVMCountPowerStateOff,
+	"on":        AttributeVMCountPowerStateOn,
+	"off":       AttributeVMCountPowerStateOff,
+	"suspended": AttributeVMCountPowerStateSuspended,
 }
 
 type metricVcenterClusterCPUEffective struct {
@@ -459,7 +463,7 @@ type metricVcenterClusterVMCount struct {
 // init fills vcenter.cluster.vm.count metric with initial data.
 func (m *metricVcenterClusterVMCount) init() {
 	m.data.SetName("vcenter.cluster.vm.count")
-	m.data.SetDescription("the number of virtual machines in the cluster.")
+	m.data.SetDescription("The number of virtual machines in the cluster.")
 	m.data.SetUnit("{virtual_machines}")
 	m.data.SetEmptySum()
 	m.data.Sum().SetIsMonotonic(false)

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -360,7 +360,7 @@ func TestMetricsBuilder(t *testing.T) {
 					validatedMetrics["vcenter.cluster.vm.count"] = true
 					assert.Equal(t, pmetric.MetricTypeSum, ms.At(i).Type())
 					assert.Equal(t, 1, ms.At(i).Sum().DataPoints().Len())
-					assert.Equal(t, "the number of virtual machines in the cluster.", ms.At(i).Description())
+					assert.Equal(t, "The number of virtual machines in the cluster.", ms.At(i).Description())
 					assert.Equal(t, "{virtual_machines}", ms.At(i).Unit())
 					assert.Equal(t, false, ms.At(i).Sum().IsMonotonic())
 					assert.Equal(t, pmetric.AggregationTemporalityCumulative, ms.At(i).Sum().AggregationTemporality())

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -91,11 +91,12 @@ attributes:
       - received
   vm_count_power_state:
     name_override: power_state
-    description: Whether the virtual machines are powered on or off.
+    description: The current power state of the virtual machine.
     type: string
     enum:
       - "on"
       - "off"
+      - "suspended"
   object_name:
     name_override: object
     description: The object on the virtual machine or host that is being reported on.
@@ -149,7 +150,7 @@ metrics:
     attributes: []
   vcenter.cluster.vm.count:
     enabled: true
-    description: the number of virtual machines in the cluster.
+    description: The number of virtual machines in the cluster.
     unit: "{virtual_machines}"
     sum:
       monotonic: false

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -124,9 +124,9 @@ func (v *vcenterMetricScraper) collectClusters(ctx context.Context, datacenter *
 	for _, c := range computes {
 		v.collectHosts(ctx, now, dcName, c, errs)
 		v.collectDatastores(ctx, now, dcName, c, errs)
-		poweredOnVMs, poweredOffVMs := v.collectVMs(ctx, now, dcName, c, errs)
+		poweredOnVMs, poweredOffVMs, suspendedVMs := v.collectVMs(ctx, now, dcName, c, errs)
 		if c.Reference().Type == "ClusterComputeResource" {
-			v.collectCluster(ctx, now, dcName, c, poweredOnVMs, poweredOffVMs, errs)
+			v.collectCluster(ctx, now, dcName, c, poweredOnVMs, poweredOffVMs, suspendedVMs, errs)
 		}
 	}
 }
@@ -136,11 +136,12 @@ func (v *vcenterMetricScraper) collectCluster(
 	now pcommon.Timestamp,
 	dcName string,
 	c *object.ComputeResource,
-	poweredOnVMs, poweredOffVMs int64,
+	poweredOnVMs, poweredOffVMs, suspendedVMs int64,
 	errs *scrapererror.ScrapeErrors,
 ) {
 	v.mb.RecordVcenterClusterVMCountDataPoint(now, poweredOnVMs, metadata.AttributeVMCountPowerStateOn)
 	v.mb.RecordVcenterClusterVMCountDataPoint(now, poweredOffVMs, metadata.AttributeVMCountPowerStateOff)
+	v.mb.RecordVcenterClusterVMCountDataPoint(now, suspendedVMs, metadata.AttributeVMCountPowerStateSuspended)
 
 	var moCluster mo.ClusterComputeResource
 	err := c.Properties(ctx, c.Reference(), []string{"summary"}, &moCluster)
@@ -366,7 +367,7 @@ func (v *vcenterMetricScraper) collectVMs(
 	dcName string,
 	compute *object.ComputeResource,
 	errs *scrapererror.ScrapeErrors,
-) (poweredOnVMs int64, poweredOffVMs int64) {
+) (poweredOnVMs int64, poweredOffVMs int64, suspendedVMs int64) {
 	// Get all VMs with property data
 	vms, err := v.client.VMs(ctx)
 	if err != nil {
@@ -398,10 +399,13 @@ func (v *vcenterMetricScraper) collectVMs(
 			continue
 		}
 
-		if string(vm.Runtime.PowerState) == "poweredOff" {
+		switch vm.Runtime.PowerState {
+		case "poweredOff":
 			poweredOffVMs++
-		} else {
+		case "poweredOn":
 			poweredOnVMs++
+		default:
+			suspendedVMs++
 		}
 
 		// vApp may not exist for a VM
@@ -460,7 +464,7 @@ func (v *vcenterMetricScraper) collectVMs(
 		v.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
-	return poweredOnVMs, poweredOffVMs
+	return poweredOnVMs, poweredOffVMs, suspendedVMs
 }
 
 func (v *vcenterMetricScraper) buildVMMetrics(

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -744,7 +744,7 @@ resourceMetrics:
                   startTimeUnixNano: "1707407684042820000"
                   timeUnixNano: "1707407733803628000"
             unit: By
-          - description: the number of virtual machines in the cluster.
+          - description: The number of virtual machines in the cluster.
             name: vcenter.cluster.vm.count
             sum:
               aggregationTemporality: 2
@@ -761,6 +761,13 @@ resourceMetrics:
                     - key: power_state
                       value:
                         stringValue: "off"
+                  startTimeUnixNano: "1707407684042820000"
+                  timeUnixNano: "1707407733803628000"
+                - asInt: "0"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "suspended"
                   startTimeUnixNano: "1707407684042820000"
                   timeUnixNano: "1707407733803628000"
             unit: "{virtual_machines}"

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -65,7 +65,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: the number of virtual machines in the cluster.
+          - description: The number of virtual machines in the cluster.
             name: vcenter.cluster.vm.count
             sum:
               aggregationTemporality: 2
@@ -82,6 +82,13 @@ resourceMetrics:
                     - key: power_state
                       value:
                         stringValue: "on"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "suspended"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{virtual_machines}'

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -62,7 +62,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: By
-          - description: the number of virtual machines in the cluster.
+          - description: The number of virtual machines in the cluster.
             name: vcenter.cluster.vm.count
             sum:
               aggregationTemporality: 2
@@ -79,6 +79,13 @@ resourceMetrics:
                     - key: power_state
                       value:
                         stringValue: "on"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "suspended"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{virtual_machines}'


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Currently the metric `vcenter.cluster.vm.count` does not include a count for suspended VMs. Instead it lumps together this count with the value it reports for "poweredOn" VMs.

Here I'm modifying the relevent metric attribute to allow for a "suspended" value, and updating the metric to report this count.

I also added a minor capitalization fix for the metadata description.

**Link to tracking Issue:** <Issue number if applicable>
#32803 

**Testing:** <Describe what testing was performed and which tests were added.>
Unit/integration tests updated and tested. Local environment tested.

**Documentation:** <Describe the documentation added.>
New documentation generated based on the metadata.