### PR TITLE
[exporter/splunk_hec] Add a new option  to limit bytes sent per HTTP connection

### DIFF
--- a/.chloggen/hec_limitcontent.yaml
+++ b/.chloggen/hec_limitcontent.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add a new configuration option `max_per_conn`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33586]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This new option enforces that each HTTP connection is rotated after sending a number of bytes.
+  By default, this limit is not set.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/splunkhecexporter/README.md
+++ b/exporter/splunkhecexporter/README.md
@@ -45,6 +45,7 @@ The following configuration options can also be configured:
   will be broken down into several requests. Default value is 2097152 bytes (2 MiB). Maximum allowed value is 838860800
   (~ 800 MB). When set to 0, it will treat as infinite length and it will create only one request per batch.
 - `max_event_size` (default: 5242880): Maximum raw uncompressed individual event size in bytes. Maximum allowed value is 838860800 (~ 800 MB).
+- `max_per_conn` (default: unset): If set, limits the number of bytes a HTTP connection can send before being closed. This setting is useful to balance requests across multiple targets behind a load balancer.
 - `splunk_app_name` (default: "OpenTelemetry Collector Contrib") App name is used to track telemetry information for Splunk App's using HEC by App name.
 - `splunk_app_version` (default: Current OpenTelemetry Collector Contrib Build Version): App version is used to track telemetry information for Splunk App's using HEC by App version. 
 - `log_data_enabled` (default: true): Specifies whether the log data is exported. Set it to `false` if you want the log 

--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -22,6 +22,8 @@ type buffer interface {
 	Reset()
 	Len() int
 	Empty() bool
+	// PayloadLen returns the size of the event payload itself
+	PayloadLen() int
 }
 
 type cancellableBytesWriter struct {
@@ -57,6 +59,10 @@ func (c *cancellableBytesWriter) Len() int {
 
 func (c *cancellableBytesWriter) Empty() bool {
 	return c.innerWriter.Len() == 0
+}
+
+func (c *cancellableBytesWriter) PayloadLen() int {
+	return c.Len()
 }
 
 type cancellableGzipWriter struct {
@@ -119,6 +125,10 @@ func (c *cancellableGzipWriter) Close() error {
 
 func (c *cancellableGzipWriter) Len() int {
 	return c.innerBuffer.Len()
+}
+
+func (c *cancellableGzipWriter) PayloadLen() int {
+	return c.rawLen
 }
 
 func (c *cancellableGzipWriter) Empty() bool {

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -111,6 +111,12 @@ type Config struct {
 	// Maximum allowed value is 838860800 (~ 800 MB).
 	MaxEventSize uint `mapstructure:"max_event_size"`
 
+	// MaxBytesPerConn enforces that a connection be closed if it has sent over event payloads in sum equal or larger
+	// than this limit.
+	// This helps fan out payloads to multiple destinations behind a load balancer.
+	// Default value is unset (no limit).
+	MaxBytesPerConn *int `mapstructure:"max_per_conn"`
+
 	// App name is used to track telemetry information for Splunk App's using HEC by App name. Defaults to "OpenTelemetry Collector Contrib".
 	SplunkAppName string `mapstructure:"splunk_app_name"`
 

--- a/exporter/splunkhecexporter/hec_worker_test.go
+++ b/exporter/splunkhecexporter/hec_worker_test.go
@@ -14,7 +14,7 @@ type mockHecWorker struct {
 	failSend bool
 }
 
-func (m *mockHecWorker) send(_ context.Context, _ buffer, _ map[string]string) error {
+func (m *mockHecWorker) send(_ context.Context, _ buffer, _ map[string]string, _ int) error {
 	if m.failSend {
 		return errHecSendFailed
 	}

--- a/exporter/splunkhecexporter/integration_test.go
+++ b/exporter/splunkhecexporter/integration_test.go
@@ -245,7 +245,7 @@ func logsTest(t *testing.T, config *Config, url *url.URL, test testCfg) {
 	}
 
 	httpClient := createInsecureClient()
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo()), settings.Logger}
+	c.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: settings.Logger}
 
 	err := c.pushLogData(context.Background(), logs)
 	require.NoError(t, err, "Must not error while sending Logs data")
@@ -268,7 +268,7 @@ func metricsTest(t *testing.T, config *Config, url *url.URL, test testCfg) {
 	metricData := prepareMetricsData(test.config.event)
 
 	httpClient := createInsecureClient()
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo()), settings.Logger}
+	c.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: settings.Logger}
 
 	err := c.pushMetricsData(context.Background(), metricData)
 	require.NoError(t, err, "Must not error while sending Metrics data")
@@ -284,7 +284,7 @@ func tracesTest(t *testing.T, config *Config, url *url.URL, test testCfg) {
 	tracesData := prepareTracesData(test.config.index, test.config.source, test.config.sourcetype)
 
 	httpClient := createInsecureClient()
-	c.hecWorker = &defaultHecWorker{url, httpClient, buildHTTPHeaders(config, component.NewDefaultBuildInfo()), settings.Logger}
+	c.hecWorker = &defaultHecWorker{url: url, client: httpClient, headers: buildHTTPHeaders(config, component.NewDefaultBuildInfo()), logger: settings.Logger}
 
 	err := c.pushTraceData(context.Background(), tracesData)
 	require.NoError(t, err, "Must not error while sending Trace data")


### PR DESCRIPTION
**Description:**
Add a new configuration option `max_per_conn`.
This new option enforces that each HTTP connection is rotated after sending a number of bytes.
By default, this limit is not set.

**Testing:**
Unit tests

**Documentation:**
Added to README.md