### PR TITLE
fix(sumologicextension): End the heartbeatloop immediately on shutdown using the parent context

### DIFF
--- a/.chloggen/fix-sumo-extension.yaml
+++ b/.chloggen/fix-sumo-extension.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sumologicextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes an issue where there was a delay in stopping heartbeat messages when the extension was stopped."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32785]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/sumologicextension/extension.go
+++ b/extension/sumologicextension/extension.go
@@ -204,7 +204,7 @@ func (se *SumologicExtension) Start(ctx context.Context, host component.Host) er
 		}
 	}
 
-	go se.heartbeatLoop()
+	go se.heartbeatLoop(ctx)
 
 	return nil
 }
@@ -556,17 +556,16 @@ func (se *SumologicExtension) registerCollectorWithBackoff(ctx context.Context, 
 	}
 }
 
-func (se *SumologicExtension) heartbeatLoop() {
+func (se *SumologicExtension) heartbeatLoop(ctx context.Context) {
 	if se.registrationInfo.CollectorCredentialID == "" || se.registrationInfo.CollectorCredentialKey == "" {
 		se.logger.Error("Collector not registered, cannot send heartbeat")
 		return
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancel := context.WithCancel(ctx)
 	go func() {
-		// When the close channel is closed ...
-		<-se.closeChan
+		// When the context is done ...
+		<-ctx.Done()
 		// ... cancel the ongoing heartbeat request.
 		cancel()
 	}()


### PR DESCRIPTION

**Description:** 

- Cancel the heartbeatloop immediately on shutdown using the parent context. The reason for a flaky test could be because the collector is started and shutdown twice in a test. When this happens the last heartbeat from the previous execution could leak in as the first request from the next collection execution

- Restart the test server to ignore any possible heartbeats from a previous heartbeatloop that was shutdown

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32785

**Testing:** Unit tests and manual testing of heartbeats