### PR TITLE
[chore] add Makefile target for installing the collector as k8s deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,13 +407,23 @@ kind-build: kind-ready docker-otelcontribcol
 
 .PHONY: kind-install-daemonset
 kind-install-daemonset: kind-ready kind-uninstall-daemonset## Install a local Collector version into the cluster.
-	@echo "Installing Collector"
+	@echo "Installing daemonset collector"
 	helm install daemonset-collector-dev open-telemetry/opentelemetry-collector --values ./examples/kubernetes/daemonset-collector-dev.yaml
 
 .PHONY: kind-uninstall-daemonset
 kind-uninstall-daemonset: kind-ready
-	@echo "Uninstalling Collector"
+	@echo "Uninstalling daemonset collector"
 	helm uninstall --ignore-not-found daemonset-collector-dev
+
+.PHONY: kind-install-deployment
+kind-install-deployment: kind-ready kind-uninstall-deployment## Install a local Collector version into the cluster.
+	@echo "Installing deployment collector"
+	helm install deployment-collector-dev open-telemetry/opentelemetry-collector --values ./examples/kubernetes/deployment-collector-dev.yaml
+
+.PHONY: kind-uninstall-deployment
+kind-uninstall-deployment: kind-ready
+	@echo "Uninstalling deployment collector"
+	helm uninstall --ignore-not-found deployment-collector-dev
 
 .PHONY: all-checklinks
 all-checklinks:

--- a/examples/kubernetes/deployment-collector-dev.yaml
+++ b/examples/kubernetes/deployment-collector-dev.yaml
@@ -1,0 +1,93 @@
+mode: deployment
+
+image:
+  repository: otelcontribcol-dev
+  tag: "0.0.1"
+  pullPolicy: IfNotPresent
+
+command:
+  name: otelcontribcol
+
+extraEnvs:
+  - name: K8S_NODE_NAME
+    valueFrom:
+      fieldRef:
+        fieldPath: spec.nodeName
+
+clusterRole:
+  create: true
+  rules:
+    - apiGroups:
+        - ""
+      resources:
+        - events
+        - namespaces
+        - namespaces/status
+        - nodes
+        - nodes/spec
+        - pods
+        - pods/status
+        - replicationcontrollers
+        - replicationcontrollers/status
+        - resourcequotas
+        - services
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - apps
+      resources:
+        - daemonsets
+        - deployments
+        - replicasets
+        - statefulsets
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - extensions
+      resources:
+        - daemonsets
+        - deployments
+        - replicasets
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - batch
+      resources:
+        - jobs
+        - cronjobs
+      verbs:
+        - get
+        - list
+        - watch
+    - apiGroups:
+        - autoscaling
+      resources:
+        - horizontalpodautoscalers
+      verbs:
+        - get
+        - list
+        - watch
+
+config:
+  exporters:
+    debug:
+      verbosity: detailed
+  receivers:
+    k8s_cluster:
+      collection_interval: 10s
+      metrics:
+        k8s.container.cpu_limit:
+          enabled: false
+
+  service:
+    pipelines:
+      metrics:
+        receivers: [k8s_cluster]
+        processors: [batch]
+        exporters: [debug]

--- a/examples/kubernetes/dev-docs.md
+++ b/examples/kubernetes/dev-docs.md
@@ -27,5 +27,5 @@ This command will install the Collector using the [`deployment-collector-dev.yam
 configuration sample.
 This only stands as a sample configuration and users need to tune this according to their needs.
 
-#### Uninstall the Daemonset
-`make kind-uninstall-daemonset`
+#### Uninstall the Deployment
+`make kind-uninstall-deployment`

--- a/examples/kubernetes/dev-docs.md
+++ b/examples/kubernetes/dev-docs.md
@@ -19,3 +19,13 @@ This only stands as a sample configuration and users need to tune this according
 
 #### Uninstall the Daemonset
 `make kind-uninstall-daemonset`
+
+#### Install the Collector as Deployment
+`make kind-install-deployment`
+
+This command will install the Collector using the [`deployment-collector-dev.yaml`](./deployment-collector-dev.yaml)
+configuration sample.
+This only stands as a sample configuration and users need to tune this according to their needs.
+
+#### Uninstall the Daemonset
+`make kind-uninstall-daemonset`


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR adds a makefile target for installing a locally built collector image (on a local k8s kind cluster) in deployment mode.

**Link to tracking Issue:** <Issue number if applicable> 
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32348
Follow up of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32349

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.> Added

/cc @andrzej-stencel who reviewed the daemonset target PR