### PR TITLE
[receiver/vcenter] Fixes Client Virtual App Call Error When No Virtual Apps

### DIFF
--- a/.chloggen/fix_vcenter-client-errors-on-empty-vapps.yaml
+++ b/.chloggen/fix_vcenter-client-errors-on-empty-vapps.yaml
@@ -1,26 +1,21 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: breaking
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: vcenterreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Removes `vcenter.cluster.name` attribute from `vcenter.datastore` metrics"
+note: "vcenterreceiver client no longer returns error if no Virtual Apps are found."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [32674]
+issues: [33073]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: | 
-  If there were multiple Clusters, Datastore metrics were being repeated under Resources differentiated with a
-  `vcenter.cluster.name` resource attribute. In the same vein, if there were standalone Hosts, in addition to
-  clusters the metrics would be repeated under a Resource without the `vcenter.cluster.name` attribute. Now there
-  will only be a single set of metrics for one Datastore (as there should be, as Datastores don't belong to
-  Clusters).
+subtext:
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -5,6 +5,7 @@ package vcenterreceiver // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 
@@ -240,7 +241,8 @@ func (vc *vcenterClient) VAppInventoryListObjects(ctx context.Context) ([]*objec
 		return vApps, nil
 	}
 
-	if _, ok := err.(*find.NotFoundError); ok {
+	var notFoundErr *find.NotFoundError
+	if errors.As(err, &notFoundErr) {
 		return []*object.VirtualApp{}, nil
 	}
 

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -236,11 +236,15 @@ func (vc *vcenterClient) ResourcePoolInventoryListObjects(ctx context.Context) (
 // VAppInventoryListObjects returns the vApps (with populated InventoryLists) of the vSphere SDK
 func (vc *vcenterClient) VAppInventoryListObjects(ctx context.Context) ([]*object.VirtualApp, error) {
 	vApps, err := vc.finder.VirtualAppList(ctx, "*")
-	if err != nil {
-		return nil, fmt.Errorf("unable to retrieve vApps with InventoryLists: %w", err)
+	if err == nil {
+		return vApps, nil
 	}
 
-	return vApps, nil
+	if _, ok := err.(*find.NotFoundError); ok {
+		return []*object.VirtualApp{}, nil
+	}
+
+	return nil, fmt.Errorf("unable to retrieve vApps with InventoryLists: %w", err)
 }
 
 // PerfMetricsQueryResult contains performance metric related data

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -51,6 +51,26 @@ func TestDatastores(t *testing.T) {
 	})
 }
 
+func TestEmptyDatastores(t *testing.T) {
+	vpx := simulator.VPX()
+	vpx.Datastore = 0
+	vpx.Machine = 0
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+		vm := view.NewManager(c)
+		client := vcenterClient{
+			vimDriver: c,
+			finder:    finder,
+			vm:        vm,
+		}
+		dc, err := finder.DefaultDatacenter(ctx)
+		require.NoError(t, err)
+		dss, err := client.Datastores(ctx, dc.Reference())
+		require.NoError(t, err)
+		require.Empty(t, dss, 0)
+	}, vpx)
+}
+
 func TestComputeResources(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
 		finder := find.NewFinder(c)
@@ -68,6 +88,24 @@ func TestComputeResources(t *testing.T) {
 	})
 }
 
+func TestComputeResourcesWithStandalone(t *testing.T) {
+	esx := simulator.ESX()
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+		vm := view.NewManager(c)
+		client := vcenterClient{
+			vimDriver: c,
+			finder:    finder,
+			vm:        vm,
+		}
+		dc, err := finder.DefaultDatacenter(ctx)
+		require.NoError(t, err)
+		crs, err := client.ComputeResources(ctx, dc.Reference())
+		require.NoError(t, err)
+		require.NotEmpty(t, crs, 0)
+	}, esx)
+}
+
 func TestHostSystems(t *testing.T) {
 	simulator.Test(func(ctx context.Context, c *vim25.Client) {
 		finder := find.NewFinder(c)
@@ -83,6 +121,27 @@ func TestHostSystems(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, hss, 0)
 	})
+}
+
+func TestEmptyHostSystems(t *testing.T) {
+	vpx := simulator.VPX()
+	vpx.Host = 0
+	vpx.ClusterHost = 0
+	vpx.Machine = 0
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+		vm := view.NewManager(c)
+		client := vcenterClient{
+			vimDriver: c,
+			finder:    finder,
+			vm:        vm,
+		}
+		dc, err := finder.DefaultDatacenter(ctx)
+		require.NoError(t, err)
+		hss, err := client.HostSystems(ctx, dc.Reference())
+		require.NoError(t, err)
+		require.Empty(t, hss, 0)
+	}, vpx)
 }
 
 func TestResourcePools(t *testing.T) {
@@ -117,6 +176,25 @@ func TestVMs(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, vms, 0)
 	})
+}
+
+func TestEmptyVMs(t *testing.T) {
+	vpx := simulator.VPX()
+	vpx.Machine = 0
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+		vm := view.NewManager(c)
+		client := vcenterClient{
+			vimDriver: c,
+			finder:    finder,
+			vm:        vm,
+		}
+		dc, err := finder.DefaultDatacenter(ctx)
+		require.NoError(t, err)
+		vms, err := client.VMs(ctx, dc.Reference())
+		require.NoError(t, err)
+		require.Empty(t, vms, 0)
+	}, vpx)
 }
 
 func TestPerfMetricsQuery(t *testing.T) {
@@ -170,6 +248,19 @@ func TestVAppInventoryListObjects(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, vApps, 0)
 	}, vpx)
+}
+
+func TestEmptyVAppInventoryListObjects(t *testing.T) {
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+		client := vcenterClient{
+			vimDriver: c,
+			finder:    finder,
+		}
+		vApps, err := client.VAppInventoryListObjects(ctx)
+		require.NoError(t, err)
+		require.Empty(t, vApps, 0)
+	})
 }
 
 func TestSessionReestablish(t *testing.T) {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Virtual Apps might not exist in an environment. Currently a `NotFound` error for the internal client is thrown when this condition occurs. I modified this to simply return an empty array, because this should simply mean that it did not find any Virtual Apps. I also added more client unit tests to test for these types of conditions.

**Link to tracking Issue:** <Issue number if applicable>
#33073 (loosely tied to this. At the very least this issue made me discover this problem)

**Testing:** <Describe what testing was performed and which tests were added.>
Added new unit tests which showed the error. Fix caused the new unit test to pass.

**Documentation:** <Describe the documentation added.>
N/A