### PR TITLE
[receiver/mysql] fix: remove the order by clause for non-existent column

### DIFF
--- a/.chloggen/fix_omissions_in_receiver_mysql_remodeling_metrics.yaml
+++ b/.chloggen/fix_omissions_in_receiver_mysql_remodeling_metrics.yaml
@@ -10,7 +10,7 @@ component: receiver/mysql
 note: Remove the order by clause for the column that does not exist
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [32693,33271]
+issues: [33271]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix_omissions_in_receiver_mysql_remodeling_metrics.yaml
+++ b/.chloggen/fix_omissions_in_receiver_mysql_remodeling_metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mysql
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove the order by clause for the column that does not exist
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32693,33271]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mysqlreceiver/client.go
+++ b/receiver/mysqlreceiver/client.go
@@ -246,8 +246,7 @@ func (c *mySQLClient) getTableStats() ([]TableStats, error) {
 	query := "SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_ROWS, " +
 		"AVG_ROW_LENGTH, DATA_LENGTH, INDEX_LENGTH " +
 		"FROM information_schema.TABLES " +
-		"WHERE TABLE_SCHEMA NOT in ('information_schema', 'sys') " +
-		"ORDER BY TABLE_LENGTH DESC;"
+		"WHERE TABLE_SCHEMA NOT in ('information_schema', 'sys');"
 	rows, err := c.client.Query(query)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Remove the unnecessary order by clause causing undefined reference error.
This order by clause was introduced in [this commit](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32680/commits/bbcb16c34494215d3aa71f8f7387b181efa5dab9). In [the next commit](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32680/commits/5437618766713dd5dd0eabc12bfb5d8863681769), the author made a change to the metrics model, but I think he forgot to remove the order by clause at that time.

I think it could be changed to order by another column, but I didn't really feel the need to keep it sorted, so I removed it.


**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33271

**Testing:** <Describe what testing was performed and which tests were added.>

Tested working as expected with mysql@8.0.35 which is reported version in the issue.

Also it can be tested as sql.
```sql
-- before
mysql> SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_ROWS, AVG_ROW_LENGTH, DATA_LENGTH, INDEX_LENGTH FROM information_schema.TABLES WHERE TABLE_SCHEMA NOT in ('information_schema', 'sys') ORDER BY TABLE_LENGTH DESC;
ERROR 1054 (42S22): Unknown column 'TABLE_LENGTH' in 'order clause'

-- after
mysql> SELECT TABLE_SCHEMA, TABLE_NAME, TABLE_ROWS, AVG_ROW_LENGTH, DATA_LENGTH, INDEX_LENGTH FROM information_schema.TABLES WHERE TABLE_SCHEMA NOT in ('information_schema', 'sys');
+--------------------+------------------------------------------------------+------------+----------------+-------------+--------------+
| TABLE_SCHEMA       | TABLE_NAME                                           | TABLE_ROWS | AVG_ROW_LENGTH | DATA_LENGTH | INDEX_LENGTH |
+--------------------+------------------------------------------------------+------------+----------------+-------------+--------------+
| mysql              | innodb_table_stats                                   |          2 |           8192 |       16384 |            0 |
| mysql              | innodb_index_stats                                   |          6 |           2730 |       16384 |            0 |
| performance_schema | cond_instances                                       |        256 |              0 |           0 |            0 |
| performance_schema | error_log                                            |          9 |              0 |           0 |            0 |
| performance_schema | events_waits_current                                 |       1536 |              0 |           0 |            0 |
(snip)
```

**Documentation:** <Describe the documentation added.>