### PR TITLE
[chore] fix setup_e2e_tests script

### DIFF
--- a/.github/workflows/scripts/setup_e2e_tests.sh
+++ b/.github/workflows/scripts/setup_e2e_tests.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/bash -x
 
 # Copyright The OpenTelemetry Authors
 # SPDX-License-Identifier: Apache-2.0
 
 TESTS="$(make -s -C testbed list-tests | xargs echo|sed 's/ /|/g')"
-TESTS=("${TESTS//|/ }")
+TESTS=(${TESTS//|/ })
 MATRIX="{\"include\":["
 curr=""
 for i in "${!TESTS[@]}"; do


### PR DESCRIPTION
The parsing of the tests was broken by https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/520cade49af66542d19fed82bcef363a663d5e84
