### PR TITLE
[pkg/ottl] Fix bug where function names were allowed in comparison

### DIFF
--- a/.chloggen/ottl-no-funcnames-in-conditions.yaml
+++ b/.chloggen/ottl-no-funcnames-in-conditions.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a bug where function name could be used in a condition, resulting in a cryptic error message.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33051]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -189,6 +189,12 @@ func Test_e2e_editors(t *testing.T) {
 			},
 		},
 		{
+			statement: `replace_pattern(attributes["http.path"], "/", "@", SHA256)`,
+			want: func(tCtx ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("http.path", "c3641f8544d7c02f3580b07c0f9887f0c6a27ff5ab1d4a3e29caf197cfc299aehealth")
+			},
+		},
+		{
 			statement: `set(attributes["test"], "pass")`,
 			want: func(tCtx ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -283,8 +283,8 @@ func (p *Parser[K]) buildArgs(ed editor, argsVal reflect.Value) error {
 			switch {
 			case arg.Value.Enum != nil:
 				name = string(*arg.Value.Enum)
-			case arg.Value.FunctionName != nil:
-				name = *arg.Value.FunctionName
+			case arg.FunctionName != nil:
+				name = *arg.FunctionName
 			default:
 				return fmt.Errorf("invalid function name given")
 			}

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -380,9 +380,7 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Function: "testing_functiongetter",
 				Arguments: []argument{
 					{
-						Value: value{
-							FunctionName: (ottltest.Strp("SHA256")),
-						},
+						FunctionName: ottltest.Strp("SHA256"),
 					},
 				},
 			},
@@ -1117,9 +1115,7 @@ func Test_NewFunctionCall(t *testing.T) {
 				Function: "testing_functiongetter",
 				Arguments: []argument{
 					{
-						Value: value{
-							FunctionName: (ottltest.Strp("SHA256")),
-						},
+						FunctionName: ottltest.Strp("SHA256"),
 					},
 				},
 			},
@@ -1131,9 +1127,7 @@ func Test_NewFunctionCall(t *testing.T) {
 				Function: "testing_functiongetter",
 				Arguments: []argument{
 					{
-						Value: value{
-							FunctionName: (ottltest.Strp("Sha256")),
-						},
+						FunctionName: ottltest.Strp("Sha256"),
 					},
 				},
 			},

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -218,8 +218,9 @@ type converter struct {
 }
 
 type argument struct {
-	Name  string `parser:"(@(Lowercase(Uppercase | Lowercase)*) Equal)?"`
-	Value value  `parser:"@@"`
+	Name         string  `parser:"(@(Lowercase(Uppercase | Lowercase)*) Equal)?"`
+	Value        value   `parser:"( @@"`
+	FunctionName *string `parser:"| @(Uppercase(Uppercase | Lowercase)*) )"`
 }
 
 func (a *argument) checkForCustomError() error {
@@ -236,7 +237,6 @@ type value struct {
 	String         *string          `parser:"| @String"`
 	Bool           *boolean         `parser:"| @Boolean"`
 	Enum           *enumSymbol      `parser:"| @Uppercase (?! Lowercase)"`
-	FunctionName   *string          `parser:"| @(Uppercase(Uppercase | Lowercase)*)"`
 	List           *list            `parser:"| @@)"`
 }
 

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -253,9 +253,7 @@ func Test_parse(t *testing.T) {
 							},
 						},
 						{
-							Value: value{
-								FunctionName: (ottltest.Strp("Sha256")),
-							},
+							FunctionName: ottltest.Strp("Sha256"),
 						},
 					},
 				},
@@ -1952,6 +1950,7 @@ func Test_parseCondition(t *testing.T) {
 		{`One() == 1`, false},
 		{`test(fail())`, true},
 		{`Test()`, false},
+		{`"test" == Foo`, true},
 	}
 	pat := regexp.MustCompile("[^a-zA-Z0-9]+")
 	for _, tt := range tests {


### PR DESCRIPTION
**Description:** 
Fix a bug where a condition like `"foo" = Bar` resulted in the error `no value field set. This is a bug in the OpenTelemetry Transformation Language`.

**Link to tracking Issue:** <Issue number if applicable>
Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33048

**Testing:** <Describe what testing was performed and which tests were added.>
Updated unit tests