### PR TITLE
[chore][CONTRIBUTING.md] Add reference to addlicense command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,6 +225,7 @@ When submitting a component to the community, consider breaking it down into sep
     * `make generate`
     * `make multimod-verify`
     * `make generate-gh-issue-templates`
+    * `make addlicense`
 * **Second PR** should include the concrete implementation of the component. If the
   size of this PR is larger than the recommended size consider splitting it in
   multiple PRs.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
When adding new components, new files are introduced. These files need to include the license header, which is done by running the `make addlicense` commnand. This should be documented for users to know what they need to do when introducing new components and files.

Also, [here's an example](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33458#issuecomment-2176617494) where it wasn't obvious that this command was necessary.