### PR TITLE
[chore][processor/probabilisticsampler] Fix sampling_percentage description

### DIFF
--- a/processor/probabilisticsamplerprocessor/README.md
+++ b/processor/probabilisticsamplerprocessor/README.md
@@ -140,7 +140,7 @@ This mode uses 14 bits of sampling precision.
 ### Error handling
 
 This processor considers it an error when the arriving data has no
-randomess.  This includes conditions where the TraceID field is
+randomness.  This includes conditions where the TraceID field is
 invalid (16 zero bytes) and where the log record attribute source has
 zero bytes of information.
 

--- a/processor/probabilisticsamplerprocessor/README.md
+++ b/processor/probabilisticsamplerprocessor/README.md
@@ -153,7 +153,7 @@ false, in which case erroneous data will pass through the processor.
 
 The following configuration options can be modified:
 
-- `sampling_percentage` (32-bit floating point, required): Percentage at which items are sampled; >= 100 samples all items, 0 rejects all items.
+- `sampling_percentage` (32-bit floating point, required): Percentage at which items are sampled; >= 100 samples all items, 0 accepts all items.
 - `hash_seed` (32-bit unsigned integer, optional, default = 0): An integer used to compute the hash algorithm. Note that all collectors for a given tier (e.g. behind the same load balancer) should have the same hash_seed.
 - `fail_closed` (boolean, optional, default = true): Whether to reject items with sampling-related errors.
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
I believe documentation is incorrect here. If >=100 samples all items, that means all items are dropped. 0, from the `config.go` description of this option means no sample. I believe no sampling means we keep all items, and they continue through the telemetry pipeline.

Also, fix unrelated typo.

_Note: I often get confused around the wording of sampling, so let me know if I'm just misunderstanding terminology here._