### PR TITLE
[receiver/statsd] log only non-EOF errors when reading payload received via TCP

### DIFF
--- a/.chloggen/statsreceiver_tcp_transport.yaml
+++ b/.chloggen/statsreceiver_tcp_transport.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdeceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Log only non-EOF errors when reading payload received via TCP.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33951]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/statsdreceiver/internal/transport/tcp_server.go
+++ b/receiver/statsdreceiver/internal/transport/tcp_server.go
@@ -85,7 +85,9 @@ func (t *tcpServer) handleConn(c net.Conn, transferChan chan<- Metric) {
 	for {
 		n, err := c.Read(payload)
 		if err != nil {
-			t.reporter.OnDebugf("TCP transport (%s) Error reading payload: %v", c.LocalAddr(), err)
+			if err != io.EOF {
+				t.reporter.OnDebugf("TCP transport (%s) Error reading payload: %v", c.LocalAddr(), err)
+			}
 			t.wg.Done()
 			return
 		}

--- a/receiver/statsdreceiver/internal/transport/tcp_server.go
+++ b/receiver/statsdreceiver/internal/transport/tcp_server.go
@@ -85,7 +85,7 @@ func (t *tcpServer) handleConn(c net.Conn, transferChan chan<- Metric) {
 	for {
 		n, err := c.Read(payload)
 		if err != nil {
-			if err != io.EOF {
+			if !errors.Is(err, io.EOF) {
 				t.reporter.OnDebugf("TCP transport (%s) Error reading payload: %v", c.LocalAddr(), err)
 			}
 			t.wg.Done()


### PR DESCRIPTION
**Description:** This PR modifies the tcp server of the statsd receiver to log errors only if they are not an `io.EOF`, as this one is expected when the payload has been read completely.

**Link to tracking Issue:** #33951

**Testing:** The affected function has already been covered by existing tests. The only thing changed was whether to log the error or not.

**Documentation:** None required, as there have been no changes from user perspective