### PR TITLE
[chore] discard response body

### DIFF
--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -5,8 +5,8 @@ package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"io"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -66,7 +66,7 @@ func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[s
 	// HTTP client will not reuse the same connection unless it is drained.
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18281 for more details.
 	if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != http.StatusBadGateway {
-		if _, errCopy := httputil.DumpResponse(resp, true); errCopy != nil {
+		if _, errCopy := io.Copy(io.Discard, resp.Body); errCopy != nil {
 			return errCopy
 		}
 	}


### PR DESCRIPTION
httputil.DumpResponse does more than just discarding the HTTP response body, it copies to a buffer. This change makes sure we discard the body buffer and don't do any allocation for it.

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
                                                     │  before.txt   │              after.txt               │
                                                     │    sec/op     │    sec/op     vs base                │
_pushLogData_10_10_1024-10                              110.1µ ± ∞ ¹   108.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               125.74µ ± ∞ ¹   93.61µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                                97.92µ ± ∞ ¹   92.51µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                               1.938m ± ∞ ¹   1.878m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10                              17.94m ± ∞ ¹   17.78m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10                              17.73m ± ∞ ¹   17.79m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                   731.4µ ± ∞ ¹   753.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                     172.2µ ± ∞ ¹   169.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                     169.9µ ± ∞ ¹   168.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                    3.819m ± ∞ ¹   3.700m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                   40.16m ± ∞ ¹   36.23m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                   37.29m ± ∞ ¹   36.27m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-10                           147.9µ ± ∞ ¹   146.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                             146.8µ ± ∞ ¹   148.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                             267.8µ ± ∞ ¹   284.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                            3.035m ± ∞ ¹   3.062m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                           28.44m ± ∞ ¹   28.70m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-10                           28.70m ± ∞ ¹   29.85m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-10                308.2µ ± ∞ ¹   310.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                  309.4µ ± ∞ ¹   309.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                  442.1µ ± ∞ ¹   449.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                 6.791m ± ∞ ¹   6.737m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10                66.05m ± ∞ ¹   65.67m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-10                66.31m ± ∞ ¹   65.77m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-10               363.8µ ± ∞ ¹   359.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                 361.1µ ± ∞ ¹   360.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                 359.4µ ± ∞ ¹   374.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10                7.192m ± ∞ ¹   7.176m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-10               69.59m ± ∞ ¹   69.52m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-10               69.56m ± ∞ ¹   69.21m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-10    508.3µ ± ∞ ¹   517.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10      509.6µ ± ∞ ¹   514.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10      510.9µ ± ∞ ¹   511.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10     10.55m ± ∞ ¹   10.51m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-10    104.5m ± ∞ ¹   105.2m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-10    103.7m ± ∞ ¹   103.5m ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-10                                  918.1µ ± ∞ ¹   934.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                 2.335m         2.311m        -1.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │  before.txt   │               after.txt               │
                                                     │     B/op      │     B/op       vs base                │
_pushLogData_10_10_1024-10                             83.09Ki ± ∞ ¹   83.10Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               72.49Ki ± ∞ ¹   72.52Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                               71.87Ki ± ∞ ¹   71.86Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                              1.394Mi ± ∞ ¹   1.397Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10                             13.98Mi ± ∞ ¹   13.98Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10                             14.07Mi ± ∞ ¹   14.07Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                  2.969Mi ± ∞ ¹   2.962Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                    73.29Ki ± ∞ ¹   73.67Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                    73.28Ki ± ∞ ¹   73.15Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                   1.395Mi ± ∞ ¹   1.392Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                  13.92Mi ± ∞ ¹   13.92Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                  13.92Mi ± ∞ ¹   13.92Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-10                          85.35Ki ± ∞ ¹   85.45Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                            92.34Ki ± ∞ ¹   92.40Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                            2.083Mi ± ∞ ¹   2.083Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                           3.637Mi ± ∞ ¹   3.637Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                          20.44Mi ± ∞ ¹   20.44Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-10                          26.44Mi ± ∞ ¹   26.44Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-10               86.01Ki ± ∞ ¹   85.60Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                 93.01Ki ± ∞ ¹   93.49Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                 2.083Mi ± ∞ ¹   2.083Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                3.644Mi ± ∞ ¹   3.640Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10               18.41Mi ± ∞ ¹   18.41Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-10               21.41Mi ± ∞ ¹   21.41Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-10              243.8Ki ± ∞ ¹   243.9Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                243.8Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                243.8Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10               4.759Mi ± ∞ ¹   4.759Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-10              47.57Mi ± ∞ ¹   47.57Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-10              47.57Mi ± ∞ ¹   47.57Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-10   244.1Ki ± ∞ ¹   244.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10     243.8Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10     244.1Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10    4.769Mi ± ∞ ¹   4.761Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-10   47.43Mi ± ∞ ¹   47.43Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-10   47.43Mi ± ∞ ¹   47.43Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-10                                 713.9Ki ± ∞ ¹   713.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                1.515Mi         1.515Mi        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │  before.txt  │              after.txt               │
                                                     │  allocs/op   │  allocs/op    vs base                │
_pushLogData_10_10_1024-10                             1.286k ± ∞ ¹   1.286k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               1.121k ± ∞ ¹   1.121k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                               1.110k ± ∞ ¹   1.110k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                              22.01k ± ∞ ¹   22.01k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_2M-10                             220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10                             220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                  1.194k ± ∞ ¹   1.194k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                    1.110k ± ∞ ¹   1.110k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                    1.110k ± ∞ ¹   1.110k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                   22.01k ± ∞ ¹   22.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                  220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                  220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-10                          1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                            1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                            1.812k ± ∞ ¹   1.812k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                           36.01k ± ∞ ¹   36.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                          360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-10                          360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-10               1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                 1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                 1.812k ± ∞ ¹   1.812k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                36.01k ± ∞ ¹   36.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10               360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M-10               360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-10              3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10               78.08k ± ∞ ¹   78.07k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M_MultiMetric-10              780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M_MultiMetric-10              780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024_MultiMetric-10   3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10     3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10     3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10    78.07k ± ∞ ¹   78.07k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M_MultiMetric-10   780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-10   780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeLogsRejected-10                                 11.01k ± ∞ ¹   11.01k ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                18.96k         18.96k        -0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
```