### PR TITLE
[chore] [receiver/kubeletstats] move utilization metrics in standalone helper func

### DIFF
--- a/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go
@@ -20,11 +20,24 @@ func addCPUMetrics(
 	if s == nil {
 		return
 	}
-	addCPUUsageMetric(mb, cpuMetrics, s, currentTime, r, nodeCPULimit)
+	addCPUUsageMetric(mb, cpuMetrics, s, currentTime)
 	addCPUTimeMetric(mb, cpuMetrics.Time, s, currentTime)
+	addCPUUtilizationMetrics(mb, cpuMetrics, s, currentTime, r, nodeCPULimit)
 }
 
 func addCPUUsageMetric(
+	mb *metadata.MetricsBuilder,
+	cpuMetrics metadata.CPUMetrics,
+	s *stats.CPUStats,
+	currentTime pcommon.Timestamp) {
+	if s.UsageNanoCores == nil {
+		return
+	}
+	value := float64(*s.UsageNanoCores) / 1_000_000_000
+	cpuMetrics.Usage(mb, currentTime, value)
+}
+
+func addCPUUtilizationMetrics(
 	mb *metadata.MetricsBuilder,
 	cpuMetrics metadata.CPUMetrics,
 	s *stats.CPUStats,
@@ -36,7 +49,6 @@ func addCPUUsageMetric(
 	}
 	value := float64(*s.UsageNanoCores) / 1_000_000_000
 	cpuMetrics.Utilization(mb, currentTime, value)
-	cpuMetrics.Usage(mb, currentTime, value)
 
 	if nodeCPULimit > 0 {
 		cpuMetrics.NodeUtilization(mb, currentTime, value/nodeCPULimit)

--- a/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go
@@ -20,44 +20,31 @@ func addCPUMetrics(
 	if s == nil {
 		return
 	}
-	addCPUUsageMetric(mb, cpuMetrics, s, currentTime)
-	addCPUTimeMetric(mb, cpuMetrics.Time, s, currentTime)
-	addCPUUtilizationMetrics(mb, cpuMetrics, s, currentTime, r, nodeCPULimit)
-}
-
-func addCPUUsageMetric(
-	mb *metadata.MetricsBuilder,
-	cpuMetrics metadata.CPUMetrics,
-	s *stats.CPUStats,
-	currentTime pcommon.Timestamp) {
-	if s.UsageNanoCores == nil {
-		return
+	if s.UsageNanoCores != nil {
+		usageCores := float64(*s.UsageNanoCores) / 1_000_000_000
+		cpuMetrics.Usage(mb, currentTime, usageCores)
+		addCPUUtilizationMetrics(mb, cpuMetrics, usageCores, currentTime, r, nodeCPULimit)
 	}
-	value := float64(*s.UsageNanoCores) / 1_000_000_000
-	cpuMetrics.Usage(mb, currentTime, value)
+	addCPUTimeMetric(mb, cpuMetrics.Time, s, currentTime)
 }
 
 func addCPUUtilizationMetrics(
 	mb *metadata.MetricsBuilder,
 	cpuMetrics metadata.CPUMetrics,
-	s *stats.CPUStats,
+	usageCores float64,
 	currentTime pcommon.Timestamp,
 	r resources,
 	nodeCPULimit float64) {
-	if s.UsageNanoCores == nil {
-		return
-	}
-	value := float64(*s.UsageNanoCores) / 1_000_000_000
-	cpuMetrics.Utilization(mb, currentTime, value)
+	cpuMetrics.Utilization(mb, currentTime, usageCores)
 
 	if nodeCPULimit > 0 {
-		cpuMetrics.NodeUtilization(mb, currentTime, value/nodeCPULimit)
+		cpuMetrics.NodeUtilization(mb, currentTime, usageCores/nodeCPULimit)
 	}
 	if r.cpuLimit > 0 {
-		cpuMetrics.LimitUtilization(mb, currentTime, value/r.cpuLimit)
+		cpuMetrics.LimitUtilization(mb, currentTime, usageCores/r.cpuLimit)
 	}
 	if r.cpuRequest > 0 {
-		cpuMetrics.RequestUtilization(mb, currentTime, value/r.cpuRequest)
+		cpuMetrics.RequestUtilization(mb, currentTime, usageCores/r.cpuRequest)
 	}
 }
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`kubeletstats` receiver performs the CPU metrics addition
in the [`addCPUMetrics`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go#L13) helper function.
This function calls respectively the [`addCPUUsageMetric`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go#L21)
and the [`addCPUTimeMetric`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go#L37). However the [`addCPUUsageMetric`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.101.0/receiver/kubeletstatsreceiver/internal/kubelet/cpu.go#L21)
adds not only the `*.usage` metric but some `*utilization` ones as well.

This change moves the addition of the `*utilization` metrics
to a standalone `addCPUUtilizationMetrics` helper function.

**Link to tracking Issue:** <Issue number if applicable> -

**Testing:** <Describe what testing was performed and which tests were added.> -

**Documentation:** <Describe the documentation added.> -