### PR TITLE
[chore] only ignore gosec linter in test

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -165,9 +165,11 @@ issues:
   exclude-rules:
     # Exclude some linters from running on tests files.
     - text: "G404:"
+      path: '(.+)_test\.go'
       linters:
         - gosec
     - text: "G402:"
+      path: '(.+)_test\.go'
       linters:
         - gosec
     - text: "SA1019: \"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/configschema"


### PR DESCRIPTION
This is as per the comment on line 163, these ignores were intended to only be ignored on test files.
