### PR TITLE
[extension/observer] Expose host and port independently in endpoint env

### DIFF
--- a/.chloggen/observer_expose_host_port.yaml
+++ b/.chloggen/observer_expose_host_port.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: observerextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Expose host and port in endpoint's environment
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33571]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/observer/endpoints.go
+++ b/extension/observer/endpoints.go
@@ -76,9 +76,12 @@ func (e *Endpoint) Env() (EndpointEnv, error) {
 	const hostKey = "host"
 	const portKey = "port"
 	host, port, err := net.SplitHostPort(e.Target)
+	// An error most likely means there was no port when splitting, so the host
+	// can simply be the target.
 	if err != nil {
 		host = e.Target
 	} else {
+		// Only try to set the port if a valid port was found when splitting the target
 		if _, keyExists := env[portKey]; !keyExists {
 			env[portKey] = port
 		}

--- a/extension/observer/endpoints_test.go
+++ b/extension/observer/endpoints_test.go
@@ -46,6 +46,7 @@ func TestEndpointEnv(t *testing.T) {
 				},
 				"uid":       "pod-uid",
 				"namespace": "pod-namespace",
+				"host":      "192.68.73.2",
 			},
 		},
 		{
@@ -88,6 +89,7 @@ func TestEndpointEnv(t *testing.T) {
 					"namespace": "pod-namespace",
 				},
 				"transport": ProtocolTCP,
+				"host":      "192.68.73.2",
 			},
 		},
 		{
@@ -124,6 +126,7 @@ func TestEndpointEnv(t *testing.T) {
 				"namespace":    "service-namespace",
 				"cluster_ip":   "192.68.73.2",
 				"service_type": "LoadBalancer",
+				"host":         "service.namespace",
 			},
 		},
 		{
@@ -148,6 +151,7 @@ func TestEndpointEnv(t *testing.T) {
 				"is_ipv6":      true,
 				"port":         uint16(2379),
 				"transport":    ProtocolUDP,
+				"host":         "127.0.0.1",
 			},
 		},
 		{
@@ -228,6 +232,54 @@ func TestEndpointEnv(t *testing.T) {
 				"labels": map[string]string{
 					"label_key": "label_val",
 				},
+				"host": "127.0.0.1",
+				"port": "1234",
+			},
+		},
+		{
+			// This is an invalid test case, to ensure "port" keeps the original value and
+			// isn't overwritten by a port parsed from the "Target". The two ports shouldn't mismatch
+			// if they're exposed in both places.
+			name: "K8s pod port - conflicting ports",
+			endpoint: Endpoint{
+				ID:     EndpointID("port_id"),
+				Target: "192.68.73.2:4321",
+				Details: &Port{
+					Name: "port_name",
+					Pod: Pod{
+						Name: "pod_name",
+						Labels: map[string]string{
+							"label_key": "label_val",
+						},
+						Annotations: map[string]string{
+							"annotation_1": "value_1",
+						},
+						Namespace: "pod-namespace",
+						UID:       "pod-uid",
+					},
+					Port:      2379,
+					Transport: ProtocolTCP,
+				},
+			},
+			want: EndpointEnv{
+				"type":     "port",
+				"endpoint": "192.68.73.2:4321",
+				"id":       "port_id",
+				"name":     "port_name",
+				"port":     uint16(2379),
+				"pod": EndpointEnv{
+					"name": "pod_name",
+					"labels": map[string]string{
+						"label_key": "label_val",
+					},
+					"annotations": map[string]string{
+						"annotation_1": "value_1",
+					},
+					"uid":       "pod-uid",
+					"namespace": "pod-namespace",
+				},
+				"transport": ProtocolTCP,
+				"host":      "192.68.73.2",
 			},
 		},
 	}

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -278,6 +278,14 @@ receivers:
         # Set a resource attribute based on endpoint value.
         rule: type == "port" && port == 6379
 
+      sqlserver:
+        rule: type == "port" && pod.name matches "(?i)mssql"
+        config:
+          server: '`host`'
+          port: '`port`'
+          username: sa
+          password: password
+
     resource_attributes:
       # Dynamic configuration values, overwriting default attributes`
       pod:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The observer extension currently only exposes `endpoint` in its endpoint environment that is made available to the receiver creator for dynamically configuring receivers. Some receivers require `host` and `port` to be configured separately, so `endpoint` containing both is incompatible with those receivers. Exposing these independently allows the receiver creator to be compatible with those receivers.

**Link to tracking Issue:** <Issue number if applicable>
Resolves #33571

**Testing:** <Describe what testing was performed and which tests were added.>
Added testing, existing testing passes

**Documentation:** <Describe the documentation added.>
Added example usage in receiver creator README.