### PR TITLE
[procesor/groupbyattrsprocessor]: fix droping metadata when processing metrics

### DIFF
--- a/.chloggen/fix-metrics-metadata.yaml
+++ b/.chloggen/fix-metrics-metadata.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/groupbyattrsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix dropping of metadata fields when copying metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33419]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/fix-metrics-metadata.yaml
+++ b/.chloggen/fix-metrics-metadata.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: processor/groupbyattrsprocessor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix dropping of metadata fields when copying metrics
+note: "Fix dropping of metadata fields when processing metrics."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [33419]

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -206,6 +206,7 @@ func getMetricInInstrumentationLibrary(ilm pmetric.ScopeMetrics, searchedMetric 
 	metric.SetDescription(searchedMetric.Description())
 	metric.SetName(searchedMetric.Name())
 	metric.SetUnit(searchedMetric.Unit())
+	searchedMetric.Metadata().CopyTo(metric.Metadata())
 
 	// Move other special type specific values
 	//exhaustive:enforce

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -870,6 +870,7 @@ func TestCompacting(t *testing.T) {
 }
 
 func Test_GetMetricInInstrumentationLibrary(t *testing.T) {
+	// input metric with datapoint
 	m := pmetric.NewMetric()
 	m.SetName("metric")
 	m.SetDescription("description")
@@ -877,6 +878,9 @@ func Test_GetMetricInInstrumentationLibrary(t *testing.T) {
 	d := m.SetEmptyGauge().DataPoints().AppendEmpty()
 	d.SetDoubleValue(1.0)
 
+	// expected metric without datapoint
+	// the datapoints are not copied to the resulting metric, since
+	// datapoints are moved in between metrics in the processor
 	m2 := pmetric.NewMetric()
 	m2.SetName("metric")
 	m2.SetDescription("description")


### PR DESCRIPTION
**Description:**
Fixes the metadata dropping when processing metrics

**Link to tracking Issue:** #33419 

**Testing:** <Describe what testing was performed and which tests were added.>
- unit tests

