### PR TITLE
[chore] exclude certain gosec linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,8 +15,8 @@ run:
   # which dirs to skip: issues from them won't be reported;
   # can use regexp here: generated.*, regexp is applied on full path;
   # default value is empty list, but default dirs are skipped independently
-  # from this option's value (see skip-dirs-use-default).
-  skip-dirs:
+  # from this option's value (see exclude-dirs-use-default).
+  exclude-dirs:
     - third_party
     - local
     - cmd/otelcontribcol
@@ -24,7 +24,7 @@ run:
 
   # default is true. Enables skipping of directories:
   #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: false
+  exclude-dirs-use-default: false
 
   # which files to skip: they will be analyzed, but issues from them
   # won't be reported. Default value is empty list, but there is
@@ -45,7 +45,7 @@ run:
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  format: colored-line-number
+  formats: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -62,9 +62,6 @@ linters-settings:
       - prefix(github.com/open-telemetry/opentelemetry-collector-contrib)
 
   govet:
-    # report about shadowed variables
-    check-shadowing: true
-
     # settings per analyzer
     settings:
       printf: # analyzer name, run `go tool vet help` to see all analyzers
@@ -134,6 +131,13 @@ linters-settings:
 
   predeclared:
     ignore: copy
+
+  gosec:
+    excludes:
+      # https://github.com/golangci/golangci-lint/issues/4735
+      - G601
+      # https://github.com/golangci/golangci-lint/issues/4735
+      - G113
 
 linters:
   enable:


### PR DESCRIPTION
This is causing performance issue w/ the linters as discussed in https://github.com/golangci/golangci-lint/issues/4735
