### PR TITLE
[CI] fix timeout on arm-unittest-matrix

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -45,6 +45,7 @@ jobs:
           - cmd-0
           - cmd-1
           - other
+    timeout-minutes: 30
     runs-on: actuated-arm64-4cpu-4gb
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
**Description:**
Adding a timeout of 30 mins on arm-unittest-matrix 

**Link to tracking Issue:** 
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32914

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
