### PR TITLE
[chore] [receiver/mongodb] Remove redundant resource grouping

### DIFF
--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
@@ -137,22 +137,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210513475000"
               isMonotonic: true
             unit: '{operations}'
-          - description: The total number of active sessions.
-            name: mongodb.session.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "19"
-                  startTimeUnixNano: "1682363190502544000"
-                  timeUnixNano: "1682363210513475000"
-            unit: '{sessions}'
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes: []
-    scopeMetrics:
-      - metrics:
           - description: The total time spent performing operations.
             name: mongodb.operation.time
             sum:
@@ -202,6 +186,15 @@ resourceMetrics:
                   timeUnixNano: "1682363210513475000"
               isMonotonic: true
             unit: ms
+          - description: The total number of active sessions.
+            name: mongodb.session.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "19"
+                  startTimeUnixNano: "1682363190502544000"
+                  timeUnixNano: "1682363210513475000"
+            unit: '{sessions}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -293,6 +286,19 @@ resourceMetrics:
                   startTimeUnixNano: "1682363190502544000"
                   timeUnixNano: "1682363210513475000"
             unit: '{extents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: system.version
+                  startTimeUnixNano: "1682363190502544000"
+                  timeUnixNano: "1682363210513475000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -350,29 +356,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210513475000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: admin
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: system.version
-                  startTimeUnixNano: "1682363190502544000"
-                  timeUnixNano: "1682363210513475000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -464,6 +447,19 @@ resourceMetrics:
                   startTimeUnixNano: "1682363190502544000"
                   timeUnixNano: "1682363210513475000"
             unit: '{extents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: system.sessions
+                  startTimeUnixNano: "1682363190502544000"
+                  timeUnixNano: "1682363210513475000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -521,29 +517,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210513475000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: config
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: system.sessions
-                  startTimeUnixNano: "1682363190502544000"
-                  timeUnixNano: "1682363210513475000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -783,6 +756,19 @@ resourceMetrics:
                   startTimeUnixNano: "1682363190502544000"
                   timeUnixNano: "1682363210513475000"
             unit: '{extents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: orders
+                  startTimeUnixNano: "1682363190502544000"
+                  timeUnixNano: "1682363210513475000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -840,29 +826,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210513475000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: testdb
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: orders
-                  startTimeUnixNano: "1682363190502544000"
-                  timeUnixNano: "1682363210513475000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_4lpu.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_4lpu.yaml
@@ -137,22 +137,6 @@ resourceMetrics:
                   timeUnixNano: "1682363222253814000"
               isMonotonic: true
             unit: '{operations}'
-          - description: The total number of active sessions.
-            name: mongodb.session.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "15"
-                  startTimeUnixNano: "1682363202250964000"
-                  timeUnixNano: "1682363222253814000"
-            unit: '{sessions}'
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes: []
-    scopeMetrics:
-      - metrics:
           - description: The total time spent performing operations.
             name: mongodb.operation.time
             sum:
@@ -202,6 +186,15 @@ resourceMetrics:
                   timeUnixNano: "1682363222253814000"
               isMonotonic: true
             unit: ms
+          - description: The total number of active sessions.
+            name: mongodb.session.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "15"
+                  startTimeUnixNano: "1682363202250964000"
+                  timeUnixNano: "1682363222253814000"
+            unit: '{sessions}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -701,6 +694,19 @@ resourceMetrics:
                   startTimeUnixNano: "1682363202250964000"
                   timeUnixNano: "1682363222253814000"
             unit: '{documents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: orders
+                  startTimeUnixNano: "1682363202250964000"
+                  timeUnixNano: "1682363222253814000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -758,29 +764,6 @@ resourceMetrics:
                   timeUnixNano: "1682363222253814000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: testdb
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: orders
-                  startTimeUnixNano: "1682363202250964000"
-                  timeUnixNano: "1682363222253814000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.yaml
@@ -137,22 +137,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210542990000"
               isMonotonic: true
             unit: '{operations}'
-          - description: The total number of active sessions.
-            name: mongodb.session.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "15"
-                  startTimeUnixNano: "1682363190539043000"
-                  timeUnixNano: "1682363210542990000"
-            unit: '{sessions}'
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes: []
-    scopeMetrics:
-      - metrics:
           - description: The total time spent performing operations.
             name: mongodb.operation.time
             sum:
@@ -202,6 +186,15 @@ resourceMetrics:
                   timeUnixNano: "1682363210542990000"
               isMonotonic: true
             unit: ms
+          - description: The total number of active sessions.
+            name: mongodb.session.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "15"
+                  startTimeUnixNano: "1682363190539043000"
+                  timeUnixNano: "1682363210542990000"
+            unit: '{sessions}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -284,6 +277,19 @@ resourceMetrics:
                   startTimeUnixNano: "1682363190539043000"
                   timeUnixNano: "1682363210542990000"
             unit: '{documents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: system.version
+                  startTimeUnixNano: "1682363190539043000"
+                  timeUnixNano: "1682363210542990000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -341,29 +347,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210542990000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: admin
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: system.version
-                  startTimeUnixNano: "1682363190539043000"
-                  timeUnixNano: "1682363210542990000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -446,6 +429,19 @@ resourceMetrics:
                   startTimeUnixNano: "1682363190539043000"
                   timeUnixNano: "1682363210542990000"
             unit: '{documents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: system.sessions
+                  startTimeUnixNano: "1682363190539043000"
+                  timeUnixNano: "1682363210542990000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -503,29 +499,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210542990000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: config
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: system.sessions
-                  startTimeUnixNano: "1682363190539043000"
-                  timeUnixNano: "1682363210542990000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest
@@ -747,6 +720,19 @@ resourceMetrics:
                   startTimeUnixNano: "1682363190539043000"
                   timeUnixNano: "1682363210542990000"
             unit: '{documents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: orders
+                  startTimeUnixNano: "1682363190539043000"
+                  timeUnixNano: "1682363210542990000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -804,29 +790,6 @@ resourceMetrics:
                   timeUnixNano: "1682363210542990000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: testdb
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: orders
-                  startTimeUnixNano: "1682363190539043000"
-                  timeUnixNano: "1682363210542990000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/expected.yaml
@@ -219,31 +219,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
-          - description: The total number of active sessions.
-            name: mongodb.session.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "19"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{sessions}'
-          - description: The amount of time that the server has been running.
-            name: mongodb.uptime
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "58965"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-              isMonotonic: true
-            unit: ms
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource: {}
-    scopeMetrics:
-      - metrics:
           - description: The total time spent performing operations.
             name: mongodb.operation.time
             sum:
@@ -289,6 +264,25 @@ resourceMetrics:
                     - key: operation
                       value:
                         stringValue: update
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: The total number of active sessions.
+            name: mongodb.session.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "19"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{sessions}'
+          - description: The amount of time that the server has been running.
+            name: mongodb.uptime
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "58965"
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -384,6 +378,26 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{extents}'
+          - description: The number of times an index has been accessed.
+            name: mongodb.index.access.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: products
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: collection
+                      value:
+                        stringValue: orders
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{accesses}'
           - description: The number of indexes.
             name: mongodb.index.count
             sum:
@@ -441,52 +455,6 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: By
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: fakedatabase
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: products
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{accesses}'
-        scope:
-          name: otelcol/mongodbreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: database
-          value:
-            stringValue: fakedatabase
-    scopeMetrics:
-      - metrics:
-          - description: The number of times an index has been accessed.
-            name: mongodb.index.access.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: collection
-                      value:
-                        stringValue: orders
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            unit: '{accesses}'
         scope:
           name: otelcol/mongodbreceiver
           version: latest


### PR DESCRIPTION
The produced metrics are unnecessarily grouped by empty resources. This change removes the excessive grouping to keep only unique resources
