### PR TITLE
[exporter/clickhouse] Remove deprecated `ttl_days` config option

### DIFF
--- a/.chloggen/clickhouseexporter-remove-deprecated-config-option.yaml
+++ b/.chloggen/clickhouseexporter-remove-deprecated-config-option.yaml
@@ -10,7 +10,7 @@ component: exporter/clickhouse
 note: Remove deprecated `ttl_days` config option, use `ttl` instead.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [33648]
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/clickhouseexporter-remove-deprecated-config-option.yaml
+++ b/.chloggen/clickhouseexporter-remove-deprecated-config-option.yaml
@@ -1,0 +1,22 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove deprecated `ttl_days` config option, use `ttl` instead.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -280,7 +280,6 @@ Connection options:
 - `username` (default = ): The authentication username.
 - `password` (default = ): The authentication password.
 - `connection_params` (default = {}). Params is the extra connection parameters with map format.
-- `ttl_days` (default = 0): **Deprecated: Use 'ttl' instead.**  The data time-to-live in days, 0 means no ttl.
 - `ttl` (default = 0): The data time-to-live example 30m, 48h. Also, 0 means no ttl.
 - `database` (default = otel): The database name.
 - `create_schema` (default = true): When set to true, will run DDL to create the database and tables. (See [schema management](#schema-management))

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -38,9 +38,6 @@ type Config struct {
 	TracesTableName string `mapstructure:"traces_table_name"`
 	// MetricsTableName is the table name for metrics. default is `otel_metrics`.
 	MetricsTableName string `mapstructure:"metrics_table_name"`
-	// TTLDays is The data time-to-live in days, 0 means no ttl.
-	// Deprecated: Use 'ttl' instead
-	TTLDays uint `mapstructure:"ttl_days"`
 	// TTL is The data time-to-live example 30m, 48h. 0 means no ttl.
 	TTL time.Duration `mapstructure:"ttl"`
 	// TableEngine is the table engine to use. default is `MergeTree()`.
@@ -63,7 +60,6 @@ const defaultTableEngineName = "MergeTree"
 var (
 	errConfigNoEndpoint      = errors.New("endpoint must be specified")
 	errConfigInvalidEndpoint = errors.New("endpoint must be url format")
-	errConfigTTL             = errors.New("both 'ttl_days' and 'ttl' can not be provided. 'ttl_days' is deprecated, use 'ttl' instead")
 )
 
 // Validate the ClickHouse server configuration.
@@ -74,10 +70,6 @@ func (cfg *Config) Validate() (err error) {
 	dsn, e := cfg.buildDSN(cfg.Database)
 	if e != nil {
 		err = errors.Join(err, e)
-	}
-
-	if cfg.TTL > 0 && cfg.TTLDays > 0 {
-		err = errors.Join(err, errConfigTTL)
 	}
 
 	// Validate DSN with clickhouse driver.

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -241,7 +241,7 @@ func createLogsTable(ctx context.Context, cfg *Config, db *sql.DB) error {
 }
 
 func renderCreateLogsTableSQL(cfg *Config) string {
-	ttlExpr := generateTTLExpr(cfg.TTLDays, cfg.TTL, "TimestampTime")
+	ttlExpr := generateTTLExpr(cfg.TTL, "TimestampTime")
 	return fmt.Sprintf(createLogsTableSQL, cfg.LogsTableName, cfg.clusterString(), cfg.tableEngineString(), ttlExpr)
 }
 

--- a/exporter/clickhouseexporter/exporter_metrics.go
+++ b/exporter/clickhouseexporter/exporter_metrics.go
@@ -47,7 +47,7 @@ func (e *metricsExporter) start(ctx context.Context, _ component.Host) error {
 		return err
 	}
 
-	ttlExpr := generateTTLExpr(e.cfg.TTLDays, e.cfg.TTL, "toDateTime(TimeUnix)")
+	ttlExpr := generateTTLExpr(e.cfg.TTL, "toDateTime(TimeUnix)")
 	return internal.NewMetricsTable(ctx, e.cfg.MetricsTableName, e.cfg.clusterString(), e.cfg.tableEngineString(), ttlExpr, e.client)
 }
 

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -295,12 +295,12 @@ func renderInsertTracesSQL(cfg *Config) string {
 }
 
 func renderCreateTracesTableSQL(cfg *Config) string {
-	ttlExpr := generateTTLExpr(cfg.TTLDays, cfg.TTL, "toDateTime(Timestamp)")
+	ttlExpr := generateTTLExpr(cfg.TTL, "toDateTime(Timestamp)")
 	return fmt.Sprintf(createTracesTableSQL, cfg.TracesTableName, cfg.clusterString(), cfg.tableEngineString(), ttlExpr)
 }
 
 func renderCreateTraceIDTsTableSQL(cfg *Config) string {
-	ttlExpr := generateTTLExpr(cfg.TTLDays, cfg.TTL, "toDateTime(Start)")
+	ttlExpr := generateTTLExpr(cfg.TTL, "toDateTime(Start)")
 	return fmt.Sprintf(createTraceIDTsTableSQL, cfg.TracesTableName, cfg.clusterString(), cfg.tableEngineString(), ttlExpr)
 }
 

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -124,11 +124,7 @@ func createMetricExporter(
 	)
 }
 
-func generateTTLExpr(ttlDays uint, ttl time.Duration, timeField string) string {
-	if ttlDays > 0 {
-		return fmt.Sprintf(`TTL %s + toIntervalDay(%d)`, timeField, ttlDays)
-	}
-
+func generateTTLExpr(ttl time.Duration, timeField string) string {
 	if ttl > 0 {
 		switch {
 		case ttl%(24*time.Hour) == 0:


### PR DESCRIPTION
`ttl_days` has been deprecated since 0.90.0. `ttl` config option should be used instead.
