### PR TITLE
[pkg/ottl] Add day, month, and year converters

### DIFF
--- a/.chloggen/add-day-month-year.yaml
+++ b/.chloggen/add-day-month-year.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds converters to extract the day/month/year from a `time.Time`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33106]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -380,6 +380,7 @@ Available Converters:
 - [Base64Decode](#base64decode)
 - [Concat](#concat)
 - [ConvertCase](#convertcase)
+- [Day](#day)
 - [ExtractPatterns](#extractpatterns)
 - [FNV](#fnv)
 - [Hour](#hour)
@@ -399,6 +400,7 @@ Available Converters:
 - [Microseconds](#microseconds)
 - [Milliseconds](#milliseconds)
 - [Minutes](#minutes)
+- [Month](#month)
 - [Nanoseconds](#nanoseconds)
 - [Now](#now)
 - [ParseCSV](#parsecsv)
@@ -421,6 +423,7 @@ Available Converters:
 - [UnixNano](#unixnano)
 - [UnixSeconds](#unixseconds)
 - [UUID](#UUID)
+- [Year][#year]
 
 ### Base64Decode
 
@@ -479,6 +482,20 @@ If `toCase` is any value other than the options above, the `ConvertCase` Convert
 Examples:
 
 - `ConvertCase(metric.name, "snake")`
+
+### Day
+
+`Day(value)`
+
+The `Day` Converter returns the day component from the specified time.  The Converter [uses the `time.Day` function](https://pkg.go.dev/time#Time.Day).
+
+`value` is a `time.Time`. If `value` is another type an error is returned.
+
+The returned type is `int64`.
+
+Examples:
+
+- `Day(Now())`
 
 ### Double
 
@@ -822,6 +839,20 @@ The returned type is `float64`.
 Examples:
 
 - `Minutes(Duration("1h"))`
+
+### Month
+
+`Month(value)`
+
+The `Month` Converter returns the month component from the specified time.  The Converter [uses the `time.Month` function](https://pkg.go.dev/time#Time.Month).
+
+`value` is a `time.Time`. If `value` is another type an error is returned.
+
+The returned type is `int64`.
+
+Examples:
+
+- `Month(Now())`
 
 ### Nanoseconds
 
@@ -1297,6 +1328,20 @@ Examples:
 `UUID()`
 
 The `UUID` function generates a v4 uuid string.
+
+### Year
+
+`Year(value)`
+
+The `Year` Converter returns the year component from the specified time. The Converter [uses the `time.Year` function](https://pkg.go.dev/time#Time.Year).
+
+`value` is a `time.Time`. If `value` is another type an error is returned.
+
+The returned type is `int64`.
+
+Examples:
+
+- `Year(Now())`
 
 ## Function syntax
 

--- a/pkg/ottl/ottlfuncs/func_day.go
+++ b/pkg/ottl/ottlfuncs/func_day.go
@@ -1,0 +1,36 @@
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type DayArguments[K any] struct {
+	Time ottl.TimeGetter[K]
+}
+
+func NewDayFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Day", &DayArguments[K]{}, createDayFunction[K])
+}
+
+func createDayFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*DayArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("DayFactory args must be of type *DayArguments[K]")
+	}
+
+	return Day(args.Time)
+}
+
+func Day[K any](duration ottl.TimeGetter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		d, err := duration.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return int64(d.Day()), nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_day_test.go
+++ b/pkg/ottl/ottlfuncs/func_day_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_Day(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     ottl.TimeGetter[any]
+		expected int64
+	}{
+		{
+			name: "some time",
+			time: &ottl.StandardTimeGetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
+				},
+			},
+			expected: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := Day(tt.time)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_Day_Error(t *testing.T) {
+	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "not a time", nil
+		},
+	}
+	exprFunc, err := Day(getter)
+	assert.NoError(t, err)
+	result, err := exprFunc(context.Background(), nil)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}

--- a/pkg/ottl/ottlfuncs/func_month.go
+++ b/pkg/ottl/ottlfuncs/func_month.go
@@ -1,0 +1,36 @@
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type MonthArguments[K any] struct {
+	Time ottl.TimeGetter[K]
+}
+
+func NewMonthFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Month", &MonthArguments[K]{}, createMonthFunction[K])
+}
+
+func createMonthFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*MonthArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("MonthFactory args must be of type *MonthArguments[K]")
+	}
+
+	return Month(args.Time)
+}
+
+func Month[K any](duration ottl.TimeGetter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		d, err := duration.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return int64(d.Month()), nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_month_test.go
+++ b/pkg/ottl/ottlfuncs/func_month_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_Month(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     ottl.TimeGetter[any]
+		expected int64
+	}{
+		{
+			name: "some time",
+			time: &ottl.StandardTimeGetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
+				},
+			},
+			expected: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := Month(tt.time)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_Month_Error(t *testing.T) {
+	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "not a time", nil
+		},
+	}
+	exprFunc, err := Month(getter)
+	assert.NoError(t, err)
+	result, err := exprFunc(context.Background(), nil)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}

--- a/pkg/ottl/ottlfuncs/func_year.go
+++ b/pkg/ottl/ottlfuncs/func_year.go
@@ -1,0 +1,36 @@
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type YearArguments[K any] struct {
+	Time ottl.TimeGetter[K]
+}
+
+func NewYearFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Year", &YearArguments[K]{}, createYearFunction[K])
+}
+
+func createYearFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*YearArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("YearFactory args must be of type *YearArguments[K]")
+	}
+
+	return Year(args.Time)
+}
+
+func Year[K any](duration ottl.TimeGetter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		d, err := duration.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return int64(d.Year()), nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_year_test.go
+++ b/pkg/ottl/ottlfuncs/func_year_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_Year(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     ottl.TimeGetter[any]
+		expected int64
+	}{
+		{
+			name: "some time",
+			time: &ottl.StandardTimeGetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
+				},
+			},
+			expected: 2006,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := Year(tt.time)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_Year_Error(t *testing.T) {
+	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "not a time", nil
+		},
+	}
+	exprFunc, err := Year(getter)
+	assert.NoError(t, err)
+	result, err := exprFunc(context.Background(), nil)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -38,6 +38,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewBase64DecodeFactory[K](),
 		NewConcatFactory[K](),
 		NewConvertCaseFactory[K](),
+		NewDayFactory[K](),
 		NewDoubleFactory[K](),
 		NewDurationFactory[K](),
 		NewExtractPatternsFactory[K](),
@@ -57,6 +58,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewMicrosecondsFactory[K](),
 		NewMillisecondsFactory[K](),
 		NewMinutesFactory[K](),
+		NewMonthFactory[K](),
 		NewNanosecondsFactory[K](),
 		NewNowFactory[K](),
 		NewParseCSVFactory[K](),
@@ -79,5 +81,6 @@ func converters[K any]() []ottl.Factory[K] {
 		NewUnixNanoFactory[K](),
 		NewUnixSecondsFactory[K](),
 		NewUUIDFactory[K](),
+		NewYearFactory[K](),
 	}
 }


### PR DESCRIPTION
**Description:**

Adds in three new ottl converters, `Day`, `Month`, and `Year`, which can be used to extract their respective components from a `time.Time`

**Link to tracking Issue:** #33106

**Testing:** Added unit tests for each, based on the existing converter, `Hour`

**Documentation:** Added each to the `README.md` for ottl