### PR TITLE
Improve AzureDataExplorerExporter: add support for WorkloadIdentity

### DIFF
--- a/.chloggen/feature_azuredataexplorer_workloadidentity.yaml
+++ b/.chloggen/feature_azuredataexplorer_workloadidentity.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/azuredataexplorerexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add support for workloadidentity to the exporter/azuredataexplorerexporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33667]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/azuredataexplorerexporter/README.md
+++ b/exporter/azuredataexplorerexporter/README.md
@@ -60,8 +60,9 @@ exporters:
     # The tenant
     tenant_id: "21ff9e36-fbaa-43c8-98ba-00431ea10bc3"
     # A managed identity id to authenticate with. 
-    # Set to "system" for system-assigned managed identity.
-    # Set the MI client Id (GUID) for user-assigned managed identity.
+    # - specify "SYSTEM" to use a system-assigned managed identity
+    # - specify "WORKLOADIDENTITY" to use a workload identity
+    # - otherwise specify the GUID of the user-assigned managed identity
     managed_identity_id: "z80da32c-108c-415c-a19e-643f461a677a"
     # Database for the logs
     db_name: "oteldb"
@@ -90,6 +91,16 @@ exporters:
     #   initial_interval: 10s
     #   max_interval: 60s
     #   max_elapsed_time: 10m
+```
+
+An example configuration using Azure WorkloadIdentity to authenticate to Kusto (e.g. running on an AKS Pod):
+```yaml
+exporters:
+  azuredataexplorer:
+    cluster_uri: https://CLUSTER.kusto.windows.net
+    managed_identity_id: WORKLOADIDENTITY
+    db_name: oteldb
+    metrics_table_name: OTELMetrics
 ```
 
 ## Attribute mapping

--- a/exporter/azuredataexplorerexporter/adx_exporter_test.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter_test.go
@@ -175,11 +175,12 @@ func TestIngestedDataRecordCount(t *testing.T) {
 func TestCreateKcsb(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name              string // name of the test
-		config            Config // config for the test
-		isMsi             bool   // is MSI enabled
-		applicationID     string // application id
-		managedIdentityID string // managed identity id
+		name               string // name of the test
+		config             Config // config for the test
+		isMsi              bool   // is MSI enabled
+		isWorkloadIdentity bool   // is WorkloadIdentity enabled
+		applicationID      string // application id
+		managedIdentityID  string // managed identity id
 	}{
 		{
 			name: "application id",
@@ -216,18 +217,28 @@ func TestCreateKcsb(t *testing.T) {
 			managedIdentityID: "636d798f-b005-41c9-9809-81a5e5a12b2e",
 			applicationID:     "",
 		},
+		{
+			name: "workload identity",
+			config: Config{
+				ClusterURI:        "https://CLUSTER.kusto.windows.net",
+				Database:          "tests",
+				ManagedIdentityID: "workloadidentity",
+			},
+			isMsi:              false,
+			isWorkloadIdentity: true,
+			managedIdentityID:  "",
+			applicationID:      "",
+		},
 	}
 	for i := range tests {
 		tt := tests[i]
 		t.Run(tt.name, func(t *testing.T) {
-			wantAppID := tt.applicationID
 			gotKcsb := createKcsb(&tt.config, "1.0.0")
 			require.NotNil(t, gotKcsb)
-			assert.Equal(t, wantAppID, gotKcsb.ApplicationClientId)
-			wantIsMsi := tt.isMsi
-			assert.Equal(t, wantIsMsi, gotKcsb.MsiAuthentication)
-			wantManagedID := tt.managedIdentityID
-			assert.Equal(t, wantManagedID, gotKcsb.ManagedServiceIdentity)
+			assert.Equal(t, tt.applicationID, gotKcsb.ApplicationClientId)
+			assert.Equal(t, tt.isMsi, gotKcsb.MsiAuthentication)
+			assert.Equal(t, tt.isWorkloadIdentity, gotKcsb.WorkloadAuthentication)
+			assert.Equal(t, tt.managedIdentityID, gotKcsb.ManagedServiceIdentity)
 			assert.Equal(t, "https://CLUSTER.kusto.windows.net", gotKcsb.DataSource)
 		})
 	}

--- a/exporter/azuredataexplorerexporter/config.go
+++ b/exporter/azuredataexplorerexporter/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	ApplicationKey                 configopaque.String `mapstructure:"application_key"`
 	TenantID                       string              `mapstructure:"tenant_id"`
 	ManagedIdentityID              string              `mapstructure:"managed_identity_id"`
+	FederatedTokenFile             string              `mapstructure:"federated_token_file"`
 	Database                       string              `mapstructure:"db_name"`
 	MetricTable                    string              `mapstructure:"metrics_table_name"`
 	LogTable                       string              `mapstructure:"logs_table_name"`
@@ -62,6 +63,12 @@ func (adxCfg *Config) Validate() error {
 			return errors.New("managed_identity_id should be a UUID string (for User Managed Identity) or system (for System Managed Identity)")
 		}
 	}
+
+	// FederatedTokenFile should only be used with Workload identity
+	if adxCfg.FederatedTokenFile != "" && (adxCfg.ManagedIdentityID != "WORKLOADIDENTITY") {
+		return errors.New("federated_token_file should be empty unless managed_identity_id is set to workloadidentity")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**Description:** Add support for WorkloadIdentity in exporter/azuredataexplorerexporter

**Link to tracking Issue:** [33667](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33667)

**Testing:** 
- ran `make`
- ran all go tests under exporter/azuredataexplorerexporter including e2e_test.go which currently uses environment identity to authenticate to kusto with a client secret.
<img width="699" alt="Screenshot 2024-06-22 at 4 11 25 PM" src="https://github.com/open-telemetry/opentelemetry-collector-contrib/assets/36454085/5d738a08-8d1f-4c77-8626-ad8fc742989b">

**Documentation:** edited the README.md for that exporter.