### PR TITLE
[chore] Clarify that cmd/otelcontribcol and top-level go.mod are not the sources of the contrib distro

### DIFF
--- a/cmd/otelcontribcol/README.md
+++ b/cmd/otelcontribcol/README.md
@@ -1,0 +1,4 @@
+# `otelcontribcol` test binary
+
+This folder contains the sources for the `otelcontribcol` test binary. This binary is intended for **TEST PURPOSES ONLY**. The source files in this folder are **NOT** the ones used to build any official OpenTelemetry Collector releases.
+Check [open-telemetry/opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) for the official releases. Check the [**`otelcol-contrib` folder**](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) on that repository for the official Collector contrib manifest.

--- a/cmd/otelcontribcol/README.md
+++ b/cmd/otelcontribcol/README.md
@@ -1,4 +1,4 @@
 # `otelcontribcol` test binary
 
-This folder contains the sources for the `otelcontribcol` test binary. This binary is intended for **TEST PURPOSES ONLY**. The source files in this folder are **NOT** the ones used to build any official OpenTelemetry Collector releases.
+This folder contains the sources for the `otelcontribcol` test binary. This binary is intended for internal **TEST PURPOSES ONLY**. The source files in this folder are **NOT** the ones used to build any official OpenTelemetry Collector releases.
 Check [open-telemetry/opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) for the official releases. Check the [**`otelcol-contrib` folder**](https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib) on that repository for the official Collector contrib manifest.

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -1,3 +1,11 @@
+# NOTE:
+# This builder configuration is NOT used to build any official binary.
+# To see the builder manifests used for official binaries, 
+# check https://github.com/open-telemetry/opentelemetry-collector-releases
+# 
+# For the OpenTelemetry Collector Contrib official distribution sources, check
+# https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otelcontribcol
   name: otelcontribcol

--- a/cmd/oteltestbedcol/README.md
+++ b/cmd/oteltestbedcol/README.md
@@ -1,0 +1,4 @@
+# `oteltestbedcol` binary
+
+This folder contains the sources for the `oteltestbedcol` test binary. This binary is intended for **TEST PURPOSES ONLY**. The source files in this folder are **NOT** the ones used to build any official OpenTelemetry Collector releases.
+Check [open-telemetry/opentelemetry-collector-releases](https://github.com/open-telemetry/opentelemetry-collector-releases) for the official releases.

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -1,3 +1,8 @@
+# NOTE:
+# This builder configuration is NOT used to build any official binary.
+# To see the builder manifests used for official binaries, 
+# check https://github.com/open-telemetry/opentelemetry-collector-releases
+
 dist:
   module: github.com/open-telemetry/opentelemetry-collector-contrib/cmd/oteltestbedcol
   name: oteltestbedcol

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,13 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib
 
+// NOTE:
+// This go.mod is NOT used to build any official binary.
+// To see the builder manifests used for official binaries,
+// check https://github.com/open-telemetry/opentelemetry-collector-releases
+//
+// For the OpenTelemetry Collector Contrib distribution specifically, see
+// https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
+
 go 1.21.0
 
 require (


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Documents the purpose of `cmd/otelcontribcol` and `cmd/oteltestbedcol` in new READMEs and in comments on the builder manifests. Adds note to top-level `go.mod`.

This is a common point of confusion and was recently confusing for users on the aftermath of CVE-2024-36129

Counterpart to open-telemetry/opentelemetry-collector/pull/10351
