### PR TITLE
A more compact format for JSON file exports

### DIFF
--- a/exporter/fileexporter/config.go
+++ b/exporter/fileexporter/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	// Options:
 	// - json[default]:  OTLP json bytes.
 	// - proto:  OTLP binary protobuf bytes.
+	// - smalljson:  JSON bytes with a minimal size
 	FormatType string `mapstructure:"format"`
 
 	// Encoding defines the encoding of the telemetry data.
@@ -107,7 +108,7 @@ func (cfg *Config) Validate() error {
 	if cfg.Append && cfg.Rotation != nil {
 		return fmt.Errorf("append and rotation enabled at the same time is not supported")
 	}
-	if cfg.FormatType != formatTypeJSON && cfg.FormatType != formatTypeProto {
+	if cfg.FormatType != formatTypeJSON && cfg.FormatType != formatTypeProto && cfg.FormatType != formatTypeSmallJSON {
 		return errors.New("format type is not supported")
 	}
 	if cfg.Compression != "" && cfg.Compression != compressionZSTD {

--- a/exporter/fileexporter/config_test.go
+++ b/exporter/fileexporter/config_test.go
@@ -140,6 +140,18 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
+			id: component.NewIDWithName(metadata.Type, "smol_json_no_grouping"),
+			expected: &Config{
+				Path:          "./flushed.json",
+				FlushInterval: 500 * time.Millisecond,
+				FormatType:    formatTypeSmallJSON,
+				GroupBy: &GroupBy{
+					MaxOpenFiles:      defaultMaxOpenFiles,
+					ResourceAttribute: defaultResourceAttribute,
+				},
+			},
+		},
+		{
 			id:           component.NewIDWithName(metadata.Type, "flush_interval_negative_value"),
 			errorMessage: "flush_interval must be larger than zero",
 		},

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -28,8 +28,9 @@ const (
 	defaultMaxBackups = 100
 
 	// the format of encoded telemetry data
-	formatTypeJSON  = "json"
-	formatTypeProto = "proto"
+	formatTypeJSON      = "json"
+	formatTypeProto     = "proto"
+	formatTypeSmallJSON = "smalljson"
 
 	// the type of compression codec
 	compressionZSTD = "zstd"

--- a/exporter/fileexporter/marshaller.go
+++ b/exporter/fileexporter/marshaller.go
@@ -4,27 +4,209 @@
 package fileexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter"
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+type SmallJSONMarshaler struct{}
+
+func jsonRepresentation(val pcommon.Value) string {
+	switch val.Type() {
+	case pcommon.ValueTypeStr:
+		return fmt.Sprintf("%q", val.AsString())
+	case pcommon.ValueTypeBool:
+		return fmt.Sprint(val.Bool())
+	case pcommon.ValueTypeInt:
+		return fmt.Sprint(val.Int())
+	case pcommon.ValueTypeDouble:
+		return fmt.Sprint(val.Double())
+	case pcommon.ValueTypeSlice:
+		buf := bytes.Buffer{}
+		buf.WriteString("[")
+		for i := 0; i < val.Slice().Len(); i++ {
+			buf.WriteString(jsonRepresentation(val.Slice().At(i)))
+			buf.WriteString(",")
+		}
+		buf.WriteString("]")
+		return buf.String()
+	case pcommon.ValueTypeMap:
+		buf := bytes.Buffer{}
+		buf.WriteString("{")
+		val.Map().Range(func(k string, v pcommon.Value) bool {
+			buf.WriteString(`"`)
+			buf.WriteString(k)
+			buf.WriteString(`":`)
+			buf.WriteString(jsonRepresentation(v))
+			buf.WriteString(",")
+			return true
+		},
+		)
+		buf.WriteString("}")
+		return buf.String()
+	}
+	return ""
+}
+
+func (m *SmallJSONMarshaler) MarshalLogs(ld plog.Logs) ([]byte, error) {
+	buf := bytes.Buffer{}
+	for i := 0; i < ld.ResourceLogs().Len(); i++ {
+		scopeLogs := ld.ResourceLogs().At(i).ScopeLogs()
+		for j := 0; j < scopeLogs.Len(); j++ {
+			logRecords := scopeLogs.At(j).LogRecords()
+			for k := 0; k < logRecords.Len(); k++ {
+				log := logRecords.At(k)
+				buf.WriteString(`{"ts":`)
+				buf.WriteString(fmt.Sprint(log.Timestamp().AsTime().UnixNano() / 1e6))
+				buf.WriteString(`,"attrs":{`)
+				log.Attributes().Range(func(k string, v pcommon.Value) bool {
+					buf.WriteString(`"`)
+					buf.WriteString(k)
+					buf.WriteString(`":`)
+					buf.WriteString(jsonRepresentation(v))
+					buf.WriteString(",")
+					return true
+				})
+				buf.WriteString(`},"body":`)
+				buf.WriteString(log.Body().Str())
+				buf.WriteString("}\n")
+			}
+
+		}
+	}
+	return buf.Bytes(), nil
+}
+func (m *SmallJSONMarshaler) MarshalMetrics(mt pmetric.Metrics) ([]byte, error) {
+	buf := bytes.Buffer{}
+	for i := 0; i < mt.ResourceMetrics().Len(); i++ {
+		scopeMetrics := mt.ResourceMetrics().At(i).ScopeMetrics()
+		for j := 0; j < scopeMetrics.Len(); j++ {
+			metrics := scopeMetrics.At(j)
+			for k := 0; k < metrics.Metrics().Len(); k++ {
+				metric := metrics.Metrics().At(k)
+				buf.WriteString(`{"name":`)
+				buf.WriteString(fmt.Sprintf("%q", metric.Name()))
+				buf.WriteString(`,"description":`)
+				buf.WriteString(fmt.Sprintf("%q", metric.Description()))
+				buf.WriteString(`,"unit":`)
+				buf.WriteString(fmt.Sprintf("%q", metric.Unit()))
+				switch metric.Type() {
+				case pmetric.MetricTypeGauge:
+					buf.WriteString(`,"type":"gauge","value":`)
+					buf.WriteString(fmt.Sprint(metric.Gauge().DataPoints().At(0).DoubleValue()))
+				case pmetric.MetricTypeSum:
+					buf.WriteString(`,"type":"sum","value":`)
+					buf.WriteString(fmt.Sprint(metric.Sum().DataPoints().At(0).IntValue()))
+				case pmetric.MetricTypeHistogram:
+					buf.WriteString(`,"type":"histogram","value":`)
+					// How to export a histogram metric??
+				case pmetric.MetricTypeSummary:
+					buf.WriteString(`,"type":"summary","value":`)
+					// How to export a summary metric??
+				case pmetric.MetricTypeExponentialHistogram:
+					buf.WriteString(`,"type":"histogram","value":`)
+					// How to export a exponential histogram metric??
+				case pmetric.MetricTypeEmpty:
+					// Nothing to do?
+				}
+				buf.WriteString("}\n")
+			}
+		}
+	}
+	return buf.Bytes(), nil
+}
+func (m *SmallJSONMarshaler) MarshalTraces(tr ptrace.Traces) ([]byte, error) {
+	buf := bytes.Buffer{}
+	for i := 0; i < tr.ResourceSpans().Len(); i++ {
+		resourceSpan := tr.ResourceSpans().At(i)
+		for j := 0; j < resourceSpan.ScopeSpans().Len(); j++ {
+			scopeSpan := resourceSpan.ScopeSpans().At(j)
+			for k := 0; k < scopeSpan.Spans().Len(); k++ {
+				span := scopeSpan.Spans().At(k)
+				buf.WriteString(`{"trace_id":`)
+				buf.WriteString(fmt.Sprintf("%q", span.TraceID().String()))
+				buf.WriteString(`,"span_id":`)
+				buf.WriteString(fmt.Sprintf("%q", span.SpanID().String()))
+				buf.WriteString(`,"parent_span_id":`)
+				buf.WriteString(fmt.Sprintf("%q", span.ParentSpanID().String()))
+				buf.WriteString(`,"name":`)
+				buf.WriteString(fmt.Sprintf("%q", span.Name()))
+				buf.WriteString(`,"start_time":`)
+				buf.WriteString(fmt.Sprint(float64(span.StartTimestamp().AsTime().UnixNano()) / 1e6))
+				buf.WriteString(`,"end_time":`)
+				buf.WriteString(fmt.Sprint(float64(span.EndTimestamp().AsTime().UnixNano()) / 1e6))
+				buf.WriteString(`,"attrs":{`)
+				span.Attributes().Range(func(k string, v pcommon.Value) bool {
+					buf.WriteString(`"`)
+					buf.WriteString(k)
+					buf.WriteString(`":`)
+					buf.WriteString(jsonRepresentation(v))
+					buf.WriteString(",")
+					return true
+				})
+				buf.WriteString(`},"events":[`)
+				for l := 0; l < span.Events().Len(); l++ {
+					event := span.Events().At(l)
+					buf.WriteString(`{"time":`)
+					buf.WriteString(fmt.Sprint(float64(event.Timestamp().AsTime().UnixNano()) / 1e6))
+					buf.WriteString(`,"attrs":{`)
+					event.Attributes().Range(func(k string, v pcommon.Value) bool {
+						buf.WriteString(`"`)
+						buf.WriteString(k)
+						buf.WriteString(`":`)
+						buf.WriteString(jsonRepresentation(v))
+						buf.WriteString(",")
+						return true
+					})
+					buf.WriteString("}},")
+				}
+				buf.WriteString(`],"links":[`)
+				for l := 0; l < span.Links().Len(); l++ {
+					link := span.Links().At(l)
+					buf.WriteString(`{"trace_id":`)
+					buf.WriteString(fmt.Sprintf("%q", link.TraceID().String()))
+					buf.WriteString(`,"span_id":`)
+					buf.WriteString(fmt.Sprintf("%q", link.SpanID().String()))
+					buf.WriteString(`,"attrs":{`)
+					link.Attributes().Range(func(k string, v pcommon.Value) bool {
+						buf.WriteString(`"`)
+						buf.WriteString(k)
+						buf.WriteString(`":`)
+						buf.WriteString(jsonRepresentation(v))
+						buf.WriteString(",")
+						return true
+					})
+					buf.WriteString("}},")
+				}
+				buf.WriteString("]}\n")
+			}
+		}
+	}
+	return buf.Bytes(), nil
+
+}
+
 // Marshaler configuration used for marhsaling Protobuf
 var tracesMarshalers = map[string]ptrace.Marshaler{
-	formatTypeJSON:  &ptrace.JSONMarshaler{},
-	formatTypeProto: &ptrace.ProtoMarshaler{},
+	formatTypeJSON:      &ptrace.JSONMarshaler{},
+	formatTypeProto:     &ptrace.ProtoMarshaler{},
+	formatTypeSmallJSON: &SmallJSONMarshaler{},
 }
 var metricsMarshalers = map[string]pmetric.Marshaler{
-	formatTypeJSON:  &pmetric.JSONMarshaler{},
-	formatTypeProto: &pmetric.ProtoMarshaler{},
+	formatTypeJSON:      &pmetric.JSONMarshaler{},
+	formatTypeProto:     &pmetric.ProtoMarshaler{},
+	formatTypeSmallJSON: &SmallJSONMarshaler{},
 }
 var logsMarshalers = map[string]plog.Marshaler{
-	formatTypeJSON:  &plog.JSONMarshaler{},
-	formatTypeProto: &plog.ProtoMarshaler{},
+	formatTypeJSON:      &plog.JSONMarshaler{},
+	formatTypeProto:     &plog.ProtoMarshaler{},
+	formatTypeSmallJSON: &SmallJSONMarshaler{},
 }
 
 type marshaller struct {

--- a/exporter/fileexporter/testdata/config.yaml
+++ b/exporter/fileexporter/testdata/config.yaml
@@ -52,6 +52,11 @@ file/flush_interval_500ms:
   path: ./flushed
   flush_interval: 500ms
 
+file/smol_json_no_grouping:
+  path: ./flushed.json
+  flush_interval: 500ms
+  format: smalljson
+
 file/flush_interval_negative_value:
   path: ./flushed
   flush_interval: "-1s"


### PR DESCRIPTION
**Description:** Adding a new export format to the `fileexporter` component: `smalljson`. Data is exported in a much more compact format than the original OTLP-based json format.

**Testing:** Added config+format tests.

**Documentation:** None added yet.

**Plan**
- [ ] Discuss/agree on adding this feature.
- [ ] Once we agree on adding the feature, add histogram, summary metric formats.
- [ ] Once we agree on adding the feature, add documentation to README for file exporter.