### PR TITLE
[chore][Weekly Report] Define required variable

### DIFF
--- a/.github/workflows/scripts/generate-weekly-report.js
+++ b/.github/workflows/scripts/generate-weekly-report.js
@@ -240,6 +240,7 @@ function generateReport({ issuesData, previousReport, componentData }) {
   }
   out.push('</ul>');
 
+  const report = out.join('\n');
   return report;
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Weekly report failure](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9167350011/job/25204346835#step:4:55) output:
```
ReferenceError: report is not defined
    at generateReport (/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/.github/workflows/scripts/generate-weekly-report.js:243:3)
    at main (/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/.github/workflows/scripts/generate-weekly-report.js:419:18)
    at async module.exports (/home/runner/work/opentelemetry-collector-contrib/opentelemetry-collector-contrib/.github/workflows/scripts/generate-weekly-report.js:425:3)
    at async eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35424:16), <anonymous>:4:1)
    at async main (/home/runner/work/_actions/actions/github-script/v7/dist/index.js:35[52](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9167350011/job/25204346835#step:4:53)2:20)
Error: Unhandled error: ReferenceError: report is not defined
```
I accidentally deleted a line I shouldn't have in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32934, this re-adds the originally deleted line.