### PR TITLE
[ptracetest] Add additional methods to ignore scope span instrumentation scope information

### DIFF
--- a/.chloggen/ptracetest_options.yaml
+++ b/.chloggen/ptracetest_options.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: ptracetest
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for ignore scope span instrumentation scope information
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32852]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/pdatatest/ptracetest/options.go
+++ b/pkg/pdatatest/ptracetest/options.go
@@ -174,6 +174,62 @@ func maskSpanAttributeValue(traces ptrace.Traces, attributeName string) {
 	}
 }
 
+// IgnoreScopeSpanInstrumentationScopeName is a CompareTracesOption that clears value of the scope span instrumentation scope name.
+func IgnoreScopeSpanInstrumentationScopeName() CompareTracesOption {
+	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {
+		maskScopeSpanInstrumentationScopeName(expected)
+		maskScopeSpanInstrumentationScopeName(actual)
+	})
+}
+
+func maskScopeSpanInstrumentationScopeName(traces ptrace.Traces) {
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		rs := traces.ResourceSpans().At(i)
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			ss.Scope().SetName("")
+		}
+	}
+}
+
+// IgnoreScopeSpanInstrumentationScopeVersion is a CompareTracesOption that clears value of the scope span instrumentation scope version.
+func IgnoreScopeSpanInstrumentationScopeVersion() CompareTracesOption {
+	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {
+		maskScopeSpanInstrumentationScopeVersion(expected)
+		maskScopeSpanInstrumentationScopeVersion(actual)
+	})
+}
+
+func maskScopeSpanInstrumentationScopeVersion(traces ptrace.Traces) {
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		rs := traces.ResourceSpans().At(i)
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			ss.Scope().SetVersion("")
+		}
+	}
+}
+
+// IgnoreScopeSpanInstrumentationScopeAttributeValue is a CompareTracesOption that clears value of the scope span instrumentation scope name.
+func IgnoreScopeSpanInstrumentationScopeAttributeValue(attributeName string) CompareTracesOption {
+	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {
+		maskScopeSpanInstrumentationScopeAttributeValue(expected, attributeName)
+		maskScopeSpanInstrumentationScopeAttributeValue(actual, attributeName)
+	})
+}
+
+func maskScopeSpanInstrumentationScopeAttributeValue(traces ptrace.Traces, attributeName string) {
+	for i := 0; i < traces.ResourceSpans().Len(); i++ {
+		rs := traces.ResourceSpans().At(i)
+		for j := 0; j < rs.ScopeSpans().Len(); j++ {
+			ss := rs.ScopeSpans().At(j)
+			if _, ok := ss.Scope().Attributes().Get(attributeName); ok {
+				ss.Scope().Attributes().PutStr(attributeName, "*")
+			}
+		}
+	}
+}
+
 // IgnoreStartTimestamp is a CompareTracesOption that clears StartTimestamp fields on all spans.
 func IgnoreStartTimestamp() CompareTracesOption {
 	return compareTracesOptionFunc(func(expected, actual ptrace.Traces) {

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-scope-attributes-mismatch/actual.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-scope-attributes-mismatch/actual.yaml
@@ -1,0 +1,17 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: host1
+    scopeSpans:
+      - scope:
+          name: scope1
+          version: v0.1.0
+          attributes:
+            - key: key1
+              value:
+                stringValue: value1
+      - scope:
+          name: scope2
+          version: v0.1.0

--- a/pkg/pdatatest/ptracetest/testdata/scopespans-scope-attributes-mismatch/expected.yaml
+++ b/pkg/pdatatest/ptracetest/testdata/scopespans-scope-attributes-mismatch/expected.yaml
@@ -1,0 +1,17 @@
+resourceSpans:
+  - resource:
+      attributes:
+        - key: host.name
+          value:
+            stringValue: host1
+    scopeSpans:
+      - scope:
+          name: scope1
+          version: v0.1.0
+          attributes:
+            - key: key1
+              value:
+                stringValue: value2
+      - scope:
+          name: scope2
+          version: v0.1.0


### PR DESCRIPTION
**Description:**
Add additional methods to ignore scope span instrumentation scope information:
* Version  `IgnoreScopeSpanInstrumentationScopeVersion`
* Name `IgnoreScopeSpanInstrumentationScopeName`
* Attributes `IgnoreScopeSpanInstrumentationScopeAttributeValue`

**Testing:**
Added to tests.
