### PR TITLE
[chore] remove references to metric/noop

### DIFF
--- a/processor/routingprocessor/factory_test.go
+++ b/processor/routingprocessor/factory_test.go
@@ -20,16 +20,9 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/processor/processorhelper"
 	"go.opentelemetry.io/collector/processor/processortest"
-	noopmetric "go.opentelemetry.io/otel/metric/noop"
-	nooptrace "go.opentelemetry.io/otel/trace/noop"
-	"go.uber.org/zap"
 )
 
-var noopTelemetrySettings = component.TelemetrySettings{
-	TracerProvider: nooptrace.NewTracerProvider(),
-	MeterProvider:  noopmetric.NewMeterProvider(),
-	Logger:         zap.NewNop(),
-}
+var noopTelemetrySettings = componenttest.NewNopTelemetrySettings()
 
 func TestProcessorGetsCreatedWithValidConfiguration(t *testing.T) {
 	// prepare

--- a/receiver/oracledbreceiver/factory_test.go
+++ b/receiver/oracledbreceiver/factory_test.go
@@ -11,10 +11,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver"
-	noopmetric "go.opentelemetry.io/otel/metric/noop"
-	nooptrace "go.opentelemetry.io/otel/trace/noop"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/oracledbreceiver/internal/metadata"
 )
@@ -24,11 +23,8 @@ func TestNewFactory(t *testing.T) {
 	_, err := factory.CreateMetricsReceiver(
 		context.Background(),
 		receiver.Settings{
-			ID: component.NewID(metadata.Type),
-			TelemetrySettings: component.TelemetrySettings{
-				TracerProvider: nooptrace.NewTracerProvider(),
-				MeterProvider:  noopmetric.NewMeterProvider(),
-			},
+			ID:                component.NewID(metadata.Type),
+			TelemetrySettings: componenttest.NewNopTelemetrySettings(),
 		},
 		factory.CreateDefaultConfig(),
 		consumertest.NewNop(),


### PR DESCRIPTION
use componenttest.NewNopTelemetrySettings() instead.
