### PR TITLE
deltatocumulative: evict only stale streams

### DIFF
--- a/.chloggen/deltatocumulative-evict-only-stale.yaml
+++ b/.chloggen/deltatocumulative-evict-only-stale.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: deltatocumulativeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Evict only stale streams
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33014]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Changes eviction behavior to only evict streams that are actually stale.
+  Currently, once the stream limit is hit, on each new stream the oldest tracked one is evicted.
+  Under heavy load this can rapidly delete all streams over and over, rendering the processor useless.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/exp/metrics/staleness/staleness.go
+++ b/internal/exp/metrics/staleness/staleness.go
@@ -88,10 +88,14 @@ func (s *Staleness[T]) Next() time.Time {
 	return ts
 }
 
-func (s *Staleness[T]) Evict() identity.Stream {
-	id, _ := s.pq.Pop()
+func (s *Staleness[T]) Evict() (identity.Stream, bool) {
+	id, ts := s.pq.Pop()
+	if ts.Add(s.Max).Before(time.Now()) {
+		return identity.Stream{}, false
+	}
+
 	s.items.Delete(id)
-	return id
+	return id, true
 }
 
 func (s *Staleness[T]) Clear() {

--- a/internal/exp/metrics/staleness/staleness.go
+++ b/internal/exp/metrics/staleness/staleness.go
@@ -89,11 +89,12 @@ func (s *Staleness[T]) Next() time.Time {
 }
 
 func (s *Staleness[T]) Evict() (identity.Stream, bool) {
-	id, ts := s.pq.Pop()
+	_, ts := s.pq.Peek()
 	if ts.Add(s.Max).Before(time.Now()) {
 		return identity.Stream{}, false
 	}
 
+	id, _ := s.pq.Pop()
 	s.items.Delete(id)
 	return id, true
 }

--- a/internal/exp/metrics/streams/streams.go
+++ b/internal/exp/metrics/streams/streams.go
@@ -58,6 +58,8 @@ func (m HashMap[T]) Clear() {
 
 // Evictors remove the "least important" stream based on some strategy such as
 // the oldest, least active, etc.
+//
+// Returns whether a stream was evicted and if so the now gone stream id
 type Evictor interface {
-	Evict() (identity.Stream, bool)
+	Evict() (gone identity.Stream, ok bool)
 }

--- a/internal/exp/metrics/streams/streams.go
+++ b/internal/exp/metrics/streams/streams.go
@@ -59,5 +59,5 @@ func (m HashMap[T]) Clear() {
 // Evictors remove the "least important" stream based on some strategy such as
 // the oldest, least active, etc.
 type Evictor interface {
-	Evict() identity.Stream
+	Evict() (identity.Stream, bool)
 }

--- a/processor/deltatocumulativeprocessor/internal/streams/limit_test.go
+++ b/processor/deltatocumulativeprocessor/internal/streams/limit_test.go
@@ -57,3 +57,52 @@ func TestLimit(t *testing.T) {
 		require.NoError(t, err)
 	}
 }
+
+func TestLimitEvict(t *testing.T) {
+	sum := random.Sum()
+	evictable := make(map[identity.Stream]struct{})
+
+	items := make(exp.HashMap[data.Number])
+	lim := streams.Limit(items, 5)
+	lim.Evictor = streams.EvictorFunc(func() (identity.Stream, bool) {
+		for id := range evictable {
+			delete(evictable, id)
+			return id, true
+		}
+		return identity.Stream{}, false
+	})
+
+	ids := make([]identity.Stream, 10)
+	dps := make([]data.Number, 10)
+	for i := 0; i < 10; i++ {
+		id, dp := sum.Stream()
+		ids[i] = id
+		dps[i] = dp
+	}
+
+	// store up to limit must work
+	for i := 0; i < 5; i++ {
+		err := lim.Store(ids[i], dps[i])
+		require.NoError(t, err)
+	}
+
+	// store beyond limit must fail
+	for i := 5; i < 10; i++ {
+		err := lim.Store(ids[i], dps[i])
+		require.Equal(t, streams.ErrLimit(5), err)
+	}
+
+	// put two streams up for eviction
+	evictable[ids[2]] = struct{}{}
+	evictable[ids[3]] = struct{}{}
+
+	// while evictable do so, fail again afterwards
+	for i := 5; i < 10; i++ {
+		err := lim.Store(ids[i], dps[i])
+		if i < 7 {
+			require.Equal(t, streams.ErrEvicted{ErrLimit: streams.ErrLimit(5), Ident: ids[i-3]}, err)
+		} else {
+			require.Equal(t, streams.ErrLimit(5), err)
+		}
+	}
+}

--- a/processor/deltatocumulativeprocessor/internal/telemetry/faults_test.go
+++ b/processor/deltatocumulativeprocessor/internal/telemetry/faults_test.go
@@ -140,11 +140,11 @@ type ts = pcommon.Timestamp
 // HeadEvictor drops the first stream on Evict()
 type HeadEvictor[T any] struct{ streams.Map[T] }
 
-func (e HeadEvictor[T]) Evict() (evicted identity.Stream) {
+func (e HeadEvictor[T]) Evict() (evicted identity.Stream, ok bool) {
 	e.Items()(func(id identity.Stream, _ T) bool {
 		e.Delete(id)
 		evicted = id
 		return false
 	})
-	return evicted
+	return evicted, true
 }


### PR DESCRIPTION
changes eviction behavior at limit to only delete streams if they are actually stale. Current behavior just deletes the oldest, which leads to rapid deletion of all streams under heavy load, making this processor unusable.

**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33014

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>