### PR TITLE
[chore][fileconsumer] Skip flaky TestFlushPeriodEOF on windows

### DIFF
--- a/pkg/stanza/fileconsumer/internal/emittest/sink.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink.go
@@ -119,7 +119,7 @@ func (s *Sink) ExpectTokens(t *testing.T, expected ...[]byte) {
 			return
 		}
 	}
-	require.ElementsMatch(t, expected, actual)
+	require.ElementsMatch(t, expected, actual, fmt.Sprintf("expected: %v, actual: %v", expected, actual))
 }
 
 func (s *Sink) ExpectCall(t *testing.T, expected []byte, attrs map[string]any) {

--- a/pkg/stanza/fileconsumer/internal/reader/reader_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_test.go
@@ -6,6 +6,7 @@ package reader
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -188,6 +189,9 @@ func TestFingerprintChangeSize(t *testing.T) {
 }
 
 func TestFlushPeriodEOF(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows; See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32715")
+	}
 	tempDir := t.TempDir()
 	temp := filetest.OpenTemp(t, tempDir)
 	// Create a long enough initial token, so the scanner can't read the whole file at once


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32715

This also adds a bit more debugging info for other tests which fail on the same expectation, since it's not very obvious what was expected vs actually found.