### PR TITLE
add redact for span name

### DIFF
--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -73,10 +73,21 @@ func (s *redaction) processResourceSpan(ctx context.Context, rs ptrace.ResourceS
 			span := ils.Spans().At(k)
 			spanAttrs := span.Attributes()
 
+			// Redact span name
+		 	span.SetName(s.redactSpanName(span.Name()))
+
 			// Attributes can also be part of span
 			s.processAttrs(ctx, spanAttrs)
 		}
 	}
+}
+
+func (s *redaction) redactSpanName(name string) string {
+	var result = name
+	for _, compiledRE := range s.blockRegexList {
+		result = compiledRE.ReplaceAllString(result, "****")
+	}
+	return result
 }
 
 // processAttrs redacts the attributes of a resource span or a span

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -83,11 +83,10 @@ func (s *redaction) processResourceSpan(ctx context.Context, rs ptrace.ResourceS
 }
 
 func (s *redaction) redactSpanName(name string) string {
-	var result = name
 	for _, compiledRE := range s.blockRegexList {
-		result = compiledRE.ReplaceAllString(result, "****")
+		name = compiledRE.ReplaceAllString(name, "****")
 	}
-	return result
+	return name
 }
 
 // processAttrs redacts the attributes of a resource span or a span


### PR DESCRIPTION
**Description:** Added redact for span name in redactprocessor
redaction processor is redact attribute but the span name is not redact. When we depends on this function to do credential redaction, the span name could still be the issue, therefore, add redaction on span name,

**Testing:** Test case is added to the unit test.
