### PR TITLE
[chore] Fix .github/CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -146,6 +146,7 @@ pkg/pdatautil/                                                      @open-teleme
 pkg/resourcetotelemetry/                                            @open-telemetry/collector-contrib-approvers @mx-psi
 pkg/sampling/                                                       @open-telemetry/collector-contrib-approvers @kentquirk @jmacd
 pkg/stanza/                                                         @open-telemetry/collector-contrib-approvers @djaglowski
+pkg/stanza/fileconsumer/                                            @open-telemetry/collector-contrib-approvers @djaglowski
 pkg/translator/azure/                                               @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @atoulme @cparkins
 pkg/translator/jaeger/                                              @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
 pkg/translator/loki/                                                @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @mar4uk


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`main` is currently failing the [`checks` action](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9588994799/job/26442043847), at the `Gen CODEOWNERS` step. This applies the required change.

This was broken by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33514, which added a `metadata.yaml` file for the `pkg/stanza/fileconsumer` package, but didn't add an entry to the CODEOWNERS file.