### PR TITLE
[exporter/sumologicexporter]: Added timeout validation 

### DIFF
--- a/.chloggen/chan-tim_timeoutValidation.yaml
+++ b/.chloggen/chan-tim_timeoutValidation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sumologicexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: added timeout validation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33151]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/sumologicexporter/config.go
+++ b/exporter/sumologicexporter/config.go
@@ -73,6 +73,10 @@ func createDefaultClientConfig() confighttp.ClientConfig {
 
 func (cfg *Config) Validate() error {
 
+	if cfg.ClientConfig.Timeout < 0 || cfg.ClientConfig.Timeout > maxTimeout {
+		return fmt.Errorf("timeout must be between 0 and 55 seconds, got %v", cfg.ClientConfig.Timeout)
+	}
+
 	switch cfg.CompressEncoding {
 	case configcompression.TypeGzip:
 	case configcompression.TypeDeflate:
@@ -171,6 +175,8 @@ const (
 	TracesPipeline PipelineType = "traces"
 	// defaultTimeout
 	defaultTimeout time.Duration = 30 * time.Second
+	// maxTimeout
+	maxTimeout time.Duration = 55 * time.Second
 	// DefaultCompress defines default Compress
 	DefaultCompress bool = true
 	// DefaultCompressEncoding defines default CompressEncoding

--- a/exporter/sumologicexporter/config.go
+++ b/exporter/sumologicexporter/config.go
@@ -73,8 +73,8 @@ func createDefaultClientConfig() confighttp.ClientConfig {
 
 func (cfg *Config) Validate() error {
 
-	if cfg.ClientConfig.Timeout < 0 || cfg.ClientConfig.Timeout > maxTimeout {
-		return fmt.Errorf("timeout must be between 0 and 55 seconds, got %v", cfg.ClientConfig.Timeout)
+	if cfg.ClientConfig.Timeout < 1 || cfg.ClientConfig.Timeout > maxTimeout {
+		return fmt.Errorf("timeout must be between 1 and 55 seconds, got %v", cfg.ClientConfig.Timeout)
 	}
 
 	switch cfg.CompressEncoding {

--- a/exporter/sumologicexporter/config_test.go
+++ b/exporter/sumologicexporter/config_test.go
@@ -6,6 +6,7 @@ package sumologicexporter // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component"
@@ -75,6 +76,46 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := component.ValidateConfig(tc.cfg)
+
+			if tc.expectedError != nil {
+				assert.EqualError(t, err, tc.expectedError.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestConfigInvalidTimeout(t *testing.T) {
+	testcases := []struct {
+		name          string
+		expectedError error
+		cfg           *Config
+	}{
+		{
+			name:          "over the limit timeout",
+			expectedError: errors.New("timeout must be between 0 and 55 seconds, got 56s"),
+			cfg: &Config{
+				ClientConfig: confighttp.ClientConfig{
+					Timeout: 56 * time.Second,
+				},
+			},
+		},
+		{
+			name:          "negative timeout",
+			expectedError: errors.New("timeout must be between 0 and 55 seconds, got -1s"),
+			cfg: &Config{
+				ClientConfig: confighttp.ClientConfig{
+					Timeout: -1 * time.Second,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
 
 			if tc.expectedError != nil {
 				assert.EqualError(t, err, tc.expectedError.Error())

--- a/exporter/sumologicexporter/config_test.go
+++ b/exporter/sumologicexporter/config_test.go
@@ -94,7 +94,7 @@ func TestConfigInvalidTimeout(t *testing.T) {
 	}{
 		{
 			name:          "over the limit timeout",
-			expectedError: errors.New("timeout must be between 0 and 55 seconds, got 56s"),
+			expectedError: errors.New("timeout must be between 1 and 55 seconds, got 56s"),
 			cfg: &Config{
 				ClientConfig: confighttp.ClientConfig{
 					Timeout: 56 * time.Second,
@@ -102,11 +102,11 @@ func TestConfigInvalidTimeout(t *testing.T) {
 			},
 		},
 		{
-			name:          "negative timeout",
-			expectedError: errors.New("timeout must be between 0 and 55 seconds, got -1s"),
+			name:          "less than 1 timeout",
+			expectedError: errors.New("timeout must be between 1 and 55 seconds, got 0s"),
 			cfg: &Config{
 				ClientConfig: confighttp.ClientConfig{
-					Timeout: -1 * time.Second,
+					Timeout: 0 * time.Second,
 				},
 			},
 		},


### PR DESCRIPTION
**Description:** <Describe what has changed.>
- Default timeout is 30 seconds with a max limit of 55. There're no validation checks for when [timeout is more than 55 seconds](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/sumologicexporter/README.md?plain=1#L104). 

**Link to tracking Issue:** 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33151 

**Testing:** 
- Unit test

**Documentation:** 
- chloggen