### PR TITLE
[chore] `headers` are strings

### DIFF
--- a/exporter/alertmanagerexporter/testdata/config.yaml
+++ b/exporter/alertmanagerexporter/testdata/config.yaml
@@ -18,5 +18,5 @@ alertmanager/2:
     max_elapsed_time: 10m
   headers:
     "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
-    header1: 234
+    header1: "234"
     another: "somevalue"

--- a/exporter/opencensusexporter/testdata/config.yaml
+++ b/exporter/opencensusexporter/testdata/config.yaml
@@ -7,7 +7,7 @@ opencensus/2:
     ca_file: /var/lib/mycert.pem
   headers:
     "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
-    header1: 234
+    header1: "234"
     another: "somevalue"
   balancer_name: "round_robin"
   keepalive:

--- a/exporter/otelarrowexporter/testdata/config.yaml
+++ b/exporter/otelarrowexporter/testdata/config.yaml
@@ -18,7 +18,7 @@ auth:
   authenticator: nop
 headers:
   "can you have a . here?": "F0000000-0000-0000-0000-000000000000"
-  header1: 234
+  header1: "234"
   another: "somevalue"
 keepalive:
   time: 20s

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -14,7 +14,7 @@ prometheusremotewrite/2:
   add_metric_suffixes: false
   headers:
     Prometheus-Remote-Write-Version: "0.1.0"
-    X-Scope-OrgID: 234
+    X-Scope-OrgID: "234"
   external_labels:
     key1: value1
     key2: value2


### PR DESCRIPTION
**Description:**

`headers` values are `configopaque.String`s, so integers make `confmap` sad

**Link to tracking Issue:** Needed for open-telemetry/opentelemetry-collector/pull/10554
