### PR TITLE
[receiver/sqlserver] Enable server config option to include port

### DIFF
--- a/.chloggen/sqlserver_endpoint.yaml
+++ b/.chloggen/sqlserver_endpoint.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlserverreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable `server` config option to include port
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33560]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlserverreceiver/README.md
+++ b/receiver/sqlserverreceiver/README.md
@@ -29,8 +29,8 @@ The following settings are optional:
 Direct connection options (optional, but all must be specified to enable):
 - `username`: The username used to connect to the SQL Server instance.
 - `password`: The password used to connect to the SQL Server instance.
-- `server`: IP Address or hostname of SQL Server instance to connect to.
-- `port`: Port of the SQL Server instance to connect to.
+- `server`: Endpoint of the SQL Server instance to connect to. Can optionally contain a port which, if included, will override the `port` option.
+- `port`: Port of the SQL Server instance to connect to. This is overridden if `server` contains a port.
 
 Windows-specific options:
 - `computer_name` (optional): The computer name identifies the SQL Server name or IP address of the computer being monitored.

--- a/receiver/sqlserverreceiver/config.go
+++ b/receiver/sqlserverreceiver/config.go
@@ -20,7 +20,6 @@ type Config struct {
 	InstanceName string `mapstructure:"instance_name"`
 	ComputerName string `mapstructure:"computer_name"`
 
-	// The following options currently do nothing. Functionality will be added in a future PR.
 	Password configopaque.String `mapstructure:"password"`
 	Port     uint                `mapstructure:"port"`
 	Server   string              `mapstructure:"server"`
@@ -35,8 +34,14 @@ func (cfg *Config) Validate() error {
 
 	if !directDBConnectionEnabled(cfg) {
 		if cfg.Server != "" || cfg.Username != "" || string(cfg.Password) != "" {
-			return fmt.Errorf("Found one or more of the following configuration options set: [server, port, username, password]. " +
+			return fmt.Errorf("Found one or more of the following configuration options set: [server, username, password]. " +
 				"All of these options must be configured to directly connect to a SQL Server instance.")
+		}
+	} else {
+		_, port := getServerPort(cfg)
+		// 0 is both an invalid port and the result of casting an empty string to uint
+		if port == "" {
+			return fmt.Errorf("The connection port of the SQL Server instance must be specified, either in the `server` or `port` configuration option.")
 		}
 	}
 

--- a/receiver/sqlserverreceiver/config.go
+++ b/receiver/sqlserverreceiver/config.go
@@ -41,7 +41,7 @@ func (cfg *Config) Validate() error {
 		_, port := getServerPort(cfg)
 		// 0 is both an invalid port and the result of casting an empty string to uint
 		if port == "" {
-			return fmt.Errorf("The connection port of the SQL Server instance must be specified, either in the `server` or `port` configuration option.")
+			return fmt.Errorf("the connection port of the SQL Server instance must be specified, either in the `server` or `port` configuration option")
 		}
 	}
 

--- a/receiver/sqlserverreceiver/config_test.go
+++ b/receiver/sqlserverreceiver/config_test.go
@@ -53,6 +53,27 @@ func TestValidate(t *testing.T) {
 			expectedSuccess: false,
 		},
 		{
+			desc: "invalid config with all direct connection settings except for port",
+			cfg: &Config{
+				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
+				Server:           "0.0.0.0",
+				Username:         "sa",
+				Password:         "password",
+			},
+			expectedSuccess: false,
+		},
+		{
+			desc: "invalid config when port is 0",
+			cfg: &Config{
+				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
+				Server:           "0.0.0.0",
+				Username:         "sa",
+				Password:         "password",
+				Port:             0,
+			},
+			expectedSuccess: false,
+		},
+		{
 			desc: "valid config with all direct connection settings",
 			cfg: &Config{
 				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
@@ -60,6 +81,16 @@ func TestValidate(t *testing.T) {
 				Username:         "sa",
 				Password:         "password",
 				Port:             1433,
+			},
+			expectedSuccess: true,
+		},
+		{
+			desc: "valid config with port included in server",
+			cfg: &Config{
+				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
+				Server:           "0.0.0.0:1433",
+				Username:         "sa",
+				Password:         "password",
 			},
 			expectedSuccess: true,
 		},

--- a/receiver/sqlserverreceiver/factory_test.go
+++ b/receiver/sqlserverreceiver/factory_test.go
@@ -78,6 +78,34 @@ func TestCreateMetricsReceiver(t *testing.T) {
 			},
 		},
 		{
+			desc: "Test direct connection string",
+			testFunc: func(t *testing.T) {
+				factory := NewFactory()
+				cfg := factory.CreateDefaultConfig().(*Config)
+				cfg.Username = "sa"
+				cfg.Password = "password"
+				cfg.Server = "0.0.0.0"
+				cfg.Port = 1433
+				require.NoError(t, cfg.Validate())
+				cfg.Metrics.SqlserverDatabaseLatency.Enabled = true
+
+				require.True(t, directDBConnectionEnabled(cfg))
+				require.Equal(t, "server=0.0.0.0;user id=sa;password=password;port=1433", getDBConnectionString(cfg))
+
+				cfg.Server = "0.0.0.0:1433"
+				cfg.Port = 0
+				require.True(t, directDBConnectionEnabled(cfg))
+				require.NoError(t, cfg.Validate())
+				require.Equal(t, "server=0.0.0.0;user id=sa;password=password;port=1433", getDBConnectionString(cfg))
+
+				cfg.Server = "0.0.0.0:9444"
+				cfg.Port = 1433
+				require.True(t, directDBConnectionEnabled(cfg))
+				require.NoError(t, cfg.Validate())
+				require.Equal(t, "server=0.0.0.0;user id=sa;password=password;port=9444", getDBConnectionString(cfg))
+			},
+		},
+		{
 			desc: "Test direct connection",
 			testFunc: func(t *testing.T) {
 				factory := NewFactory()


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables the `server` config option to include a port as well as the server/hostname endpoint. If a port is included in the `server` config option, it will override the value in the `port` configuration option.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33560

**Testing:** <Describe what testing was performed and which tests were added.>
Added testing

**Documentation:** <Describe the documentation added.>
Updated README