### PR TITLE
[chore][CI/CD][arm] Trigger arm runs on label

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -6,6 +6,9 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+*'
   merge_group:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
 env:
   TEST_RESULTS: testbed/tests/results/junit/results.xml
   # Make sure to exit early if cache segment download times out after 2 minutes.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I found in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32948 that the label `Run ARM` has been added, but the `build-and-test-arm / arm-unittest-matrix (pull_request) ` workflow is still skipped. This is because the `label` action does not trigger a retry.

From [documentation](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request):
```
if no activity types are specified, the workflow runs when a pull request is opened or reopened or when the head branch of the pull request is updated.
```

We need to specify that labelling issues should trigger the workflow to check to see if it needs to run again. I've copied the added section from the Windows workflow. I also added that we should only run on PRs against `main`.

**Testing:**
This PR shows it's working as it should now. Arm test was [originally skipped](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9009218559/job/24753003216?pr=32955), but after adding the label, tests [have started](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9009223570/job/24753017935?pr=32955)