### PR TITLE
[receiver/kafkareceiver] Add encoding extensions support

### DIFF
--- a/.chloggen/kafkareceiver-encoding-extensions.yaml
+++ b/.chloggen/kafkareceiver-encoding-extensions.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kafkareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for encoding extensions in the Kafka receiver.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33888]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change adds support for encoding extensions in the Kafka receiver. Loading extensions takes precedence over the internally supported encodings.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -29,7 +29,7 @@ The following settings can be optionally configured:
 - `resolve_canonical_bootstrap_servers_only` (default = false): Whether to resolve then reverse-lookup broker IPs during startup
 - `topic` (default = otlp_spans for traces, otlp_metrics for metrics, otlp_logs for logs): The name of the kafka topic to read from.
   Only one telemetry type may be used for a given topic.
-- `encoding` (default = otlp_proto): The encoding of the payload received from kafka. Available encodings:
+- `encoding` (default = otlp_proto): The encoding of the payload received from kafka. Supports encoding extensions. Tries to load an encoding extension and falls back to internal encodings if no extension was loaded. Available internal encodings:
   - `otlp_proto`: the payload is deserialized to `ExportTraceServiceRequest`, `ExportLogsServiceRequest` or `ExportMetricsServiceRequest` respectively.
   - `jaeger_proto`: the payload is deserialized to a single Jaeger proto `Span`.
   - `jaeger_json`: the payload is deserialized to a single Jaeger JSON Span using `jsonpb`.

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -37,7 +37,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{tracesUnmarshalers: defaultTracesUnmarshalers()}
+	f := kafkaReceiverFactory{}
 	r, err := f.createTracesReceiver(context.Background(), receivertest.NewNopSettings(), cfg, nil)
 	require.NoError(t, err)
 	// no available broker
@@ -46,7 +46,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 
 func TestWithTracesUnmarshalers(t *testing.T) {
 	unmarshaler := &customTracesUnmarshaler{}
-	f := NewFactory(withTracesUnmarshalers(unmarshaler))
+	f := NewFactory()
 	cfg := createDefaultConfig().(*Config)
 	// disable contacting broker
 	cfg.Metadata.Full = false
@@ -76,7 +76,7 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{metricsUnmarshalers: defaultMetricsUnmarshalers()}
+	f := kafkaReceiverFactory{}
 	r, err := f.createMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, nil)
 	require.NoError(t, err)
 	// no available broker
@@ -85,7 +85,7 @@ func TestCreateMetricsReceiver(t *testing.T) {
 
 func TestWithMetricsUnmarshalers(t *testing.T) {
 	unmarshaler := &customMetricsUnmarshaler{}
-	f := NewFactory(withMetricsUnmarshalers(unmarshaler))
+	f := NewFactory()
 	cfg := createDefaultConfig().(*Config)
 	// disable contacting broker
 	cfg.Metadata.Full = false
@@ -115,7 +115,7 @@ func TestCreateLogsReceiver(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Brokers = []string{"invalid:9092"}
 	cfg.ProtocolVersion = "2.0.0"
-	f := kafkaReceiverFactory{logsUnmarshalers: defaultLogsUnmarshalers("Test Version", zap.NewNop())}
+	f := kafkaReceiverFactory{}
 	r, err := f.createLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, nil)
 	require.NoError(t, err)
 	// no available broker
@@ -146,7 +146,7 @@ func TestGetLogsUnmarshaler_encoding_text_error(t *testing.T) {
 
 func TestWithLogsUnmarshalers(t *testing.T) {
 	unmarshaler := &customLogsUnmarshaler{}
-	f := NewFactory(withLogsUnmarshalers(unmarshaler))
+	f := NewFactory()
 	cfg := createDefaultConfig().(*Config)
 	// disable contacting broker
 	cfg.Metadata.Full = false

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -39,21 +40,20 @@ func TestNewTracesReceiver_version_err(t *testing.T) {
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
-	r, err := newTracesReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newTracesReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
 }
 
 func TestNewTracesReceiver_encoding_err(t *testing.T) {
-	c := Config{
-		Encoding: "foo",
-	}
-	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
-	r, err := newTracesReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	c := createDefaultConfig().(*Config)
+	c.Encoding = "foo"
+	r, err := newTracesReceiver(*c, receivertest.NewNopSettings(), consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	err = r.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
-	assert.Nil(t, r)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 }
 
@@ -72,9 +72,9 @@ func TestNewTracesReceiver_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
-	r, err := newTracesReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newTracesReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
+	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 }
@@ -84,9 +84,9 @@ func TestNewTracesReceiver_initial_offset_err(t *testing.T) {
 		InitialOffset: "foo",
 		Encoding:      defaultEncoding,
 	}
-	unmarshaler := defaultTracesUnmarshalers()[c.Encoding]
-	r, err := newTracesReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newTracesReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
+	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
 	assert.EqualError(t, err, errInvalidInitialOffset.Error())
@@ -94,6 +94,7 @@ func TestNewTracesReceiver_initial_offset_err(t *testing.T) {
 
 func TestTracesReceiverStart(t *testing.T) {
 	c := kafkaTracesConsumer{
+		config:           Config{Encoding: defaultEncoding},
 		nextConsumer:     consumertest.NewNop(),
 		settings:         receivertest.NewNopSettings(),
 		consumerGroup:    &testConsumerGroup{},
@@ -131,6 +132,7 @@ func TestTracesReceiver_error(t *testing.T) {
 
 	expectedErr := errors.New("handler error")
 	c := kafkaTracesConsumer{
+		config:           Config{Encoding: defaultEncoding},
 		nextConsumer:     consumertest.NewNop(),
 		settings:         settings,
 		consumerGroup:    &testConsumerGroup{err: expectedErr},
@@ -363,13 +365,34 @@ func TestTracesConsumerGroupHandler_error_nextConsumer(t *testing.T) {
 	wg.Wait()
 }
 
+func TestTracesReceiver_encoding_extension(t *testing.T) {
+	zcore, logObserver := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(zcore)
+	settings := receivertest.NewNopSettings()
+	settings.Logger = logger
+
+	expectedErr := errors.New("handler error")
+	c := kafkaTracesConsumer{
+		config:           Config{Encoding: "traces_encoding"},
+		nextConsumer:     consumertest.NewNop(),
+		settings:         settings,
+		consumerGroup:    &testConsumerGroup{err: expectedErr},
+		telemetryBuilder: nopTelemetryBuilder(t),
+	}
+
+	require.NoError(t, c.Start(context.Background(), &testComponentHost{}))
+	require.NoError(t, c.Shutdown(context.Background()))
+	assert.Eventually(t, func() bool {
+		return logObserver.FilterField(zap.Error(expectedErr)).Len() > 0
+	}, 10*time.Second, time.Millisecond*100)
+}
+
 func TestNewMetricsReceiver_version_err(t *testing.T) {
 	c := Config{
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
-	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
@@ -379,9 +402,10 @@ func TestNewMetricsReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
-	_, err := newMetricsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
-	require.Error(t, err)
+	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 }
 
@@ -400,9 +424,9 @@ func TestNewMetricsExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
-	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
+	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
@@ -413,9 +437,9 @@ func TestNewMetricsReceiver_initial_offset_err(t *testing.T) {
 		InitialOffset: "foo",
 		Encoding:      defaultEncoding,
 	}
-	unmarshaler := defaultMetricsUnmarshalers()[c.Encoding]
-	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newMetricsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
+	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
 	assert.EqualError(t, err, errInvalidInitialOffset.Error())
@@ -448,6 +472,7 @@ func TestMetricsReceiver_error(t *testing.T) {
 
 	expectedErr := errors.New("handler error")
 	c := kafkaMetricsConsumer{
+		config:           Config{Encoding: defaultEncoding},
 		nextConsumer:     consumertest.NewNop(),
 		settings:         settings,
 		consumerGroup:    &testConsumerGroup{err: expectedErr},
@@ -678,14 +703,36 @@ func TestMetricsConsumerGroupHandler_error_nextConsumer(t *testing.T) {
 	wg.Wait()
 }
 
+func TestMetricsReceiver_encoding_extension(t *testing.T) {
+	zcore, logObserver := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(zcore)
+	settings := receivertest.NewNopSettings()
+	settings.Logger = logger
+
+	expectedErr := errors.New("handler error")
+	c := kafkaMetricsConsumer{
+		config:           Config{Encoding: "metrics_encoding"},
+		nextConsumer:     consumertest.NewNop(),
+		settings:         settings,
+		consumerGroup:    &testConsumerGroup{err: expectedErr},
+		telemetryBuilder: nopTelemetryBuilder(t),
+	}
+
+	require.NoError(t, c.Start(context.Background(), &testComponentHost{}))
+	require.NoError(t, c.Shutdown(context.Background()))
+	assert.Eventually(t, func() bool {
+		return logObserver.FilterField(zap.Error(expectedErr)).Len() > 0
+	}, 10*time.Second, time.Millisecond*100)
+}
+
 func TestNewLogsReceiver_version_err(t *testing.T) {
 	c := Config{
 		Encoding:        defaultEncoding,
 		ProtocolVersion: "none",
 	}
-	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
-	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
+	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
 }
@@ -694,10 +741,11 @@ func TestNewLogsReceiver_encoding_err(t *testing.T) {
 	c := Config{
 		Encoding: "foo",
 	}
-	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
-	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
-	require.Error(t, err)
-	assert.Nil(t, r)
+	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	err = r.Start(context.Background(), componenttest.NewNopHost())
+	assert.Error(t, err)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 }
 
@@ -716,9 +764,9 @@ func TestNewLogsExporter_err_auth_type(t *testing.T) {
 			Full: false,
 		},
 	}
-	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
-	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
+	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
@@ -729,9 +777,9 @@ func TestNewLogsReceiver_initial_offset_err(t *testing.T) {
 		InitialOffset: "foo",
 		Encoding:      defaultEncoding,
 	}
-	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[c.Encoding]
-	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newLogsReceiver(c, receivertest.NewNopSettings(), consumertest.NewNop())
 	require.NoError(t, err)
+	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
 	require.Error(t, err)
 	assert.EqualError(t, err, errInvalidInitialOffset.Error())
@@ -739,6 +787,7 @@ func TestNewLogsReceiver_initial_offset_err(t *testing.T) {
 
 func TestLogsReceiverStart(t *testing.T) {
 	c := kafkaLogsConsumer{
+		config:           *createDefaultConfig().(*Config),
 		nextConsumer:     consumertest.NewNop(),
 		settings:         receivertest.NewNopSettings(),
 		consumerGroup:    &testConsumerGroup{},
@@ -1123,10 +1172,34 @@ func TestCreateLogsReceiver_encoding_text_error(t *testing.T) {
 	cfg := Config{
 		Encoding: "text_uft-8",
 	}
-	unmarshaler := defaultLogsUnmarshalers("Test Version", zap.NewNop())[cfg.Encoding]
-	_, err := newLogsReceiver(cfg, receivertest.NewNopSettings(), unmarshaler, consumertest.NewNop())
+	r, err := newLogsReceiver(cfg, receivertest.NewNopSettings(), consumertest.NewNop())
+	require.NoError(t, err)
+	require.NotNil(t, r)
+	err = r.Start(context.Background(), componenttest.NewNopHost())
 	// encoding error comes first
 	assert.Error(t, err, "unsupported encoding")
+}
+
+func TestLogsReceiver_encoding_extension(t *testing.T) {
+	zcore, logObserver := observer.New(zapcore.ErrorLevel)
+	logger := zap.New(zcore)
+	settings := receivertest.NewNopSettings()
+	settings.Logger = logger
+
+	expectedErr := errors.New("handler error")
+	c := kafkaLogsConsumer{
+		config:           Config{Encoding: "logs_encoding"},
+		nextConsumer:     consumertest.NewNop(),
+		settings:         settings,
+		consumerGroup:    &testConsumerGroup{err: expectedErr},
+		telemetryBuilder: nopTelemetryBuilder(t),
+	}
+
+	require.NoError(t, c.Start(context.Background(), &testComponentHost{}))
+	require.NoError(t, c.Shutdown(context.Background()))
+	assert.Eventually(t, func() bool {
+		return logObserver.FilterField(zap.Error(expectedErr)).Len() > 0
+	}, 10*time.Second, time.Millisecond*100)
 }
 
 func TestToSaramaInitialOffset_earliest(t *testing.T) {
@@ -1303,4 +1376,65 @@ func nopTelemetryBuilder(t *testing.T) *metadata.TelemetryBuilder {
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(receivertest.NewNopSettings().TelemetrySettings)
 	require.NoError(t, err)
 	return telemetryBuilder
+}
+
+func TestLoadEncodingExtension_logs(t *testing.T) {
+	extension, err := loadEncodingExtension[plog.Unmarshaler](&testComponentHost{}, "logs_encoding")
+	require.NoError(t, err)
+	require.NotNil(t, extension)
+}
+
+func TestLoadEncodingExtension_notfound_error(t *testing.T) {
+	extension, err := loadEncodingExtension[plog.Unmarshaler](&testComponentHost{}, "logs_notfound")
+	require.Error(t, err)
+	require.Nil(t, extension)
+}
+
+func TestLoadEncodingExtension_nounmarshaler_error(t *testing.T) {
+	extension, err := loadEncodingExtension[plog.Unmarshaler](&testComponentHost{}, "logs_nounmarshaler")
+	require.Error(t, err)
+	require.Nil(t, extension)
+}
+
+type testComponentHost struct{}
+
+func (h *testComponentHost) GetExtensions() map[component.ID]component.Component {
+	return map[component.ID]component.Component{
+		component.MustNewID("logs_encoding"):      &nopComponent{},
+		component.MustNewID("logs_nounmarshaler"): &nopNoUnmarshalerComponent{},
+		component.MustNewID("metrics_encoding"):   &nopComponent{},
+		component.MustNewID("traces_encoding"):    &nopComponent{},
+	}
+}
+
+type nopComponent struct{}
+
+func (c *nopComponent) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (c *nopComponent) Shutdown(_ context.Context) error {
+	return nil
+}
+
+func (c *nopComponent) UnmarshalLogs(_ []byte) (plog.Logs, error) {
+	return plog.NewLogs(), nil
+}
+
+func (c *nopComponent) UnmarshalMetrics(_ []byte) (pmetric.Metrics, error) {
+	return pmetric.NewMetrics(), nil
+}
+
+func (c *nopComponent) UnmarshalTraces(_ []byte) (ptrace.Traces, error) {
+	return ptrace.NewTraces(), nil
+}
+
+type nopNoUnmarshalerComponent struct{}
+
+func (c *nopNoUnmarshalerComponent) Start(_ context.Context, _ component.Host) error {
+	return nil
+}
+
+func (c *nopNoUnmarshalerComponent) Shutdown(_ context.Context) error {
+	return nil
 }

--- a/receiver/kafkareceiver/unmarshaler.go
+++ b/receiver/kafkareceiver/unmarshaler.go
@@ -86,3 +86,45 @@ func defaultLogsUnmarshalers(version string, logger *zap.Logger) map[string]Logs
 		json.Encoding():              json,
 	}
 }
+
+// tracesEncodingUnmarshaler is a wrapper around ptrace.Unmarshaler that implements TracesUnmarshaler.
+type tracesEncodingUnmarshaler struct {
+	unmarshaler ptrace.Unmarshaler
+	encoding    string
+}
+
+func (t *tracesEncodingUnmarshaler) Unmarshal(data []byte) (ptrace.Traces, error) {
+	return t.unmarshaler.UnmarshalTraces(data)
+}
+
+func (t *tracesEncodingUnmarshaler) Encoding() string {
+	return t.encoding
+}
+
+// metricsEncodingUnmarshaler is a wrapper around pmetric.Unmarshaler that implements MetricsUnmarshaler.
+type metricsEncodingUnmarshaler struct {
+	unmarshaler pmetric.Unmarshaler
+	encoding    string
+}
+
+func (m *metricsEncodingUnmarshaler) Unmarshal(data []byte) (pmetric.Metrics, error) {
+	return m.unmarshaler.UnmarshalMetrics(data)
+}
+
+func (m *metricsEncodingUnmarshaler) Encoding() string {
+	return m.encoding
+}
+
+// logsEncodingUnmarshaler is a wrapper around plog.Unmarshaler that implements LogsUnmarshaler.
+type logsEncodingUnmarshaler struct {
+	unmarshaler plog.Unmarshaler
+	encoding    string
+}
+
+func (l *logsEncodingUnmarshaler) Unmarshal(data []byte) (plog.Logs, error) {
+	return l.unmarshaler.UnmarshalLogs(data)
+}
+
+func (l *logsEncodingUnmarshaler) Encoding() string {
+	return l.encoding
+}


### PR DESCRIPTION
**Description:** Add support for encoding extensions in the kafkareceiver
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.-->
To be able to use encoding extensions this PR adds extension support and proposes to rename the existing `encoding` configuration property to `format` and reusing the `encoding` property for configuring encoding extensions. Reason is to be consistent with other receivers/exporters like the `fileexporter` that already support extensions.

**Link to tracking Issue:** n/a

**Testing:** Tested with the existing avro_log_encoding extension as well with receivers internal json encoding.

**Documentation:**: Updated README.md within the receiver describing the use of encoding extensions.