### PR TITLE
#32974 add edge dimensions

### DIFF
--- a/connector/servicegraphconnector/config.go
+++ b/connector/servicegraphconnector/config.go
@@ -28,6 +28,11 @@ type Config struct {
 	// https://github.com/open-telemetry/opentelemetry-collector/blob/main/model/semconv/opentelemetry.go.
 	Dimensions []string `mapstructure:"dimensions"`
 
+	// EdgeDimensions defines the list of additional Edge dimensions on top of the provided:
+	// - server_key
+	// - client_key
+	EdgeDimensions []string `mapstructure:"edge_dimensions"`
+
 	// Store contains the config for the in-memory store used to find requests between services by pairing spans.
 	Store StoreConfig `mapstructure:"store"`
 	// CacheLoop is the time to cleans the cache periodically.

--- a/connector/servicegraphconnector/config_test.go
+++ b/connector/servicegraphconnector/config_test.go
@@ -32,6 +32,7 @@ func TestLoadConfig(t *testing.T) {
 		&Config{
 			LatencyHistogramBuckets: []time.Duration{1, 2, 3, 4, 5},
 			Dimensions:              []string{"dimension-1", "dimension-2"},
+			EdgeDimensions:          []string{"server-dimension-1", "client-dimension-2"},
 			Store: StoreConfig{
 				TTL:      time.Second,
 				MaxItems: 10,

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -593,7 +593,7 @@ func (p *serviceGraphConnector) buildMetricKey(clientName, serverName, connectio
 	var metricKey strings.Builder
 	metricKey.WriteString(clientName + metricKeySeparator + serverName + metricKeySeparator + connectionType)
 
-	for _, dimName := range p.config.Dimensions {
+	for _, dimName := range p.config.EdgeDimensions {
 		dim, ok := edgeDimensions[dimName]
 		if !ok {
 			continue

--- a/connector/servicegraphconnector/testdata/service-graph-connector-config.yaml
+++ b/connector/servicegraphconnector/testdata/service-graph-connector-config.yaml
@@ -10,6 +10,9 @@ connectors:
     dimensions:
       - dimension-1
       - dimension-2
+    edge_dimensions:
+      - server-dimension-1
+      - client-dimension-2
     store:
       ttl: 1s
       max_items: 10


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

When our system collects trace data, it uses AppKeys for categorization. We take advantage of this by adding AppKeys as Dimensions in Config. However, in usertDimensions, we prefix this Dimensions. such as `client_app_key`, `server_app_key`

However, when creating a key to aggregate edge information, we also use the dimensions set in Config in the edge's Dimesions.
Naturally, we can't find it because it's already prefixed.

The config Dimensions are app_key
Edge's dimensions are `server_app_key`, `client_app_key`


**Link to tracking Issue:** <Issue number if applicable>
#32973 Dimensions on an Edge that is used as a Key in a Metric aggregation must be managed as a separate Config.

**Testing:** <Describe what testing was performed and which tests were added.>
I tested in config_test.go that edge_dimensions is read correctly.

**Documentation:** <Describe the documentation added.>
a separate EdgeDimensions setting (with the prefix)