### PR TITLE
[receiver/postgresql] Fixes `postgresql.rows` always returning 0 for `state="dead"`

### DIFF
--- a/.chloggen/postgresqlreceiver_dead_rows_fix.yaml
+++ b/.chloggen/postgresqlreceiver_dead_rows_fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes `postgresql.rows` always returning 0 for `state="dead"`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33489]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -299,6 +299,7 @@ func (c *postgreSQLClient) getDatabaseTableMetrics(ctx context.Context, db strin
 			schema:      schema,
 			table:       table,
 			live:        live,
+			dead:        dead,
 			inserts:     ins,
 			upd:         upd,
 			del:         del,


### PR DESCRIPTION
**Description:** 
Fixes `postgresql.rows` always returning 0 for `state="dead"`. The respective field on `tableStats` was never set.

**Testing:** 
No additional tests were added.

**Documentation:** 
No documentation was added.