### PR TITLE
[connector/spanmetrics] Replace `connector.servicegraph.virtualNode` feature gate with config options

### DIFF
--- a/connector/servicegraphconnector/config.go
+++ b/connector/servicegraphconnector/config.go
@@ -35,7 +35,11 @@ type Config struct {
 	// CacheLoop is the time to expire old entries from the store periodically.
 	StoreExpirationLoop time.Duration `mapstructure:"store_expiration_loop"`
 	// VirtualNodePeerAttributes the list of attributes need to match, the higher the front, the higher the priority.
+	//TODO: Remove VirtualNodePeerAttributes in a few weeks? How many versions should we wait for?
 	VirtualNodePeerAttributes []string `mapstructure:"virtual_node_peer_attributes"`
+
+	ClientVirtualNodes VirtualNodes `mapstructure:"client_virtual_nodes"`
+	ServerVirtualNodes VirtualNodes `mapstructure:"server_virtual_nodes"`
 
 	// MetricsFlushInterval is the interval at which metrics are flushed to the exporter.
 	// If set to 0, metrics are flushed on every received batch of traces.
@@ -51,4 +55,16 @@ type StoreConfig struct {
 	MaxItems int `mapstructure:"max_items"`
 	// TTL is the time to live for items in the store.
 	TTL time.Duration `mapstructure:"ttl"`
+}
+
+type VirtualNodes struct {
+	// Enabled is the flag to enable virtual nodes.
+	Enabled bool `mapstructure:"enabled"`
+	// NodeNameFromAttributes is the list of attributes to use to create the virtual node name.
+	// The span attributes will be searched in order and the first one found will be used.
+	// If no attribute is found, the NodeName parameter will be used.
+	NodeNameFromAttributes []string `mapstructure:"node_name_from_attributes"`
+	// NodeName is the name of the virtual node.
+	// It is only used if NodeNameFromAttributes is empty or no attribute is found.
+	NodeName string `mapstructure:"node_name"`
 }

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
@@ -62,31 +63,115 @@ func TestConnectorShutdown(t *testing.T) {
 }
 
 func TestConnectorConsume(t *testing.T) {
-	// Prepare
-	cfg := &Config{
-		Dimensions: []string{"some-attribute", "non-existing-attribute"},
-		Store:      StoreConfig{MaxItems: 10},
+	for _, tc := range []struct {
+		name          string
+		cfg           *Config
+		gates         []*featuregate.Gate
+		sampleTraces  ptrace.Traces
+		verifyMetrics func(t *testing.T, md pmetric.Metrics)
+	}{
+		{
+			name: "traces with client and server span",
+			cfg: &Config{
+				Dimensions: []string{"some-attribute", "non-existing-attribute"},
+				Store: StoreConfig{
+					MaxItems: 10,
+					TTL:      time.Nanosecond,
+				},
+			},
+			sampleTraces:  buildSampleTrace(t, "val"),
+			verifyMetrics: verifyHappyCaseMetrics,
+		},
+		{
+			name: "incomplete traces with virtual server span",
+			cfg: &Config{
+				Dimensions: []string{"some-attribute", "non-existing-attribute"},
+				Store: StoreConfig{
+					MaxItems: 10,
+					TTL:      time.Nanosecond,
+				},
+			},
+			sampleTraces: incompleteClientTraces(),
+			verifyMetrics: func(t *testing.T, md pmetric.Metrics) {
+				v, ok := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Get("server")
+				assert.True(t, ok)
+				assert.Equal(t, "AuthTokenCache", v.Str())
+			},
+		},
+		{
+			name: "incomplete traces with virtual client span",
+			cfg: &Config{
+				Dimensions: []string{"some-attribute", "non-existing-attribute"},
+				Store: StoreConfig{
+					MaxItems: 10,
+					TTL:      time.Nanosecond,
+				},
+			},
+			sampleTraces: incompleteServerTraces(false),
+			verifyMetrics: func(t *testing.T, md pmetric.Metrics) {
+				v, ok := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Sum().DataPoints().At(0).Attributes().Get("client")
+				assert.True(t, ok)
+				assert.Equal(t, "user", v.Str())
+			},
+		},
+		{
+			name: "incomplete traces with client span lost",
+			cfg: &Config{
+				Dimensions: []string{"some-attribute", "non-existing-attribute"},
+				Store: StoreConfig{
+					MaxItems: 10,
+					TTL:      time.Nanosecond,
+				},
+			},
+			sampleTraces: incompleteServerTraces(true),
+			verifyMetrics: func(t *testing.T, md pmetric.Metrics) {
+				assert.Equal(t, 0, md.MetricCount())
+			},
+		},
+		{
+			name: "complete traces with legacy latency metrics",
+			cfg: &Config{
+				Dimensions: []string{"some-attribute", "non-existing-attribute"},
+				Store: StoreConfig{
+					MaxItems: 10,
+					TTL:      time.Nanosecond,
+				},
+			}, sampleTraces: buildSampleTrace(t, "val"),
+			gates:         []*featuregate.Gate{legacyLatencyUnitMsFeatureGate},
+			verifyMetrics: verifyHappyCaseMetricsWithDuration(1000),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Set feature gates
+			for _, gate := range tc.gates {
+				require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), true))
+			}
+
+			// Prepare
+			set := componenttest.NewNopTelemetrySettings()
+			set.Logger = zaptest.NewLogger(t)
+			conn, err := newConnector(set, tc.cfg, newMockMetricsExporter())
+			require.NoError(t, err)
+			assert.NoError(t, conn.Start(context.Background(), componenttest.NewNopHost()))
+
+			// Send spans to the connector
+			assert.NoError(t, conn.ConsumeTraces(context.Background(), tc.sampleTraces))
+
+			// Force collection
+			conn.store.Expire()
+			md, err := conn.buildMetrics()
+			assert.NoError(t, err)
+			tc.verifyMetrics(t, md)
+
+			// Shutdown the connector
+			assert.NoError(t, conn.Shutdown(context.Background()))
+
+			// Unset feature gates
+			for _, gate := range tc.gates {
+				require.NoError(t, featuregate.GlobalRegistry().Set(gate.ID(), false))
+			}
+		})
 	}
-
-	set := componenttest.NewNopTelemetrySettings()
-	set.Logger = zaptest.NewLogger(t)
-	conn, err := newConnector(set, cfg, newMockMetricsExporter())
-	require.NoError(t, err)
-	assert.NoError(t, conn.Start(context.Background(), componenttest.NewNopHost()))
-
-	// Test & verify
-	td := buildSampleTrace(t, "val")
-	// The assertion is part of verifyHappyCaseMetrics func.
-	assert.NoError(t, conn.ConsumeTraces(context.Background(), td))
-
-	// Force collection
-	conn.store.Expire()
-	md, err := conn.buildMetrics()
-	assert.NoError(t, err)
-	verifyHappyCaseMetrics(t, md)
-
-	// Shutdown the connector
-	assert.NoError(t, conn.Shutdown(context.Background()))
 }
 
 func verifyHappyCaseMetrics(t *testing.T, md pmetric.Metrics) {
@@ -204,6 +289,53 @@ func buildSampleTrace(t *testing.T, attrValue string) ptrace.Traces {
 	serverSpan.SetStartTimestamp(pcommon.NewTimestampFromTime(tStart))
 	serverSpan.SetEndTimestamp(pcommon.NewTimestampFromTime(tEnd))
 
+	return traces
+}
+
+func incompleteClientTraces() ptrace.Traces {
+	tStart := time.Date(2022, 1, 2, 3, 4, 5, 6, time.UTC)
+	tEnd := time.Date(2022, 1, 2, 3, 4, 6, 6, time.UTC)
+
+	traces := ptrace.NewTraces()
+
+	resourceSpans := traces.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr(semconv.AttributeServiceName, "some-client-service")
+
+	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+	anotherTraceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	anotherClientSpanID := pcommon.SpanID([8]byte{1, 2, 3, 4, 4, 3, 2, 1})
+	clientSpanNoServerSpan := scopeSpans.Spans().AppendEmpty()
+	clientSpanNoServerSpan.SetName("client span")
+	clientSpanNoServerSpan.SetSpanID(anotherClientSpanID)
+	clientSpanNoServerSpan.SetTraceID(anotherTraceID)
+	clientSpanNoServerSpan.SetKind(ptrace.SpanKindClient)
+	clientSpanNoServerSpan.SetStartTimestamp(pcommon.NewTimestampFromTime(tStart))
+	clientSpanNoServerSpan.SetEndTimestamp(pcommon.NewTimestampFromTime(tEnd))
+	clientSpanNoServerSpan.Attributes().PutStr(semconv.AttributePeerService, "AuthTokenCache") // Attribute selected as dimension for metrics
+
+	return traces
+}
+
+func incompleteServerTraces(withParentSpan bool) ptrace.Traces {
+	tStart := time.Date(2022, 1, 2, 3, 4, 5, 6, time.UTC)
+	tEnd := time.Date(2022, 1, 2, 3, 4, 6, 6, time.UTC)
+
+	traces := ptrace.NewTraces()
+
+	resourceSpans := traces.ResourceSpans().AppendEmpty()
+	resourceSpans.Resource().Attributes().PutStr(semconv.AttributeServiceName, "some-server-service")
+	scopeSpans := resourceSpans.ScopeSpans().AppendEmpty()
+	anotherTraceID := pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 8, 7, 6, 5, 4, 3, 2, 1})
+	serverSpanNoClientSpan := scopeSpans.Spans().AppendEmpty()
+	serverSpanNoClientSpan.SetName("server span")
+	serverSpanNoClientSpan.SetSpanID([8]byte{0x19, 0x20, 0x21, 0x22, 0x23, 0x24, 0x25, 0x26})
+	if withParentSpan {
+		serverSpanNoClientSpan.SetParentSpanID([8]byte{0x27, 0x28, 0x29, 0x30, 0x31, 0x32, 0x33, 0x34})
+	}
+	serverSpanNoClientSpan.SetTraceID(anotherTraceID)
+	serverSpanNoClientSpan.SetKind(ptrace.SpanKindServer)
+	serverSpanNoClientSpan.SetStartTimestamp(pcommon.NewTimestampFromTime(tStart))
+	serverSpanNoClientSpan.SetEndTimestamp(pcommon.NewTimestampFromTime(tEnd))
 	return traces
 }
 

--- a/connector/servicegraphconnector/factory.go
+++ b/connector/servicegraphconnector/factory.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/connector"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/featuregate"
+	semconv "go.opentelemetry.io/collector/semconv/v1.13.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/servicegraphconnector/internal/metadata"
 )
@@ -28,6 +29,8 @@ const (
 var virtualNodeFeatureGate, legacyMetricNamesFeatureGate, legacyLatencyUnitMsFeatureGate *featuregate.Gate
 
 func init() {
+	//TODO: Delete this feature fate in a few weeks? How many versions should we wait for?
+	// We cannot change its status from StageBeta to StageDeprecated, because this would disable it and break users.
 	virtualNodeFeatureGate = featuregate.GlobalRegistry().MustRegister(
 		virtualNodeFeatureGateID,
 		featuregate.StageBeta,
@@ -66,6 +69,20 @@ func createDefaultConfig() component.Config {
 		},
 		CacheLoop:           time.Minute,
 		StoreExpirationLoop: 2 * time.Second,
+		ClientVirtualNodes: VirtualNodes{
+			// This is enabled by default in order to not break users who rely on the
+			// "connector.servicegraph.virtualNode" feature gate to be enabled by default.
+			Enabled:  true,
+			NodeName: "user",
+		},
+		ServerVirtualNodes: VirtualNodes{
+			// This is enabled by default in order to not break users who rely on the
+			// "connector.servicegraph.virtualNode" feature gate to be enabled by default.
+			Enabled: true,
+			NodeNameFromAttributes: []string{
+				semconv.AttributePeerService, semconv.AttributeDBName, semconv.AttributeDBSystem,
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR intends to deprecate the `connector.servicegraph.virtualNode` feature gate and the `virtual_node_peer_attributes `config argument. They will be replaced by new `client_virtual_nodes` and `server_virtual_nodes` config arguments.

The `connector.servicegraph.virtualNode` feature gate has a few issues:
* It's not possible to configure server and client virtual nodes independently. We can't disable one but enable the other. For example, the only ways to [disable client virtual nodes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/821c864db937ab7170e6c61bc096ead9cf405311/connector/servicegraphconnector/connector.go#L348-L350) are:
  * Disabling the feature gate entirely. This is not a long term solution, because feature gates are meant to be only temporary.
  * Set `virtual_node_peer_attributes ` to an empty list. This is weird, because `virtual_node_peer_attributes` is only meant to be used for server virtual nodes - not for client virtual nodes.
* The client virtual nodes are always set to "user". It's not possible to extract them from span attributes.

**Testing:** <Describe what testing was performed and which tests were added.>
This PR adds tests which were added in #17350 removed in #30149.
I am also happy to add more tests if the overall goal of the PR is accepted.

**Documentation:** <Describe the documentation added.>
I will update the docs once the overall goal of the PR has been accepted.

cc @JaredTan95 and @ogxd who worked on virtual nodes previously.