### PR TITLE
[chore][pkg/stanza] skip rotation test on windows

### DIFF
--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -318,6 +318,9 @@ func TestRotatedOutOfPatternMoveCreate(t *testing.T) {
 // When a file it rotated out of pattern via copy/truncate, we should
 // detect that our old handle is stale and not attempt to read from it.
 func TestRotatedOutOfPatternCopyTruncate(t *testing.T) {
+	if runtime.GOOS == windowsOS {
+		t.Skip("Rotation tests have been flaky on Windows. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16331")
+	}
 	t.Parallel()
 
 	tempDir := t.TempDir()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Since other rotation related tests are skipped on Windows, I guess it makes sense to skip this one too.
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16331.

Spotted failure: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9418728481/job/25946842048?pr=33428#step:6:848 (https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33428)


**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>