### PR TITLE
[exporter/sentry] Add instructions for improving transaction grouping

### DIFF
--- a/exporter/sentryexporter/README.md
+++ b/exporter/sentryexporter/README.md
@@ -38,7 +38,9 @@ See the [docs](./docs/transformation.md) for more details on how this transforma
 
 Currently, Sentry Tracing leverages a transaction-based system, where a transaction contains one or more spans. The exporter will try to group spans from a trace under one or more transactions based on internal heuristics, but this may lead to the creation of transactions that contain only one or two spans. These transactions will still be viewable and associated under a single trace in the Sentry UI.
 
-One consequence of this result is that very large traces with a large number of spans (500+) and only one root span might be split up into a large number of transactions. There are no current ways to work around this.
+One consequence of this result is that very large traces with a large number of spans (500+) and only one root span might be split up into a large number of transactions.
+
+To improve the transaction grouping, you can use the [`groupbytrace` processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/groupbytraceprocessor) to buffer complete traces before exporting them with the Sentry Exporter. (If you load balance between multiple collectors you may also need to use a trace-aware load balancer, such as the [`loadbalancing` exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/loadbalancingexporter), to ensure that all spans for a trace are routed to the same collector instance).
 
 ### Associating with Sentry Errors
 


### PR DESCRIPTION
The Sentry Exporter's README correctly notes that it only operates on one batch of spans at a time: if spans that would logically belong to the same Sentry transaction arrive in different batches, they'll be split into separate transactions by the exporter.

There actually is a workaround: by using the `groupbytrace` processor, spans will be buffered until (presumably) a complete trace has been received. At that point the Sentry Exporter should be able to accurately split them into transactions.

Also added a note pointing users to the `loadbalancing` exporter, which is a requirement for `groupbytrace` to work correctly when load balancing between collector instances.