### PR TITLE
[chore][receiver/kubeletstats] Add ChrsMark to kubeletstats codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,7 +240,7 @@ receiver/k8seventsreceiver/                                         @open-teleme
 receiver/k8sobjectsreceiver/                                        @open-telemetry/collector-contrib-approvers @dmitryax @hvaghani221 @TylerHelmuth
 receiver/kafkametricsreceiver/                                      @open-telemetry/collector-contrib-approvers @dmitryax
 receiver/kafkareceiver/                                             @open-telemetry/collector-contrib-approvers @pavolloffay @MovieStoreGuy
-receiver/kubeletstatsreceiver/                                      @open-telemetry/collector-contrib-approvers @dmitryax @TylerHelmuth
+receiver/kubeletstatsreceiver/                                      @open-telemetry/collector-contrib-approvers @dmitryax @TylerHelmuth @ChrsMark
 receiver/lokireceiver/                                              @open-telemetry/collector-contrib-approvers @mar4uk @jpkrohling
 receiver/memcachedreceiver/                                         @open-telemetry/collector-contrib-approvers @djaglowski
 receiver/mongodbatlasreceiver/                                      @open-telemetry/collector-contrib-approvers @djaglowski @schmikei

--- a/receiver/kubeletstatsreceiver/README.md
+++ b/receiver/kubeletstatsreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Fkubeletstats%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Fkubeletstats) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Fkubeletstats%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Fkubeletstats) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@dmitryax](https://www.github.com/dmitryax), [@TylerHelmuth](https://www.github.com/TylerHelmuth) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@dmitryax](https://www.github.com/dmitryax), [@TylerHelmuth](https://www.github.com/TylerHelmuth), [@ChrsMark](https://www.github.com/ChrsMark) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -7,7 +7,7 @@ status:
     beta: [metrics]
   distributions: [contrib]
   codeowners:
-    active: [dmitryax, TylerHelmuth]
+    active: [dmitryax, TylerHelmuth, ChrsMark]
 
 resource_attributes:
   k8s.node.name:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Having recently been working with the `kubeletstats` receiver (using it and contributing to it), I would like to volunteer to help with its maintainance by intending to dedicate time to contribute to the component as well as help with the existing and future issue queue.

Also being a member of the [semconv-k8s-approvers](https://github.com/orgs/open-telemetry/teams/semconv-k8s-approvers) and [semconv-container-approvers](https://github.com/orgs/open-telemetry/teams/semconv-container-approvers) will help to bring more alignment between the [Semantic Conventions](https://github.com/open-telemetry/semantic-conventions/issues/1032) and the Collector's implementation within this specific scope.

-  ✅ Being a member of Opentelemetry organization 
 - PRs authored: https://github.com/open-telemetry/opentelemetry-collector-contrib/pulls?q=is%3Apr+author%3AChrsMark++label%3Areceiver%2Fkubeletstats%2Cinternal%2Fkubeletstats%2Cinternal%2Fkubelet
- Issues have been involved: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aissue+commenter%3AChrsMark+label%3Areceiver%2Fkubeletstats%2Cinternal%2Fkubeletstats+

/cc @dmitryax @TylerHelmuth with whom I have already discussed about it

**Link to tracking Issue:** <Issue number if applicable> ~

**Testing:** <Describe what testing was performed and which tests were added.> ~

**Documentation:** <Describe the documentation added.> ~