### PR TITLE
[processor/geoipprocessor]Fix Windows test error

### DIFF
--- a/processor/geoipprocessor/internal/provider/maxmindprovider/provider_test.go
+++ b/processor/geoipprocessor/internal/provider/maxmindprovider/provider_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/maxmind/MaxMind-DB/pkg/writer"
@@ -19,10 +20,14 @@ import (
 
 func TestInvalidNewProvider(t *testing.T) {
 	_, err := newMaxMindProvider(&Config{})
-	require.ErrorContains(t, err, "could not open geoip database: open : no such file or directory")
+	expectedErrMsgSuffix := "no such file or directory"
+	if runtime.GOOS == "windows" {
+		expectedErrMsgSuffix = "The system cannot find the file specified."
+	}
+	require.ErrorContains(t, err, "could not open geoip database: open : " + expectedErrMsgSuffix)
 
 	_, err = newMaxMindProvider(&Config{DatabasePath: "no valid path"})
-	require.ErrorContains(t, err, "could not open geoip database: open no valid path: no such file or directory")
+	require.ErrorContains(t, err, "could not open geoip database: open no valid path: " + expectedErrMsgSuffix)
 }
 
 // generateLocalDB generates *.mmdb databases files given a source directory data. It uses a the writer functionality provided by MaxMind-Db/pkg/writer

--- a/processor/geoipprocessor/internal/provider/maxmindprovider/provider_test.go
+++ b/processor/geoipprocessor/internal/provider/maxmindprovider/provider_test.go
@@ -24,10 +24,10 @@ func TestInvalidNewProvider(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		expectedErrMsgSuffix = "The system cannot find the file specified."
 	}
-	require.ErrorContains(t, err, "could not open geoip database: open : " + expectedErrMsgSuffix)
+	require.ErrorContains(t, err, "could not open geoip database: open : "+expectedErrMsgSuffix)
 
 	_, err = newMaxMindProvider(&Config{DatabasePath: "no valid path"})
-	require.ErrorContains(t, err, "could not open geoip database: open no valid path: " + expectedErrMsgSuffix)
+	require.ErrorContains(t, err, "could not open geoip database: open no valid path: "+expectedErrMsgSuffix)
 }
 
 // generateLocalDB generates *.mmdb databases files given a source directory data. It uses a the writer functionality provided by MaxMind-Db/pkg/writer


### PR DESCRIPTION
The tests are failing on `Run Windows` due to the different error message generated on Windows.