### PR TITLE
Fix cross-compile pipeline job building for ARM 7

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -480,8 +480,8 @@ jobs:
           - s390x
         include:
           - os: linux
-          - arch: arm
-          - arm: 7
+            arch: arm
+            arm: 7
         exclude:
           - os: darwin
             arch: 386


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This PR fixes a small issue in the `cross-compile` pipeline job. https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/23436 aimed to introduce a new specific matrix configuration that built for linux/arm with ARMv7 but accidentally built all arm jobs with ARMv7 with some magic of YAML and GitHub actions matrix definitions 😇 

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29542

**Testing:** not sure how to test, since this is just pipeline changes

**Documentation:** no docs added