### PR TITLE
[chore][receiver/cloudfoundry] Remove @pellared from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,7 +203,7 @@ receiver/bigipreceiver/                                  @open-telemetry/collect
 receiver/carbonreceiver/                                 @open-telemetry/collector-contrib-approvers @aboguszewski-sumo
 receiver/chronyreceiver/                                 @open-telemetry/collector-contrib-approvers @MovieStoreGuy @jamesmoessis
 receiver/cloudflarereceiver/                             @open-telemetry/collector-contrib-approvers @dehaansa @djaglowski
-receiver/cloudfoundryreceiver/                           @open-telemetry/collector-contrib-approvers @pellared @crobert-1
+receiver/cloudfoundryreceiver/                           @open-telemetry/collector-contrib-approvers @crobert-1
 receiver/collectdreceiver/                               @open-telemetry/collector-contrib-approvers @atoulme
 receiver/couchdbreceiver/                                @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/datadogreceiver/                                @open-telemetry/collector-contrib-approvers @boostchicken @gouthamve @jpkrohling @MovieStoreGuy

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -203,7 +203,7 @@ receiver/bigipreceiver/                                  @open-telemetry/collect
 receiver/carbonreceiver/                                 @open-telemetry/collector-contrib-approvers @aboguszewski-sumo
 receiver/chronyreceiver/                                 @open-telemetry/collector-contrib-approvers @MovieStoreGuy @jamesmoessis
 receiver/cloudflarereceiver/                             @open-telemetry/collector-contrib-approvers @dehaansa @djaglowski
-receiver/cloudfoundryreceiver/                           @open-telemetry/collector-contrib-approvers @crobert-1
+receiver/cloudfoundryreceiver/                           @open-telemetry/collector-contrib-approvers @pellared @crobert-1
 receiver/collectdreceiver/                               @open-telemetry/collector-contrib-approvers @atoulme
 receiver/couchdbreceiver/                                @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/datadogreceiver/                                @open-telemetry/collector-contrib-approvers @boostchicken @gouthamve @jpkrohling @MovieStoreGuy

--- a/receiver/cloudfoundryreceiver/README.md
+++ b/receiver/cloudfoundryreceiver/README.md
@@ -6,8 +6,8 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fcloudfoundry%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fcloudfoundry) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fcloudfoundry%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fcloudfoundry) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@pellared](https://www.github.com/pellared), [@crobert-1](https://www.github.com/crobert-1) |
-| Emeritus      | [@agoallikmaa](https://www.github.com/agoallikmaa) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@crobert-1](https://www.github.com/crobert-1) |
+| Emeritus      | [@agoallikmaa](https://www.github.com/agoallikmaa), [@pellared](https://www.github.com/pellared) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/cloudfoundryreceiver/metadata.yaml
+++ b/receiver/cloudfoundryreceiver/metadata.yaml
@@ -7,8 +7,8 @@ status:
     beta: [metrics]
   distributions: [contrib]
   codeowners:
-    active: [pellared, crobert-1]
-    emeritus: [agoallikmaa]
+    active: [crobert-1]
+    emeritus: [agoallikmaa, pellared]
 
 tests:
   config:


### PR DESCRIPTION
The truth is that I am not currently a code owner of this component.