### PR TITLE
statsdreceiver observability

### DIFF
--- a/.chloggen/feature-statsdreceiver-metrics.yaml
+++ b/.chloggen/feature-statsdreceiver-metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added accepted/refused metrics using receiverhelper.obsreport
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [24278]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/feature-statsdreceiver-metrics.yaml
+++ b/.chloggen/feature-statsdreceiver-metrics.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: statsdreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added accepted/refused metrics using receiverhelper.obsreport
+note: Added received/accepted/refused metrics
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [24278]

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -16,8 +16,10 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.uber.org/zap"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/protocol"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport"
 )
@@ -31,6 +33,7 @@ type statsdReceiver struct {
 
 	server       transport.Server
 	reporter     transport.Reporter
+	obsrecv      *receiverhelper.ObsReport
 	parser       protocol.Parser
 	nextConsumer consumer.Metrics
 	cancel       context.CancelFunc
@@ -52,10 +55,21 @@ func newReceiver(
 		return nil, err
 	}
 
+	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
+		LongLivedCtx:           true,
+		ReceiverID:             set.ID,
+		ReceiverCreateSettings: set,
+		Transport:              metadata.Type.String(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	r := &statsdReceiver{
 		settings:     set,
 		config:       &config,
 		nextConsumer: nextConsumer,
+		obsrecv:      obsrecv,
 		reporter:     rep,
 		parser: &protocol.StatsDParser{
 			BuildInfo: set.BuildInfo,
@@ -110,10 +124,13 @@ func (r *statsdReceiver) Start(ctx context.Context, _ component.Host) error {
 				batchMetrics := r.parser.GetMetrics()
 				for _, batch := range batchMetrics {
 					batchCtx := client.NewContext(ctx, batch.Info)
-
-					if err := r.Flush(batchCtx, batch.Metrics, r.nextConsumer); err != nil {
+					numPoints := batch.Metrics.DataPointCount()
+					flushCtx := r.obsrecv.StartMetricsOp(batchCtx)
+					err := r.Flush(flushCtx, batch.Metrics, r.nextConsumer)
+					if err != nil {
 						r.reporter.OnDebugf("Error flushing metrics", zap.Error(err))
 					}
+					r.obsrecv.EndMetricsOp(flushCtx, metadata.Type.String(), numPoints, err)
 				}
 			case metric := <-transferChan:
 				if err := r.parser.Aggregate(metric.Raw, metric.Addr); err != nil {

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver/internal/transport/client"
 )
 
@@ -116,9 +115,6 @@ func Test_statsdreceiver_EndToEnd(t *testing.T) {
 			rcv, err := newReceiver(receivertest.NewNopSettings(), *cfg, sink)
 			require.NoError(t, err)
 			r := rcv.(*statsdReceiver)
-
-			mr := transport.NewMockReporter(1)
-			r.reporter = mr
 
 			require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()))
 			defer func() {


### PR DESCRIPTION
Description:
Add received statsd / accepted/refused metrics to statsdreceiver

Resurrecting https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/31822 since #31839 is closed.

Link to tracking Issue:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24278

Testing:
This works in our internal testing environments. Took a profile and didn't see metric recording taking much cpu

Documentation:

cc @jmacd @dmitryax @TylerHelmuth 