### PR TITLE
[processor/resourcedetection] Move `processor.resourcedetection.hostCPUSteppingAsString` to beta

### DIFF
--- a/.chloggen/mx-psi_stepping-beta.yaml
+++ b/.chloggen/mx-psi_stepping-beta.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change type of `host.cpu.stepping` from int to string.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31136]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  - Disable the `processor.resourcedetection.hostCPUSteppingAsString` feature gate to get the old behavior.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -35,7 +35,7 @@ var (
 	hostCPUSteppingAsStringID          = "processor.resourcedetection.hostCPUSteppingAsString"
 	hostCPUSteppingAsStringFeatureGate = featuregate.GlobalRegistry().MustRegister(
 		hostCPUSteppingAsStringID,
-		featuregate.StageAlpha,
+		featuregate.StageBeta,
 		featuregate.WithRegisterDescription("Change type of host.cpu.stepping to string."),
 		featuregate.WithRegisterFromVersion("v0.95.0"),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/semantic-conventions/issues/664"),


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Follow up to #31165. The feature gate has been in alpha since v0.95.0.

**Link to tracking Issue:** Relates to #31136 and https://github.com/open-telemetry/semantic-conventions/issues/664

cc @ChrsMark 