### PR TITLE
[exporter/elasticsearch] Support preserving attributes when mapping to ECS

### DIFF
--- a/.chloggen/es_preserve_host_name.yaml
+++ b/.chloggen/es_preserve_host_name.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for preserving resource attributes when mapping to ECS
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/es_preserve_host_name.yaml
+++ b/.chloggen/es_preserve_host_name.yaml
@@ -10,7 +10,7 @@ component: elasticsearchexporter
 note: Add support for preserving resource attributes when mapping to ECS
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [33670]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/es_preserve_host_name.yaml
+++ b/.chloggen/es_preserve_host_name.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add support for preserving resource attributes when mapping to ECS
+note: Preserve `host.name` resource attribute in ECS mode
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [33670]

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -254,7 +254,7 @@ func encodeLogAttributesECSMode(document *objmodel.Document, attrs pcommon.Map, 
 			}
 
 			document.AddAttribute(ecsKey, v)
-			if _, ok := preserveMap[k]; ok {
+			if preserve := preserveMap[k]; preserve {
 				document.AddAttribute(k, v)
 			}
 			return true

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -231,7 +231,7 @@ func TestEncodeLogECSModeDuplication(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	want := `{"@timestamp":"2024-03-12T20:00:41.123456789Z","agent":{"name":"otlp"},"container":{"image":{"tag":["v3.4.0"]}},"event":{"action":"user-password-change"},"host":{"hostname":"localhost","os":{"full":"Mac OS Mojave","name":"Mac OS X","platform":"darwin","type":"macos","version":"10.14.1"}},"service":{"name":"foo.bar","version":"1.1.0"}}`
+	want := `{"@timestamp":"2024-03-12T20:00:41.123456789Z","agent":{"name":"otlp"},"container":{"image":{"tag":["v3.4.0"]}},"event":{"action":"user-password-change"},"host":{"hostname":"localhost","name":"localhost","os":{"full":"Mac OS Mojave","name":"Mac OS X","platform":"darwin","type":"macos","version":"10.14.1"}},"service":{"name":"foo.bar","version":"1.1.0"}}`
 	require.NoError(t, err)
 
 	resourceContainerImageTags := resource.Attributes().PutEmptySlice(semconv.AttributeContainerImageTags)
@@ -336,6 +336,7 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"container.image.name":    "my-app",
 		"container.runtime":       "docker",
 		"host.hostname":           "i-103de39e0a.gke.us-west-1b.cloud.google.com",
+		"host.name":               "i-103de39e0a.gke.us-west-1b.cloud.google.com",
 		"host.id":                 "i-103de39e0a",
 		"host.type":               "t2.medium",
 		"host.architecture":       "x86_64",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR adds support for preserving resource attributes that are valid ECS fields in addition of mapping them. At the moment the `host.name` is mapped to the `host.hostname`. Both are valid ECS fields but can differ in some cases. Since there is no such distinction in SemConv right now, it does makes sense to preserve both.

refs:
- https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-name
- https://www.elastic.co/guide/en/ecs/current/ecs-host.html#field-host-hostname

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Using the testing notes from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33622.

Stored document:
```json
 {
    "app": {
      "label": {
        "component": "migration-logger"
      }
    },
    "kubernetes": {
      "node": {
        "name": "kind-control-plane"
      },
      "pod": {
        "uid": "0eda57cd-a4ae-4e89-88fa-c771d3bf0c77",
        "name": "daemonset-logs-4sqjq"
      },
      "namespace": "default"
    },
    "agent": {
      "name": "otlp"
    },
    "@timestamp": "2024-06-20T07:27:42.589678923Z",
    "log": {
      "iostream": "stdout",
      "file": {
        "path": "/var/log/pods/default_daemonset-logs-4sqjq_0eda57cd-a4ae-4e89-88fa-c771d3bf0c77/busybox/0.log"
      }
    },
    "service": {
      "name": "migration-logger"
    },
    "k8s": {
      "container": {
        "restart_count": "0",
        "name": "busybox"
      },
      "pod": {
        "start_time": "2024-06-20T07:27:21Z"
      },
      "daemonset": {
        "name": "daemonset-logs"
      }
    },
    "host": {
      "hostname": "daemonset-opentelemetry-collector-agent-l6pzp",
      "os": {
        "type": "linux",
        "platform": "linux"
      },
      "name": "daemonset-opentelemetry-collector-agent-l6pzp"
    },
    "time": "2024-06-20T07:27:42.589678923Z",
    "message": "otel logs at 07:27:42",
    "logtag": "F"
  }
```

**Documentation:** <Describe the documentation added.> ~

/cc @lahsivjar @andrzej-stencel @carsonip 