### PR TITLE
Move Aneurysm9 to emeritus status

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -11,7 +11,6 @@ useAssigneeGroups: true
 assigneeGroups:
   approvers_maintainers:
     # Approvers
-    - Aneurysm9
     - atoulme
     - bryan-aguilar
     - crobert-1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -253,7 +253,6 @@ The following GitHub users are the currently available sponsors, either by being
 * [@crobert-1](https://github.com/crobert-1)
 * [@djaglowski](https://github.com/djaglowski)
 * [@codeboten](https://github.com/codeboten)
-* [@Aneurysm9](https://github.com/Aneurysm9)
 * [@mx-psi](https://github.com/mx-psi)
 * [@dmitryax](https://github.com/dmitryax)
 * [@evan-bradley](https://github.com/evan-bradley)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,6 @@ Emeritus Triagers:
 
 Approvers ([@open-telemetry/collector-contrib-approvers](https://github.com/orgs/open-telemetry/teams/collector-contrib-approvers)):
 
-- [Anthony Mirabella](https://github.com/Aneurysm9), AWS
 - [Antoine Toulme](https://github.com/atoulme), Splunk
 - [Bryan Aguilar](https://github.com/bryan-aguilar), AWS
 - [Curtis Robert](https://github.com/crobert-1), Splunk
@@ -97,6 +96,7 @@ Emeritus Approvers:
 
 - [Przemek Maciolek](https://github.com/pmm-sumo)
 - [Ruslan Kovalov](https://github.com/kovrus)
+- [Anthony Mirabella](https://github.com/Aneurysm9), AWS
 
 Maintainers ([@open-telemetry/collector-contrib-maintainer](https://github.com/orgs/open-telemetry/teams/collector-contrib-maintainer)):
 


### PR DESCRIPTION
I have been unable to provide this position the bandwidth that it deserves and it is time to formalize recognition of that fact.