### PR TITLE
[chore][CODEOWNERS] Fix Loki exporter entry

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -65,7 +65,7 @@ exporter/kineticaexporter/                                          @open-teleme
 exporter/loadbalancingexporter/                                     @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/logicmonitorexporter/                                      @open-telemetry/collector-contrib-approvers @bogdandrutu @khyatigandhi6 @avadhut123pisal
 exporter/logzioexporter/                                            @open-telemetry/collector-contrib-approvers @yotamloe
-exporter/lokiexporter/                                              @open-telemetry/collector-contrib-approvers @gramidt @gouthamve @jpkrohling @mar4uk
+exporter/lokiexporter/                                              @open-telemetry/collector-contrib-approvers @gramidt @jpkrohling @mar4uk
 exporter/mezmoexporter/                                             @open-telemetry/collector-contrib-approvers @dashpole @billmeyer @gjanco
 exporter/opencensusexporter/                                        @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 exporter/opensearchexporter/                                        @open-telemetry/collector-contrib-approvers @Aneurysm9 @MitchellGale @MaxKsyunz @YANG-DB


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Check codeowners is failing as the CODEOWNERS file no longer matches the metadata.yaml entry for the Loki exporter. This updates the entry to match.

[Failing check](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9863048627/job/27235019821#step:16:25)

**Link to tracking Issue:** <Issue number if applicable>
Caused by https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33918