### PR TITLE
[chore][exporter/elasticsearch]Extend benchmarks for mapping mode

### DIFF
--- a/exporter/elasticsearchexporter/integrationtest/exporter_bench_test.go
+++ b/exporter/elasticsearchexporter/integrationtest/exporter_bench_test.go
@@ -25,32 +25,34 @@ import (
 
 func BenchmarkExporter(b *testing.B) {
 	for _, eventType := range []string{"logs", "traces"} {
-		for _, tc := range []struct {
-			name      string
-			batchSize int
-		}{
-			{name: "small_batch", batchSize: 10},
-			{name: "medium_batch", batchSize: 100},
-			{name: "large_batch", batchSize: 1000},
-			{name: "xlarge_batch", batchSize: 10000},
-		} {
-			b.Run(fmt.Sprintf("%s/%s", eventType, tc.name), func(b *testing.B) {
-				switch eventType {
-				case "logs":
-					benchmarkLogs(b, tc.batchSize)
-				case "traces":
-					benchmarkTraces(b, tc.batchSize)
-				}
-			})
+		for _, mappingMode := range []string{"none", "ecs", "raw"} {
+			for _, tc := range []struct {
+				name      string
+				batchSize int
+			}{
+				{name: "small_batch", batchSize: 10},
+				{name: "medium_batch", batchSize: 100},
+				{name: "large_batch", batchSize: 1000},
+				{name: "xlarge_batch", batchSize: 10000},
+			} {
+				b.Run(fmt.Sprintf("%s/%s/%s", eventType, mappingMode, tc.name), func(b *testing.B) {
+					switch eventType {
+					case "logs":
+						benchmarkLogs(b, tc.batchSize, mappingMode)
+					case "traces":
+						benchmarkTraces(b, tc.batchSize, mappingMode)
+					}
+				})
+			}
 		}
 	}
 }
 
-func benchmarkLogs(b *testing.B, batchSize int) {
+func benchmarkLogs(b *testing.B, batchSize int, mappingMode string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	runnerCfg := prepareBenchmark(b, batchSize)
+	runnerCfg := prepareBenchmark(b, batchSize, mappingMode)
 	exporter, err := runnerCfg.factory.CreateLogsExporter(
 		ctx, exportertest.NewNopCreateSettings(), runnerCfg.esCfg,
 	)
@@ -73,11 +75,11 @@ func benchmarkLogs(b *testing.B, batchSize int) {
 	require.NoError(b, exporter.Shutdown(ctx))
 }
 
-func benchmarkTraces(b *testing.B, batchSize int) {
+func benchmarkTraces(b *testing.B, batchSize int, mappingMode string) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	runnerCfg := prepareBenchmark(b, batchSize)
+	runnerCfg := prepareBenchmark(b, batchSize, mappingMode)
 	exporter, err := runnerCfg.factory.CreateTracesExporter(
 		ctx, exportertest.NewNopCreateSettings(), runnerCfg.esCfg,
 	)
@@ -111,6 +113,7 @@ type benchRunnerCfg struct {
 func prepareBenchmark(
 	b *testing.B,
 	batchSize int,
+	mappingMode string,
 ) *benchRunnerCfg {
 	b.Helper()
 
@@ -122,6 +125,7 @@ func prepareBenchmark(
 
 	cfg.factory = elasticsearchexporter.NewFactory()
 	cfg.esCfg = cfg.factory.CreateDefaultConfig().(*elasticsearchexporter.Config)
+	cfg.esCfg.Mapping.Mode = mappingMode
 	cfg.esCfg.Endpoints = []string{receiver.endpoint}
 	cfg.esCfg.LogsIndex = TestLogsIndex
 	cfg.esCfg.TracesIndex = TestTracesIndex


### PR DESCRIPTION
**Description:** Updates benchmarks to consider mapping mode. Mapping mode has a big impact on the benchmark runs since each mapping mode is implemented in a different way. This is a precursor to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33374 which aims to improve performance by optimizing allocations.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32504

**Testing:** <Describe what testing was performed and which tests were added.> `cd integrationtest && go test -count=1 -bench=BenchmarkExporter -run=^$ -v ./...`

<details>
<summary> Benchmark results from my personal PC</summary>

```
$ go test -count=1 -bench=BenchmarkExporter -run=^$ -v ./...                        [11:43:00]
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/integrationtest
BenchmarkExporter
BenchmarkExporter/logs/none/small_batch
BenchmarkExporter/logs/none/small_batch-10         	   19693	     62644 ns/op	    159633 events/s	   59476 B/op	     352 allocs/op
BenchmarkExporter/logs/none/medium_batch
BenchmarkExporter/logs/none/medium_batch-10        	    2174	    549870 ns/op	    181861 events/s	  586538 B/op	    3425 allocs/op
BenchmarkExporter/logs/none/large_batch
BenchmarkExporter/logs/none/large_batch-10         	     225	   5291466 ns/op	    188984 events/s	 5856818 B/op	   34148 allocs/op
BenchmarkExporter/logs/none/xlarge_batch
BenchmarkExporter/logs/none/xlarge_batch-10        	      22	  51000769 ns/op	    196075 events/s	58486725 B/op	  341268 allocs/op
BenchmarkExporter/logs/ecs/small_batch
BenchmarkExporter/logs/ecs/small_batch-10          	   31297	     38221 ns/op	    261637 events/s	   48742 B/op	     161 allocs/op
BenchmarkExporter/logs/ecs/medium_batch
BenchmarkExporter/logs/ecs/medium_batch-10         	    3559	    335623 ns/op	    297953 events/s	  479045 B/op	    1520 allocs/op
BenchmarkExporter/logs/ecs/large_batch
BenchmarkExporter/logs/ecs/large_batch-10          	     343	   3313594 ns/op	    301787 events/s	 4784951 B/op	   15102 allocs/op
BenchmarkExporter/logs/ecs/xlarge_batch
BenchmarkExporter/logs/ecs/xlarge_batch-10         	      34	  33257379 ns/op	    300685 events/s	47837431 B/op	  150861 allocs/op
BenchmarkExporter/logs/raw/small_batch
BenchmarkExporter/logs/raw/small_batch-10          	   22364	     54047 ns/op	    185025 events/s	   58119 B/op	     291 allocs/op
BenchmarkExporter/logs/raw/medium_batch
BenchmarkExporter/logs/raw/medium_batch-10         	    2452	    484758 ns/op	    206288 events/s	  572996 B/op	    2819 allocs/op
BenchmarkExporter/logs/raw/large_batch
BenchmarkExporter/logs/raw/large_batch-10          	     252	   4782239 ns/op	    209107 events/s	 5722459 B/op	   28098 allocs/op
BenchmarkExporter/logs/raw/xlarge_batch
BenchmarkExporter/logs/raw/xlarge_batch-10         	      25	  46517563 ns/op	    214973 events/s	57311327 B/op	  281046 allocs/op
BenchmarkExporter/traces/none/small_batch
BenchmarkExporter/traces/none/small_batch-10       	   18934	     64383 ns/op	    155321 events/s	   61103 B/op	     392 allocs/op
BenchmarkExporter/traces/none/medium_batch
BenchmarkExporter/traces/none/medium_batch-10      	    2078	    573554 ns/op	    174352 events/s	  602734 B/op	    3826 allocs/op
BenchmarkExporter/traces/none/large_batch
BenchmarkExporter/traces/none/large_batch-10       	     204	   5506740 ns/op	    181596 events/s	 6019500 B/op	   38163 allocs/op
BenchmarkExporter/traces/none/xlarge_batch
BenchmarkExporter/traces/none/xlarge_batch-10      	      21	  55099689 ns/op	    181489 events/s	60130968 B/op	  381435 allocs/op
BenchmarkExporter/traces/ecs/small_batch
BenchmarkExporter/traces/ecs/small_batch-10        	   18612	     64431 ns/op	    155204 events/s	   61111 B/op	     392 allocs/op
BenchmarkExporter/traces/ecs/medium_batch
BenchmarkExporter/traces/ecs/medium_batch-10       	    2086	    579508 ns/op	    172560 events/s	  602838 B/op	    3826 allocs/op
BenchmarkExporter/traces/ecs/large_batch
BenchmarkExporter/traces/ecs/large_batch-10        	     210	   5637313 ns/op	    177389 events/s	 6019330 B/op	   38168 allocs/op
BenchmarkExporter/traces/ecs/xlarge_batch
BenchmarkExporter/traces/ecs/xlarge_batch-10       	      20	  53797696 ns/op	    185882 events/s	60170108 B/op	  381418 allocs/op
BenchmarkExporter/traces/raw/small_batch
BenchmarkExporter/traces/raw/small_batch-10        	   19999	     64957 ns/op	    153949 events/s	   60193 B/op	     372 allocs/op
BenchmarkExporter/traces/raw/medium_batch
BenchmarkExporter/traces/raw/medium_batch-10       	    2197	    533394 ns/op	    187479 events/s	  592292 B/op	    3625 allocs/op
BenchmarkExporter/traces/raw/large_batch
BenchmarkExporter/traces/raw/large_batch-10        	     223	   5158606 ns/op	    193851 events/s	 5917039 B/op	   36155 allocs/op
BenchmarkExporter/traces/raw/xlarge_batch
BenchmarkExporter/traces/raw/xlarge_batch-10       	      22	  51159360 ns/op	    195468 events/s	59215624 B/op	  361363 allocs/op
PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/integrationtest	93.126s
```
</details>

**Documentation:** <Describe the documentation added.> N/A