### PR TITLE
[chore][exporter/datadog] Set MaxSenderRetries to 4

### DIFF
--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -211,6 +211,7 @@ func newTraceAgentConfig(ctx context.Context, params exporter.Settings, cfg *Con
 	acfg.ComputeStatsBySpanKind = cfg.Traces.ComputeStatsBySpanKind
 	acfg.PeerTagsAggregation = cfg.Traces.PeerTagsAggregation
 	acfg.PeerTags = cfg.Traces.PeerTags
+	acfg.MaxSenderRetries = 4
 	if v := cfg.Traces.flushInterval; v > 0 {
 		acfg.TraceWriter.FlushPeriodSeconds = v
 	}


### PR DESCRIPTION
This matches the default value in datadog agent https://github.com/DataDog/datadog-agent/blob/2043b6415b70dd3d5bb09a2d37cd33417e4902d1/comp/trace/config/setup.go#L536