### PR TITLE
[chore][golangci-lint] Remove gosec excludes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,13 +132,6 @@ linters-settings:
   predeclared:
     ignore: copy
 
-  gosec:
-    excludes:
-      # https://github.com/golangci/golangci-lint/issues/4735
-      - G601
-      # https://github.com/golangci/golangci-lint/issues/4735
-      - G113
-
 linters:
   enable:
     - decorder


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The upstream issue was fixed by https://github.com/golangci/golangci-lint/pull/4748, which was included in release [`v1.59.0`](https://github.com/golangci/golangci-lint/releases/tag/v1.59.0) of `golangci-lint`. From local testing, we're pulling version `v1.59.1` of `golangci-lint`, so the issue should be resolved.

Local runtime with excludes:
```
$ .tools/golangci-lint run -v --enable-only gosec
...
INFO Execution took 10.927544867s
INFO Execution took 8.011302204s
INFO Execution took 7.716441258s
INFO Execution took 7.441336833s
```
Local runtime without excludes:
```
$ .tools/golangci-lint run -v --enable-only gosec
...
INFO Execution took 9.780250262s
INFO Execution took 8.175492516s
INFO Execution took 7.550060974s
INFO Execution took 7.526585686s
```

Note: I ran `.tools/golangci-lint cache clean` between each test to clean the cache and keep results as consistent as possible. I admit that I don't know why the values keep going down with every run, the cache cleaning command may not entirely be working.

**Link to tracking Issue:** <Issue number if applicable>
These excludes were introduced in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33192
I've opened a PR in core for this issue as well: https://github.com/open-telemetry/opentelemetry-collector/pull/10411