### PR TITLE
[pkg/ottl] Add Hex() convertor

### DIFF
--- a/.chloggen/add-hex-function.yaml
+++ b/.chloggen/add-hex-function.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Added support for converting values to hex
+note: Added Hex() converter function
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [31929]

--- a/.chloggen/add-hex-function.yaml
+++ b/.chloggen/add-hex-function.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added support for converting values to hex
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [31929]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -418,6 +418,30 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], Hex(1.0))`,
+			want: func(tCtx ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "1")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Hex(true))`,
+			want: func(tCtx ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "1")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Hex(12))`,
+			want: func(tCtx ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "c")
+			},
+		},
+		{
+			statement: `set(attributes["test"], Hex("12"))`,
+			want: func(tCtx ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "c")
+			},
+		},
+		{
 			statement: `set(attributes["test"], "pass") where IsBool(false)`,
 			want: func(tCtx ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -420,25 +420,25 @@ func Test_e2e_converters(t *testing.T) {
 		{
 			statement: `set(attributes["test"], Hex(1.0))`,
 			want: func(tCtx ottllog.TransformContext) {
-				tCtx.GetLogRecord().Attributes().PutStr("test", "1")
+				tCtx.GetLogRecord().Attributes().PutStr("test", "3ff0000000000000")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hex(true))`,
 			want: func(tCtx ottllog.TransformContext) {
-				tCtx.GetLogRecord().Attributes().PutStr("test", "1")
+				tCtx.GetLogRecord().Attributes().PutStr("test", "01")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hex(12))`,
 			want: func(tCtx ottllog.TransformContext) {
-				tCtx.GetLogRecord().Attributes().PutStr("test", "c")
+				tCtx.GetLogRecord().Attributes().PutStr("test", "000000000000000c")
 			},
 		},
 		{
 			statement: `set(attributes["test"], Hex("12"))`,
 			want: func(tCtx ottllog.TransformContext) {
-				tCtx.GetLogRecord().Attributes().PutStr("test", "c")
+				tCtx.GetLogRecord().Attributes().PutStr("test", "3132")
 			},
 		},
 		{

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -457,6 +457,7 @@ Available Converters:
 - [UnixSeconds](#unixseconds)
 - [UUID](#UUID)
 - [Year](#year)
+- [Hex](#hex)
 
 ### Base64Decode
 
@@ -657,6 +658,33 @@ Examples:
 
 
 - `Int("2.0")`
+
+### Hex
+
+`Hex(value)`
+
+The `Hex` converter converts the `value` to its hexadecimal representation.
+
+The returned type is byte slice.
+
+The input `value` types:
+
+- float64
+- string
+- bool
+- int64
+- []byte
+
+If `value` is another type or parsing failed nil is always returned.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `Hex(attributes["http.status_code"])`
+
+
+- `Hex("2.0")`
 
 ### IsBool
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -665,7 +665,7 @@ Examples:
 
 The `Hex` converter converts the `value` to its hexadecimal representation.
 
-The returned type is byte slice.
+The returned type is string representation of the hexadecimal value.
 
 The input `value` types:
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -615,11 +615,11 @@ The returned type is string representation of the hexadecimal value.
 
 The input `value` types:
 
-- float64
-- string
-- bool
-- int64
-- []byte
+- float64 (`1.1` will result to `0x3ff199999999999a`)
+- string (`"1"` will result in `0x31`)
+- bool (`true` will result in `0x01`; `false` to `0x00`)
+- int64 (`12` will result in `0xC`)
+- []byte (without any changes - `0x02` will result to `0x02`)
 
 If `value` is another type or parsing failed nil is always returned.
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -605,6 +605,33 @@ Examples:
 
 - `FNV("name")`
 
+### Hex
+
+`Hex(value)`
+
+The `Hex` converter converts the `value` to its hexadecimal representation.
+
+The returned type is string representation of the hexadecimal value.
+
+The input `value` types:
+
+- float64
+- string
+- bool
+- int64
+- []byte
+
+If `value` is another type or parsing failed nil is always returned.
+
+The `value` is either a path expression to a telemetry field to retrieve or a literal.
+
+Examples:
+
+- `Hex(attributes["http.status_code"])`
+
+
+- `Hex(2.0)`
+
 ### Hour
 
 `Hour(value)`
@@ -658,33 +685,6 @@ Examples:
 
 
 - `Int("2.0")`
-
-### Hex
-
-`Hex(value)`
-
-The `Hex` converter converts the `value` to its hexadecimal representation.
-
-The returned type is string representation of the hexadecimal value.
-
-The input `value` types:
-
-- float64
-- string
-- bool
-- int64
-- []byte
-
-If `value` is another type or parsing failed nil is always returned.
-
-The `value` is either a path expression to a telemetry field to retrieve or a literal.
-
-Examples:
-
-- `Hex(attributes["http.status_code"])`
-
-
-- `Hex(2.0)`
 
 ### IsBool
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -415,6 +415,7 @@ Available Converters:
 - [Day](#day)
 - [ExtractPatterns](#extractpatterns)
 - [FNV](#fnv)
+- [Hex](#hex)
 - [Hour](#hour)
 - [Hours](#hours)
 - [Double](#double)
@@ -457,7 +458,6 @@ Available Converters:
 - [UnixSeconds](#unixseconds)
 - [UUID](#UUID)
 - [Year](#year)
-- [Hex](#hex)
 
 ### Base64Decode
 
@@ -684,7 +684,7 @@ Examples:
 - `Hex(attributes["http.status_code"])`
 
 
-- `Hex("2.0")`
+- `Hex(2.0)`
 
 ### IsBool
 

--- a/pkg/ottl/ottlfuncs/func_hex.go
+++ b/pkg/ottl/ottlfuncs/func_hex.go
@@ -35,9 +35,6 @@ func Hex[K any](target ottl.ByteSliceLikeGetter[K]) (ottl.ExprFunc[K], error) {
 		if err != nil {
 			return nil, err
 		}
-		if value == nil {
-			return nil, nil
-		}
 		return hex.EncodeToString(value), nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_hex.go
+++ b/pkg/ottl/ottlfuncs/func_hex.go
@@ -5,6 +5,7 @@ package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-c
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
@@ -37,6 +38,6 @@ func Hex[K any](target ottl.ByteSliceLikeGetter[K]) (ottl.ExprFunc[K], error) {
 		if value == nil {
 			return nil, nil
 		}
-		return value, nil
+		return hex.EncodeToString(value), nil
 	}, nil
 }

--- a/pkg/ottl/ottlfuncs/func_hex.go
+++ b/pkg/ottl/ottlfuncs/func_hex.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type HexArguments[K any] struct {
+	Target ottl.ByteSliceLikeGetter[K]
+}
+
+func NewHexFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Hex", &HexArguments[K]{}, createHexFunction[K])
+}
+
+func createHexFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*HexArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("HexFactory args must be of type *HexArguments[K]")
+	}
+
+	return Hex(args.Target)
+}
+
+func Hex[K any](target ottl.ByteSliceLikeGetter[K]) (ottl.ExprFunc[K], error) {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		value, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		if value == nil {
+			return nil, nil
+		}
+		return value, nil
+	}, nil
+}

--- a/pkg/ottl/ottlfuncs/func_hex_test.go
+++ b/pkg/ottl/ottlfuncs/func_hex_test.go
@@ -1,0 +1,76 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func TestHex(t *testing.T) {
+	type args struct {
+		target ottl.ByteSliceLikeGetter[any]
+	}
+	type testCase struct {
+		name     string
+		args     args
+		wantFunc func() any
+		wantErr  error
+	}
+	tests := []testCase{
+		{
+			name: "int64",
+			args: args{
+				target: &ottl.StandardByteSliceLikeGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return int64(12), nil
+					},
+				},
+			},
+			wantFunc: func() any {
+				return "c"
+			},
+		},
+		{
+			name: "nil",
+			args: args{
+				target: &ottl.StandardByteSliceLikeGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return nil, nil
+					},
+				},
+			},
+			wantFunc: func() any {
+				return nil
+			},
+			wantErr: nil,
+		},
+		{
+			name: "error",
+			args: args{
+				target: &ottl.StandardByteSliceLikeGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return map[string]string{"hi": "hi"}, nil
+					},
+				},
+			},
+			wantFunc: func() any {
+				return nil
+			},
+			wantErr: ottl.TypeError("unsupported type: map[string]string"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			expressionFunc, _ := Hex(tt.args.target)
+			got, err := expressionFunc(context.Background(), tt.args)
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.wantFunc(), got)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_hex_test.go
+++ b/pkg/ottl/ottlfuncs/func_hex_test.go
@@ -33,7 +33,7 @@ func TestHex(t *testing.T) {
 				},
 			},
 			wantFunc: func() any {
-				return "c"
+				return "000000000000000c"
 			},
 		},
 		{

--- a/pkg/ottl/ottlfuncs/func_hex_test.go
+++ b/pkg/ottl/ottlfuncs/func_hex_test.go
@@ -46,7 +46,7 @@ func TestHex(t *testing.T) {
 				},
 			},
 			wantFunc: func() any {
-				return nil
+				return ""
 			},
 			wantErr: nil,
 		},

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -86,5 +86,6 @@ func converters[K any]() []ottl.Factory[K] {
 		NewURLFactory[K](),
 		NewAppendFactory[K](),
 		NewYearFactory[K](),
+		NewHexFactory[K](),
 	}
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Adds a Hex function to the OTTL package. This function can be applied to following values:

- float64
- string
- bool
- int64
- []byte

The resulting value will be of type []byte.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31929

**Testing:**
- unit tests
- e2e tests

Depends on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33536