### PR TITLE
[cmd/opampsupervisor]: Add storage dir to e2e test config to fix test failure

### DIFF
--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
@@ -11,6 +11,9 @@ capabilities:
   reports_remote_config: true
   accepts_restart_command: true
 
+storage:
+  directory: "{{.storage_dir}}"
+
 agent:
   executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}
   description:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
fixes test failure observed in #33093 (due to merge of #32819 and #32618)

**Link to tracking Issue:** Closes #33093

**Testing:** run supervisor e2e tests
