### PR TITLE
[chore] Remove usage of `Providers` in `confmap.ResolverSettings`

### DIFF
--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -271,12 +271,11 @@ func getIntegrationTestCollector(t *testing.T, cfgStr string, url string, factor
 	_, err = otelcoltest.LoadConfigAndValidate(confFile.Name(), factories)
 	require.NoError(t, err, "All yaml config must be valid.")
 
-	fmp := fileprovider.NewFactory().Create(confmap.ProviderSettings{})
 	configProvider, err := otelcol.NewConfigProvider(
 		otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
-				URIs:      []string{confFile.Name()},
-				Providers: map[string]confmap.Provider{fmp.Scheme(): fmp},
+				URIs:              []string{confFile.Name()},
+				ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
 			},
 		})
 	require.NoError(t, err)

--- a/exporter/elasticsearchexporter/integrationtest/collector.go
+++ b/exporter/elasticsearchexporter/integrationtest/collector.go
@@ -167,11 +167,10 @@ func (c *recreatableOtelCol) Start(_ testbed.StartParams) error {
 		return err
 	}
 
-	fmp := fileprovider.NewFactory().Create(confmap.ProviderSettings{})
 	cfgProviderSettings := otelcol.ConfigProviderSettings{
 		ResolverSettings: confmap.ResolverSettings{
-			URIs:      []string{confFile.Name()},
-			Providers: map[string]confmap.Provider{fmp.Scheme(): fmp},
+			URIs:              []string{confFile.Name()},
+			ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
 		},
 	}
 

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -146,12 +146,11 @@ service:
 		Processors: processors,
 	}
 
-	fmp := fileprovider.NewFactory().Create(confmap.ProviderSettings{})
 	configProvider, err := otelcol.NewConfigProvider(
 		otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
-				URIs:      []string{confFile.Name()},
-				Providers: map[string]confmap.Provider{fmp.Scheme(): fmp},
+				URIs:              []string{confFile.Name()},
+				ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
 			},
 		})
 	require.NoError(t, err)

--- a/testbed/testbed/in_process_collector.go
+++ b/testbed/testbed/in_process_collector.go
@@ -57,12 +57,11 @@ func (ipp *inProcessCollector) Start(_ StartParams) error {
 	}
 	ipp.configFile = confFile.Name()
 
-	fmp := fileprovider.NewFactory().Create(confmap.ProviderSettings{})
 	configProvider, err := otelcol.NewConfigProvider(
 		otelcol.ConfigProviderSettings{
 			ResolverSettings: confmap.ResolverSettings{
-				URIs:      []string{ipp.configFile},
-				Providers: map[string]confmap.Provider{fmp.Scheme(): fmp},
+				URIs:              []string{ipp.configFile},
+				ProviderFactories: []confmap.ProviderFactory{fileprovider.NewFactory()},
 			},
 		})
 	if err != nil {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

`Providers` has been deprecated since v0.99.0.

Needed for https://github.com/open-telemetry/opentelemetry-collector/pull/10173.