### PR TITLE
[chore][receiver/sqlserver] Update documentation for lock wait rate metric

### DIFF
--- a/receiver/sqlserverreceiver/documentation.md
+++ b/receiver/sqlserverreceiver/documentation.md
@@ -46,8 +46,6 @@ This metric is only available when running on Windows.
 
 Number of lock requests resulting in a wait.
 
-This metric is only available when running on Windows.
-
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
 | {requests}/s | Gauge | Double |

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -61,7 +61,6 @@ metrics:
     unit: "{requests}/s"
     gauge:
       value_type: double
-    extended_documentation: This metric is only available when running on Windows.
   sqlserver.batch.request.rate:
     enabled: true
     description: Number of batch requests received by SQL Server.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As a result of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32932 the metric `sqlserver.lock.wait.rate` is now available on Windows, or when directly connecting to a SQL server instance. Since this metric is always available, it no longer needs extended documentation about availability.