### PR TITLE
support multiline filelog receiver in container operator

### DIFF
--- a/.chloggen/container-multiline.yaml
+++ b/.chloggen/container-multiline.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: support multiline filelog receiver in container operator
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33826]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/parser/container/parser_test.go
+++ b/pkg/stanza/operator/parser/container/parser_test.go
@@ -150,7 +150,8 @@ func TestProcess(t *testing.T) {
 				return cfg.Build(set)
 			},
 			&entry.Entry{
-				Body: `{"log":"INFO: log line here","stream":"stdout","time":"2029-03-30T08:31:20.545192187Z"}`,
+				Body: `{"log":"INFO: log line here","stream":"stdout","time":"2029-03-30T08:31:20.545192187Z"}
+{"log":"next line","stream":"stdout","time":"2029-03-30T08:31:20.545192187Z"}`,
 				Attributes: map[string]any{
 					"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
 				},
@@ -161,7 +162,7 @@ func TestProcess(t *testing.T) {
 					"log.iostream":  "stdout",
 					"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
 				},
-				Body: "INFO: log line here",
+				Body: "INFO: log line here\nnext line",
 				Resource: map[string]any{
 					"k8s.pod.name":                "kube-scheduler-kind-control-plane",
 					"k8s.pod.uid":                 "49cc7c1fd3702c40b2686ea7486091d3",
@@ -205,7 +206,8 @@ func TestRecombineProcess(t *testing.T) {
 			},
 			[]*entry.Entry{
 				{
-					Body: `2024-04-13T07:59:37.505201169-10:00 stdout F standalone crio line which is awesome!`,
+					Body: `2024-04-13T07:59:37.505201169-10:00 stdout F standalone crio line which is awesome!
+2024-04-13T07:59:37.505201169-10:00 stdout F new line`,
 					Attributes: map[string]any{
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
 					},
@@ -219,7 +221,7 @@ func TestRecombineProcess(t *testing.T) {
 						"logtag":        "F",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
 					},
-					Body: "standalone crio line which is awesome!",
+					Body: "standalone crio line which is awesome!\nnew line",
 					Resource: map[string]any{
 						"k8s.pod.name":                "kube-scheduler-kind-control-plane",
 						"k8s.pod.uid":                 "49cc7c1fd3702c40b2686ea7486091d3",
@@ -241,7 +243,8 @@ func TestRecombineProcess(t *testing.T) {
 			},
 			[]*entry.Entry{
 				{
-					Body: `2024-04-13T07:59:37.505201169Z stdout F standalone containerd line which is awesome!`,
+					Body: `2024-04-13T07:59:37.505201169Z stdout F standalone containerd line which is awesome!
+2024-04-13T07:59:37.505201169Z stdout F new line`,
 					Attributes: map[string]any{
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
 					},
@@ -262,7 +265,7 @@ func TestRecombineProcess(t *testing.T) {
 						"k8s.container.restart_count": "1",
 						"k8s.namespace.name":          "some",
 					},
-					Body:      "standalone containerd line which is awesome!",
+					Body:      "standalone containerd line which is awesome!\nnew line",
 					Timestamp: time.Date(2024, time.April, 13, 7, 59, 37, 505201169, time.UTC),
 				},
 			},


### PR DESCRIPTION
**Description:**

example config where multiline didn't work:

```yaml
    receivers:
      filelog:
        include:
          - /var/log/pods/*/anti-fraud/*.log
        include_file_path: true
        multiline:
          line_start_pattern: '.*stdout F \d{4}-'
        operators:
        - id: container-parser
          type: container
```

input log file - as emitted by the app:

```log
2024-07-02T08:47:51.349Z  INFO 1 --- [http-nio-8080-exec-1] com.zaxxer.hikari.HikariDataSource       : HikariPool-1 - Start com
2024-07-02T08:47:52.446Z  WARN 1 --- [http-nio-8080-exec-1] c.m.antifraud.FraudDetectionController   : Exception processing checkOrder(orderPrice=300, shippingCountry=, customerIpAddress=127.0.0.1) - trace_id=832030a81b1a6dbc25eb1cba4b746c6f, span_id=7
                                                                                                                                                                                                                                                            
java.lang.RuntimeException: Fraud Detection Processing Exception                                                                                                                                                                                            
    at com.mycompany.antifraud.FraudDetectionController.checkOrder(FraudDetectionController.java:126)                                                                                                                                                       
    at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)                                                                                                                                                                     
    at java.base/java.lang.reflect.Method.invoke(Unknown Source)                                                                                                                                                                                            
    at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:255)                                                                                                                                              
    at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188)                                                                                                                                      
    at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:118)                                                                                                          
    at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:926)                                                                                                        
    at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:831)                                                                                                             
    at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)                                                                                                                                 
    at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1089)                                                                                                                                                            
    at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:979)                                                                                                                                                              
    at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1014)                                                                                                                                                          
    at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:903)                                                                                                                                                                    
    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:564)                                                                                                                                                                                       
    at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:885)                                                                                                                                                                  
    at jakarta.servlet.http.HttpServlet.service(HttpServlet.java:658)                                                                                                                                                                                       
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:195)                                                                                                                                                    
    at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:140)                                                                                                                                                            
    at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:51)                                                                                                                                                                               
    at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:164)                              
```

as written do disk:

```log
2024-07-02T08:47:52.450371265Z stdout F 2024-07-02T08:47:52.446Z  WARN 1 --- [http-nio-8080-exec-1] c.m.antifraud.FraudDetectionController   : Exception processing checkOrder(orderPrice=300, shippingCountry=, customerIpAddress=127.0.0.1) - trace_id=832030a81b1a6dbc25eb1cba4b746c6f, span_id=795d7271a33db5cb, service.name=anti-fraud, service.namespace=shop, service.instance.id=485f3a49-75c7-4f2f-82d2-0cb5b240b2f8, deployment.environment=staging
2024-07-02T08:47:52.450388803Z stdout F 
2024-07-02T08:47:52.450391238Z stdout F java.lang.RuntimeException: Fraud Detection Processing Exception
2024-07-02T08:47:52.450403102Z stdout F 	at com.mycompany.antifraud.FraudDetectionController.checkOrder(FraudDetectionController.java:126)
2024-07-02T08:47:52.450405413Z stdout F 	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(Unknown Source)
2024-07-02T08:47:52.450406896Z stdout F 	at java.base/java.lang.reflect.Method.invoke(Unknown Source)
2024-07-02T08:47:52.450408388Z stdout F 	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:255)
2024-07-02T08:47:52.450410085Z stdout F 	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:188)
```

**Testing:** 

adjusted existing tests

**Documentation:** 

not sure if it's needed - sounds more like this is a bug fix