### PR TITLE
[connector/count] update stability to alpha

### DIFF
--- a/.chloggen/codeboten_alpha-countconnector.yaml
+++ b/.chloggen/codeboten_alpha-countconnector.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: countconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Updating the stability to reflect that the component is shipped as part of contrib.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_alpha-countconnector.yaml
+++ b/.chloggen/codeboten_alpha-countconnector.yaml
@@ -10,7 +10,7 @@ component: countconnector
 note: Updating the stability to reflect that the component is shipped as part of contrib.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [33903]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/connector/countconnector/README.md
+++ b/connector/countconnector/README.md
@@ -6,16 +6,16 @@
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aconnector%2Fcount%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aconnector%2Fcount) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aconnector%2Fcount%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aconnector%2Fcount) |
 | [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@djaglowski](https://www.github.com/djaglowski), [@jpkrohling](https://www.github.com/jpkrohling) |
 
-[development]: https://github.com/open-telemetry/opentelemetry-collector#development
+[alpha]: https://github.com/open-telemetry/opentelemetry-collector#alpha
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib
 
 ## Supported Pipeline Types
 
 | [Exporter Pipeline Type] | [Receiver Pipeline Type] | [Stability Level] |
 | ------------------------ | ------------------------ | ----------------- |
-| traces | metrics | [development] |
-| metrics | metrics | [development] |
-| logs | metrics | [development] |
+| traces | metrics | [alpha] |
+| metrics | metrics | [alpha] |
+| logs | metrics | [alpha] |
 
 [Exporter Pipeline Type]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md#exporter-pipeline-type
 [Receiver Pipeline Type]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/connector/README.md#receiver-pipeline-type

--- a/connector/countconnector/internal/metadata/generated_status.go
+++ b/connector/countconnector/internal/metadata/generated_status.go
@@ -11,7 +11,7 @@ var (
 )
 
 const (
-	TracesToMetricsStability  = component.StabilityLevelDevelopment
-	MetricsToMetricsStability = component.StabilityLevelDevelopment
-	LogsToMetricsStability    = component.StabilityLevelDevelopment
+	TracesToMetricsStability  = component.StabilityLevelAlpha
+	MetricsToMetricsStability = component.StabilityLevelAlpha
+	LogsToMetricsStability    = component.StabilityLevelAlpha
 )

--- a/connector/countconnector/metadata.yaml
+++ b/connector/countconnector/metadata.yaml
@@ -4,7 +4,7 @@ scope_name: otelcol/countconnector
 status:
   class: connector
   stability:
-    development: [traces_to_metrics, metrics_to_metrics, logs_to_metrics]
+    alpha: [traces_to_metrics, metrics_to_metrics, logs_to_metrics]
   distributions: [contrib]
   codeowners:
     active: [djaglowski, jpkrohling]


### PR DESCRIPTION
This component has shipped in the contrib distribution for some time now. Marking it as alpha to follow our distribution guidelines.
