### PR TITLE
[pkg/ottl] Add `Sprintf` OTTL Converter

### DIFF
--- a/.chloggen/sinkingpoint_sprintf_func.yaml
+++ b/.chloggen/sinkingpoint_sprintf_func.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds an `Format` function to OTTL that calls `fmt.Sprintf`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33405]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -385,6 +385,12 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["test"], Format("%03d-%s", [7, "test"]))`,
+			want: func(tCtx ottllog.TransformContext) {
+				tCtx.GetLogRecord().Attributes().PutStr("test", "007-test")
+			},
+		},
+		{
 			statement: `set(attributes["test"], Hour(Time("12", "%H")))`,
 			want: func(tCtx ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutInt("test", 12)

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -415,6 +415,7 @@ Available Converters:
 - [Day](#day)
 - [ExtractPatterns](#extractpatterns)
 - [FNV](#fnv)
+- [Format](#format)
 - [Hex](#hex)
 - [Hour](#hour)
 - [Hours](#hours)
@@ -605,6 +606,25 @@ Examples:
 
 
 - `FNV("name")`
+
+### Format
+
+```Format(formatString, []formatArguments)```
+
+The `Format` Converter takes the given format string and formats it using `fmt.Sprintf` and the given arguments.
+
+`formatString` is a string. `formatArguments` is an array of values.
+
+If the `formatString` is not a string or does not exist, the `Format` Converter will return an error.
+If any of the `formatArgs` are incorrect (e.g. missing, or an incorrect type for the corresponding format specifier), then a string will still be returned, but with Go's default error handling for `fmt.Sprintf`.
+
+Format specifiers that can be used in `formatString` are documented in Go's [fmt package documentation](https://pkg.go.dev/fmt#hdr-Printing)
+
+Examples:
+
+- `Format("%02d", [attributes["priority"]])`
+- `Format("%04d-%02d-%02d", [Year(Now()), Month(Now()), Day(Now())])`
+- `Format("%s/%s/%04d-%02d-%02d.log", [attributes["hostname"], body["program"], Year(Now()), Month(Now()), Day(Now())])`
 
 ### Hex
 

--- a/pkg/ottl/ottlfuncs/func_format.go
+++ b/pkg/ottl/ottlfuncs/func_format.go
@@ -1,0 +1,45 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type FormatArguments[K any] struct {
+	Format string
+	Vals   []ottl.Getter[K]
+}
+
+func NewFormatFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("Format", &FormatArguments[K]{}, createFormatFunction[K])
+}
+
+func createFormatFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*FormatArguments[K])
+	if !ok {
+		return nil, fmt.Errorf("FormatFactory args must be of type *FormatArguments[K]")
+	}
+
+	return format(args.Format, args.Vals), nil
+}
+
+func format[K any](formatString string, vals []ottl.Getter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		formatArgs := make([]any, 0, len(vals))
+		for _, arg := range vals {
+			formatArg, err := arg.Get(ctx, tCtx)
+			if err != nil {
+				return nil, err
+			}
+
+			formatArgs = append(formatArgs, formatArg)
+		}
+
+		return fmt.Sprintf(formatString, formatArgs...), nil
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_format_test.go
+++ b/pkg/ottl/ottlfuncs/func_format_test.go
@@ -1,0 +1,78 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type getterFunc[K any] func(ctx context.Context, tCtx K) (any, error)
+
+func (g getterFunc[K]) Get(ctx context.Context, tCtx K) (any, error) {
+	return g(ctx, tCtx)
+}
+
+func Test_Format(t *testing.T) {
+	tests := []struct {
+		name         string
+		formatString string
+		formatArgs   []ottl.Getter[any]
+		expected     string
+	}{
+		{
+			name:         "non formatting string",
+			formatString: "test",
+			formatArgs:   []ottl.Getter[any]{},
+			expected:     "test",
+		},
+		{
+			name:         "padded int",
+			formatString: "test-%04d",
+			formatArgs: []ottl.Getter[any]{
+				getterFunc[any](func(_ context.Context, _ any) (any, error) {
+					return 2, nil
+				}),
+			},
+			expected: "test-0002",
+		},
+		{
+			name:         "multiple-args",
+			formatString: "test-%04d-%4s",
+			formatArgs: []ottl.Getter[any]{
+				getterFunc[any](func(_ context.Context, _ any) (any, error) {
+					return 2, nil
+				}),
+				getterFunc[any](func(_ context.Context, _ any) (any, error) {
+					return "te", nil
+				}),
+			},
+			expected: "test-0002-  te",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc := format(tt.formatString, tt.formatArgs)
+			result, err := exprFunc(nil, nil)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestFormat_error(t *testing.T) {
+	target := getterFunc[any](func(_ context.Context, _ any) (any, error) {
+		return nil, errors.New("failed to get")
+	})
+
+	exprFunc := format[any]("test-%d", []ottl.Getter[any]{target})
+	_, err := exprFunc(context.Background(), nil)
+	assert.Error(t, err)
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -72,6 +72,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewSHA256Factory[K](),
 		NewSpanIDFactory[K](),
 		NewSplitFactory[K](),
+		NewFormatFactory[K](),
 		NewStringFactory[K](),
 		NewSubstringFactory[K](),
 		NewTimeFactory[K](),


### PR DESCRIPTION
**Description:**

This adds in a converter that calls `fmt.Sprintf` with a format string and a set of arguments.

**Link to tracking Issue:**  #33405

**Testing:** Added in a couple of unit tests

**Documentation:** Added the new converter to the functions readme