### PR TITLE
[chore] Fix pinging and labelling on new issues

### DIFF
--- a/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
+++ b/.github/workflows/scripts/ping-codeowners-on-new-issue.sh
@@ -30,7 +30,7 @@ fi
 if [[ -n "${TITLE_COMPONENT}" && ! ("${TITLE_COMPONENT}" =~ " ") ]]; then
   CODEOWNERS=$(COMPONENT="${TITLE_COMPONENT}" "${CUR_DIRECTORY}/get-codeowners.sh" || true)
   
-  if [[ -n "${CODEOWNERS}" && ! ("${CODEOWNERS}" =~ ${OPENER}) ]]; then
+  if [[ -n "${CODEOWNERS}" ]]; then
     PING_LINES+="- ${TITLE_COMPONENT}: ${CODEOWNERS}\n"
     PINGED_COMPONENTS["${TITLE_COMPONENT}"]=1
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The current behavior of pinging code owners and adding labels to new issues is tied together. The existing logic was to only add a label and ping code owners if the person filing the issue was **not** a code owner. However, this can lead to issues lacking labels, and some code owners not being properly notified of issues.

Recent example: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33433 (There have been many examples of this, but I choose this one as I used it for my investigation.)

This issue was filed by a code owner. The result was that no labels were added, and the other three code owners were not notified.

I think it makes sense to at least add the label to the issue, and I don't see much harm in the extra noise for the person filing the issue to get a notification.

This change is essentially the same as https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/30136, just for new issues.