### PR TITLE
[receiver/webhookevent] Webhook event timestamp

### DIFF
--- a/.chloggen/webhook-event-timestamp.yaml
+++ b/.chloggen/webhook-event-timestamp.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: enhancement
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: webhookeventreceiver

--- a/.chloggen/webhook-event-timestamp.yaml
+++ b/.chloggen/webhook-event-timestamp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: webhookeventreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: added a timestamp to the logs generated from incoming events.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33702]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -13,8 +13,8 @@ import (
 
 var (
 	errMissingEndpointFromConfig   = errors.New("missing receiver server endpoint from config")
-	errReadTimeoutExceedsMaxValue  = errors.New("The duration specified for read_timeout exceeds the maximum allowed value of 10s")
-	errWriteTimeoutExceedsMaxValue = errors.New("The duration specified for write_timeout exceeds the maximum allowed value of 10s")
+	errReadTimeoutExceedsMaxValue  = errors.New("the duration specified for read_timeout exceeds the maximum allowed value of 10s")
+	errWriteTimeoutExceedsMaxValue = errors.New("the duration specified for write_timeout exceeds the maximum allowed value of 10s")
 	errRequiredHeader              = errors.New("both key and value are required to assign a required_header")
 )
 

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -31,7 +31,7 @@ func reqToLog(sc *bufio.Scanner,
 
 	for sc.Scan() {
 		logRecord := scopeLog.LogRecords().AppendEmpty()
-		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+		logRecord.SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 		line := sc.Text()
 		logRecord.Body().SetStr(line)
 	}

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -6,7 +6,9 @@ package webhookeventreceiver // import "github.com/open-telemetry/opentelemetry-
 import (
 	"bufio"
 	"net/url"
+	"time"
 
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
 
@@ -29,6 +31,7 @@ func reqToLog(sc *bufio.Scanner,
 
 	for sc.Scan() {
 		logRecord := scopeLog.LogRecords().AppendEmpty()
+		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 		line := sc.Text()
 		logRecord.Body().SetStr(line)
 	}


### PR DESCRIPTION
**Description:** Added the optional ObservedTimestamp field to log record created when an event is received. Also fixed some erroneously capitalized letters in two error descriptions.

**Link to tracking Issue:** [33702](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33702)

**Testing:** built collector and passed unittests

**Documentation:** None