### PR TITLE
[pkg/ottl] Add `Year` converter

### DIFF
--- a/.chloggen/add-year-converter.yaml
+++ b/.chloggen/add-year-converter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a `Year` converter for extracting the int year component from a time.Time
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33106]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -421,6 +421,7 @@ Available Converters:
 - [UnixNano](#unixnano)
 - [UnixSeconds](#unixseconds)
 - [UUID](#UUID)
+- [Year](#year)
 
 ### Base64Decode
 
@@ -1297,6 +1298,20 @@ Examples:
 `UUID()`
 
 The `UUID` function generates a v4 uuid string.
+
+### Year
+
+`Year(value)`
+
+The `Year` Converter returns the year component from the specified time using the Go stdlib [`time.Year` function](https://pkg.go.dev/time#Time.Year).
+
+`value` is a `time.Time`. If `value` is another type, an error is returned.
+
+The returned type is `int64`.
+
+Examples:
+
+- `Year(Now())`
 
 ## Function syntax
 

--- a/pkg/ottl/ottlfuncs/func_year.go
+++ b/pkg/ottl/ottlfuncs/func_year.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type YearArguments[K any] struct {
+	Time ottl.TimeGetter[K]
+}
+
+func NewYearFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Year", &YearArguments[K]{}, createYearFunction[K])
+}
+
+func createYearFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*YearArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("YearFactory args must be of type *YearArguments[K]")
+	}
+
+	return Year(args.Time)
+}
+
+func Year[K any](time ottl.TimeGetter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		t, err := time.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		return int64(t.Year()), nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_year_test.go
+++ b/pkg/ottl/ottlfuncs/func_year_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_Year(t *testing.T) {
+	tests := []struct {
+		name     string
+		time     ottl.TimeGetter[any]
+		expected int64
+	}{
+		{
+			name: "some time",
+			time: &ottl.StandardTimeGetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC), nil
+				},
+			},
+			expected: 2006,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := Year(tt.time)
+			assert.NoError(t, err)
+			result, err := exprFunc(nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_Year_Error(t *testing.T) {
+	var getter ottl.TimeGetter[any] = &ottl.StandardTimeGetter[any]{
+		Getter: func(_ context.Context, _ any) (any, error) {
+			return "not a time", nil
+		},
+	}
+	exprFunc, err := Year(getter)
+	assert.NoError(t, err)
+	result, err := exprFunc(context.Background(), nil)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -79,5 +79,6 @@ func converters[K any]() []ottl.Factory[K] {
 		NewUnixNanoFactory[K](),
 		NewUnixSecondsFactory[K](),
 		NewUUIDFactory[K](),
+		NewYearFactory[K](),
 	}
 }


### PR DESCRIPTION
**Description:**

This adds in a `Year` converter that takes a `time.Time` and returns the int month component. Analogous to what we already have with `Hour`

**Link to tracking Issue:** #33106

**Testing:** Added two unit tests based on the existing `Hour` ones

**Documentation:** Added the new converter to the ottlfuncs README.md