### PR TITLE
[chore][extension/oauth2clientauth] Drop duplicate testing

### DIFF
--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -106,7 +106,6 @@ func TestOAuthClientSettings(t *testing.T) {
 }
 
 func TestOAuthClientSettingsCredsConfig(t *testing.T) {
-	// test files for TLS testing
 	var (
 		testCredsFile        = "testdata/test-cred.txt"
 		testCredsEmptyFile   = "testdata/test-cred-empty.txt"
@@ -125,8 +124,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDFile: testCredsFile,
 				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
-				Scopes:       []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testcreds",
@@ -140,8 +137,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:         "testclientid",
 				ClientSecretFile: testCredsFile,
-				TokenURL:         "https://example.com/v1/token",
-				Scopes:           []string{"resource.read"},
 			},
 			expectedClientConfig: &clientcredentials.Config{
 				ClientID:     "testclientid",
@@ -155,8 +150,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientIDFile: testCredsEmptyFile,
 				ClientSecret: "testsecret",
-				TokenURL:     "https://example.com/v1/token",
-				Scopes:       []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientIDProvided,
@@ -166,8 +159,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			settings: &Config{
 				ClientID:         "testclientid",
 				ClientSecretFile: testCredsMissingFile,
-				TokenURL:         "https://example.com/v1/token",
-				Scopes:           []string{"resource.read"},
 			},
 			shouldError:   true,
 			expectedError: &errNoClientSecretProvided,
@@ -186,13 +177,6 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedClientConfig.ClientID, cfg.ClientID)
 			assert.Equal(t, test.expectedClientConfig.ClientSecret, cfg.ClientSecret)
-
-			// test tls settings
-			transport := rc.client.Transport.(*http.Transport)
-			tlsClientConfig := transport.TLSClientConfig
-			tlsTestSettingConfig, err := test.settings.TLSSetting.LoadTLSConfig(context.Background())
-			assert.NoError(t, err)
-			assert.Equal(t, tlsClientConfig.Certificates, tlsTestSettingConfig.Certificates)
 		})
 	}
 }


### PR DESCRIPTION
**Description:**

Drop duplicate testing of parts related to TLS settings which already verified more extensively in other tests. This led to relevant changes requiring identical modifications in multiple places (e.g., #32332,
 #32394).

Also remove 'TokenURL' and 'Scopes' from the corresponding configs as they are not required anymore (since #30469).

For more details, see also
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32623#discussion_r1593908779
