### PR TITLE
fix(test): Skip flaky test around forcing collector re-registration until the root cause is confirmed

### DIFF
--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -562,6 +562,7 @@ func TestRegisterEmptyCollectorName(t *testing.T) {
 }
 
 func TestRegisterEmptyCollectorNameForceRegistration(t *testing.T) {
+	t.SkipNow() // Skip this test for now as it is flaky
 	t.Parallel()
 
 	hostname, err := getHostname(zap.NewNop())


### PR DESCRIPTION
**Description:** Remove flaky test around forcing collector re-registration until the root cause is confirmed

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32785

**Testing:** Unit tests
