### PR TITLE
[chore] discard response body

### DIFF
--- a/exporter/splunkhecexporter/hec_worker.go
+++ b/exporter/splunkhecexporter/hec_worker.go
@@ -5,8 +5,8 @@ package splunkhecexporter // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"io"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -66,7 +66,7 @@ func (hec *defaultHecWorker) send(ctx context.Context, buf buffer, headers map[s
 	// HTTP client will not reuse the same connection unless it is drained.
 	// See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18281 for more details.
 	if resp.StatusCode != http.StatusTooManyRequests && resp.StatusCode != http.StatusBadGateway {
-		if _, errCopy := httputil.DumpResponse(resp, true); errCopy != nil {
+		if _, errCopy := io.Copy(io.Discard, resp.Body); errCopy != nil {
 			return errCopy
 		}
 	}


### PR DESCRIPTION
**Description:**
Rather than using httputil.DumpResponse, use io.Copy(io.Discard, resp.Body) to reduce allocations.

Before:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024-10                                        10886            110069 ns/op           85086 B/op       1286 allocs/op
Benchmark_pushLogData_10_10_8K-10                                          12171            125738 ns/op           74231 B/op       1121 allocs/op
Benchmark_pushLogData_10_10_2M-10                                          12324             97922 ns/op           73592 B/op       1110 allocs/op
Benchmark_pushLogData_10_200_2M-10                                           592           1937688 ns/op         1461636 B/op      22011 allocs/op
Benchmark_pushLogData_100_200_2M-10                                           66          17943886 ns/op        14659459 B/op     220025 allocs/op
Benchmark_pushLogData_100_200_5M-10                                           67          17726719 ns/op        14750905 B/op     220014 allocs/op
Benchmark_pushLogData_compressed_10_10_1024-10                              1608            731421 ns/op         3113743 B/op       1194 allocs/op
Benchmark_pushLogData_compressed_10_10_8K-10                                6874            172187 ns/op           75049 B/op       1110 allocs/op
Benchmark_pushLogData_compressed_10_10_2M-10                                6457            169863 ns/op           75037 B/op       1110 allocs/op
Benchmark_pushLogData_compressed_10_200_2M-10                                324           3818677 ns/op         1462718 B/op      22011 allocs/op
Benchmark_pushLogData_compressed_100_200_2M-10                                30          40161269 ns/op        14599913 B/op     220015 allocs/op
Benchmark_pushLogData_compressed_100_200_5M-10                                30          37288412 ns/op        14599672 B/op     220015 allocs/op
Benchmark_pushMetricData_10_10_1024-10                                      8053            147929 ns/op           87397 B/op       1811 allocs/op
Benchmark_pushMetricData_10_10_8K-10                                        8258            146820 ns/op           94560 B/op       1811 allocs/op
Benchmark_pushMetricData_10_10_2M-10                                        4231            267759 ns/op         2184341 B/op       1812 allocs/op
Benchmark_pushMetricData_10_200_2M-10                                        392           3035303 ns/op         3813707 B/op      36013 allocs/op
Benchmark_pushMetricData_100_200_2M-10                                        38          28439496 ns/op        21429592 B/op     360035 allocs/op
Benchmark_pushMetricData_100_200_5M-10                                        38          28699036 ns/op        27721316 B/op     360035 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024-10                           3849            308233 ns/op           88071 B/op       1811 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K-10                             3830            309395 ns/op           95247 B/op       1811 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M-10                             2642            442132 ns/op         2184493 B/op       1812 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M-10                             177           6790847 ns/op         3821045 B/op      36013 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M-10                             16          66048047 ns/op        19305152 B/op     360017 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M-10                             16          66311557 ns/op        22450371 B/op     360017 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric-10                          3343            363826 ns/op          249651 B/op       3935 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric-10                            3333            361072 ns/op          249656 B/op       3935 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric-10                            3254            359366 ns/op          249631 B/op       3935 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric-10                            166           7191673 ns/op         4990020 B/op      78075 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric-10                            15          69585222 ns/op        49881336 B/op     780368 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric-10                            15          69559936 ns/op        49880897 B/op     780362 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-10               2349            508300 ns/op          249995 B/op       3935 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-10                 2318            509592 ns/op          249645 B/op       3935 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-10                 2323            510947 ns/op          249991 B/op       3935 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-10                 100          10549857 ns/op         5000645 B/op      78072 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-10                 10         104526088 ns/op        49737504 B/op     780370 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-10                 10         103702858 ns/op        49737788 B/op     780369 allocs/op
BenchmarkConsumeLogsRejected-10                                             1296            918060 ns/op          731060 B/op      11013 allocs/op
```

After:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
Benchmark_pushLogData_10_10_1024-10                                        11007            108674 ns/op           85090 B/op       1286 allocs/op
Benchmark_pushLogData_10_10_8K-10                                          12853             93607 ns/op           74262 B/op       1121 allocs/op
Benchmark_pushLogData_10_10_2M-10                                          12843             92506 ns/op           73587 B/op       1110 allocs/op
Benchmark_pushLogData_10_200_2M-10                                           646           1877843 ns/op         1464967 B/op      22012 allocs/op
Benchmark_pushLogData_100_200_2M-10                                           66          17775886 ns/op        14659444 B/op     220025 allocs/op
Benchmark_pushLogData_100_200_5M-10                                           67          17786048 ns/op        14750626 B/op     220014 allocs/op
Benchmark_pushLogData_compressed_10_10_1024-10                              1485            753384 ns/op         3105473 B/op       1194 allocs/op
Benchmark_pushLogData_compressed_10_10_8K-10                                7161            169034 ns/op           75439 B/op       1110 allocs/op
Benchmark_pushLogData_compressed_10_10_2M-10                                7030            168845 ns/op           74904 B/op       1110 allocs/op
Benchmark_pushLogData_compressed_10_200_2M-10                                326           3700271 ns/op         1460119 B/op      22011 allocs/op
Benchmark_pushLogData_compressed_100_200_2M-10                                31          36225909 ns/op        14598496 B/op     220015 allocs/op
Benchmark_pushLogData_compressed_100_200_5M-10                                31          36269402 ns/op        14598473 B/op     220015 allocs/op
Benchmark_pushMetricData_10_10_1024-10                                      8238            146291 ns/op           87497 B/op       1811 allocs/op
Benchmark_pushMetricData_10_10_8K-10                                        7850            148590 ns/op           94617 B/op       1811 allocs/op
Benchmark_pushMetricData_10_10_2M-10                                        4063            284434 ns/op         2184558 B/op       1812 allocs/op
Benchmark_pushMetricData_10_200_2M-10                                        387           3062144 ns/op         3813842 B/op      36013 allocs/op
Benchmark_pushMetricData_100_200_2M-10                                        37          28696250 ns/op        21432637 B/op     360035 allocs/op
Benchmark_pushMetricData_100_200_5M-10                                        37          29850587 ns/op        27724310 B/op     360035 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024-10                           3788            310700 ns/op           87651 B/op       1811 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K-10                             3685            309713 ns/op           95730 B/op       1811 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M-10                             2706            449835 ns/op         2184448 B/op       1812 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M-10                             178           6737157 ns/op         3816504 B/op      36013 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M-10                             16          65667492 ns/op        19305178 B/op     360018 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M-10                             16          65769258 ns/op        22450886 B/op     360017 allocs/op
Benchmark_pushMetricData_10_10_1024_MultiMetric-10                          3312            359765 ns/op          249704 B/op       3935 allocs/op
Benchmark_pushMetricData_10_10_8K_MultiMetric-10                            3412            360093 ns/op          249648 B/op       3935 allocs/op
Benchmark_pushMetricData_10_10_2M_MultiMetric-10                            3327            374431 ns/op          249695 B/op       3935 allocs/op
Benchmark_pushMetricData_10_200_2M_MultiMetric-10                            165           7175992 ns/op         4990086 B/op      78074 allocs/op
Benchmark_pushMetricData_100_200_2M_MultiMetric-10                            15          69520503 ns/op        49880896 B/op     780361 allocs/op
Benchmark_pushMetricData_100_200_5M_MultiMetric-10                            15          69210933 ns/op        49881483 B/op     780366 allocs/op
Benchmark_pushMetricData_compressed_10_10_1024_MultiMetric-10               2228            517242 ns/op          250408 B/op       3935 allocs/op
Benchmark_pushMetricData_compressed_10_10_8K_MultiMetric-10                 2234            514438 ns/op          249669 B/op       3935 allocs/op
Benchmark_pushMetricData_compressed_10_10_2M_MultiMetric-10                 2320            511637 ns/op          249653 B/op       3935 allocs/op
Benchmark_pushMetricData_compressed_10_200_2M_MultiMetric-10                 100          10505132 ns/op         4992097 B/op      78073 allocs/op
Benchmark_pushMetricData_compressed_100_200_2M_MultiMetric-10                 10         105228554 ns/op        49736452 B/op     780370 allocs/op
Benchmark_pushMetricData_compressed_100_200_5M_MultiMetric-10                 10         103545542 ns/op        49736097 B/op     780373 allocs/op
BenchmarkConsumeLogsRejected-10                                             1306            934624 ns/op          730755 B/op      11012 allocs/op
```

Comparison:
```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/splunkhecexporter
                                                     │  before.txt   │              after.txt               │
                                                     │    sec/op     │    sec/op     vs base                │
_pushLogData_10_10_1024-10                              110.1µ ± ∞ ¹   108.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               125.74µ ± ∞ ¹   93.61µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                                97.92µ ± ∞ ¹   92.51µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                               1.938m ± ∞ ¹   1.878m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10                              17.94m ± ∞ ¹   17.78m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10                              17.73m ± ∞ ¹   17.79m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                   731.4µ ± ∞ ¹   753.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                     172.2µ ± ∞ ¹   169.0µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                     169.9µ ± ∞ ¹   168.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                    3.819m ± ∞ ¹   3.700m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                   40.16m ± ∞ ¹   36.23m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                   37.29m ± ∞ ¹   36.27m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-10                           147.9µ ± ∞ ¹   146.3µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                             146.8µ ± ∞ ¹   148.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                             267.8µ ± ∞ ¹   284.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                            3.035m ± ∞ ¹   3.062m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                           28.44m ± ∞ ¹   28.70m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-10                           28.70m ± ∞ ¹   29.85m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-10                308.2µ ± ∞ ¹   310.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                  309.4µ ± ∞ ¹   309.7µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                  442.1µ ± ∞ ¹   449.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                 6.791m ± ∞ ¹   6.737m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10                66.05m ± ∞ ¹   65.67m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-10                66.31m ± ∞ ¹   65.77m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-10               363.8µ ± ∞ ¹   359.8µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                 361.1µ ± ∞ ¹   360.1µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                 359.4µ ± ∞ ¹   374.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10                7.192m ± ∞ ¹   7.176m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-10               69.59m ± ∞ ¹   69.52m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-10               69.56m ± ∞ ¹   69.21m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-10    508.3µ ± ∞ ¹   517.2µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10      509.6µ ± ∞ ¹   514.4µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10      510.9µ ± ∞ ¹   511.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10     10.55m ± ∞ ¹   10.51m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-10    104.5m ± ∞ ¹   105.2m ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-10    103.7m ± ∞ ¹   103.5m ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-10                                  918.1µ ± ∞ ¹   934.6µ ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                 2.335m         2.311m        -1.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │  before.txt   │               after.txt               │
                                                     │     B/op      │     B/op       vs base                │
_pushLogData_10_10_1024-10                             83.09Ki ± ∞ ¹   83.10Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               72.49Ki ± ∞ ¹   72.52Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                               71.87Ki ± ∞ ¹   71.86Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                              1.394Mi ± ∞ ¹   1.397Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10                             13.98Mi ± ∞ ¹   13.98Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10                             14.07Mi ± ∞ ¹   14.07Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                  2.969Mi ± ∞ ¹   2.962Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                    73.29Ki ± ∞ ¹   73.67Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                    73.28Ki ± ∞ ¹   73.15Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                   1.395Mi ± ∞ ¹   1.392Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                  13.92Mi ± ∞ ¹   13.92Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                  13.92Mi ± ∞ ¹   13.92Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-10                          85.35Ki ± ∞ ¹   85.45Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                            92.34Ki ± ∞ ¹   92.40Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                            2.083Mi ± ∞ ¹   2.083Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                           3.637Mi ± ∞ ¹   3.637Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                          20.44Mi ± ∞ ¹   20.44Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-10                          26.44Mi ± ∞ ¹   26.44Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-10               86.01Ki ± ∞ ¹   85.60Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                 93.01Ki ± ∞ ¹   93.49Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                 2.083Mi ± ∞ ¹   2.083Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                3.644Mi ± ∞ ¹   3.640Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10               18.41Mi ± ∞ ¹   18.41Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M-10               21.41Mi ± ∞ ¹   21.41Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-10              243.8Ki ± ∞ ¹   243.9Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                243.8Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                243.8Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10               4.759Mi ± ∞ ¹   4.759Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M_MultiMetric-10              47.57Mi ± ∞ ¹   47.57Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M_MultiMetric-10              47.57Mi ± ∞ ¹   47.57Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024_MultiMetric-10   244.1Ki ± ∞ ¹   244.5Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10     243.8Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10     244.1Ki ± ∞ ¹   243.8Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10    4.769Mi ± ∞ ¹   4.761Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M_MultiMetric-10   47.43Mi ± ∞ ¹   47.43Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-10   47.43Mi ± ∞ ¹   47.43Mi ± ∞ ¹       ~ (p=1.000 n=1) ²
ConsumeLogsRejected-10                                 713.9Ki ± ∞ ¹   713.6Ki ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                                1.515Mi         1.515Mi        +0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                                     │  before.txt  │              after.txt               │
                                                     │  allocs/op   │  allocs/op    vs base                │
_pushLogData_10_10_1024-10                             1.286k ± ∞ ¹   1.286k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                               1.121k ± ∞ ¹   1.121k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                               1.110k ± ∞ ¹   1.110k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10                              22.01k ± ∞ ¹   22.01k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushLogData_100_200_2M-10                             220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10                             220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10                  1.194k ± ∞ ¹   1.194k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10                    1.110k ± ∞ ¹   1.110k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10                    1.110k ± ∞ ¹   1.110k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10                   22.01k ± ∞ ¹   22.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10                  220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10                  220.0k ± ∞ ¹   220.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024-10                          1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K-10                            1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M-10                            1.812k ± ∞ ¹   1.812k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M-10                           36.01k ± ∞ ¹   36.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_2M-10                          360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_100_200_5M-10                          360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_1024-10               1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K-10                 1.811k ± ∞ ¹   1.811k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M-10                 1.812k ± ∞ ¹   1.812k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M-10                36.01k ± ∞ ¹   36.01k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_2M-10               360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_5M-10               360.0k ± ∞ ¹   360.0k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_1024_MultiMetric-10              3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_8K_MultiMetric-10                3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_10_2M_MultiMetric-10                3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_10_200_2M_MultiMetric-10               78.08k ± ∞ ¹   78.07k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_2M_MultiMetric-10              780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_100_200_5M_MultiMetric-10              780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_10_10_1024_MultiMetric-10   3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_8K_MultiMetric-10     3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_10_2M_MultiMetric-10     3.935k ± ∞ ¹   3.935k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_10_200_2M_MultiMetric-10    78.07k ± ∞ ¹   78.07k ± ∞ ¹       ~ (p=1.000 n=1) ³
_pushMetricData_compressed_100_200_2M_MultiMetric-10   780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushMetricData_compressed_100_200_5M_MultiMetric-10   780.4k ± ∞ ¹   780.4k ± ∞ ¹       ~ (p=1.000 n=1) ³
ConsumeLogsRejected-10                                 11.01k ± ∞ ¹   11.01k ± ∞ ¹       ~ (p=1.000 n=1) ³
geomean                                                18.96k         18.96k        -0.00%
¹ need >= 6 samples for confidence interval at level 0.95
² all samples are equal
³ need >= 4 samples to detect a difference at alpha level 0.05
```