### PR TITLE
[statsdreceiver] add source attributes and option to disable aggregation by source address

### DIFF
--- a/receiver/statsdreceiver/README.md
+++ b/receiver/statsdreceiver/README.md
@@ -28,6 +28,8 @@ The Following settings are optional:
 
 - `aggregation_interval: 70s`(default value is 60s): The aggregation time that the receiver aggregates the metrics (similar to the flush interval in StatsD server)
 
+- `aggregate_by_source_address: true`(default value is true): Aggregate the metrics by source address. If it is false, the receiver will not aggregate by the source address. In that case it is recommended your application sends identifying tags and use the [groupbyattrsprocessor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbyattrsprocessor).
+
 - `enable_metric_type: true`(default value is false): Enable the statsd receiver to be able to emit the metric type(gauge, counter, timer(in the future), histogram(in the future)) as a label.
 
 - `enable_simple_tags: true`(default value is false): Enable parsing tags that do not have a value, e.g. `#mykey` instead of `#mykey:myvalue`. DogStatsD supports such tagging.
@@ -51,6 +53,7 @@ receivers:
   statsd/2:
     endpoint: "localhost:8127"
     aggregation_interval: 70s
+    aggregate_by_source_address: true
     enable_metric_type: true
     is_monotonic_counter: false
     timer_histogram_mapping:

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -18,6 +18,7 @@ import (
 type Config struct {
 	NetAddr               confignet.AddrConfig             `mapstructure:",squash"`
 	AggregationInterval   time.Duration                    `mapstructure:"aggregation_interval"`
+	AggregateBySourceAddr bool                             `mapstructure:"aggregate_by_source_address"`
 	EnableMetricType      bool                             `mapstructure:"enable_metric_type"`
 	EnableSimpleTags      bool                             `mapstructure:"enable_simple_tags"`
 	IsMonotonicCounter    bool                             `mapstructure:"is_monotonic_counter"`

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -42,6 +42,7 @@ func TestLoadConfig(t *testing.T) {
 					Transport: confignet.TransportTypeUDP6,
 				},
 				AggregationInterval: 70 * time.Second,
+				AggregateBySourceAddr: true,
 				TimerHistogramMapping: []protocol.TimerHistogramMapping{
 					{
 						StatsdType:   "histogram",

--- a/receiver/statsdreceiver/factory.go
+++ b/receiver/statsdreceiver/factory.go
@@ -19,6 +19,7 @@ import (
 const (
 	defaultBindEndpoint        = "localhost:8125"
 	defaultAggregationInterval = 60 * time.Second
+	defaultAggregateBySourceAddr = true
 	defaultEnableMetricType    = false
 	defaultIsMonotonicCounter  = false
 )
@@ -43,6 +44,7 @@ func createDefaultConfig() component.Config {
 			Transport: confignet.TransportTypeUDP,
 		},
 		AggregationInterval:   defaultAggregationInterval,
+		AggregateBySourceAddr: defaultAggregateBySourceAddr,
 		EnableMetricType:      defaultEnableMetricType,
 		IsMonotonicCounter:    defaultIsMonotonicCounter,
 		TimerHistogramMapping: defaultTimerHistogramMapping,

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser.go
@@ -202,7 +202,16 @@ func (p *StatsDParser) GetMetrics() []BatchMetrics {
 			Metrics: pmetric.NewMetrics(),
 		}
 		rm := batch.Metrics.ResourceMetrics().AppendEmpty()
-		rm.Resource().Attributes().PutStr("source", instrument.addr.String())
+
+		// https://opentelemetry.io/docs/specs/semconv/attributes-registry/source/
+		// Set source.address and source.port attributes if able to parse.
+		if instrument.addr != nil {
+			host, port, err := net.SplitHostPort(instrument.addr.String())
+			if err == nil {
+				rm.Resource().Attributes().PutStr("source.address", host)
+				rm.Resource().Attributes().PutStr("source.port", port)
+			}
+		}
 		for _, metric := range instrument.gauges {
 			p.copyMetricAndScope(rm, metric)
 		}

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser.go
@@ -202,6 +202,7 @@ func (p *StatsDParser) GetMetrics() []BatchMetrics {
 			Metrics: pmetric.NewMetrics(),
 		}
 		rm := batch.Metrics.ResourceMetrics().AppendEmpty()
+		rm.Resource().Attributes().PutStr("source", instrument.addr.String())
 		for _, metric := range instrument.gauges {
 			p.copyMetricAndScope(rm, metric)
 		}

--- a/receiver/statsdreceiver/internal/transport/client/client.go
+++ b/receiver/statsdreceiver/internal/transport/client/client.go
@@ -14,7 +14,7 @@ import (
 type StatsD struct {
 	transport string
 	address   string
-	conn      io.Writer
+	Conn      net.Conn
 }
 
 // NewStatsD creates a new StatsD instance to support the need for testing
@@ -41,13 +41,13 @@ func (s *StatsD) connect() error {
 		if err != nil {
 			return err
 		}
-		s.conn, err = net.DialUDP(s.transport, nil, udpAddr)
+		s.Conn, err = net.DialUDP(s.transport, nil, udpAddr)
 		if err != nil {
 			return err
 		}
 	case "tcp":
 		var err error
-		s.conn, err = net.Dial(s.transport, s.address)
+		s.Conn, err = net.Dial(s.transport, s.address)
 		if err != nil {
 			return err
 		}
@@ -61,16 +61,16 @@ func (s *StatsD) connect() error {
 // Disconnect closes the StatsD.conn.
 func (s *StatsD) Disconnect() error {
 	var err error
-	if cl, ok := s.conn.(io.Closer); ok {
+	if cl, ok := s.Conn.(io.Closer); ok {
 		err = cl.Close()
 	}
-	s.conn = nil
+	s.Conn = nil
 	return err
 }
 
 // SendMetric sends the input metric to the StatsD connection.
 func (s *StatsD) SendMetric(metric Metric) error {
-	_, err := io.Copy(s.conn, strings.NewReader(metric.String()))
+	_, err := io.Copy(s.Conn, strings.NewReader(metric.String()))
 	if err != nil {
 		return fmt.Errorf("send metric on test client: %w", err)
 	}

--- a/receiver/statsdreceiver/metadata.yaml
+++ b/receiver/statsdreceiver/metadata.yaml
@@ -8,3 +8,9 @@ status:
   distributions: [contrib]
   codeowners:
     active: [jmacd, dmitryax]
+
+resource_attributes:
+  source:
+    description: Source address of the data
+    type: string
+    enabled: true

--- a/receiver/statsdreceiver/metadata.yaml
+++ b/receiver/statsdreceiver/metadata.yaml
@@ -10,7 +10,11 @@ status:
     active: [jmacd, dmitryax]
 
 resource_attributes:
-  source:
-    description: Source address of the data
+  source.address:
+    description: Source address
     type: string
+    enabled: true
+  source.port:
+    description: Source port number
+    type: int
     enabled: true

--- a/receiver/statsdreceiver/testdata/config.yaml
+++ b/receiver/statsdreceiver/testdata/config.yaml
@@ -3,6 +3,7 @@ statsd/receiver_settings:
   endpoint: "localhost:12345"
   transport: "udp6"
   aggregation_interval: 70s
+  aggregate_by_source_address: true
   enable_metric_type: false
   timer_histogram_mapping:
     - statsd_type: "histogram"


### PR DESCRIPTION
**Description:**
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
- Add source attributes following sematic -> https://opentelemetry.io/docs/specs/semconv/attributes-registry/source/
- Add option to aggregate metrics by client source address

Fixes #23809

**Link to tracking Issue:** #23809

**Testing:**
Added unit tests for the new attributes for both setting states.

Tested by running collector and manually pushing metrics.

```bash
# Test same instance two connections
echo "test.metric:1|ms|@1|#myKey:foo" | nc -v -u 127.0.0.1 8125;
echo "test.metric:2|ms|@1|#myKey:foo" | nc -v -u 127.0.0.1 8125;

# Test same instance one connection
echo -e "test.metric:1|ms|@1|#myKey:bar\ntest.metric:2|ms|@1|#myKey:bar" | nc -v -u 127.0.0.1 8125;
```

```log
Detaching and terminating target process
dlv dap (910189) exited with code: 0
Starting: /home/user/go/bin/dlv dap --listen=127.0.0.1:39177 --log-dest=3 from /home/user/sources/public/opentelemetry-collector-contrib/cmd/oteltestbedcol
DAP server listening at: 127.0.0.1:39177
Type 'dlv help' for list of commands.
2024-05-13T11:23:49.017+0200	info	service@v0.100.0/service.go:102	Setting up own telemetry...
2024-05-13T11:23:49.018+0200	info	service@v0.100.0/telemetry.go:103	Serving metrics	{"address": ":8889", "level": "Normal"}
2024-05-13T11:23:49.018+0200	debug	exporter@v0.100.0/exporter.go:273	Alpha component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "file"}
2024-05-13T11:23:49.018+0200	info	exporter@v0.100.0/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
2024-05-13T11:23:49.018+0200	debug	receiver@v0.100.0/receiver.go:308	Beta component. May change in the future.	{"kind": "receiver", "name": "statsd", "data_type": "metrics"}
2024-05-13T11:23:49.019+0200	info	service@v0.100.0/service.go:169	Starting oteltestbedcol...	{"Version": "0.100.0-dev", "NumCPU": 12}
2024-05-13T11:23:49.019+0200	info	extensions/extensions.go:34	Starting extensions...
2024-05-13T11:23:49.020+0200	info	service@v0.100.0/service.go:195	Everything is ready. Begin running and processing data.
2024-05-13T11:23:49.020+0200	warn	localhostgate/featuregate.go:63	The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.	{"feature gate ID": "component.UseLocalHostAsDefaultHost"}
2024-05-13T11:24:49.021+0200	info	MetricsExporter	{"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 1, "metrics": 1, "data points": 1}
2024-05-13T11:24:49.021+0200	info	ResourceMetrics #0
Resource SchemaURL: 
Resource attributes:
     -> source.address: Str(127.0.0.1)
     -> source.port: Str(39085)
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope otelcol/statsdreceiver 0.100.0-dev
Metric #0
Descriptor:
     -> Name: test.metric
     -> Description: 
     -> Unit: 
     -> DataType: ExponentialHistogram
     -> AggregationTemporality: Delta
ExponentialHistogramDataPoints #0
Data point attributes:
     -> myKey: Str(foo)
StartTimestamp: 2024-05-13 09:24:19.020417893 +0000 UTC
Timestamp: 2024-05-13 09:24:49.021130768 +0000 UTC
Count: 1
Sum: 1.000000
Min: 1.000000
Max: 1.000000
Bucket (0.999999, 1.000000], Count: 1
	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
2024-05-13T11:24:49.022+0200	info	MetricsExporter	{"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 1, "metrics": 1, "data points": 1}
2024-05-13T11:24:49.022+0200	info	ResourceMetrics #0
Resource SchemaURL: 
Resource attributes:
     -> source.address: Str(127.0.0.1)
     -> source.port: Str(40992)
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope otelcol/statsdreceiver 0.100.0-dev
Metric #0
Descriptor:
     -> Name: test.metric
     -> Description: 
     -> Unit: 
     -> DataType: ExponentialHistogram
     -> AggregationTemporality: Delta
ExponentialHistogramDataPoints #0
Data point attributes:
     -> myKey: Str(foo)
StartTimestamp: 2024-05-13 09:24:19.020417893 +0000 UTC
Timestamp: 2024-05-13 09:24:49.021130768 +0000 UTC
Count: 1
Sum: 2.000000
Min: 2.000000
Max: 2.000000
Bucket (1.999999, 2.000000], Count: 1
	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
2024-05-13T11:24:49.022+0200	info	ResourceMetrics #0
Resource SchemaURL: 
Resource attributes:
     -> source.address: Str(127.0.0.1)
     -> source.port: Str(36759)
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope otelcol/statsdreceiver 0.100.0-dev
Metric #0
Descriptor:
     -> Name: test.metric
     -> Description: 
     -> Unit: 
     -> DataType: ExponentialHistogram
     -> AggregationTemporality: Delta
ExponentialHistogramDataPoints #0
Data point attributes:
     -> myKey: Str(bar)
StartTimestamp: 2024-05-13 09:24:19.020417893 +0000 UTC
Timestamp: 2024-05-13 09:24:49.021130768 +0000 UTC
Count: 2
Sum: 3.000000
Min: 1.000000
Max: 2.000000
Bucket (0.917004, 1.000000], Count: 1
Bucket (1.000000, 1.090508], Count: 0
Bucket (1.090508, 1.189207], Count: 0
Bucket (1.189207, 1.296840], Count: 0
Bucket (1.296840, 1.414214], Count: 0
Bucket (1.414214, 1.542211], Count: 0
Bucket (1.542211, 1.681793], Count: 0
Bucket (1.681793, 1.834008], Count: 0
Bucket (1.834008, 2.000000], Count: 1
	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
```

And the result when using `aggregate_by_source_address: false`

```log
Detaching and terminating target process
dlv dap (910618) exited with code: 0
Starting: /home/user/go/bin/dlv dap --listen=127.0.0.1:36633 --log-dest=3 from /home/user/sources/public/opentelemetry-collector-contrib/cmd/oteltestbedcol
DAP server listening at: 127.0.0.1:36633
Type 'dlv help' for list of commands.
2024-05-13T11:27:12.119+0200	info	service@v0.100.0/service.go:102	Setting up own telemetry...
2024-05-13T11:27:12.119+0200	info	service@v0.100.0/telemetry.go:103	Serving metrics	{"address": ":8889", "level": "Normal"}
2024-05-13T11:27:12.119+0200	info	exporter@v0.100.0/exporter.go:275	Development component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "debug"}
2024-05-13T11:27:12.119+0200	debug	exporter@v0.100.0/exporter.go:273	Alpha component. May change in the future.	{"kind": "exporter", "data_type": "metrics", "name": "file"}
2024-05-13T11:27:12.119+0200	debug	receiver@v0.100.0/receiver.go:308	Beta component. May change in the future.	{"kind": "receiver", "name": "statsd", "data_type": "metrics"}
2024-05-13T11:27:12.120+0200	info	service@v0.100.0/service.go:169	Starting oteltestbedcol...	{"Version": "0.100.0-dev", "NumCPU": 12}
2024-05-13T11:27:12.120+0200	info	extensions/extensions.go:34	Starting extensions...
2024-05-13T11:27:12.120+0200	info	service@v0.100.0/service.go:195	Everything is ready. Begin running and processing data.
2024-05-13T11:27:12.120+0200	warn	localhostgate/featuregate.go:63	The default endpoints for all servers in components will change to use localhost instead of 0.0.0.0 in a future version. Use the feature gate to preview the new default.	{"feature gate ID": "component.UseLocalHostAsDefaultHost"}
2024-05-13T11:27:42.121+0200	info	MetricsExporter	{"kind": "exporter", "data_type": "metrics", "name": "debug", "resource metrics": 1, "metrics": 2, "data points": 2}
2024-05-13T11:27:42.122+0200	info	ResourceMetrics #0
Resource SchemaURL: 
Resource attributes:
     -> source.address: Str(0.0.0.0)
     -> source.port: Str(8125)
ScopeMetrics #0
ScopeMetrics SchemaURL: 
InstrumentationScope otelcol/statsdreceiver 0.100.0-dev
Metric #0
Descriptor:
     -> Name: test.metric
     -> Description: 
     -> Unit: 
     -> DataType: ExponentialHistogram
     -> AggregationTemporality: Delta
ExponentialHistogramDataPoints #0
Data point attributes:
     -> myKey: Str(foo)
StartTimestamp: 2024-05-13 09:27:12.120608796 +0000 UTC
Timestamp: 2024-05-13 09:27:42.120704563 +0000 UTC
Count: 2
Sum: 3.000000
Min: 1.000000
Max: 2.000000
Bucket (0.917004, 1.000000], Count: 1
Bucket (1.000000, 1.090508], Count: 0
Bucket (1.090508, 1.189207], Count: 0
Bucket (1.189207, 1.296840], Count: 0
Bucket (1.296840, 1.414214], Count: 0
Bucket (1.414214, 1.542211], Count: 0
Bucket (1.542211, 1.681793], Count: 0
Bucket (1.681793, 1.834008], Count: 0
Bucket (1.834008, 2.000000], Count: 1
ScopeMetrics #1
ScopeMetrics SchemaURL: 
InstrumentationScope otelcol/statsdreceiver 0.100.0-dev
Metric #0
Descriptor:
     -> Name: test.metric
     -> Description: 
     -> Unit: 
     -> DataType: ExponentialHistogram
     -> AggregationTemporality: Delta
ExponentialHistogramDataPoints #0
Data point attributes:
     -> myKey: Str(bar)
StartTimestamp: 2024-05-13 09:27:12.120608796 +0000 UTC
Timestamp: 2024-05-13 09:27:42.120704563 +0000 UTC
Count: 2
Sum: 3.000000
Min: 1.000000
Max: 2.000000
Bucket (0.917004, 1.000000], Count: 1
Bucket (1.000000, 1.090508], Count: 0
Bucket (1.090508, 1.189207], Count: 0
Bucket (1.189207, 1.296840], Count: 0
Bucket (1.296840, 1.414214], Count: 0
Bucket (1.414214, 1.542211], Count: 0
Bucket (1.542211, 1.681793], Count: 0
Bucket (1.681793, 1.834008], Count: 0
Bucket (1.834008, 2.000000], Count: 1
	{"kind": "exporter", "data_type": "metrics", "name": "debug"}

```

**Documentation:**
- Added the new resource attributes to the metadata file
- Describe the new config option and recommendation when disabling the default