### PR TITLE
[processor/resourcedetection] Move `processor.resourcedetection.hostCPUModelAndFamilyAsString` feature gate to stable

### DIFF
--- a/.chloggen/mx-psi_featuregatestable.yaml
+++ b/.chloggen/mx-psi_featuregatestable.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move `processor.resourcedetection.hostCPUModelAndFamilyAsString` feature gate to stable.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29025]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/internal/system/internal/metadata/resource_int_version.go
+++ b/processor/resourcedetectionprocessor/internal/system/internal/metadata/resource_int_version.go
@@ -3,20 +3,6 @@
 
 package metadata // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/system/internal/metadata"
 
-// SetHostCPUFamilyAsInt sets provided value as "host.cpu.family" attribute as int.
-func (rb *ResourceBuilder) SetHostCPUFamilyAsInt(val int64) {
-	if rb.config.HostCPUFamily.Enabled {
-		rb.res.Attributes().PutInt("host.cpu.family", val)
-	}
-}
-
-// SetHostCPUModelIDAsInt sets provided value as "host.cpu.model.id" attribute as int.
-func (rb *ResourceBuilder) SetHostCPUModelIDAsInt(val int64) {
-	if rb.config.HostCPUModelID.Enabled {
-		rb.res.Attributes().PutInt("host.cpu.model.id", val)
-	}
-}
-
 // SetHostCPUSteppingAsInt sets provided value as "host.cpu.stepping" attribute as int.
 func (rb *ResourceBuilder) SetHostCPUSteppingAsInt(val int64) {
 	if rb.config.HostCPUModelID.Enabled {

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -28,6 +28,7 @@ var (
 		featuregate.StageStable,
 		featuregate.WithRegisterDescription("Change type of host.cpu.model.id and host.cpu.model.family to string."),
 		featuregate.WithRegisterFromVersion("v0.89.0"),
+		featuregate.WithRegisterToVersion("v0.101.0"),
 		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/semantic-conventions/issues/495"),
 	)
 	hostCPUSteppingAsStringID          = "processor.resourcedetection.hostCPUSteppingAsString"

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -153,10 +153,7 @@ func (d *Detector) Detect(ctx context.Context) (resource pcommon.Resource, schem
 			d.rb.SetHostMac(hostMACAttribute)
 			d.rb.SetOsDescription(osDescription)
 			if len(cpuInfo) > 0 {
-				err = setHostCPUInfo(d, cpuInfo[0])
-				if err != nil {
-					d.logger.Warn("failed to get host cpuinfo", zap.Error(err))
-				}
+				setHostCPUInfo(d, cpuInfo[0])
 			}
 			return d.rb.Emit(), conventions.SchemaURL, nil
 		}
@@ -200,7 +197,7 @@ func reverseLookupHost(d *Detector) (string, error) {
 	return hostname, nil
 }
 
-func setHostCPUInfo(d *Detector, cpuInfo cpu.InfoStat) error {
+func setHostCPUInfo(d *Detector, cpuInfo cpu.InfoStat) {
 	d.logger.Debug("getting host's cpuinfo", zap.String("coreID", cpuInfo.CoreID))
 	d.rb.SetHostCPUVendorID(cpuInfo.VendorID)
 	d.rb.SetHostCPUFamily(cpuInfo.Family)
@@ -224,5 +221,4 @@ func setHostCPUInfo(d *Detector, cpuInfo cpu.InfoStat) error {
 		d.rb.SetHostCPUSteppingAsInt(int64(cpuInfo.Stepping))
 	}
 	d.rb.SetHostCPUCacheL2Size(int64(cpuInfo.CacheSize))
-	return nil
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Follows #29152 and #29462. The feature gate has been in beta since v0.91.0. 

**Link to tracking Issue:** Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29025 and to
https://github.com/open-telemetry/semantic-conventions/issues/495