### PR TITLE
[chore] try out macos-14 to run arm tests

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -14,7 +14,6 @@ env:
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
-  GOPROXY: https://goproxy1.cncf.selfactuated.dev,direct
 
 # Do not cancel this workflow on main. See https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/16616
 concurrency:

--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -46,7 +46,7 @@ jobs:
           - cmd-1
           - other
     timeout-minutes: 30
-    runs-on: actuated-arm64-4cpu-4gb
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -72,7 +72,7 @@ jobs:
         run: make -j2 gotest GROUP=${{ matrix.group }}
   arm-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
-    runs-on: actuated-arm64-4cpu-4gb
+    runs-on: macos-14
     needs: [arm-unittest-matrix]
     steps:
       - name: Print result

--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -26,6 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os: [otel-linux-arm64, macos-14]
         group:
           - receiver-0
           - receiver-1
@@ -45,7 +46,7 @@ jobs:
           - cmd-1
           - other
     timeout-minutes: 30
-    runs-on: macos-14
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -71,7 +72,7 @@ jobs:
         run: make -j2 gotest GROUP=${{ matrix.group }}
   arm-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     needs: [arm-unittest-matrix]
     steps:
       - name: Print result

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -102,7 +103,7 @@ func TestBearerAuthenticator(t *testing.T) {
 
 func TestBearerStartWatchStop(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
-	cfg.Filename = "test.token"
+	cfg.Filename = filepath.Join("testdata", t.Name()+".token")
 
 	bauth := newBearerTokenAuth(cfg, zaptest.NewLogger(t))
 	assert.NotNil(t, bauth)
@@ -152,7 +153,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 func TestBearerTokenFileContentUpdate(t *testing.T) {
 	scheme := "TestScheme"
 	cfg := createDefaultConfig().(*Config)
-	cfg.Filename = "test.token"
+	cfg.Filename = filepath.Join("testdata", t.Name()+".token")
 	cfg.Scheme = scheme
 
 	bauth := newBearerTokenAuth(cfg, zaptest.NewLogger(t))

--- a/extension/bearertokenauthextension/test.token
+++ b/extension/bearertokenauthextension/test.token
@@ -1,1 +1,0 @@
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...+file+

--- a/extension/bearertokenauthextension/testdata/TestBearerStartWatchStop.token
+++ b/extension/bearertokenauthextension/testdata/TestBearerStartWatchStop.token
@@ -1,0 +1,1 @@
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...+file+

--- a/extension/bearertokenauthextension/testdata/TestBearerTokenFileContentUpdate.token
+++ b/extension/bearertokenauthextension/testdata/TestBearerTokenFileContentUpdate.token
@@ -1,0 +1,1 @@
+eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...+file

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper"
 )
 
-var armMetrics = []string{
+var allMetrics = []string{
 	"system.cpu.time",
 	"system.cpu.load_average.1m",
 	"system.cpu.load_average.5m",
@@ -54,11 +54,7 @@ var armMetrics = []string{
 	"system.network.io",
 	"system.network.packets",
 	"system.paging.operations",
-}
-
-var archSpecificMetrics = map[string][]string{
-	"arm64": armMetrics,
-	"amd64": append(armMetrics, "system.paging.usage"),
+	"system.paging.usage",
 }
 
 var resourceMetrics = []string{
@@ -174,7 +170,7 @@ func assertIncludesExpectedMetrics(t *testing.T, got pmetric.Metrics) {
 
 	// verify the expected list of metrics returned (os dependent)
 	var expectedMetrics []string
-	expectedMetrics = append(expectedMetrics, archSpecificMetrics[runtime.GOARCH]...)
+	expectedMetrics = append(expectedMetrics, allMetrics...)
 	expectedMetrics = append(expectedMetrics, systemSpecificMetrics[runtime.GOOS]...)
 	assert.Equal(t, len(expectedMetrics), len(returnedMetrics))
 	for _, expected := range expectedMetrics {

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -54,7 +54,6 @@ var allMetrics = []string{
 	"system.network.io",
 	"system.network.packets",
 	"system.paging.operations",
-	"system.paging.usage",
 }
 
 var resourceMetrics = []string{
@@ -168,9 +167,12 @@ func assertIncludesExpectedMetrics(t *testing.T, got pmetric.Metrics) {
 		}
 	}
 
-	// verify the expected list of metrics returned (os dependent)
-	var expectedMetrics []string
-	expectedMetrics = append(expectedMetrics, allMetrics...)
+	// verify the expected list of metrics returned (os/arch dependent)
+	expectedMetrics := allMetrics
+	if !(runtime.GOOS == "linux" && runtime.GOARCH == "arm64") {
+		expectedMetrics = append(expectedMetrics, "system.paging.usage")
+	}
+
 	expectedMetrics = append(expectedMetrics, systemSpecificMetrics[runtime.GOOS]...)
 	assert.Equal(t, len(expectedMetrics), len(returnedMetrics))
 	for _, expected := range expectedMetrics {

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
@@ -82,10 +82,6 @@ func TestScrape(t *testing.T) {
 			if runtime.GOOS == "windows" {
 				expectedMetrics = 3
 			}
-			// ARM runner has no swap:
-			if runtime.GOARCH == "arm64" {
-				expectedMetrics = 2
-			}
 
 			assert.Equal(t, expectedMetrics, md.MetricCount())
 
@@ -100,12 +96,11 @@ func TestScrape(t *testing.T) {
 
 			internal.AssertSameTimeStampForMetrics(t, metrics, 0, metrics.Len()-2)
 			startIndex++
-			if runtime.GOARCH != "arm64" {
-				assertPagingUsageMetricValid(t, metrics.At(startIndex))
-				internal.AssertSameTimeStampForMetrics(t, metrics, startIndex, metrics.Len())
-				startIndex++
-				assertPagingUtilizationMetricValid(t, metrics.At(startIndex))
-			}
+
+			assertPagingUsageMetricValid(t, metrics.At(startIndex))
+			internal.AssertSameTimeStampForMetrics(t, metrics, startIndex, metrics.Len())
+			startIndex++
+			assertPagingUtilizationMetricValid(t, metrics.At(startIndex))
 		})
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_test.go
@@ -83,6 +83,11 @@ func TestScrape(t *testing.T) {
 				expectedMetrics = 3
 			}
 
+			// linux + ARM runner has no swap
+			if runtime.GOOS == "linux" && runtime.GOARCH == "arm64" {
+				expectedMetrics = 2
+			}
+
 			assert.Equal(t, expectedMetrics, md.MetricCount())
 
 			startIndex := 0
@@ -97,10 +102,12 @@ func TestScrape(t *testing.T) {
 			internal.AssertSameTimeStampForMetrics(t, metrics, 0, metrics.Len()-2)
 			startIndex++
 
-			assertPagingUsageMetricValid(t, metrics.At(startIndex))
-			internal.AssertSameTimeStampForMetrics(t, metrics, startIndex, metrics.Len())
-			startIndex++
-			assertPagingUtilizationMetricValid(t, metrics.At(startIndex))
+			if !(runtime.GOOS == "linux" && runtime.GOARCH == "arm64") {
+				assertPagingUsageMetricValid(t, metrics.At(startIndex))
+				internal.AssertSameTimeStampForMetrics(t, metrics, startIndex, metrics.Len())
+				startIndex++
+				assertPagingUtilizationMetricValid(t, metrics.At(startIndex))
+			}
 		})
 	}
 }


### PR DESCRIPTION
As documented in this blog post https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

The actuated runner has been causing build failures pretty consistently on main. Possibly fix the following flaky tests:

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32391
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32395
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32839
