### PR TITLE
exp/metrics: evict only stale

### DIFF
--- a/.chloggen/fix-staleness-evict.yaml
+++ b/.chloggen/fix-staleness-evict.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exp/metrics
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fixes staleness.Evict such that it only ever evicts actually stale metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33265]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user,api]

--- a/internal/exp/metrics/staleness/staleness.go
+++ b/internal/exp/metrics/staleness/staleness.go
@@ -90,7 +90,7 @@ func (s *Staleness[T]) Next() time.Time {
 
 func (s *Staleness[T]) Evict() (identity.Stream, bool) {
 	_, ts := s.pq.Peek()
-	if ts.Add(s.Max).Before(time.Now()) {
+	if NowFunc().Sub(ts) < s.Max {
 		return identity.Stream{}, false
 	}
 

--- a/internal/exp/metrics/staleness/staleness_test.go
+++ b/internal/exp/metrics/staleness/staleness_test.go
@@ -103,11 +103,13 @@ func TestEvict(t *testing.T) {
 
 	now = 10
 	idA := generateStreamID(t, map[string]any{"aaa": "123"})
-	stale.Store(idA, 0)
+	err := stale.Store(idA, 0)
+	require.NoError(t, err)
 
 	now = 20
 	idB := generateStreamID(t, map[string]any{"bbb": "456"})
-	stale.Store(idB, 1)
+	err = stale.Store(idB, 1)
+	require.NoError(t, err)
 
 	require.Equal(t, 2, stale.Len())
 

--- a/internal/exp/metrics/staleness/staleness_test.go
+++ b/internal/exp/metrics/staleness/staleness_test.go
@@ -92,3 +92,39 @@ func validateStalenessMapEntries(t *testing.T, expected map[identity.Stream]int,
 	})
 	require.Equal(t, expected, actual)
 }
+
+func TestEvict(t *testing.T) {
+	now := 0
+	NowFunc = func() time.Time {
+		return time.Unix(int64(now), 0)
+	}
+
+	stale := NewStaleness(1*time.Minute, make(streams.HashMap[int]))
+
+	now = 10
+	idA := generateStreamID(t, map[string]any{"aaa": "123"})
+	stale.Store(idA, 0)
+
+	now = 20
+	idB := generateStreamID(t, map[string]any{"bbb": "456"})
+	stale.Store(idB, 1)
+
+	require.Equal(t, 2, stale.Len())
+
+	// nothing stale yet, must not evict
+	_, ok := stale.Evict()
+	require.False(t, ok)
+	require.Equal(t, 2, stale.Len())
+
+	// idA stale
+	now = 71
+	gone, ok := stale.Evict()
+	require.True(t, ok)
+	require.NotZero(t, gone)
+	require.Equal(t, 1, stale.Len())
+
+	// idB not yet stale
+	_, ok = stale.Evict()
+	require.False(t, ok)
+	require.Equal(t, 1, stale.Len())
+}


### PR DESCRIPTION
**Description:** 
fixes broken check in eviction behavior such that it only evicts actually stale metrics.
this was already attempted in #33015, but was insufficient


**Testing:** tests were added