### PR TITLE
[exporter/datadog] Fail when API validation key failed with a 403

### DIFF
--- a/.chloggen/mx-psi_error-when-validation-failed.yaml
+++ b/.chloggen/mx-psi_error-when-validation-failed.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Exit when API key validation fails and `api::fail_on_invalid_key` is set to `true`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33935]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -46,6 +46,9 @@ func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiC
 	}
 	if err != nil {
 		logger.Warn("Error while validating API key", zap.Error(err))
+		if httpresp.StatusCode == 403 {
+			return WrapError(ErrInvalidAPI, httpresp)
+		}
 		return nil
 	}
 	logger.Warn(ErrInvalidAPI.Error())

--- a/exporter/datadogexporter/internal/clientutil/api.go
+++ b/exporter/datadogexporter/internal/clientutil/api.go
@@ -45,10 +45,10 @@ func ValidateAPIKey(ctx context.Context, apiKey string, logger *zap.Logger, apiC
 		return nil
 	}
 	if err != nil {
-		logger.Warn("Error while validating API key", zap.Error(err))
-		if httpresp.StatusCode == 403 {
+		if httpresp != nil && httpresp.StatusCode == 403 {
 			return WrapError(ErrInvalidAPI, httpresp)
 		}
+		logger.Warn("Error while validating API key", zap.Error(err))
 		return nil
 	}
 	logger.Warn(ErrInvalidAPI.Error())


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

The API key validation endpoint returns a 403 in some situations when validating an API key. This makes the exporter fail on that case.

**Link to tracking Issue:** Fixes #33935
