### PR TITLE
[chore] fix ARM build

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -43,12 +43,11 @@ jobs:
           - cmd-1
           - other
     runs-on: actuated-arm64-4cpu-4gb
-    needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.2"
+          go-version: "~1.22.2"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -58,13 +57,19 @@ jobs:
           path: |
             ~/go/bin
             ~/go/pkg/mod
-          key: go-build-cache-${{ runner.os }}-${{ matrix.group }}-go-${{ hashFiles('**/go.sum') }}
+          key: go-build-cache-${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+      - name: Install dependencies
+        if: steps.go-cache.outputs.cache-hit != 'true'
+        run: make -j2 gomoddownload
+      - name: Install Tools
+        if: steps.go-cache.outputs.cache-hit != 'true'
+        run: make install-tools
       - name: Run Unit Tests
         run: make -j2 gotest GROUP=${{ matrix.group }}
   arm-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
     runs-on: actuated-arm64-4cpu-4gb
-    needs: [setup-environment, unittest-matrix]
+    needs: [arm-unittest-matrix]
     steps:
       - name: Print result
         run: echo ${{ needs.arm-unittest-matrix.result }}


### PR DESCRIPTION
**Description:**
Fix ARM build:
* Remove dependency on setup-environment as this step is gone
* Add back some of the cache download of setup-environment
* Rename the workflow file to mention arm.
* Relax go version requirement to use the latest minor version.