### PR TITLE
[receiver/splunk_hec] Fix parsing of a single metric value payload

### DIFF
--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -128,7 +128,7 @@ func buildAttributes(dimensions map[string]any) pcommon.Map {
 	attributes.EnsureCapacity(len(dimensions))
 	for key, val := range dimensions {
 
-		if strings.HasPrefix(key, "metric_name") {
+		if strings.HasPrefix(key, "metric_name") || key == "_value" {
 			continue
 		}
 		if key == "" || val == nil {

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -55,6 +55,19 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 			hecConfig:       defaultTestingHecConfig,
 		},
 		{
+			name: "int_gauge_v7",
+			splunkDataPoint: func() *splunk.Event {
+				pt := buildDefaultSplunkDataPt()
+				delete(pt.Fields, "metric_name:single")
+				pt.Fields["metric_name"] = "single"
+				pt.Fields["_value"] = int64Ptr(13)
+				return pt
+
+			}(),
+			wantMetricsData: buildDefaultMetricsData(nanos),
+			hecConfig:       defaultTestingHecConfig,
+		},
+		{
 			name: "multiple",
 			splunkDataPoint: func() *splunk.Event {
 				pt := buildDefaultSplunkDataPt()


### PR DESCRIPTION
Remove redundant `_value` attribute as it's set in the datapoint value.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33084
