### PR TITLE
[cmd/opampsupervisor] Forward custom messages to/from agent

### DIFF
--- a/.chloggen/feat_supervisor-passthrough-custom-capabilities.yaml
+++ b/.chloggen/feat_supervisor-passthrough-custom-capabilities.yaml
@@ -1,0 +1,13 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Adds support for forwarding custom messages to/from the agent"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33575]

--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -15,7 +15,7 @@ import (
 type flattenedSettings struct {
 	onMessageFunc         func(conn serverTypes.Connection, message *protobufs.AgentToServer)
 	onConnectingFunc      func(request *http.Request) (shouldConnect bool, rejectStatusCode int)
-	onConnectionCloseFunc func(ctx context.Context, conn serverTypes.Connection)
+	onConnectionCloseFunc func(conn serverTypes.Connection)
 	endpoint              string
 }
 
@@ -44,9 +44,9 @@ func newServerSettings(fs flattenedSettings) server.StartSettings {
 
 								return &protobufs.ServerToAgent{}
 							},
-							OnConnectedFunc: func(ctx context.Context, conn serverTypes.Connection) {
+							OnConnectionCloseFunc: func(conn serverTypes.Connection) {
 								if fs.onConnectionCloseFunc != nil {
-									fs.onConnectionCloseFunc(ctx, conn)
+									fs.onConnectionCloseFunc(conn)
 								}
 							},
 						},

--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -19,41 +19,44 @@ type flattenedSettings struct {
 	endpoint              string
 }
 
-func newServerSettings(fs flattenedSettings) server.StartSettings {
+func (fs flattenedSettings) toServerSettings() server.StartSettings {
 	return server.StartSettings{
 		Settings: server.Settings{
-			Callbacks: server.CallbacksStruct{
-				OnConnectingFunc: func(request *http.Request) serverTypes.ConnectionResponse {
-					if fs.onConnectingFunc != nil {
-						shouldConnect, rejectStatusCode := fs.onConnectingFunc(request)
-						if !shouldConnect {
-							return serverTypes.ConnectionResponse{
-								Accept:         false,
-								HTTPStatusCode: rejectStatusCode,
-							}
-						}
-					}
-
-					return serverTypes.ConnectionResponse{
-						Accept: true,
-						ConnectionCallbacks: server.ConnectionCallbacksStruct{
-							OnMessageFunc: func(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
-								if fs.onMessageFunc != nil {
-									fs.onMessageFunc(conn, message)
-								}
-
-								return &protobufs.ServerToAgent{}
-							},
-							OnConnectionCloseFunc: func(conn serverTypes.Connection) {
-								if fs.onConnectionCloseFunc != nil {
-									fs.onConnectionCloseFunc(conn)
-								}
-							},
-						},
-					}
-				},
-			},
+			Callbacks: fs,
 		},
 		ListenEndpoint: fs.endpoint,
+	}
+}
+
+func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.ConnectionResponse {
+	if fs.onConnectingFunc != nil {
+		shouldConnect, rejectStatusCode := fs.onConnectingFunc(request)
+		if !shouldConnect {
+			return serverTypes.ConnectionResponse{
+				Accept:         false,
+				HTTPStatusCode: rejectStatusCode,
+			}
+		}
+	}
+
+	return serverTypes.ConnectionResponse{
+		Accept:              true,
+		ConnectionCallbacks: fs,
+	}
+}
+
+func (fs flattenedSettings) OnConnected(_ context.Context, _ serverTypes.Connection) {}
+
+func (fs flattenedSettings) OnMessage(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
+	if fs.onMessageFunc != nil {
+		fs.onMessageFunc(conn, message)
+	}
+
+	return &protobufs.ServerToAgent{}
+}
+
+func (fs flattenedSettings) OnConnectionClose(conn serverTypes.Connection) {
+	if fs.onConnectionCloseFunc != nil {
+		fs.onConnectionCloseFunc(conn)
 	}
 }

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -539,9 +539,7 @@ func (s *Supervisor) forwardCustomMessagesToServerLoop() {
 	for {
 		select {
 		case cm := <-s.customMessageToServer:
-		sendLoop:
 			for {
-
 				sendingChan, err := s.opampClient.SendCustomMessage(cm)
 				switch {
 				case errors.Is(err, types.ErrCustomMessagePending):
@@ -553,8 +551,7 @@ func (s *Supervisor) forwardCustomMessagesToServerLoop() {
 				default:
 					s.logger.Error("Failed to send custom message to OpAMP server")
 				}
-
-				break sendLoop
+				break
 			}
 		case <-s.doneChan:
 			return

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -297,7 +297,7 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 
 	// Start a one-shot server to get the Collector's agent description
 	// using the Collector's OpAMP extension.
-	err = srv.Start(newServerSettings(flattenedSettings{
+	err = srv.Start(flattenedSettings{
 		endpoint: fmt.Sprintf("localhost:%d", s.opampServerPort),
 		onConnectingFunc: func(_ *http.Request) (bool, int) {
 			connected.Store(true)
@@ -332,7 +332,7 @@ func (s *Supervisor) getBootstrapInfo() (err error) {
 				done <- nil
 			}
 		},
-	}))
+	}.toServerSettings())
 	if err != nil {
 		return err
 	}
@@ -471,7 +471,7 @@ func (s *Supervisor) startOpAMPServer() error {
 
 	connected := &atomic.Bool{}
 
-	err = s.opampServer.Start(newServerSettings(flattenedSettings{
+	err = s.opampServer.Start(flattenedSettings{
 		endpoint: fmt.Sprintf("localhost:%d", s.opampServerPort),
 		onConnectingFunc: func(_ *http.Request) (bool, int) {
 			// Only allow one agent to be connected the this server at a time.
@@ -482,7 +482,7 @@ func (s *Supervisor) startOpAMPServer() error {
 		onConnectionCloseFunc: func(_ serverTypes.Connection) {
 			connected.Store(false)
 		},
-	}))
+	}.toServerSettings())
 	if err != nil {
 		return err
 	}

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -479,7 +479,7 @@ func (s *Supervisor) startOpAMPServer() error {
 			return !alreadyConnected, http.StatusConflict
 		},
 		onMessageFunc: s.handleAgentOpAMPMessage,
-		onConnectionCloseFunc: func(_ context.Context, _ serverTypes.Connection) {
+		onConnectionCloseFunc: func(_ serverTypes.Connection) {
 			connected.Store(false)
 		},
 	}))

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -357,23 +357,23 @@ func (m mockOpAMPClient) AgentDescription() *protobufs.AgentDescription {
 	return m.agentDesc
 }
 
-func (mockOpAMPClient) SetHealth(health *protobufs.ComponentHealth) error {
+func (mockOpAMPClient) SetHealth(_ *protobufs.ComponentHealth) error {
 	return nil
 }
 
-func (mockOpAMPClient) UpdateEffectiveConfig(ctx context.Context) error {
+func (mockOpAMPClient) UpdateEffectiveConfig(_ context.Context) error {
 	return nil
 }
 
-func (mockOpAMPClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
+func (mockOpAMPClient) SetRemoteConfigStatus(_ *protobufs.RemoteConfigStatus) error {
 	return nil
 }
 
-func (mockOpAMPClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
+func (mockOpAMPClient) SetPackageStatuses(_ *protobufs.PackageStatuses) error {
 	return nil
 }
 
-func (mockOpAMPClient) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
+func (mockOpAMPClient) RequestConnectionSettings(_ *protobufs.ConnectionSettingsRequest) error {
 	return nil
 }
 

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -6,14 +6,17 @@ package supervisor
 import (
 	"bytes"
 	"context"
+	"net"
 	"os"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/client"
 	"github.com/open-telemetry/opamp-go/client/types"
 	"github.com/open-telemetry/opamp-go/protobufs"
+	serverTypes "github.com/open-telemetry/opamp-go/server/types"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
@@ -140,10 +143,270 @@ func Test_onMessage(t *testing.T) {
 
 		require.Equal(t, testUUID, s.persistentState.InstanceID)
 	})
+
+	t.Run("CustomMessage - Custom message from server is forwarded to agent", func(t *testing.T) {
+		customMessage := &protobufs.CustomMessage{
+			Capability: "teapot",
+			Type:       "brew",
+			Data:       []byte("chamomile"),
+		}
+
+		testUUID := uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")
+		gotMessage := false
+		var agentConn serverTypes.Connection = &mockConn{
+			sendFunc: func(_ context.Context, message *protobufs.ServerToAgent) error {
+				require.Equal(t, &protobufs.ServerToAgent{
+					InstanceUid:   testUUID[:],
+					CustomMessage: customMessage,
+				}, message)
+				gotMessage = true
+
+				return nil
+			},
+		}
+
+		agentConnAtomic := &atomic.Value{}
+		agentConnAtomic.Store(agentConn)
+
+		s := Supervisor{
+			logger:                       zap.NewNop(),
+			pidProvider:                  defaultPIDProvider{},
+			config:                       config.Supervisor{},
+			hasNewConfig:                 make(chan struct{}, 1),
+			persistentState:              &persistentState{InstanceID: testUUID},
+			agentConfigOwnMetricsSection: &atomic.Value{},
+			effectiveConfig:              &atomic.Value{},
+			agentConn:                    agentConnAtomic,
+			agentHealthCheckEndpoint:     "localhost:8000",
+			customMessageToServer:        make(chan *protobufs.CustomMessage, 10),
+			doneChan:                     make(chan struct{}),
+		}
+
+		s.onMessage(context.Background(), &types.MessageData{
+			CustomMessage: customMessage,
+		})
+
+		require.True(t, gotMessage, "Message was not sent to agent")
+	})
+
+	t.Run("CustomCapabilities - Custom capabilities from server are forwarded to agent", func(t *testing.T) {
+		customCapabilities := &protobufs.CustomCapabilities{
+			Capabilities: []string{"coffeemaker", "teapot"},
+		}
+		testUUID := uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")
+		gotMessage := false
+		var agentConn serverTypes.Connection = &mockConn{
+			sendFunc: func(_ context.Context, message *protobufs.ServerToAgent) error {
+				require.Equal(t, &protobufs.ServerToAgent{
+					InstanceUid:        testUUID[:],
+					CustomCapabilities: customCapabilities,
+				}, message)
+				gotMessage = true
+
+				return nil
+			},
+		}
+
+		agentConnAtomic := &atomic.Value{}
+		agentConnAtomic.Store(agentConn)
+
+		s := Supervisor{
+			logger:                       zap.NewNop(),
+			pidProvider:                  defaultPIDProvider{},
+			config:                       config.Supervisor{},
+			hasNewConfig:                 make(chan struct{}, 1),
+			persistentState:              &persistentState{InstanceID: testUUID},
+			agentConfigOwnMetricsSection: &atomic.Value{},
+			effectiveConfig:              &atomic.Value{},
+			agentConn:                    agentConnAtomic,
+			agentHealthCheckEndpoint:     "localhost:8000",
+			customMessageToServer:        make(chan *protobufs.CustomMessage, 10),
+			doneChan:                     make(chan struct{}),
+		}
+
+		s.onMessage(context.Background(), &types.MessageData{
+			CustomCapabilities: customCapabilities,
+		})
+
+		require.True(t, gotMessage, "Message was not sent to agent")
+	})
+
+}
+
+func Test_handleAgentOpAMPMessage(t *testing.T) {
+	t.Run("CustomMessage - Custom message from agent is forwarded to server", func(t *testing.T) {
+		customMessage := &protobufs.CustomMessage{
+			Capability: "teapot",
+			Type:       "brew",
+			Data:       []byte("chamomile"),
+		}
+
+		gotMessageChan := make(chan struct{})
+		client := &mockOpAMPClient{
+			sendCustomMessageFunc: func(message *protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error) {
+				require.Equal(t, customMessage, message)
+
+				close(gotMessageChan)
+				msgChan := make(chan struct{}, 1)
+				msgChan <- struct{}{}
+				return msgChan, nil
+			},
+		}
+
+		testUUID := uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")
+		s := Supervisor{
+			logger:                       zap.NewNop(),
+			pidProvider:                  defaultPIDProvider{},
+			config:                       config.Supervisor{},
+			hasNewConfig:                 make(chan struct{}, 1),
+			persistentState:              &persistentState{InstanceID: testUUID},
+			agentConfigOwnMetricsSection: &atomic.Value{},
+			effectiveConfig:              &atomic.Value{},
+			agentConn:                    &atomic.Value{},
+			opampClient:                  client,
+			agentHealthCheckEndpoint:     "localhost:8000",
+			customMessageToServer:        make(chan *protobufs.CustomMessage, 10),
+			doneChan:                     make(chan struct{}),
+		}
+
+		loopDoneChan := make(chan struct{})
+		go func() {
+			defer close(loopDoneChan)
+			s.forwardCustomMessagesToServerLoop()
+		}()
+
+		s.handleAgentOpAMPMessage(&mockConn{}, &protobufs.AgentToServer{
+			CustomMessage: customMessage,
+		})
+
+		select {
+		case <-gotMessageChan:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for custom message to send")
+		}
+
+		close(s.doneChan)
+
+		select {
+		case <-loopDoneChan:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for forward loop to stop")
+		}
+	})
+
+	t.Run("CustomCapabilities - Custom capabilities from agent are forwarded to server", func(t *testing.T) {
+		customCapabilities := &protobufs.CustomCapabilities{
+			Capabilities: []string{"coffeemaker", "teapot"},
+		}
+
+		client := &mockOpAMPClient{
+			setCustomCapabilitiesFunc: func(caps *protobufs.CustomCapabilities) error {
+				require.Equal(t, customCapabilities, caps)
+				return nil
+			},
+		}
+
+		testUUID := uuid.MustParse("018fee23-4a51-7303-a441-73faed7d9deb")
+		s := Supervisor{
+			logger:                       zap.NewNop(),
+			pidProvider:                  defaultPIDProvider{},
+			config:                       config.Supervisor{},
+			hasNewConfig:                 make(chan struct{}, 1),
+			persistentState:              &persistentState{InstanceID: testUUID},
+			agentConfigOwnMetricsSection: &atomic.Value{},
+			effectiveConfig:              &atomic.Value{},
+			agentConn:                    &atomic.Value{},
+			opampClient:                  client,
+			agentHealthCheckEndpoint:     "localhost:8000",
+			customMessageToServer:        make(chan *protobufs.CustomMessage, 10),
+			doneChan:                     make(chan struct{}),
+		}
+
+		s.handleAgentOpAMPMessage(&mockConn{}, &protobufs.AgentToServer{
+			CustomCapabilities: customCapabilities,
+		})
+	})
 }
 
 type staticPIDProvider int
 
 func (s staticPIDProvider) PID() int {
 	return int(s)
+}
+
+type mockOpAMPClient struct {
+	agentDesc                 *protobufs.AgentDescription
+	sendCustomMessageFunc     func(message *protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error)
+	setCustomCapabilitiesFunc func(customCapabilities *protobufs.CustomCapabilities) error
+}
+
+func (mockOpAMPClient) Start(_ context.Context, _ types.StartSettings) error {
+	return nil
+}
+
+func (mockOpAMPClient) Stop(_ context.Context) error {
+	return nil
+}
+
+func (m *mockOpAMPClient) SetAgentDescription(descr *protobufs.AgentDescription) error {
+	m.agentDesc = descr
+	return nil
+}
+
+func (m mockOpAMPClient) AgentDescription() *protobufs.AgentDescription {
+	return m.agentDesc
+}
+
+func (mockOpAMPClient) SetHealth(health *protobufs.ComponentHealth) error {
+	return nil
+}
+
+func (mockOpAMPClient) UpdateEffectiveConfig(ctx context.Context) error {
+	return nil
+}
+
+func (mockOpAMPClient) SetRemoteConfigStatus(status *protobufs.RemoteConfigStatus) error {
+	return nil
+}
+
+func (mockOpAMPClient) SetPackageStatuses(statuses *protobufs.PackageStatuses) error {
+	return nil
+}
+
+func (mockOpAMPClient) RequestConnectionSettings(request *protobufs.ConnectionSettingsRequest) error {
+	return nil
+}
+
+func (m mockOpAMPClient) SetCustomCapabilities(customCapabilities *protobufs.CustomCapabilities) error {
+	if m.setCustomCapabilitiesFunc != nil {
+		return m.setCustomCapabilitiesFunc(customCapabilities)
+	}
+	return nil
+}
+
+func (m mockOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (messageSendingChannel chan struct{}, err error) {
+	if m.sendCustomMessageFunc != nil {
+		return m.sendCustomMessageFunc(message)
+	}
+
+	msgChan := make(chan struct{}, 1)
+	msgChan <- struct{}{}
+	return msgChan, nil
+}
+
+type mockConn struct {
+	sendFunc func(ctx context.Context, message *protobufs.ServerToAgent) error
+}
+
+func (mockConn) Connection() net.Conn {
+	return nil
+}
+func (m mockConn) Send(ctx context.Context, message *protobufs.ServerToAgent) error {
+	if m.sendFunc != nil {
+		return m.sendFunc(ctx, message)
+	}
+	return nil
+}
+func (mockConn) Disconnect() error {
+	return nil
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
* Forwards custom messages through the supervisor to/from the agent

**Link to tracking Issue:** Closes #33575

**Testing:**
* Tested against BindPlane
* E2E tests aren't possible since there is no component using custom messages in contrib right now. 
* Added a couple unit tests