### PR TITLE
[chore] [receiver/receivercreator] fix bad copypasta in test (createErr -> err)

### DIFF
--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -108,7 +108,7 @@ func (run *receiverRunner) start(
 	}
 
 	if err = wr.Start(context.Background(), run.host); err != nil {
-		return nil, fmt.Errorf("failed starting endpoint-derived receiver: %w", createError)
+		return nil, fmt.Errorf("failed starting endpoint-derived receiver: %w", err)
 	}
 
 	return wr, nil


### PR DESCRIPTION
Chore/bugfix, goes from this

```
{"level":"error","ts":1719538225.8125398,"caller":"receivercreator@v0.103.0/observerhandler.go:159","msg":"failed to start receiver","kind":"receiver","receiver":"jmx/cassandra","error":"failed starting endpoint-derived receiver: %!w(<nil>)",
```

to this


```
{"level":"error","ts":1719548614.7125309,"caller":"receivercreator@v0.103.0/observerhandler.go:159","msg":"failed to start receiver","kind":"receiver","receiver":"jmx/cassandra","error":"failed starting endpoint-derived receiver: failed to parse Endpoint \"172.20.0.2:7199\": parse \"172.20.0.2:7199\": first path segment in URL cannot contain colon"
```

(fixing the issue with [`url.Parse`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/jmxreceiver/receiver.go#L174) [error](https://github.com/golang/go/blob/master/src/net/url/url.go#L557) is another topic entirely, given the jmx code accepts it without the `jmx` prefix, but that's another issue...)