### PR TITLE
[processor/groupbytrace] Fix metric names in test

### DIFF
--- a/processor/groupbytraceprocessor/metrics_test.go
+++ b/processor/groupbytraceprocessor/metrics_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestProcessorMetrics(t *testing.T) {
 	expectedViewNames := []string{
-		"processor_groupbytrace_processor_groupbytrace_conf_num_traces",
-		"processor_groupbytrace_processor_groupbytrace_num_events_in_queue",
-		"processor_groupbytrace_processor_groupbytrace_num_traces_in_memory",
-		"processor_groupbytrace_processor_groupbytrace_traces_evicted",
-		"processor_groupbytrace_processor_groupbytrace_spans_released",
-		"processor_groupbytrace_processor_groupbytrace_traces_released",
-		"processor_groupbytrace_processor_groupbytrace_incomplete_releases",
-		"processor_groupbytrace_processor_groupbytrace_event_latency",
+		"processor_groupbytrace_conf_num_traces",
+		"processor_groupbytrace_num_events_in_queue",
+		"processor_groupbytrace_num_traces_in_memory",
+		"processor_groupbytrace_traces_evicted",
+		"processor_groupbytrace_spans_released",
+		"processor_groupbytrace_traces_released",
+		"processor_groupbytrace_incomplete_releases",
+		"processor_groupbytrace_event_latency",
 	}
 
 	views := metricViews()


### PR DESCRIPTION
This is caused by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32698 , which apparently didn't fail with this.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
