### PR TITLE
[exporter/coralogix] feat: allow setting application name from custom  resource attributes

### DIFF
--- a/.chloggen/coralogix-exporter.yaml
+++ b/.chloggen/coralogix-exporter.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: coralogixexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "allow setting application name from cx.application.name and cx.subsystem.name attributes"
+note: "Allow setting application name from `cx.application.name` and `cx.subsystem.name` resource attributes"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [33217]

--- a/.chloggen/coralogix-exporter.yaml
+++ b/.chloggen/coralogix-exporter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: coralogixexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "allow setting application name from cx.application.name and cx.subsystem.name attributes"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33217]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/coralogixexporter/README.md
+++ b/exporter/coralogixexporter/README.md
@@ -231,7 +231,7 @@ exporters:
 
 ### Exporting to multiple teams based on attributes
 You can export the signals based on your business logic (attributes) to different Coralogix teams. To achieve this, you'll need to use the [`filter`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/filterprocessor/README.md) processor and setup one pipeline per team. You can setup your `filter` processors as following (example with metrics):
-```
+```yaml
 processors:  
   filter/teamA:
     metrics:
@@ -246,7 +246,7 @@ processors:
 This configuration ensures separate processor per each team. Any data points without an attribute for a particular team will be dropped from exporting. 
 
 Secondly, set up an individual exporter per each team:
-```
+```yaml
 exporters:
   coralogix/teamA:
     metrics:
@@ -263,7 +263,7 @@ exporters:
 ```
 
 Finally, join each processor and exporter (and any other components you wish) in the pipelines. Here is an example with a Prometheus receiver:
-```
+```yaml
 service:
   pipelines:
     metrics/1:
@@ -274,6 +274,44 @@ service:
       receivers: [prometheus]
       processors: [filter/teamB]
       exporters: [coralogix/teamB]
+```
+
+### Custom application and subsystem name
+
+You can pass custom application and subsystem name via the following resource attributes:
+
+- `cx.subsystem.name`
+- `cx.application.name`
+For example:
+
+```yaml
+receivers:
+  filelog/nginx:
+    include:
+      - '/tmp/tmp.log'
+    include_file_path: true
+    include_file_name: false
+    start_at: end
+    resource: 
+      cx.subsystem.name: nginx
+  filelog/access-log:
+    include:
+      - '/tmp/access.log'
+    include_file_path: true
+    include_file_name: false
+    resource: 
+      cx.subsystem.name: access-log
+exporters:
+  coralogix:
+    domain: 'coralogix.com'
+    private_key: "XXX"
+    application_name: 'app_name'
+    timeout: 30s
+service:
+  pipelines:
+    logs:
+      receivers: [filelog/nginx, filelog/access-log]
+      exporters: [coralogix]
 ```
 
 ### Need help?

--- a/exporter/coralogixexporter/config.go
+++ b/exporter/coralogixexporter/config.go
@@ -113,6 +113,18 @@ func (c *Config) getMetadataFromResource(res pcommon.Resource) (appName, subsyst
 		subsystem = c.SubSystem
 	}
 
+	if appName == "" {
+		attr, ok := res.Attributes().Get(cxAppNameAttrName)
+		if ok && attr.AsString() != "" {
+			appName = attr.AsString()
+		}
+	}
+	if subsystem == "" {
+		attr, ok := res.Attributes().Get(cxSubsystemNameAttrName)
+		if ok && attr.AsString() != "" {
+			subsystem = attr.AsString()
+		}
+	}
 	return appName, subsystem
 }
 

--- a/exporter/coralogixexporter/config_test.go
+++ b/exporter/coralogixexporter/config_test.go
@@ -293,6 +293,10 @@ func TestGetMetadataFromResource(t *testing.T) {
 	r2.Attributes().PutStr("k8s.node.name", "node-test")
 	r2.Attributes().PutStr("k8s.namespace.name", "namespace-test")
 
+	r3 := pcommon.NewResource()
+	r3.Attributes().PutStr("cx.application.name", "application")
+	r3.Attributes().PutStr("cx.subsystem.name", "subsystem")
+
 	c := &Config{
 		AppNameAttributes:   []string{"k8s.container.name", "k8s.deployment.name", "k8s.node.name"},
 		SubSystemAttributes: []string{"k8s.namespace.name", "k8s.node.name"},
@@ -305,4 +309,8 @@ func TestGetMetadataFromResource(t *testing.T) {
 	appName, subSystemName = c.getMetadataFromResource(r2)
 	assert.Equal(t, "node-test", appName)
 	assert.Equal(t, "namespace-test", subSystemName)
+
+	appName, subSystemName = c.getMetadataFromResource(r3)
+	assert.Equal(t, "application", appName)
+	assert.Equal(t, "subsystem", subSystemName)
 }


### PR DESCRIPTION
**Description:** 

allow setting application name from cx.application.name and cx.subsystem.name attributes. To support simplified use case, such as:

```yaml
receivers:
  filelog/nginx:
    include:
      - '/tmp/tmp.log'
    include_file_path: true
    include_file_name: false
    start_at: end
    resource: 
      cx.subsystem.name: nginx
  filelog/access-log:
    include:
      - '/tmp/access.log'
    include_file_path: true
    include_file_name: false
    resource: 
      cx.subsystem.name: access-log
exporters:
  coralogix:
    domain: 'coralogix.com'
    private_key: "XXX"
    application_name: 'app_name'
    timeout: 30s
service:
  pipelines:
    logs:
      receivers: [filelog/nginx, filelog/access-log]
      exporters: [coralogix]
```

**Link to tracking Issue:** <Issue number if applicable>
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33217

**Testing:** <Describe what testing was performed and which tests were added.>
- unit tests
- manually tested

**Documentation:** <Describe the documentation added.>

- updated docs