### PR TITLE
[exporter/kafka] Implement partitioning by resource attributes for logs

### DIFF
--- a/.chloggen/kafka-partition-logs-by-resources.yaml
+++ b/.chloggen/kafka-partition-logs-by-resources.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkaexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add an ability to partition logs based on resource attributes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33229]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/exporter/kafkaexporter/README.md
+++ b/exporter/kafkaexporter/README.md
@@ -38,6 +38,7 @@ The following settings can be optionally configured:
     - `raw`: if the log record body is a byte array, it is sent as is. Otherwise, it is serialized to JSON. Resource and record attributes are discarded.
 - `partition_traces_by_id` (default = false): configures the exporter to include the trace ID as the message key in trace messages sent to kafka. *Please note:* this setting does not have any effect on Jaeger encoding exporters since Jaeger exporters include trace ID as the message key by default.
 - `partition_metrics_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in metric messages sent to kafka.
+- `partition_logs_by_resource_attributes` (default = false)  configures the exporter to include the hash of sorted resource attributes as the message partitioning key in log messages sent to kafka.
 - `auth`
   - `plain_text`
     - `username`: The username to use.

--- a/exporter/kafkaexporter/config.go
+++ b/exporter/kafkaexporter/config.go
@@ -53,6 +53,8 @@ type Config struct {
 
 	PartitionMetricsByResourceAttributes bool `mapstructure:"partition_metrics_by_resource_attributes"`
 
+	PartitionLogsByResourceAttributes bool `mapstructure:"partition_logs_by_resource_attributes"`
+
 	// Metadata is the namespace for metadata management properties used by the
 	// Client, and shared by the Producer/Consumer.
 	Metadata Metadata `mapstructure:"metadata"`

--- a/exporter/kafkaexporter/config_test.go
+++ b/exporter/kafkaexporter/config_test.go
@@ -59,6 +59,7 @@ func TestLoadConfig(t *testing.T) {
 				Encoding:                             "otlp_proto",
 				PartitionTracesByID:                  true,
 				PartitionMetricsByResourceAttributes: true,
+				PartitionLogsByResourceAttributes:    true,
 				Brokers:                              []string{"foo:123", "bar:456"},
 				ClientID:                             "test_client_id",
 				Authentication: kafka.Authentication{
@@ -114,6 +115,7 @@ func TestLoadConfig(t *testing.T) {
 				Encoding:                             "otlp_proto",
 				PartitionTracesByID:                  true,
 				PartitionMetricsByResourceAttributes: true,
+				PartitionLogsByResourceAttributes:    true,
 				Brokers:                              []string{"foo:123", "bar:456"},
 				ClientID:                             "test_client_id",
 				Authentication: kafka.Authentication{
@@ -168,6 +170,7 @@ func TestLoadConfig(t *testing.T) {
 				Encoding:                             "otlp_proto",
 				PartitionTracesByID:                  true,
 				PartitionMetricsByResourceAttributes: true,
+				PartitionLogsByResourceAttributes:    true,
 				Brokers:                              []string{"foo:123", "bar:456"},
 				ClientID:                             "test_client_id",
 				ResolveCanonicalBootstrapServersOnly: true,

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -204,15 +204,14 @@ func newSaramaProducer(config Config) (sarama.SyncProducer, error) {
 	return producer, nil
 }
 
-func newMetricsExporter(config Config, set exporter.Settings, marshalers map[string]MetricsMarshaler) (*kafkaMetricsProducer, error) {
-	marshaler := marshalers[config.Encoding]
+func newMetricsExporter(config Config, set exporter.Settings) (*kafkaMetricsProducer, error) {
+	marshaler, err := createMetricMarshaler(config)
+	if err != nil {
+		return nil, err
+	}
+
 	if marshaler == nil {
 		return nil, errUnrecognizedEncoding
-	}
-	if config.PartitionMetricsByResourceAttributes {
-		if keyableMarshaler, ok := marshaler.(KeyableMetricsMarshaler); ok {
-			keyableMarshaler.Key()
-		}
 	}
 
 	return &kafkaMetricsProducer{
@@ -224,15 +223,10 @@ func newMetricsExporter(config Config, set exporter.Settings, marshalers map[str
 }
 
 // newTracesExporter creates Kafka exporter.
-func newTracesExporter(config Config, set exporter.Settings, marshalers map[string]TracesMarshaler) (*kafkaTracesProducer, error) {
-	marshaler := marshalers[config.Encoding]
-	if marshaler == nil {
-		return nil, errUnrecognizedEncoding
-	}
-	if config.PartitionTracesByID {
-		if keyableMarshaler, ok := marshaler.(KeyableTracesMarshaler); ok {
-			keyableMarshaler.Key()
-		}
+func newTracesExporter(config Config, set exporter.Settings) (*kafkaTracesProducer, error) {
+	marshaler, err := createTracesMarshaler(config)
+	if err != nil {
+		return nil, err
 	}
 
 	return &kafkaTracesProducer{
@@ -242,10 +236,10 @@ func newTracesExporter(config Config, set exporter.Settings, marshalers map[stri
 	}, nil
 }
 
-func newLogsExporter(config Config, set exporter.Settings, marshalers map[string]LogsMarshaler) (*kafkaLogsProducer, error) {
-	marshaler := marshalers[config.Encoding]
-	if marshaler == nil {
-		return nil, errUnrecognizedEncoding
+func newLogsExporter(config Config, set exporter.Settings) (*kafkaLogsProducer, error) {
+	marshaler, err := createLogMarshaler(config)
+	if err != nil {
+		return nil, err
 	}
 
 	return &kafkaLogsProducer{

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestNewExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	texp, err := newTracesExporter(c, exportertest.NewNopSettings(), tracesMarshalers())
+	texp, err := newTracesExporter(c, exportertest.NewNopSettings())
 	require.NoError(t, err)
 	err = texp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
@@ -34,14 +34,14 @@ func TestNewExporter_err_version(t *testing.T) {
 
 func TestNewExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "foo"}
-	texp, err := newTracesExporter(c, exportertest.NewNopSettings(), tracesMarshalers())
+	texp, err := newTracesExporter(c, exportertest.NewNopSettings())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, texp)
 }
 
 func TestNewMetricsExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings())
 	require.NoError(t, err)
 	err = mexp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
@@ -49,21 +49,21 @@ func TestNewMetricsExporter_err_version(t *testing.T) {
 
 func TestNewMetricsExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "bar"}
-	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewMetricsExporter_err_traces_encoding(t *testing.T) {
 	c := Config{Encoding: "jaeger_proto"}
-	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_version(t *testing.T) {
 	c := Config{ProtocolVersion: "0.0.0", Encoding: defaultEncoding}
-	lexp, err := newLogsExporter(c, exportertest.NewNopSettings(), logsMarshalers())
+	lexp, err := newLogsExporter(c, exportertest.NewNopSettings())
 	require.NoError(t, err)
 	err = lexp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
@@ -71,14 +71,14 @@ func TestNewLogsExporter_err_version(t *testing.T) {
 
 func TestNewLogsExporter_err_encoding(t *testing.T) {
 	c := Config{Encoding: "bar"}
-	mexp, err := newLogsExporter(c, exportertest.NewNopSettings(), logsMarshalers())
+	mexp, err := newLogsExporter(c, exportertest.NewNopSettings())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
 
 func TestNewLogsExporter_err_traces_encoding(t *testing.T) {
 	c := Config{Encoding: "jaeger_proto"}
-	mexp, err := newLogsExporter(c, exportertest.NewNopSettings(), logsMarshalers())
+	mexp, err := newLogsExporter(c, exportertest.NewNopSettings())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
 }
@@ -101,17 +101,17 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 			Compression: "none",
 		},
 	}
-	texp, err := newTracesExporter(c, exportertest.NewNopSettings(), tracesMarshalers())
+	texp, err := newTracesExporter(c, exportertest.NewNopSettings())
 	require.NoError(t, err)
 	err = texp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
-	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings(), metricsMarshalers())
+	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings())
 	require.NoError(t, err)
 	err = mexp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
-	lexp, err := newLogsExporter(c, exportertest.NewNopSettings(), logsMarshalers())
+	lexp, err := newLogsExporter(c, exportertest.NewNopSettings())
 	require.NoError(t, err)
 	err = lexp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
@@ -126,7 +126,7 @@ func TestNewExporter_err_compression(t *testing.T) {
 			Compression: "idk",
 		},
 	}
-	texp, err := newTracesExporter(c, exportertest.NewNopSettings(), tracesMarshalers())
+	texp, err := newTracesExporter(c, exportertest.NewNopSettings())
 	require.NoError(t, err)
 	err = texp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
@@ -140,7 +140,7 @@ func TestTracesPusher(t *testing.T) {
 
 	p := kafkaTracesProducer{
 		producer:  producer,
-		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -159,7 +159,7 @@ func TestTracesPusher_attr(t *testing.T) {
 			TopicFromAttribute: "kafka_topic",
 		},
 		producer:  producer,
-		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -176,7 +176,7 @@ func TestTracesPusher_err(t *testing.T) {
 
 	p := kafkaTracesProducer{
 		producer:  producer,
-		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false),
 		logger:    zap.NewNop(),
 	}
 	t.Cleanup(func() {
@@ -206,7 +206,7 @@ func TestMetricsDataPusher(t *testing.T) {
 
 	p := kafkaMetricsProducer{
 		producer:  producer,
-		marshaler: newPdataMetricsMarshaler(&pmetric.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataMetricsMarshaler(&pmetric.ProtoMarshaler{}, defaultEncoding, false),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -225,7 +225,7 @@ func TestMetricsDataPusher_attr(t *testing.T) {
 			TopicFromAttribute: "kafka_topic",
 		},
 		producer:  producer,
-		marshaler: newPdataMetricsMarshaler(&pmetric.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataMetricsMarshaler(&pmetric.ProtoMarshaler{}, defaultEncoding, false),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -242,7 +242,7 @@ func TestMetricsDataPusher_err(t *testing.T) {
 
 	p := kafkaMetricsProducer{
 		producer:  producer,
-		marshaler: newPdataMetricsMarshaler(&pmetric.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataMetricsMarshaler(&pmetric.ProtoMarshaler{}, defaultEncoding, false),
 		logger:    zap.NewNop(),
 	}
 	t.Cleanup(func() {
@@ -272,7 +272,7 @@ func TestLogsDataPusher(t *testing.T) {
 
 	p := kafkaLogsProducer{
 		producer:  producer,
-		marshaler: newPdataLogsMarshaler(&plog.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataLogsMarshaler(&plog.ProtoMarshaler{}, defaultEncoding, false),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -291,7 +291,7 @@ func TestLogsDataPusher_attr(t *testing.T) {
 			TopicFromAttribute: "kafka_topic",
 		},
 		producer:  producer,
-		marshaler: newPdataLogsMarshaler(&plog.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataLogsMarshaler(&plog.ProtoMarshaler{}, defaultEncoding, false),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -308,7 +308,7 @@ func TestLogsDataPusher_err(t *testing.T) {
 
 	p := kafkaLogsProducer{
 		producer:  producer,
-		marshaler: newPdataLogsMarshaler(&plog.ProtoMarshaler{}, defaultEncoding),
+		marshaler: newPdataLogsMarshaler(&plog.ProtoMarshaler{}, defaultEncoding, false),
 		logger:    zap.NewNop(),
 	}
 	t.Cleanup(func() {

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -28,12 +29,12 @@ func TestDefaultTracesMarshalers(t *testing.T) {
 		"jaeger_proto",
 		"jaeger_json",
 	}
-	marshalers := tracesMarshalers()
-	assert.Equal(t, len(expectedEncodings), len(marshalers))
 	for _, e := range expectedEncodings {
 		t.Run(e, func(t *testing.T) {
-			m, ok := marshalers[e]
-			require.True(t, ok)
+			m, err := createTracesMarshaler(Config{
+				Encoding: e,
+			})
+			require.Nil(t, err)
 			assert.NotNil(t, m)
 		})
 	}
@@ -44,12 +45,12 @@ func TestDefaultMetricsMarshalers(t *testing.T) {
 		"otlp_proto",
 		"otlp_json",
 	}
-	marshalers := metricsMarshalers()
-	assert.Equal(t, len(expectedEncodings), len(marshalers))
 	for _, e := range expectedEncodings {
 		t.Run(e, func(t *testing.T) {
-			m, ok := marshalers[e]
-			require.True(t, ok)
+			m, err := createMetricMarshaler(Config{
+				Encoding: e,
+			})
+			require.Nil(t, err)
 			assert.NotNil(t, m)
 		})
 	}
@@ -61,12 +62,12 @@ func TestDefaultLogsMarshalers(t *testing.T) {
 		"otlp_json",
 		"raw",
 	}
-	marshalers := logsMarshalers()
-	assert.Equal(t, len(expectedEncodings), len(marshalers))
 	for _, e := range expectedEncodings {
 		t.Run(e, func(t *testing.T) {
-			m, ok := marshalers[e]
-			require.True(t, ok)
+			m, err := createLogMarshaler(Config{
+				Encoding: e,
+			})
+			require.Nil(t, err)
 			assert.NotNil(t, m)
 		})
 	}
@@ -75,17 +76,17 @@ func TestDefaultLogsMarshalers(t *testing.T) {
 func TestOTLPMetricsJsonMarshaling(t *testing.T) {
 	tests := []struct {
 		name                 string
-		keyEnabled           bool
+		partitionByResources bool
 		messagePartitionKeys []sarama.Encoder
 	}{
 		{
 			name:                 "partitioning_disabled",
-			keyEnabled:           false,
+			partitionByResources: false,
 			messagePartitionKeys: []sarama.Encoder{nil},
 		},
 		{
-			name:       "partitioning_enabled",
-			keyEnabled: true,
+			name:                 "partitioning_enabled",
+			partitionByResources: true,
 			messagePartitionKeys: []sarama.Encoder{
 				sarama.ByteEncoder{0x62, 0x7f, 0x20, 0x34, 0x85, 0x49, 0x55, 0x2e, 0xfa, 0x93, 0xae, 0xd7, 0xde, 0x91, 0xd7, 0x16},
 				sarama.ByteEncoder{0x75, 0x6b, 0xb4, 0xd6, 0xff, 0xeb, 0x92, 0x22, 0xa, 0x68, 0x65, 0x48, 0xe0, 0xd3, 0x94, 0x44},
@@ -116,16 +117,76 @@ func TestOTLPMetricsJsonMarshaling(t *testing.T) {
 			r1.Attributes().PutStr("service.name", "my_service_name")
 			r1.CopyTo(metric.ResourceMetrics().AppendEmpty().Resource())
 
-			standardMarshaler := metricsMarshalers()["otlp_json"]
-			keyableMarshaler, ok := standardMarshaler.(KeyableMetricsMarshaler)
-			require.True(t, ok, "Must be a KeyableMetricsMarshaler")
-			if tt.keyEnabled {
-				keyableMarshaler.Key()
-			}
+			marshaler, err := createMetricMarshaler(
+				Config{
+					Encoding:                             "otlp_json",
+					PartitionMetricsByResourceAttributes: tt.partitionByResources,
+				})
+			require.Nil(t, err)
 
-			msgs, err := standardMarshaler.Marshal(metric, "KafkaTopicX")
+			msgs, err := marshaler.Marshal(metric, "KafkaTopicX")
 			require.NoError(t, err, "Must have marshaled the data without error")
+			require.Len(t, msgs, len(tt.messagePartitionKeys), "Number of messages must be %d, but was %d", len(tt.messagePartitionKeys), len(msgs))
 
+			for i := 0; i < len(tt.messagePartitionKeys); i++ {
+				require.Equal(t, tt.messagePartitionKeys[i], msgs[i].Key, "message %d has incorrect key", i)
+			}
+		})
+	}
+}
+
+func TestOTLPLogsJsonMarshaling(t *testing.T) {
+	tests := []struct {
+		name                 string
+		partitionByResources bool
+		messagePartitionKeys []sarama.Encoder
+	}{
+		{
+			name:                 "partitioning_disabled",
+			partitionByResources: false,
+			messagePartitionKeys: []sarama.Encoder{nil},
+		},
+		{
+			name:                 "partitioning_enabled",
+			partitionByResources: true,
+			messagePartitionKeys: []sarama.Encoder{
+				sarama.ByteEncoder{0x62, 0x7f, 0x20, 0x34, 0x85, 0x49, 0x55, 0x2e, 0xfa, 0x93, 0xae, 0xd7, 0xde, 0x91, 0xd7, 0x16},
+				sarama.ByteEncoder{0x75, 0x6b, 0xb4, 0xd6, 0xff, 0xeb, 0x92, 0x22, 0xa, 0x68, 0x65, 0x48, 0xe0, 0xd3, 0x94, 0x44},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			log := plog.NewLogs()
+			r := pcommon.NewResource()
+			r.Attributes().PutStr("service.name", "my_service_name")
+			r.Attributes().PutStr("service.instance.id", "kek_x_1")
+			r.CopyTo(log.ResourceLogs().AppendEmpty().Resource())
+
+			rm := log.ResourceLogs().At(0)
+			rm.SetSchemaUrl(conventions.SchemaURL)
+
+			sl := rm.ScopeLogs().AppendEmpty()
+			plog.NewScopeLogs()
+			l := sl.LogRecords().AppendEmpty()
+			l.SetSeverityText("INFO")
+			l.SetTimestamp(pcommon.Timestamp(1))
+			l.Body().SetStr("Simple log message")
+
+			r1 := pcommon.NewResource()
+			r1.Attributes().PutStr("service.instance.id", "kek_x_2")
+			r1.Attributes().PutStr("service.name", "my_service_name")
+			r1.CopyTo(log.ResourceLogs().AppendEmpty().Resource())
+
+			marshaler, err := createLogMarshaler(
+				Config{
+					Encoding:                          "otlp_json",
+					PartitionLogsByResourceAttributes: tt.partitionByResources,
+				})
+			require.Nil(t, err)
+
+			msgs, err := marshaler.Marshal(log, "KafkaTopicX")
+			require.NoError(t, err, "Must have marshaled the data without error")
 			require.Len(t, msgs, len(tt.messagePartitionKeys), "Number of messages must be %d, but was %d", len(tt.messagePartitionKeys), len(msgs))
 
 			for i := 0; i < len(tt.messagePartitionKeys); i++ {
@@ -382,28 +443,25 @@ func TestOTLPTracesJsonMarshaling(t *testing.T) {
 
 	tests := []struct {
 		encoding            string
-		keyed               bool
+		partitionTracesByID bool
 		numExpectedMessages int
 		expectedJSON        []any
 		expectedMessageKey  []sarama.Encoder
 		unmarshaled         any
 	}{
 		{encoding: "otlp_json", numExpectedMessages: 1, expectedJSON: unkeyedOtlpJSONResult, expectedMessageKey: unkeyedMessageKey, unmarshaled: map[string]any{}},
-		{encoding: "otlp_json", keyed: true, numExpectedMessages: 2, expectedJSON: keyedOtlpJSONResult, expectedMessageKey: keyedMessageKey, unmarshaled: map[string]any{}},
+		{encoding: "otlp_json", partitionTracesByID: true, numExpectedMessages: 2, expectedJSON: keyedOtlpJSONResult, expectedMessageKey: keyedMessageKey, unmarshaled: map[string]any{}},
 		{encoding: "zipkin_json", numExpectedMessages: 1, expectedJSON: unkeyedZipkinJSONResult, expectedMessageKey: unkeyedMessageKey, unmarshaled: []map[string]any{}},
-		{encoding: "zipkin_json", keyed: true, numExpectedMessages: 2, expectedJSON: keyedZipkinJSONResult, expectedMessageKey: keyedMessageKey, unmarshaled: []map[string]any{}},
+		{encoding: "zipkin_json", partitionTracesByID: true, numExpectedMessages: 2, expectedJSON: keyedZipkinJSONResult, expectedMessageKey: keyedMessageKey, unmarshaled: []map[string]any{}},
 	}
 
 	for _, test := range tests {
 
-		marshaler, ok := tracesMarshalers()[test.encoding]
-		require.True(t, ok, fmt.Sprintf("Must have %s marshaller", test.encoding))
-
-		if test.keyed {
-			keyableMarshaler, ok := marshaler.(KeyableTracesMarshaler)
-			require.True(t, ok, "Must be a KeyableTracesMarshaler")
-			keyableMarshaler.Key()
-		}
+		marshaler, err := createTracesMarshaler(Config{
+			Encoding:            test.encoding,
+			PartitionTracesByID: test.partitionTracesByID,
+		})
+		require.Nil(t, err, fmt.Sprintf("Must have %s marshaler", test.encoding))
 
 		msg, err := marshaler.Marshal(traces, t.Name())
 		require.NoError(t, err, "Must have marshaled the data without error")

--- a/exporter/kafkaexporter/testdata/config.yaml
+++ b/exporter/kafkaexporter/testdata/config.yaml
@@ -14,6 +14,7 @@ kafka:
   timeout: 10s
   partition_traces_by_id: true
   partition_metrics_by_resource_attributes: true
+  partition_logs_by_resource_attributes: true
   auth:
     plain_text:
       username: jdoe


### PR DESCRIPTION
**Description:**  Add resource attributes based partitioning for logs

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33229

**Testing:** Added test and tested locally

**Documentation:** Documented new flag.

Additionally, as discussed with @dmitryax in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31315, removed trait with Key method and refactored the code to pass flags directly to marshaller constructors. Please let me know if this way is acceptable.

I also removed an ability to add custom marshallers - option to add custom marshallers was unexposed in 0.89.0, so now the code was just sitting there unused.