### PR TITLE
[clickhouse/exporter] Update create schema config option

### DIFF
--- a/.chloggen/clickhouse-update-create-schema-config-option.yaml
+++ b/.chloggen/clickhouse-update-create-schema-config-option.yaml
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [api]

--- a/.chloggen/clickhouse-update-create-schema-config-option.yaml
+++ b/.chloggen/clickhouse-update-create-schema-config-option.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/clickhouse
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Change internal config type for `create_schema` to use a `bool` instead of `*bool`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/clickhouse-update-create-schema-config-option.yaml
+++ b/.chloggen/clickhouse-update-create-schema-config-option.yaml
@@ -10,7 +10,7 @@ component: exporter/clickhouse
 note: "Change internal config type for `create_schema` to use a `bool` instead of `*bool`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [33694]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clickhouse-update-create-schema-config-option.yaml
+++ b/.chloggen/clickhouse-update-create-schema-config-option.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: exporter/clickhouse

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -45,7 +45,7 @@ type Config struct {
 	// ClusterName if set will append `ON CLUSTER` with the provided name when creating tables.
 	ClusterName string `mapstructure:"cluster_name"`
 	// CreateSchema if set to true will run the DDL for creating the database and tables. default is true.
-	CreateSchema *bool `mapstructure:"create_schema"`
+	CreateSchema bool `mapstructure:"create_schema"`
 }
 
 // TableEngine defines the ENGINE string value when creating the table.
@@ -133,11 +133,7 @@ func (cfg *Config) buildDB() (*sql.DB, error) {
 
 // shouldCreateSchema returns true if the exporter should run the DDL for creating database/tables.
 func (cfg *Config) shouldCreateSchema() bool {
-	if cfg.CreateSchema == nil {
-		return true // default to true
-	}
-
-	return *cfg.CreateSchema
+	return cfg.CreateSchema
 }
 
 // tableEngineString generates the ENGINE string.

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -33,7 +33,6 @@ func TestLoadConfig(t *testing.T) {
 	defaultCfg := createDefaultConfig()
 	defaultCfg.(*Config).Endpoint = defaultEndpoint
 
-	createSchema := true
 	storageID := component.MustNewIDWithName("file_storage", "clickhouse")
 
 	tests := []struct {
@@ -56,7 +55,7 @@ func TestLoadConfig(t *testing.T) {
 				LogsTableName:    "otel_logs",
 				TracesTableName:  "otel_traces",
 				MetricsTableName: "otel_metrics",
-				CreateSchema:     &createSchema,
+				CreateSchema:     true,
 				TimeoutSettings: exporterhelper.TimeoutSettings{
 					Timeout: 5 * time.Second,
 				},
@@ -275,14 +274,11 @@ func TestConfig_buildDSN(t *testing.T) {
 func TestShouldCreateSchema(t *testing.T) {
 	t.Parallel()
 
-	createSchemaTrue := true
-	createSchemaFalse := false
-
 	caseDefault := createDefaultConfig().(*Config)
 	caseCreateSchemaTrue := createDefaultConfig().(*Config)
-	caseCreateSchemaTrue.CreateSchema = &createSchemaTrue
+	caseCreateSchemaTrue.CreateSchema = true
 	caseCreateSchemaFalse := createDefaultConfig().(*Config)
-	caseCreateSchemaFalse.CreateSchema = &createSchemaFalse
+	caseCreateSchemaFalse.CreateSchema = false
 
 	tests := []struct {
 		name     string

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -32,7 +32,6 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	queueSettings := exporterhelper.NewDefaultQueueSettings()
 	queueSettings.NumConsumers = 1
-	defaultCreateSchema := true
 
 	return &Config{
 		TimeoutSettings:  exporterhelper.NewDefaultTimeoutSettings(),
@@ -44,7 +43,7 @@ func createDefaultConfig() component.Config {
 		TracesTableName:  "otel_traces",
 		MetricsTableName: "otel_metrics",
 		TTL:              0,
-		CreateSchema:     &defaultCreateSchema,
+		CreateSchema:     true,
 	}
 }
 


### PR DESCRIPTION
#### EXTRACTED FROM #33614 
#### DEPENDS ON #33693 

**Description:**

A follow-up to #32282 that changes `create_schema` from `*bool` to `bool`, while also properly using the default config / factory.

**Testing:** 
- Updated tests