### PR TITLE
[exporter/clickhouse] change how default database is read from config

### DIFF
--- a/.chloggen/clickhouse-change-default-database.yaml
+++ b/.chloggen/clickhouse-change-default-database.yaml
@@ -10,7 +10,7 @@ component: exporter/clickhouse
 note: "Change behavior of how default database is read from the config"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [33693]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clickhouse-change-default-database.yaml
+++ b/.chloggen/clickhouse-change-default-database.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change behavior of how default database is read from the config"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Changed the default `database` to `default`.
+  The final database will prioritize `endpoint`, unless `database` is set to a value not equal to `default`.
+  If neither are specified then it defaults to the `default` database.
+  Possible breaking change if someone has the DSN configured in combination with `database` config option.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -110,18 +110,33 @@ func TestConfig_buildDSN(t *testing.T) {
 		Database         string
 		ConnectionParams map[string]string
 	}
-	type args struct {
-		database string
+	mergeConfigWithFields := func(cfg *Config, fields fields) {
+		if fields.Endpoint != "" {
+			cfg.Endpoint = fields.Endpoint
+		}
+		if fields.Username != "" {
+			cfg.Username = fields.Username
+		}
+		if fields.Password != "" {
+			cfg.Password = configopaque.String(fields.Password)
+		}
+		if fields.Database != "" {
+			cfg.Database = fields.Database
+		}
+		if fields.ConnectionParams != nil {
+			cfg.ConnectionParams = fields.ConnectionParams
+		}
 	}
+
 	type ChOptions struct {
 		Secure      bool
 		DialTimeout time.Duration
 		Compress    clickhouse.CompressionMethod
 	}
+
 	tests := []struct {
 		name          string
 		fields        fields
-		args          args
 		want          string
 		wantChOptions ChOptions
 		wantErr       error
@@ -131,7 +146,6 @@ func TestConfig_buildDSN(t *testing.T) {
 			fields: fields{
 				Endpoint: defaultEndpoint,
 			},
-			args: args{},
 			wantChOptions: ChOptions{
 				Secure: false,
 			},
@@ -142,7 +156,6 @@ func TestConfig_buildDSN(t *testing.T) {
 			fields: fields{
 				Endpoint: "tcp://127.0.0.1:9000",
 			},
-			args: args{},
 			wantChOptions: ChOptions{
 				Secure: false,
 			},
@@ -156,9 +169,6 @@ func TestConfig_buildDSN(t *testing.T) {
 				Password: "bar",
 				Database: "otel",
 			},
-			args: args{
-				database: "otel",
-			},
 			wantChOptions: ChOptions{
 				Secure: false,
 			},
@@ -170,10 +180,6 @@ func TestConfig_buildDSN(t *testing.T) {
 				Endpoint: "clickhouse://foo:bar@127.0.0.1:9000/otel",
 				Username: "foo",
 				Password: "bar",
-				Database: "",
-			},
-			args: args{
-				database: "",
 			},
 			wantChOptions: ChOptions{
 				Secure: false,
@@ -198,7 +204,6 @@ func TestConfig_buildDSN(t *testing.T) {
 			wantChOptions: ChOptions{
 				Secure: true,
 			},
-			args: args{},
 			want: "https://127.0.0.1:9000/default?secure=true",
 		},
 		{
@@ -209,7 +214,6 @@ func TestConfig_buildDSN(t *testing.T) {
 			wantChOptions: ChOptions{
 				Secure: true,
 			},
-			args: args{},
 			want: "clickhouse://127.0.0.1:9000/default?foo=bar&secure=true",
 		},
 		{
@@ -222,7 +226,6 @@ func TestConfig_buildDSN(t *testing.T) {
 				DialTimeout: 30 * time.Second,
 				Compress:    clickhouse.CompressionLZ4,
 			},
-			args: args{},
 			want: "https://127.0.0.1:9000/default?compress=lz4&dial_timeout=30s&secure=true",
 		},
 		{
@@ -234,43 +237,35 @@ func TestConfig_buildDSN(t *testing.T) {
 			wantChOptions: ChOptions{
 				Secure: true,
 			},
-			args: args{},
 			want: "clickhouse://127.0.0.1:9000/default?foo=bar&secure=true",
 		},
 		{
-			name: "support replace database in DSN to default database",
+			name: "support replace database in DSN with config to override database",
 			fields: fields{
 				Endpoint: "tcp://127.0.0.1:9000/otel",
+				Database: "override",
 			},
-			args: args{
-				database: defaultDatabase,
-			},
-			want: "tcp://127.0.0.1:9000/default",
+			want: "tcp://127.0.0.1:9000/override",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfg := &Config{
-				Endpoint:         tt.fields.Endpoint,
-				Username:         tt.fields.Username,
-				Password:         configopaque.String(tt.fields.Password),
-				Database:         tt.fields.Database,
-				ConnectionParams: tt.fields.ConnectionParams,
-			}
-			got, err := cfg.buildDSN(tt.args.database)
+			cfg := createDefaultConfig().(*Config)
+			mergeConfigWithFields(cfg, tt.fields)
+			dsn, err := cfg.buildDSN()
 
 			if tt.wantErr != nil {
-				assert.ErrorIs(t, err, tt.wantErr, "buildDSN(%v)", tt.args.database)
+				assert.ErrorIs(t, err, tt.wantErr, "buildDSN()")
 			} else {
 				// Validate DSN
-				opts, err := clickhouse.ParseDSN(got)
+				opts, err := clickhouse.ParseDSN(dsn)
 				assert.NoError(t, err)
 				assert.Equalf(t, tt.wantChOptions.Secure, opts.TLS != nil, "TLSConfig is not nil")
 				assert.Equalf(t, tt.wantChOptions.DialTimeout, opts.DialTimeout, "DialTimeout is not nil")
 				if tt.wantChOptions.Compress != 0 {
 					assert.Equalf(t, tt.wantChOptions.Compress, opts.Compression.Method, "Compress is not nil")
 				}
-				assert.Equalf(t, tt.want, got, "buildDSN(%v)", tt.args.database)
+				assert.Equalf(t, tt.want, dsn, "buildDSN()")
 			}
 
 		})

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -205,7 +205,7 @@ var driverName = "clickhouse" // for testing
 
 // newClickhouseClient create a clickhouse client.
 func newClickhouseClient(cfg *Config) (*sql.DB, error) {
-	db, err := cfg.buildDB(cfg.Database)
+	db, err := cfg.buildDB()
 	if err != nil {
 		return nil, err
 	}
@@ -218,7 +218,7 @@ func createDatabase(ctx context.Context, cfg *Config) error {
 		return nil
 	}
 
-	db, err := cfg.buildDB(defaultDatabase)
+	db, err := cfg.buildDB()
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func createDatabase(ctx context.Context, cfg *Config) error {
 	query := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s %s", cfg.Database, cfg.clusterString())
 	_, err = db.ExecContext(ctx, query)
 	if err != nil {
-		return fmt.Errorf("create database:%w", err)
+		return fmt.Errorf("create database: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
### EXTRACTED FROM #33614

**Description:**

Changes how the database is read from the config. The intent is to simplify the behavior, and give a proper default value. In the current version it's hard to distinguish in tests between empty string vs default.

**Testing:**
Updated tests, and test structure for parse DSN
