### PR TITLE
Allow the otel collector to live without a server to manage it

### DIFF
--- a/.chloggen/live-without-server.yaml
+++ b/.chloggen/live-without-server.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix a bug in the opamp supervisor that caused to return when it could not contact an OpAMP server at startup.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33275]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -565,6 +565,7 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 func (s *Supervisor) waitForOpAMPConnection() error {
 	// wait for the OpAMP client to connect to the server or timeout
 	select {
+	// This channel is unbuffered, so this will block until we listen on the channel in `OnConnectFunc`.
 	case s.connectedToOpAMPServer <- struct{}{}:
 		close(s.connectedToOpAMPServer)
 		return nil


### PR DESCRIPTION
**Description:** An OpAMP supervisor+agent need to be able to work without an opamp server to manage them.

**Testing:** Added passing e2e test. All other e2e tests continue to pass.

**Documentation:** None added so far.