### PR TITLE
[receiver/mongodb] Add mongodb host resource attributes

### DIFF
--- a/.chloggen/mongodb_add_address_res_attr.yaml
+++ b/.chloggen/mongodb_add_address_res_attr.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/mongodbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `server.address` and `server.port` resource attributes to MongoDB receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32810, 32350]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The new resource attributes are added to the MongoDB receiver to distinguish metrics coming from different MongoDB instances.
+    - `server.address`: The address of the MongoDB host, enabled by default.
+    - `server.port`: The port of the MongoDB host, disabled by default.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -136,7 +136,7 @@ func TestBadTLSConfigs(t *testing.T) {
 				Password: "pword",
 				Hosts: []confignet.TCPAddrConfig{
 					{
-						Endpoint: "localhost:27017",
+						Endpoint: defaultEndpoint,
 					},
 				},
 				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
@@ -156,7 +156,7 @@ func TestOptions(t *testing.T) {
 	cfg := &Config{
 		Hosts: []confignet.TCPAddrConfig{
 			{
-				Endpoint: "localhost:27017",
+				Endpoint: defaultEndpoint,
 			},
 		},
 		Username:   "uname",
@@ -181,7 +181,7 @@ func TestOptionsTLS(t *testing.T) {
 	cfg := &Config{
 		Hosts: []confignet.TCPAddrConfig{
 			{
-				Endpoint: "localhost:27017",
+				Endpoint: defaultEndpoint,
 			},
 		},
 		ClientConfig: configtls.ClientConfig{
@@ -209,7 +209,7 @@ func TestLoadConfig(t *testing.T) {
 	expected := factory.CreateDefaultConfig().(*Config)
 	expected.Hosts = []confignet.TCPAddrConfig{
 		{
-			Endpoint: "localhost:27017",
+			Endpoint: defaultEndpoint,
 		},
 	}
 	expected.Username = "otel"

--- a/receiver/mongodbreceiver/documentation.md
+++ b/receiver/mongodbreceiver/documentation.md
@@ -353,3 +353,5 @@ The amount of time that the server has been running.
 | Name | Description | Values | Enabled |
 | ---- | ----------- | ------ | ------- |
 | database | The name of a database. | Any Str | true |
+| server.address | The address of the MongoDB host. | Any Str | true |
+| server.port | The port of the MongoDB host. | Any Int | false |

--- a/receiver/mongodbreceiver/factory.go
+++ b/receiver/mongodbreceiver/factory.go
@@ -5,6 +5,7 @@ package mongodbreceiver // import "github.com/open-telemetry/opentelemetry-colle
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -16,6 +17,10 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver/internal/metadata"
 )
+
+const defaultMongoDBPort = 27017
+
+var defaultEndpoint = "localhost:" + strconv.Itoa(defaultMongoDBPort)
 
 // NewFactory creates a factory for mongodb receiver.
 func NewFactory() receiver.Factory {
@@ -31,7 +36,7 @@ func createDefaultConfig() component.Config {
 		Timeout:          time.Minute,
 		Hosts: []confignet.TCPAddrConfig{
 			{
-				Endpoint: "localhost:27017",
+				Endpoint: defaultEndpoint,
 			},
 		},
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),

--- a/receiver/mongodbreceiver/integration_test.go
+++ b/receiver/mongodbreceiver/integration_test.go
@@ -71,6 +71,7 @@ func integrationTest(name string, script []string, cfgMod func(*Config)) func(*t
 			pmetrictest.IgnoreMetricDataPointsOrder(),
 			pmetrictest.IgnoreStartTimestamp(),
 			pmetrictest.IgnoreTimestamp(),
+			pmetrictest.IgnoreResourceAttributeValue("server.address"),
 		),
 	).Run
 }

--- a/receiver/mongodbreceiver/internal/metadata/generated_config.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config.go
@@ -183,13 +183,21 @@ func (rac *ResourceAttributeConfig) Unmarshal(parser *confmap.Conf) error {
 
 // ResourceAttributesConfig provides config for mongodb resource attributes.
 type ResourceAttributesConfig struct {
-	Database ResourceAttributeConfig `mapstructure:"database"`
+	Database      ResourceAttributeConfig `mapstructure:"database"`
+	ServerAddress ResourceAttributeConfig `mapstructure:"server.address"`
+	ServerPort    ResourceAttributeConfig `mapstructure:"server.port"`
 }
 
 func DefaultResourceAttributesConfig() ResourceAttributesConfig {
 	return ResourceAttributesConfig{
 		Database: ResourceAttributeConfig{
 			Enabled: true,
+		},
+		ServerAddress: ResourceAttributeConfig{
+			Enabled: true,
+		},
+		ServerPort: ResourceAttributeConfig{
+			Enabled: false,
 		},
 	}
 }

--- a/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_config_test.go
@@ -57,7 +57,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbUptime:                 MetricConfig{Enabled: true},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
-					Database: ResourceAttributeConfig{Enabled: true},
+					Database:      ResourceAttributeConfig{Enabled: true},
+					ServerAddress: ResourceAttributeConfig{Enabled: true},
+					ServerPort:    ResourceAttributeConfig{Enabled: true},
 				},
 			},
 		},
@@ -97,7 +99,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					MongodbUptime:                 MetricConfig{Enabled: false},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
-					Database: ResourceAttributeConfig{Enabled: false},
+					Database:      ResourceAttributeConfig{Enabled: false},
+					ServerAddress: ResourceAttributeConfig{Enabled: false},
+					ServerPort:    ResourceAttributeConfig{Enabled: false},
 				},
 			},
 		},
@@ -134,13 +138,17 @@ func TestResourceAttributesConfig(t *testing.T) {
 		{
 			name: "all_set",
 			want: ResourceAttributesConfig{
-				Database: ResourceAttributeConfig{Enabled: true},
+				Database:      ResourceAttributeConfig{Enabled: true},
+				ServerAddress: ResourceAttributeConfig{Enabled: true},
+				ServerPort:    ResourceAttributeConfig{Enabled: true},
 			},
 		},
 		{
 			name: "none_set",
 			want: ResourceAttributesConfig{
-				Database: ResourceAttributeConfig{Enabled: false},
+				Database:      ResourceAttributeConfig{Enabled: false},
+				ServerAddress: ResourceAttributeConfig{Enabled: false},
+				ServerPort:    ResourceAttributeConfig{Enabled: false},
 			},
 		},
 	}

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -1903,6 +1903,18 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	if mbc.ResourceAttributes.Database.MetricsExclude != nil {
 		mb.resourceAttributeExcludeFilter["database"] = filter.CreateFilter(mbc.ResourceAttributes.Database.MetricsExclude)
 	}
+	if mbc.ResourceAttributes.ServerAddress.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["server.address"] = filter.CreateFilter(mbc.ResourceAttributes.ServerAddress.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.ServerAddress.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["server.address"] = filter.CreateFilter(mbc.ResourceAttributes.ServerAddress.MetricsExclude)
+	}
+	if mbc.ResourceAttributes.ServerPort.MetricsInclude != nil {
+		mb.resourceAttributeIncludeFilter["server.port"] = filter.CreateFilter(mbc.ResourceAttributes.ServerPort.MetricsInclude)
+	}
+	if mbc.ResourceAttributes.ServerPort.MetricsExclude != nil {
+		mb.resourceAttributeExcludeFilter["server.port"] = filter.CreateFilter(mbc.ResourceAttributes.ServerPort.MetricsExclude)
+	}
 
 	for _, op := range options {
 		op(mb)

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics_test.go
@@ -182,6 +182,8 @@ func TestMetricsBuilder(t *testing.T) {
 
 			rb := mb.NewResourceBuilder()
 			rb.SetDatabase("database-val")
+			rb.SetServerAddress("server.address-val")
+			rb.SetServerPort(11)
 			res := rb.Emit()
 			metrics := mb.Emit(WithResource(res))
 

--- a/receiver/mongodbreceiver/internal/metadata/generated_resource.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_resource.go
@@ -28,6 +28,20 @@ func (rb *ResourceBuilder) SetDatabase(val string) {
 	}
 }
 
+// SetServerAddress sets provided value as "server.address" attribute.
+func (rb *ResourceBuilder) SetServerAddress(val string) {
+	if rb.config.ServerAddress.Enabled {
+		rb.res.Attributes().PutStr("server.address", val)
+	}
+}
+
+// SetServerPort sets provided value as "server.port" attribute.
+func (rb *ResourceBuilder) SetServerPort(val int64) {
+	if rb.config.ServerPort.Enabled {
+		rb.res.Attributes().PutInt("server.port", val)
+	}
+}
+
 // Emit returns the built resource and resets the internal builder state.
 func (rb *ResourceBuilder) Emit() pcommon.Resource {
 	r := rb.res

--- a/receiver/mongodbreceiver/internal/metadata/generated_resource_test.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_resource_test.go
@@ -14,15 +14,17 @@ func TestResourceBuilder(t *testing.T) {
 			cfg := loadResourceAttributesConfig(t, test)
 			rb := NewResourceBuilder(cfg)
 			rb.SetDatabase("database-val")
+			rb.SetServerAddress("server.address-val")
+			rb.SetServerPort(11)
 
 			res := rb.Emit()
 			assert.Equal(t, 0, rb.Emit().Attributes().Len()) // Second call should return empty Resource
 
 			switch test {
 			case "default":
-				assert.Equal(t, 1, res.Attributes().Len())
+				assert.Equal(t, 2, res.Attributes().Len())
 			case "all_set":
-				assert.Equal(t, 1, res.Attributes().Len())
+				assert.Equal(t, 3, res.Attributes().Len())
 			case "none_set":
 				assert.Equal(t, 0, res.Attributes().Len())
 				return
@@ -34,6 +36,16 @@ func TestResourceBuilder(t *testing.T) {
 			assert.True(t, ok)
 			if ok {
 				assert.EqualValues(t, "database-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("server.address")
+			assert.True(t, ok)
+			if ok {
+				assert.EqualValues(t, "server.address-val", val.Str())
+			}
+			val, ok = res.Attributes().Get("server.port")
+			assert.Equal(t, test == "all_set", ok)
+			if ok {
+				assert.EqualValues(t, 11, val.Int())
 			}
 		})
 	}

--- a/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/mongodbreceiver/internal/metadata/testdata/config.yaml
@@ -64,6 +64,10 @@ all_set:
   resource_attributes:
     database:
       enabled: true
+    server.address:
+      enabled: true
+    server.port:
+      enabled: true
 none_set:
   metrics:
     mongodb.cache.operations:
@@ -129,9 +133,21 @@ none_set:
   resource_attributes:
     database:
       enabled: false
+    server.address:
+      enabled: false
+    server.port:
+      enabled: false
 filter_set_include:
   resource_attributes:
     database:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+    server.address:
+      enabled: true
+      metrics_include:
+        - regexp: ".*"
+    server.port:
       enabled: true
       metrics_include:
         - regexp: ".*"
@@ -141,3 +157,11 @@ filter_set_exclude:
       enabled: true
       metrics_exclude:
         - strict: "database-val"
+    server.address:
+      enabled: true
+      metrics_exclude:
+        - strict: "server.address-val"
+    server.port:
+      enabled: true
+      metrics_exclude:
+        - regexp: ".*"

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -11,6 +11,14 @@ status:
     seeking_new: true
 
 resource_attributes:
+  server.address:
+    description: The address of the MongoDB host.
+    enabled: true
+    type: string
+  server.port:
+    description: The port of the MongoDB host.
+    enabled: false
+    type: int
   database:
     description: The name of a database.
     enabled: true

--- a/receiver/mongodbreceiver/scraper_test.go
+++ b/receiver/mongodbreceiver/scraper_test.go
@@ -98,7 +98,6 @@ var (
 	errAllClientFailedFetch = errors.New(
 		strings.Join(
 			[]string{
-				"failed to fetch admin server status metrics: some admin server status error",
 				"failed to fetch top stats metrics: some top stats error",
 				"failed to fetch database stats metrics: some database stats error",
 				"failed to fetch server status metrics: some server status error",
@@ -109,7 +108,6 @@ var (
 	errCollectionNames = errors.New(
 		strings.Join(
 			[]string{
-				"failed to fetch admin server status metrics: some admin server status error",
 				"failed to fetch top stats metrics: some top stats error",
 				"failed to fetch database stats metrics: some database stats error",
 				"failed to fetch server status metrics: some server status error",
@@ -159,12 +157,13 @@ func TestScraperScrape(t *testing.T) {
 				fc := &fakeClient{}
 				mongo40, err := version.NewVersion("4.0")
 				require.NoError(t, err)
+				adminStatus, err := loadAdminStatusAsMap()
 				require.NoError(t, err)
 				fakeDatabaseName := "fakedatabase"
 				fc.On("GetVersion", mock.Anything).Return(mongo40, nil)
 				fc.On("ListDatabaseNames", mock.Anything, mock.Anything, mock.Anything).Return([]string{fakeDatabaseName}, nil)
 				fc.On("ServerStatus", mock.Anything, fakeDatabaseName).Return(bson.M{}, errors.New("some server status error"))
-				fc.On("ServerStatus", mock.Anything, "admin").Return(bson.M{}, errors.New("some admin server status error"))
+				fc.On("ServerStatus", mock.Anything, "admin").Return(adminStatus, nil)
 				fc.On("DBStats", mock.Anything, fakeDatabaseName).Return(bson.M{}, errors.New("some database stats error"))
 				fc.On("TopStats", mock.Anything).Return(bson.M{}, errors.New("some top stats error"))
 				fc.On("ListCollectionNames", mock.Anything, fakeDatabaseName).Return([]string{}, errors.New("some collection names error"))
@@ -185,12 +184,13 @@ func TestScraperScrape(t *testing.T) {
 				fc := &fakeClient{}
 				mongo40, err := version.NewVersion("4.0")
 				require.NoError(t, err)
+				adminStatus, err := loadAdminStatusAsMap()
 				require.NoError(t, err)
 				fakeDatabaseName := "fakedatabase"
 				fc.On("GetVersion", mock.Anything).Return(mongo40, nil)
 				fc.On("ListDatabaseNames", mock.Anything, mock.Anything, mock.Anything).Return([]string{fakeDatabaseName}, nil)
 				fc.On("ServerStatus", mock.Anything, fakeDatabaseName).Return(bson.M{}, errors.New("some server status error"))
-				fc.On("ServerStatus", mock.Anything, "admin").Return(bson.M{}, errors.New("some admin server status error"))
+				fc.On("ServerStatus", mock.Anything, "admin").Return(adminStatus, nil)
 				fc.On("DBStats", mock.Anything, fakeDatabaseName).Return(bson.M{}, errors.New("some database stats error"))
 				fc.On("TopStats", mock.Anything).Return(bson.M{}, errors.New("some top stats error"))
 				fc.On("ListCollectionNames", mock.Anything, fakeDatabaseName).Return([]string{"products", "orders"}, nil)
@@ -230,7 +230,7 @@ func TestScraperScrape(t *testing.T) {
 				return fc
 			},
 			expectedMetricGen: func(t *testing.T) pmetric.Metrics {
-				goldenPath := filepath.Join("testdata", "scraper", "partial_scrape.yaml")
+				goldenPath := filepath.Join("testdata", "scraper", "db_count_only.yaml")
 				expectedMetrics, err := golden.ReadMetrics(goldenPath)
 				require.NoError(t, err)
 				return expectedMetrics
@@ -381,4 +381,62 @@ func TestTopMetricsAggregation(t *testing.T) {
 		require.EqualValues(t, expectedGetmoreValues, actualOperationTimeValues["getmore"])
 		require.EqualValues(t, expectedCommandValues, actualOperationTimeValues["commands"])
 	})
+}
+
+func TestServerAddressAndPort(t *testing.T) {
+	tests := []struct {
+		name            string
+		serverStatus    bson.M
+		expectedAddress string
+		expectedPort    int64
+		expectedErr     error
+	}{
+		{
+			name: "address_only",
+			serverStatus: bson.M{
+				"host": "localhost",
+			},
+			expectedAddress: "localhost",
+			expectedPort:    defaultMongoDBPort,
+		},
+		{
+			name: "address_and_port",
+			serverStatus: bson.M{
+				"host": "localhost:27018",
+			},
+			expectedAddress: "localhost",
+			expectedPort:    27018,
+		},
+		{
+			name:         "missing_host",
+			serverStatus: bson.M{},
+			expectedErr:  errors.New("host field not found in server status"),
+		},
+		{
+			name: "invalid_port",
+			serverStatus: bson.M{
+				"host": "localhost:invalid",
+			},
+			expectedErr: errors.New("failed to parse port: strconv.ParseInt: parsing \"invalid\": invalid syntax"),
+		},
+		{
+			name: "invalid_host_format",
+			serverStatus: bson.M{
+				"host": "localhost:27018:extra",
+			},
+			expectedErr: errors.New("unexpected host format: localhost:27018:extra"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address, port, err := serverAddressAndPort(tt.serverStatus)
+			if tt.expectedErr != nil {
+				require.EqualError(t, err, tt.expectedErr.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expectedAddress, address)
+				require.Equal(t, tt.expectedPort, port)
+			}
+		})
+	}
 }

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
@@ -203,6 +203,9 @@ resourceMetrics:
         - key: database
           value:
             stringValue: admin
+        - key: server.address
+          value:
+            stringValue: admin
     scopeMetrics:
       - metrics:
           - description: The number of collections.

--- a/receiver/mongodbreceiver/testdata/only_storage_engine.json
+++ b/receiver/mongodbreceiver/testdata/only_storage_engine.json
@@ -1,5 +1,6 @@
 {
-    "storageEngine": {
+    "host": "mongodb-host-1",
+	"storageEngine": {
 		"name": "wiredTiger",
 		"persistent": true,
 		"readOnly": false,

--- a/receiver/mongodbreceiver/testdata/scraper/db_count_only.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/db_count_only.yaml
@@ -1,0 +1,20 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: server.address
+          value:
+            stringValue: mongodb-host-1
+    scopeMetrics:
+      - metrics:
+          - description: The number of existing databases.
+            name: mongodb.database.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{databases}'
+        scope:
+          name: otelcol/mongodbreceiver
+          version: latest

--- a/receiver/mongodbreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/expected.yaml
@@ -1,5 +1,9 @@
 resourceMetrics:
-  - resource: {}
+  - resource:
+      attributes:
+        - key: server.address
+          value:
+            stringValue: ecb6adf34046
     scopeMetrics:
       - metrics:
           - description: The number of cache operations of the instance.
@@ -292,6 +296,9 @@ resourceMetrics:
           version: latest
   - resource:
       attributes:
+        - key: server.address
+          value:
+            stringValue: ecb6adf34046
         - key: database
           value:
             stringValue: fakedatabase

--- a/receiver/mongodbreceiver/testdata/scraper/partial_scrape.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/partial_scrape.yaml
@@ -1,7 +1,50 @@
 resourceMetrics:
-  - resource: {}
+  - resource:
+      attributes:
+        - key: server.address
+          value:
+            stringValue: ecb6adf34046
     scopeMetrics:
       - metrics:
+          - description: The number of cache operations of the instance.
+            name: mongodb.cache.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "201"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: hit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "14"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: miss
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The number of open cursors maintained for clients.
+            name: mongodb.cursor.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{cursors}'
+          - description: The number of cursors that have timed out.
+            name: mongodb.cursor.timeout.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{cursors}'
           - description: The number of existing databases.
             name: mongodb.database.count
             sum:
@@ -11,6 +54,194 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{databases}'
+          - description: The time the global lock has been held.
+            name: mongodb.global_lock.time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "58964"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: The health status of the server.
+            gauge:
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: mongodb.health
+            unit: "1"
+          - description: The number of bytes received.
+            name: mongodb.network.io.receive
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "3056"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of by transmitted.
+            name: mongodb.network.io.transmit
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5393"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of requests received by the server.
+            name: mongodb.network.request.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "20"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{requests}'
+          - description: The number of operations executed.
+            name: mongodb.operation.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: update
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The latency of operations.
+            gauge:
+              dataPoints:
+                - asInt: "8631"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: mongodb.operation.latency.time
+            unit: us
+          - description: The number of replicated operations executed.
+            name: mongodb.operation.repl.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "27"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: command
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: getmore
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: insert
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: update
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The total number of active sessions.
+            name: mongodb.session.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "19"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{sessions}'
+          - description: The amount of time that the server has been running.
+            name: mongodb.uptime
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "58965"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
         scope:
           name: otelcol/mongodbreceiver
           version: latest


### PR DESCRIPTION
The new attribute are added to the MongoDB receiver to distinguish metrics coming from different MongoDB instances.
  - `server.address`: The address of the MongoDB host, enabled by default.
  - `server.port`: The port of the MongoDB host, disabled by default.

Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32350 and https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32810