### PR TITLE
[chore] start and stop otlp exporter once

### DIFF
--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -79,7 +79,7 @@ func (bor *BaseOTLPDataReceiver) Start(tc consumer.Traces, mc consumer.Metrics, 
 		return err
 	}
 
-	// we reuse the receiver across signals. Starting the log receiver shuts down the metrics and traces receiver.
+	// we reuse the receiver across signals. Starting the log receiver starts the metrics and traces receiver.
 	return bor.logReceiver.Start(context.Background(), componenttest.NewNopHost())
 }
 

--- a/testbed/testbed/receivers.go
+++ b/testbed/testbed/receivers.go
@@ -79,12 +79,7 @@ func (bor *BaseOTLPDataReceiver) Start(tc consumer.Traces, mc consumer.Metrics, 
 		return err
 	}
 
-	if err = bor.traceReceiver.Start(context.Background(), componenttest.NewNopHost()); err != nil {
-		return err
-	}
-	if err = bor.metricsReceiver.Start(context.Background(), componenttest.NewNopHost()); err != nil {
-		return err
-	}
+	// we reuse the receiver across signals. Starting the log receiver shuts down the metrics and traces receiver.
 	return bor.logReceiver.Start(context.Background(), componenttest.NewNopHost())
 }
 
@@ -104,12 +99,7 @@ func (bor *BaseOTLPDataReceiver) WithQueue(sendingQueue string) *BaseOTLPDataRec
 }
 
 func (bor *BaseOTLPDataReceiver) Stop() error {
-	if err := bor.traceReceiver.Shutdown(context.Background()); err != nil {
-		return err
-	}
-	if err := bor.metricsReceiver.Shutdown(context.Background()); err != nil {
-		return err
-	}
+	// we reuse the receiver across signals. Shutting down the log receiver shuts down the metrics and traces receiver.
 	return bor.logReceiver.Shutdown(context.Background())
 }
 


### PR DESCRIPTION
The testbed starts and stops the exporter once per signal, but we know it's the same exporter underneath.

This PR changes the behavior of testbed to start and stop the exporter just once. This change is needed to support  https://github.com/open-telemetry/opentelemetry-collector/pull/10059