### PR TITLE
[exporter/clickhouse] Default `async_insert` to true. Added related config option.

### DIFF
--- a/.chloggen/clickhouse-default-async-insert.yaml
+++ b/.chloggen/clickhouse-default-async-insert.yaml
@@ -23,10 +23,6 @@ subtext: |
   Keep in mind this setting is added since the exporter now sets it to default.
   Async insert and its related settings can still be defined in `endpoint` and `connection_params`, which take priority over the new config option.
 
-  This set of changes also includes and internal change for `create_schema`, which no longer uses a `bool` pointer.
-  It also changes `database` to `default`. The final database will prioritize `endpoint`, unless `database` is set to a value not equal to `default`.
-  If neither are specified then it defaults to the `default` database.
-
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.

--- a/.chloggen/clickhouse-default-async-insert.yaml
+++ b/.chloggen/clickhouse-default-async-insert.yaml
@@ -10,7 +10,7 @@ component: exporter/clickhouse
 note: "Add `async_insert` config option to enable inserting asynchronously by default."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [32340]
+issues: []
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clickhouse-default-async-insert.yaml
+++ b/.chloggen/clickhouse-default-async-insert.yaml
@@ -10,7 +10,7 @@ component: exporter/clickhouse
 note: Enable async inserts by default, with added async_insert config option.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [32340]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clickhouse-default-async-insert.yaml
+++ b/.chloggen/clickhouse-default-async-insert.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: exporter/clickhouse
@@ -21,6 +21,8 @@ subtext: |
   The `async_insert` option can be set to `true` or `false` to enable or disable async inserts, respectively. The default value is `true`.
   Keep in mind this setting is added since the exporter now sets it to default.
   Async insert and its related settings can still be defined in `endpoint` and `connection_params`, which take priority over the new config option.
+
+  While this change won't immediately break deployments, it is a change that should be highlighted.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/clickhouse-default-async-insert.yaml
+++ b/.chloggen/clickhouse-default-async-insert.yaml
@@ -10,7 +10,7 @@ component: exporter/clickhouse
 note: "Add `async_insert` config option to enable inserting asynchronously by default."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [33614]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clickhouse-default-async-insert.yaml
+++ b/.chloggen/clickhouse-default-async-insert.yaml
@@ -23,6 +23,10 @@ subtext: |
   Keep in mind this setting is added since the exporter now sets it to default.
   Async insert and its related settings can still be defined in `endpoint` and `connection_params`, which take priority over the new config option.
 
+  This set of changes also includes and internal change for `create_schema`, which no longer uses a `bool` pointer.
+  It also changes `database` to `default`. The final database will prioritize `endpoint`, unless `database` is set to a value not equal to `default`.
+  If neither are specified then it defaults to the `default` database.
+
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
 # Optional: The change log or logs in which this entry should be included.

--- a/.chloggen/clickhouse-default-async-insert.yaml
+++ b/.chloggen/clickhouse-default-async-insert.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: exporter/clickhouse
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Enable async inserts by default, with added async_insert config option.
+note: "Add `async_insert` config option to enable inserting asynchronously by default."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [32340]
@@ -16,13 +16,12 @@ issues: [32340]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  This change enables async inserts by default, and adds new `async_insert` config option.
+  Adds `async_insert` config option to enable inserting asynchronously by default.
+  To preserve the previous behavior, set `async_insert` to `false` in your config.
   When enabled, the exporter will insert asynchronously, which can improve performance for high-throughput deployments.
   The `async_insert` option can be set to `true` or `false` to enable or disable async inserts, respectively. The default value is `true`.
   Keep in mind this setting is added since the exporter now sets it to default.
   Async insert and its related settings can still be defined in `endpoint` and `connection_params`, which take priority over the new config option.
-
-  While this change won't immediately break deployments, it is a change that should be highlighted.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/default-async-insert.yaml
+++ b/.chloggen/default-async-insert.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable async inserts by default, with added async_insert config option.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change enables async inserts by default, and adds new `async_insert` config option.
+  When enabled, the exporter will insert asynchronously, which can improve performance for high-throughput deployments.
+  The `async_insert` option can be set to `true` or `false` to enable or disable async inserts, respectively. The default value is `true`.
+  Keep in mind this setting is added since the exporter now sets it to default.
+  Async insert and its related settings can still be defined in `endpoint` and `connection_params`, which take priority over the new config option.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -46,6 +46,10 @@ type Config struct {
 	ClusterName string `mapstructure:"cluster_name"`
 	// CreateSchema if set to true will run the DDL for creating the database and tables. default is true.
 	CreateSchema bool `mapstructure:"create_schema"`
+	// AsyncInsert if true will enable async inserts. Default is `true`.
+	// Ignored if async inserts are configured in the `endpoint` or `connection_params`.
+	// Async inserts may still be overridden server-side.
+	AsyncInsert bool `mapstructure:"async_insert"`
 }
 
 // TableEngine defines the ENGINE string value when creating the table.
@@ -97,6 +101,11 @@ func (cfg *Config) buildDSN() (string, error) {
 	// Enable TLS if scheme is https. This flag is necessary to support https connections.
 	if dsnURL.Scheme == "https" {
 		queryParams.Set("secure", "true")
+	}
+
+	// Use async_insert from config if not specified in DSN.
+	if !queryParams.Has("async_insert") {
+		queryParams.Set("async_insert", fmt.Sprintf("%t", cfg.AsyncInsert))
 	}
 
 	// Use database from config if not specified in path, or if config is not default.

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -38,12 +38,13 @@ func createDefaultConfig() component.Config {
 		QueueSettings:    queueSettings,
 		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 		ConnectionParams: map[string]string{},
-		Database:         defaultDatabase,
+		Database:         "default",
 		LogsTableName:    "otel_logs",
 		TracesTableName:  "otel_traces",
 		MetricsTableName: "otel_metrics",
 		TTL:              0,
 		CreateSchema:     true,
+		AsyncInsert:      true,
 	}
 }
 

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -38,7 +38,7 @@ func createDefaultConfig() component.Config {
 		QueueSettings:    queueSettings,
 		BackOffConfig:    configretry.NewDefaultBackOffConfig(),
 		ConnectionParams: map[string]string{},
-		Database:         "default",
+		Database:         defaultDatabase,
 		LogsTableName:    "otel_logs",
 		TracesTableName:  "otel_traces",
 		MetricsTableName: "otel_metrics",


### PR DESCRIPTION
### DEPENDS ON #33693, #33694

**Description:**
Sets `async_insert` to true by default to enable [asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts).
Because this value is being given a default, I have added a config option under the same name.
Keep in mind that if `async_insert` is provided in `endpoint` or `connection_params` it will take precedence and ignore this new config option.

This is similar to how the `database` config option behaves.
The goal is to provide better insert performance by default, since not all users will know to set it in their DSN URL.

This also opens the discussion to ___**whether or not this is a breaking change**___. Depending on the deployment's telemetry throughput, this could be an unexpected change that leads to [`TOO_MANY_PARTS`](https://clickhouse.com/docs/knowledgebase/exception-too-many-parts) errors. I don't expect this to be the case however, but I welcome any discussion about this concern.

This PR is being resubmitted with suggestions from @crobert-1 and @dmitryax  applied.
Here are the extra changes with these suggestions applied:
- Extracted unrelated changes into separate PRs
- Updated `async_insert` to avoid using a `bool` pointer
- Updated tests to be able to support these non-pointer-yet-still-optional test cases

**Testing:**
Ran integration tests. Also added an abundance of tests to check the behavior of `async_insert` when present in `endpoint`, `connection_params`, and exporter config.

**Documentation:**
- Updated README for all related changes

Unrelated change, also updated README's SQL samples to use `sql` instead of `clickhouse` for the code samples to enable proper syntax highlighting. ClickHouse SQL is compatible with plain SQL.