### PR TITLE
[chore][receiver/sqlserver] Document Windows-only metrics

### DIFF
--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -16,6 +16,8 @@ metrics:
 
 Number of batch requests received by SQL Server.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {requests}/s | Gauge | Double |
@@ -23,6 +25,8 @@ Number of batch requests received by SQL Server.
 ### sqlserver.batch.sql_compilation.rate
 
 Number of SQL compilations needed.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -32,6 +36,8 @@ Number of SQL compilations needed.
 
 Number of SQL recompilations needed.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {compilations}/s | Gauge | Double |
@@ -39,6 +45,8 @@ Number of SQL recompilations needed.
 ### sqlserver.lock.wait.rate
 
 Number of lock requests resulting in a wait.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -48,6 +56,8 @@ Number of lock requests resulting in a wait.
 
 Average wait time for all lock requests that had to wait.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | ms | Gauge | Double |
@@ -55,6 +65,8 @@ Average wait time for all lock requests that had to wait.
 ### sqlserver.page.buffer_cache.hit_ratio
 
 Pages found in the buffer pool without having to read from disk.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -64,6 +76,8 @@ Pages found in the buffer pool without having to read from disk.
 
 Number of pages flushed by operations requiring dirty pages to be flushed.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {pages}/s | Gauge | Double |
@@ -71,6 +85,8 @@ Number of pages flushed by operations requiring dirty pages to be flushed.
 ### sqlserver.page.lazy_write.rate
 
 Number of lazy writes moving dirty pages to disk.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -80,6 +96,8 @@ Number of lazy writes moving dirty pages to disk.
 
 Time a page will stay in the buffer pool.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | s | Gauge | Int |
@@ -87,6 +105,8 @@ Time a page will stay in the buffer pool.
 ### sqlserver.page.operation.rate
 
 Number of physical database page operations issued.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -102,6 +122,8 @@ Number of physical database page operations issued.
 
 Number of pages split as a result of overflowing index pages.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {pages}/s | Gauge | Double |
@@ -109,6 +131,8 @@ Number of pages split as a result of overflowing index pages.
 ### sqlserver.transaction.rate
 
 Number of transactions started for the database (not including XTP-only transactions).
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -118,6 +142,8 @@ Number of transactions started for the database (not including XTP-only transact
 
 Number of transactions that wrote to the database and committed.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {transactions}/s | Gauge | Double |
@@ -125,6 +151,8 @@ Number of transactions that wrote to the database and committed.
 ### sqlserver.transaction_log.flush.data.rate
 
 Total number of log bytes flushed.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -134,6 +162,8 @@ Total number of log bytes flushed.
 
 Number of log flushes.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {flushes}/s | Gauge | Double |
@@ -141,6 +171,8 @@ Number of log flushes.
 ### sqlserver.transaction_log.flush.wait.rate
 
 Number of commits waiting for a transaction log flush.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
@@ -150,6 +182,8 @@ Number of commits waiting for a transaction log flush.
 
 Total number of transaction log expansions for a database.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | {growths} | Sum | Int | Cumulative | true |
@@ -157,6 +191,8 @@ Total number of transaction log expansions for a database.
 ### sqlserver.transaction_log.shrink.count
 
 Total number of transaction log shrinks for a database.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
@@ -166,6 +202,8 @@ Total number of transaction log shrinks for a database.
 
 Percent of transaction log space used.
 
+This metric is only available when running on Windows.
+
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | % | Gauge | Int |
@@ -173,6 +211,8 @@ Percent of transaction log space used.
 ### sqlserver.user.connection.count
 
 Number of users connected to the SQL Server.
+
+This metric is only available when running on Windows.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -47,66 +47,77 @@ metrics:
     unit: "{connections}"
     gauge:
       value_type: int
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.lock.wait_time.avg:
     enabled: true
     description: Average wait time for all lock requests that had to wait.
     unit: ms
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.lock.wait.rate:
     enabled: true
     description: Number of lock requests resulting in a wait.
     unit: "{requests}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.batch.request.rate:
     enabled: true
     description: Number of batch requests received by SQL Server.
     unit: "{requests}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.batch.sql_compilation.rate:
     enabled: true
     description: Number of SQL compilations needed.
     unit: "{compilations}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.batch.sql_recompilation.rate:
     enabled: true
     description: Number of SQL recompilations needed.
     unit: "{compilations}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.page.buffer_cache.hit_ratio:
     enabled: true
     description: Pages found in the buffer pool without having to read from disk.
     unit: "%"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.page.life_expectancy:
     enabled: true
     description: Time a page will stay in the buffer pool.
     unit: s
     gauge:
       value_type: int
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.page.split.rate:
     enabled: true
     description: Number of pages split as a result of overflowing index pages.
     unit: "{pages}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.page.lazy_write.rate:
     enabled: true
     description: Number of lazy writes moving dirty pages to disk.
     unit: "{writes}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.page.checkpoint.flush.rate:
     enabled: true
     description: Number of pages flushed by operations requiring dirty pages to be flushed.
     unit: "{pages}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.page.operation.rate:
     enabled: true
     description: Number of physical database page operations issued.
@@ -114,6 +125,7 @@ metrics:
     gauge:
       value_type: double
     attributes: [page.operations]
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction_log.growth.count:
     enabled: true
     description: Total number of transaction log expansions for a database.
@@ -122,6 +134,7 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
       value_type: int
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction_log.shrink.count:
     enabled: true
     description: Total number of transaction log shrinks for a database.
@@ -130,42 +143,49 @@ metrics:
       monotonic: true
       aggregation_temporality: cumulative
       value_type: int
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction_log.usage:
     enabled: true
     description: Percent of transaction log space used.
     unit: "%"
     gauge:
       value_type: int
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction_log.flush.wait.rate:
     enabled: true
     description: Number of commits waiting for a transaction log flush.
     unit: "{commits}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction_log.flush.rate:
     enabled: true
     description: Number of log flushes.
     unit: "{flushes}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction_log.flush.data.rate:
     enabled: true
     description: Total number of log bytes flushed.
     unit: By/s
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction.rate:
     enabled: true
     description: Number of transactions started for the database (not including XTP-only transactions).
     unit: "{transactions}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.transaction.write.rate:
     enabled: true
     description: Number of transactions that wrote to the database and committed.
     unit: "{transactions}/s"
     gauge:
       value_type: double
+    extended_documentation: This metric is only available when running on Windows.
   sqlserver.database.io.read_latency:
     enabled: false
     description: Total time that the users waited for reads issued on this file.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The referenced metrics are being gathered from Windows perf counters, thus they're currently only available on Windows. With the introduction of direct connection and other supported OSs, I think it would be good to be clear to users about metric availability.