### PR TITLE
feat: set on last timestamp from last event rather than time.Now() `SPIKE`

### DIFF
--- a/receiver/awscloudwatchreceiver/logs.go
+++ b/receiver/awscloudwatchreceiver/logs.go
@@ -239,11 +239,6 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 			continue
 		}
 
-		parsedTimestamp := time.UnixMilli(*e.Timestamp)
-		if lastEvent == nil || parsedTimestamp.After(*lastEvent) {
-			lastEvent = &parsedTimestamp
-		}
-
 		if e.EventId == nil {
 			l.logger.Error("no event ID was present on the event, skipping entry")
 			continue
@@ -285,6 +280,9 @@ func (l *logsReceiver) processEvents(now pcommon.Timestamp, logGroupName string,
 
 		logRecord.SetObservedTimestamp(now)
 		ts := time.UnixMilli(*e.Timestamp)
+		if lastEvent == nil || ts.After(*lastEvent) {
+			lastEvent = &ts
+		}
 		logRecord.SetTimestamp(pcommon.NewTimestampFromTime(ts))
 		logRecord.Body().SetStr(*e.Message)
 		logRecord.Attributes().PutStr("id", *e.EventId)


### PR DESCRIPTION
**Description:** Submitting as a draft until further validation is done
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Assumption is that the current approach of setting the nextStartTime by looking at the endTime of the previous request may be susceptible to later ingestion by cloudwatch or some sort of delay under certain environments.

Submitting this as a spike as we explorie if grabbing the timestamp of the last processed log is an acceptable approach in this circumstance.

**Link to tracking Issue:** Exploring #32231 (not resolves yet)

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>