### PR TITLE
[receiver/splunkehecreceiver] Align acking behavior with that of Splu…

### DIFF
--- a/.chloggen/hec-ack-alignment.yaml
+++ b/.chloggen/hec-ack-alignment.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Make the channelID header check case-insensitive and allow hecreceiver endpoints able to extract channelID from query params
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32995]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strconv"
 	"strings"
 	"sync"
@@ -400,9 +399,7 @@ func (r *splunkReceiver) extractChannel(req *http.Request) (string, bool) {
 		}
 	}
 	// check query param
-	u, _ := url.Parse(req.URL.String())
-	q := u.Query()
-	for k, v := range q {
+	for k, v := range req.URL.Query() {
 		if strings.EqualFold(k, "channel") {
 			return strings.ToUpper(v[0]), true
 		}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -1399,7 +1399,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 	config.Ack.Extension = &id
 	currentTime := float64(time.Now().UnixNano()) / 1e6
 	splunkMsg := buildSplunkHecMsg(currentTime, 3)
-
+	currAckID := uint64(0)
 	tests := []struct {
 		name                  string
 		req                   *http.Request
@@ -1469,13 +1469,14 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
 					processEvent: func(_ string) (ackID uint64) {
-						return uint64(1)
+						currAckID += 1
+						return currAckID
 					},
 					ack: func(_ string, _ uint64) {},
 				}
 			},
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
-				assertHecSuccessResponseWithAckID(t, resp, body, 1)
+				assertHecSuccessResponseWithAckID(t, resp, body, currAckID)
 			},
 		},
 		{
@@ -1490,13 +1491,14 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
 					processEvent: func(_ string) (ackID uint64) {
-						return uint64(1)
+						currAckID += 1
+						return currAckID
 					},
 					ack: func(_ string, _ uint64) {},
 				}
 			},
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
-				assertHecSuccessResponseWithAckID(t, resp, body, 1)
+				assertHecSuccessResponseWithAckID(t, resp, body, currAckID)
 			},
 		},
 		{
@@ -1510,13 +1512,14 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
 					processEvent: func(_ string) (ackID uint64) {
-						return uint64(1)
+						currAckID += 1
+						return currAckID
 					},
 					ack: func(_ string, _ uint64) {},
 				}
 			},
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
-				assertHecSuccessResponseWithAckID(t, resp, body, 1)
+				assertHecSuccessResponseWithAckID(t, resp, body, currAckID)
 			},
 		},
 	}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -1296,6 +1296,65 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 				}}, body)
 			},
 		},
+		{
+			name: "happy_path_with_case_insensitive_header",
+			req: func() *http.Request {
+				msgBytes, err := json.Marshal(buildSplunkHecAckMsg([]uint64{1, 2, 3}))
+				require.NoError(t, err)
+				req := httptest.NewRequest("POST", "http://localhost/ack", bytes.NewReader(msgBytes))
+				req.Header.Set("x-splunk-request-channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
+				return req
+			}(),
+			setupMockAckExtension: func() component.Component {
+				return &mockAckExtension{
+					queryAcks: func(_ string, _ []uint64) map[uint64]bool {
+						return map[uint64]bool{
+							1: true,
+							2: false,
+							3: true,
+						}
+					},
+				}
+			},
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{"acks": map[string]any{
+					"1": true,
+					"2": false,
+					"3": true,
+				}}, body)
+			},
+		},
+		{
+			name: "happy_path_with_query_param",
+			req: func() *http.Request {
+				msgBytes, err := json.Marshal(buildSplunkHecAckMsg([]uint64{1, 2, 3}))
+				require.NoError(t, err)
+				req := httptest.NewRequest("POST", "http://localhost/ack?channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90", bytes.NewReader(msgBytes))
+				return req
+			}(),
+			setupMockAckExtension: func() component.Component {
+				return &mockAckExtension{
+					queryAcks: func(_ string, _ []uint64) map[uint64]bool {
+						return map[uint64]bool{
+							1: true,
+							2: false,
+							3: true,
+						}
+					},
+				}
+			},
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				status := resp.StatusCode
+				assert.Equal(t, http.StatusOK, status)
+				assert.Equal(t, map[string]any{"acks": map[string]any{
+					"1": true,
+					"2": false,
+					"3": true,
+				}}, body)
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1405,6 +1464,47 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 				require.NoError(t, err)
 				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
+				return req
+			}(),
+			setupMockAckExtension: func() component.Component {
+				return &mockAckExtension{
+					processEvent: func(_ string) (ackID uint64) {
+						return uint64(1)
+					},
+					ack: func(_ string, _ uint64) {},
+				}
+			},
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				assertHecSuccessResponseWithAckID(t, resp, body, 1)
+			},
+		},
+		{
+			name: "happy_path_with_case_insensitive_header",
+			req: func() *http.Request {
+				msgBytes, err := json.Marshal(splunkMsg)
+				require.NoError(t, err)
+				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req.Header.Set("x-splunk-request-channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
+				return req
+			}(),
+			setupMockAckExtension: func() component.Component {
+				return &mockAckExtension{
+					processEvent: func(_ string) (ackID uint64) {
+						return uint64(1)
+					},
+					ack: func(_ string, _ uint64) {},
+				}
+			},
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				assertHecSuccessResponseWithAckID(t, resp, body, 1)
+			},
+		},
+		{
+			name: "happy_path_with_query_param",
+			req: func() *http.Request {
+				msgBytes, err := json.Marshal(splunkMsg)
+				require.NoError(t, err)
+				req := httptest.NewRequest("POST", "http://localhost/foo?Channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1536,6 +1636,55 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				require.NoError(t, err)
 				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
+				return req
+			}(),
+			setupMockAckExtension: func() component.Component {
+				return &mockAckExtension{
+					processEvent: func(_ string) (ackID uint64) {
+						return uint64(1)
+					},
+					ack: func(_ string, _ uint64) {
+					},
+				}
+			},
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				assertHecSuccessResponseWithAckID(t, resp, body, 1)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Equal(t, 1, len(sink.AllLogs()))
+			},
+		},
+		{
+			name: "msg_accepted_with_case_insensitive_header",
+			req: func() *http.Request {
+				msgBytes, err := json.Marshal(splunkMsg)
+				require.NoError(t, err)
+				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req.Header.Set("x-splunk-request-channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
+				return req
+			}(),
+			setupMockAckExtension: func() component.Component {
+				return &mockAckExtension{
+					processEvent: func(_ string) (ackID uint64) {
+						return uint64(1)
+					},
+					ack: func(_ string, _ uint64) {
+					},
+				}
+			},
+			assertResponse: func(t *testing.T, resp *http.Response, body any) {
+				assertHecSuccessResponseWithAckID(t, resp, body, 1)
+			},
+			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
+				assert.Equal(t, 1, len(sink.AllLogs()))
+			},
+		},
+		{
+			name: "msg_accepted_with_query_param",
+			req: func() *http.Request {
+				msgBytes, err := json.Marshal(splunkMsg)
+				require.NoError(t, err)
+				req := httptest.NewRequest("POST", "http://localhost/foo?channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90&isCheesy=true", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -1469,7 +1469,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
 					processEvent: func(_ string) (ackID uint64) {
-						currAckID += 1
+						currAckID++
 						return currAckID
 					},
 					ack: func(_ string, _ uint64) {},
@@ -1491,7 +1491,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
 					processEvent: func(_ string) (ackID uint64) {
-						currAckID += 1
+						currAckID++
 						return currAckID
 					},
 					ack: func(_ string, _ uint64) {},
@@ -1512,7 +1512,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{
 					processEvent: func(_ string) (ackID uint64) {
-						currAckID += 1
+						currAckID++
 						return currAckID
 					},
 					ack: func(_ string, _ uint64) {},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- Make the channelID header case-insensitive
- Make hecreceiver endpoints able to extract channelID from query params

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32995

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests
