### PR TITLE
Enable vSphere CPU and host metrics by default

### DIFF
--- a/.chloggen/update_vcenter_host_vm_metrics_to_default.yaml
+++ b/.chloggen/update_vcenter_host_vm_metrics_to_default.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enables various vCenter metrics that were disabled by default until v0.105"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following metrics will be enabled by default "vcenter.host.network.packet.drop.rate",
+  "vcenter.vm.cpu.readiness", "vcenter.host.cpu.capacity", and "vcenter.host.cpu.reserved".
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/update_vcenter_host_vm_metrics_to_default.yaml
+++ b/.chloggen/update_vcenter_host_vm_metrics_to_default.yaml
@@ -10,7 +10,7 @@ component: vcenterreceiver
 note: "Enables various vCenter metrics that were disabled by default until v0.105"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34022]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -16,30 +16,30 @@ metrics:
 
 The effective CPU available to the cluster. This value excludes CPU from hosts in maintenance mode or are unresponsive.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum | Int | Cumulative | false |
+| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ----- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.cluster.cpu.limit
 
 The amount of CPU available to the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum | Int | Cumulative | false |
+| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ----- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.cluster.host.count
 
 The number of hosts in the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {hosts} | Sum | Int | Cumulative | false |
+| Unit    | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ------- | ----------- | ---------- | ----------------------- | --------- |
+| {hosts} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
+| Name      | Description                                           | Values   |
+| --------- | ----------------------------------------------------- | -------- |
 | effective | Whether the host is effective in the vCenter cluster. | Any Bool |
 
 ### vcenter.cluster.memory.effective
@@ -50,7 +50,7 @@ This value excludes memory from hosts that are either in maintenance mode or are
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| By   | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.cluster.memory.limit
 
@@ -58,29 +58,29 @@ The available memory of the cluster.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| By   | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.cluster.vm.count
 
 The number of virtual machines in the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {virtual_machines} | Sum | Int | Cumulative | false |
+| Unit               | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ------------------ | ----------- | ---------- | ----------------------- | --------- |
+| {virtual_machines} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| power_state | The current power state of the virtual machine. | Str: ``on``, ``off``, ``suspended``, ``unknown`` |
+| Name        | Description                                     | Values                                   |
+| ----------- | ----------------------------------------------- | ---------------------------------------- |
+| power_state | The current power state of the virtual machine. | Str: `on`, `off`, `suspended`, `unknown` |
 
 ### vcenter.cluster.vm_template.count
 
 The number of virtual machine templates in the cluster.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {virtual_machine_templates} | Sum | Int | Cumulative | false |
+| Unit                        | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| --------------------------- | ----------- | ---------- | ----------------------- | --------- |
+| {virtual_machine_templates} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.datastore.disk.usage
 
@@ -88,13 +88,13 @@ The amount of space in the datastore.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| By   | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
+| Name       | Description                                                       | Values                   |
+| ---------- | ----------------------------------------------------------------- | ------------------------ |
+| disk_state | The state of storage and whether it is already allocated or free. | Str: `available`, `used` |
 
 ### vcenter.datastore.disk.utilization
 
@@ -102,7 +102,29 @@ The utilization of the datastore.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| %    | Gauge       | Double     |
+
+### vcenter.host.cpu.capacity
+
+Total CPU capacity of the host system.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| MHz  | Sum         | Int        | Cumulative              | false     |
+
+### vcenter.host.cpu.reserved
+
+The CPU of the host reserved for use by virtual machines.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| MHz  | Sum         | Int        | Cumulative              | false     |
+
+#### Attributes
+
+| Name                 | Description                               | Values               |
+| -------------------- | ----------------------------------------- | -------------------- |
+| cpu_reservation_type | The type of CPU reservation for the host. | Str: `total`, `used` |
 
 ### vcenter.host.cpu.usage
 
@@ -110,7 +132,7 @@ The amount of CPU used by the host.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz | Sum | Int | Cumulative | false |
+| MHz  | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.host.cpu.utilization
 
@@ -118,7 +140,7 @@ The CPU utilization of the host system.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| %    | Gauge       | Double     |
 
 ### vcenter.host.disk.latency.avg
 
@@ -128,14 +150,14 @@ This latency is the sum of the device and kernel read and write latencies. Requi
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| ms   | Gauge       | Int        |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of disk latency. | Str: ``read``, ``write`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values               |
+| --------- | -------------------------------------------------------------------- | -------------------- |
+| direction | The direction of disk latency.                                       | Str: `read`, `write` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str              |
 
 ### vcenter.host.disk.latency.max
 
@@ -145,12 +167,12 @@ As measured over the most recent 20s interval. Requires Performance Level 3.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| ms   | Gauge       | Int        |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
+| Name   | Description                                                          | Values  |
+| ------ | -------------------------------------------------------------------- | ------- |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.disk.throughput
@@ -159,16 +181,16 @@ Average number of kilobytes read from or written to the disk each second.
 
 As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum | Int | Cumulative | false |
+| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| -------- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of disk latency. | Str: ``read``, ``write`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values               |
+| --------- | -------------------------------------------------------------------- | -------------------- |
+| direction | The direction of disk latency.                                       | Str: `read`, `write` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str              |
 
 ### vcenter.host.memory.usage
 
@@ -176,7 +198,7 @@ The amount of memory the host system is using.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.host.memory.utilization
 
@@ -184,7 +206,24 @@ The percentage of the host system's memory capacity that is being utilized.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| %    | Gauge       | Double     |
+
+### vcenter.host.network.packet.drop.rate
+
+The rate of packets dropped across each physical NIC (network interface controller) instance on the host.
+
+As measured over the most recent 20s interval.
+
+| Unit          | Metric Type | Value Type |
+| ------------- | ----------- | ---------- |
+| {packets/sec} | Gauge       | Double     |
+
+#### Attributes
+
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.host.network.packet.error.rate
 
@@ -192,16 +231,16 @@ The rate of packet errors transmitted or received on the host network.
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {errors/sec} | Gauge | Double |
+| Unit         | Metric Type | Value Type |
+| ------------ | ----------- | ---------- |
+| {errors/sec} | Gauge       | Double     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.host.network.packet.rate
 
@@ -209,16 +248,16 @@ The rate of packets transmitted or received across each physical NIC (network in
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {packets/sec} | Gauge | Double |
+| Unit          | Metric Type | Value Type |
+| ------------- | ----------- | ---------- |
+| {packets/sec} | Gauge       | Double     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.host.network.throughput
 
@@ -226,54 +265,54 @@ The amount of data that was transmitted or received over the network by the host
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum | Int | Cumulative | false |
+| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| -------- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.host.network.usage
 
 The sum of the data transmitted and received for all the NIC instances of the host.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum | Int | Cumulative | false |
+| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| -------- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
+| Name   | Description                                                          | Values  |
+| ------ | -------------------------------------------------------------------- | ------- |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.resource_pool.cpu.shares
 
 The amount of shares of CPU in the resource pool.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {shares} | Sum | Int | Cumulative | false |
+| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| -------- | ----------- | ---------- | ----------------------- | --------- |
+| {shares} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.resource_pool.cpu.usage
 
 The usage of the CPU used by the resource pool.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum | Int | Cumulative | false |
+| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ----- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.resource_pool.memory.shares
 
 The amount of shares of memory in the resource pool.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {shares} | Sum | Int | Cumulative | false |
+| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| -------- | ----------- | ---------- | ----------------------- | --------- |
+| {shares} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.resource_pool.memory.usage
 
@@ -281,13 +320,21 @@ The usage of the memory by the resource pool.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| type | The type of memory usage. | Str: ``guest``, ``host``, ``overhead`` |
+| Name | Description               | Values                           |
+| ---- | ------------------------- | -------------------------------- |
+| type | The type of memory usage. | Str: `guest`, `host`, `overhead` |
+
+### vcenter.vm.cpu.readiness
+
+Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| %    | Gauge       | Int        |
 
 ### vcenter.vm.cpu.usage
 
@@ -295,7 +342,7 @@ The amount of CPU used by the VM.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz | Sum | Int | Cumulative | false |
+| MHz  | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.vm.cpu.utilization
 
@@ -303,7 +350,7 @@ The CPU utilization of the VM.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| %    | Gauge       | Double     |
 
 ### vcenter.vm.disk.latency.avg
 
@@ -313,15 +360,15 @@ Requires Performance Counter level 2 for metric to populate. As measured over th
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| ms   | Gauge       | Int        |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of disk latency. | Str: ``read``, ``write`` |
-| disk_type | The type of storage device that is being recorded. | Str: ``virtual``, ``physical`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                     |
+| --------- | -------------------------------------------------------------------- | -------------------------- |
+| direction | The direction of disk latency.                                       | Str: `read`, `write`       |
+| disk_type | The type of storage device that is being recorded.                   | Str: `virtual`, `physical` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                    |
 
 ### vcenter.vm.disk.latency.max
 
@@ -329,12 +376,12 @@ The highest reported total latency (device and kernel times) over an interval of
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms | Gauge | Int |
+| ms   | Gauge       | Int        |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
+| Name   | Description                                                          | Values  |
+| ------ | -------------------------------------------------------------------- | ------- |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.disk.throughput
@@ -343,16 +390,16 @@ Average number of kilobytes read from or written to the virtual disk each second
 
 As measured over the most recent 20s interval. Requires Performance Level 2.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {KiBy/s} | Gauge | Int |
+| Unit     | Metric Type | Value Type |
+| -------- | ----------- | ---------- |
+| {KiBy/s} | Gauge       | Int        |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of disk latency. | Str: ``read``, ``write`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values               |
+| --------- | -------------------------------------------------------------------- | -------------------- |
+| direction | The direction of disk latency.                                       | Str: `read`, `write` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str              |
 
 ### vcenter.vm.disk.usage
 
@@ -360,13 +407,13 @@ The amount of storage space used by the virtual machine.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| By   | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
+| Name       | Description                                                       | Values                   |
+| ---------- | ----------------------------------------------------------------- | ------------------------ |
+| disk_state | The state of storage and whether it is already allocated or free. | Str: `available`, `used` |
 
 ### vcenter.vm.disk.utilization
 
@@ -374,7 +421,7 @@ The utilization of storage on the virtual machine.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| %    | Gauge       | Double     |
 
 ### vcenter.vm.memory.ballooned
 
@@ -382,7 +429,7 @@ The amount of memory that is ballooned due to virtualization.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.vm.memory.swapped
 
@@ -390,7 +437,7 @@ The portion of memory that is granted to this VM from the host's swap space.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.vm.memory.swapped_ssd
 
@@ -398,7 +445,7 @@ The amount of memory swapped to fast disk device such as SSD.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| KiBy | Sum | Int | Cumulative | false |
+| KiBy | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.vm.memory.usage
 
@@ -406,7 +453,7 @@ The amount of memory that is used by the virtual machine.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.vm.memory.utilization
 
@@ -414,7 +461,7 @@ The memory utilization of the VM.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| % | Gauge | Double |
+| %    | Gauge       | Double     |
 
 ### vcenter.vm.network.packet.drop.rate
 
@@ -422,16 +469,16 @@ The rate of transmitted or received packets dropped by each vNIC (virtual networ
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {packets/sec} | Gauge | Double |
+| Unit          | Metric Type | Value Type |
+| ------------- | ----------- | ---------- |
+| {packets/sec} | Gauge       | Double     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.vm.network.packet.rate
 
@@ -439,16 +486,16 @@ The rate of packets transmitted or received by each vNIC (virtual network interf
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {packets/sec} | Gauge | Double |
+| Unit          | Metric Type | Value Type |
+| ------------- | ----------- | ---------- |
+| {packets/sec} | Gauge       | Double     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.vm.network.throughput
 
@@ -456,16 +503,16 @@ The amount of data that was transmitted or received over the network of the virt
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By/sec | Sum | Int | Cumulative | false |
+| Unit   | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ------ | ----------- | ---------- | ----------------------- | --------- |
+| By/sec | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.vm.network.usage
 
@@ -473,14 +520,14 @@ The network utilization combined transmit and receive rates during an interval.
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum | Int | Cumulative | false |
+| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| -------- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
+| Name   | Description                                                          | Values  |
+| ------ | -------------------------------------------------------------------- | ------- |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ## Optional Metrics
@@ -497,31 +544,31 @@ metrics:
 
 The number of clusters in the datacenter.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {clusters} | Sum | Int | Cumulative | false |
+| Unit       | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---------- | ----------- | ---------- | ----------------------- | --------- |
+| {clusters} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
+| Name   | Description                               | Values                                |
+| ------ | ----------------------------------------- | ------------------------------------- |
+| status | The current status of the managed entity. | Str: `red`, `yellow`, `green`, `gray` |
 
 ### vcenter.datacenter.cpu.limit
 
 The total amount of CPU available to the datacenter.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum | Int | Cumulative | false |
+| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ----- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.datacenter.datastore.count
 
 The number of datastores in the datacenter.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {datastores} | Sum | Int | Cumulative | false |
+| Unit         | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ------------ | ----------- | ---------- | ----------------------- | --------- |
+| {datastores} | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.datacenter.disk.space
 
@@ -529,28 +576,28 @@ The amount of available and used disk space in the datacenter.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| By   | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
+| Name       | Description                                                       | Values                   |
+| ---------- | ----------------------------------------------------------------- | ------------------------ |
+| disk_state | The state of storage and whether it is already allocated or free. | Str: `available`, `used` |
 
 ### vcenter.datacenter.host.count
 
 The number of hosts in the datacenter.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {hosts} | Sum | Int | Cumulative | false |
+| Unit    | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ------- | ----------- | ---------- | ----------------------- | --------- |
+| {hosts} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
-| power_state | The current power state of the host. | Str: ``on``, ``off``, ``standby``, ``unknown`` |
+| Name        | Description                               | Values                                 |
+| ----------- | ----------------------------------------- | -------------------------------------- |
+| status      | The current status of the managed entity. | Str: `red`, `yellow`, `green`, `gray`  |
+| power_state | The current power state of the host.      | Str: `on`, `off`, `standby`, `unknown` |
 
 ### vcenter.datacenter.memory.limit
 
@@ -558,22 +605,22 @@ The total amount of memory available to the datacenter.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
+| By   | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.datacenter.vm.count
 
 The number of VM's in the datacenter.
 
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {virtual_machines} | Sum | Int | Cumulative | false |
+| Unit               | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ------------------ | ----------- | ---------- | ----------------------- | --------- |
+| {virtual_machines} | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
-| power_state | The current power state of the virtual machine. | Str: ``on``, ``off``, ``suspended``, ``unknown`` |
+| Name        | Description                                     | Values                                   |
+| ----------- | ----------------------------------------------- | ---------------------------------------- |
+| status      | The current status of the managed entity.       | Str: `red`, `yellow`, `green`, `gray`    |
+| power_state | The current power state of the virtual machine. | Str: `on`, `off`, `suspended`, `unknown` |
 
 ### vcenter.host.cpu.capacity
 
@@ -581,7 +628,7 @@ Total CPU capacity of the host system.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz | Sum | Int | Cumulative | false |
+| MHz  | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.host.cpu.reserved
 
@@ -589,13 +636,13 @@ The CPU of the host reserved for use by virtual machines.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz | Sum | Int | Cumulative | false |
+| MHz  | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| cpu_reservation_type | The type of CPU reservation for the host. | Str: ``total``, ``used`` |
+| Name                 | Description                               | Values               |
+| -------------------- | ----------------------------------------- | -------------------- |
+| cpu_reservation_type | The type of CPU reservation for the host. | Str: `total`, `used` |
 
 ### vcenter.host.network.packet.drop.rate
 
@@ -603,16 +650,16 @@ The rate of packets dropped across each physical NIC (network interface controll
 
 As measured over the most recent 20s interval.
 
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {packets/sec} | Gauge | Double |
+| Unit          | Metric Type | Value Type |
+| ------------- | ----------- | ---------- |
+| {packets/sec} | Gauge       | Double     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
-| object | The object on the virtual machine or host that is being reported on. | Any Str |
+| Name      | Description                                                          | Values                         |
+| --------- | -------------------------------------------------------------------- | ------------------------------ |
+| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
+| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
 
 ### vcenter.resource_pool.memory.ballooned
 
@@ -620,7 +667,7 @@ The amount of memory in a resource pool that is ballooned due to virtualization.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 ### vcenter.resource_pool.memory.granted
 
@@ -628,13 +675,13 @@ The amount of memory that is granted to VMs in the resource pool from shared and
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 #### Attributes
 
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| type | The type of memory granted. | Str: ``private``, ``shared`` |
+| Name | Description                 | Values                   |
+| ---- | --------------------------- | ------------------------ |
+| type | The type of memory granted. | Str: `private`, `shared` |
 
 ### vcenter.resource_pool.memory.swapped
 
@@ -642,29 +689,21 @@ The amount of memory that is granted to VMs in the resource pool from the host's
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
-
-### vcenter.vm.cpu.readiness
-
-Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| % | Gauge | Int |
+| MiBy | Sum         | Int        | Cumulative              | false     |
 
 ## Resource Attributes
 
-| Name | Description | Values | Enabled |
-| ---- | ----------- | ------ | ------- |
-| vcenter.cluster.name | The name of the vCenter cluster. | Any Str | true |
-| vcenter.datacenter.name | The name of the vCenter datacenter. | Any Str | true |
-| vcenter.datastore.name | The name of the vCenter datastore. | Any Str | true |
-| vcenter.host.name | The hostname of the vCenter ESXi host. | Any Str | true |
-| vcenter.resource_pool.inventory_path | The inventory path of the resource pool. | Any Str | true |
-| vcenter.resource_pool.name | The name of the resource pool. | Any Str | true |
-| vcenter.virtual_app.inventory_path | The inventory path of the vApp. | Any Str | true |
-| vcenter.virtual_app.name | The name of the vApp. | Any Str | true |
-| vcenter.vm.id | The instance UUID of the virtual machine. | Any Str | true |
-| vcenter.vm.name | The name of the virtual machine. | Any Str | true |
-| vcenter.vm_template.id | The instance UUID of the virtual machine template. | Any Str | true |
-| vcenter.vm_template.name | The name of the virtual machine template. | Any Str | true |
+| Name                                 | Description                                        | Values  | Enabled |
+| ------------------------------------ | -------------------------------------------------- | ------- | ------- |
+| vcenter.cluster.name                 | The name of the vCenter cluster.                   | Any Str | true    |
+| vcenter.datacenter.name              | The name of the vCenter datacenter.                | Any Str | true    |
+| vcenter.datastore.name               | The name of the vCenter datastore.                 | Any Str | true    |
+| vcenter.host.name                    | The hostname of the vCenter ESXi host.             | Any Str | true    |
+| vcenter.resource_pool.inventory_path | The inventory path of the resource pool.           | Any Str | true    |
+| vcenter.resource_pool.name           | The name of the resource pool.                     | Any Str | true    |
+| vcenter.virtual_app.inventory_path   | The inventory path of the vApp.                    | Any Str | true    |
+| vcenter.virtual_app.name             | The name of the vApp.                              | Any Str | true    |
+| vcenter.vm.id                        | The instance UUID of the virtual machine.          | Any Str | true    |
+| vcenter.vm.name                      | The name of the virtual machine.                   | Any Str | true    |
+| vcenter.vm_template.id               | The instance UUID of the virtual machine template. | Any Str | true    |
+| vcenter.vm_template.name             | The name of the virtual machine template.          | Any Str | true    |

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -16,30 +16,30 @@ metrics:
 
 The effective CPU available to the cluster. This value excludes CPU from hosts in maintenance mode or are unresponsive.
 
-| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ----- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum | Int | Cumulative | false |
 
 ### vcenter.cluster.cpu.limit
 
 The amount of CPU available to the cluster.
 
-| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ----- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum | Int | Cumulative | false |
 
 ### vcenter.cluster.host.count
 
 The number of hosts in the cluster.
 
-| Unit    | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ------- | ----------- | ---------- | ----------------------- | --------- |
-| {hosts} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {hosts} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name      | Description                                           | Values   |
-| --------- | ----------------------------------------------------- | -------- |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
 | effective | Whether the host is effective in the vCenter cluster. | Any Bool |
 
 ### vcenter.cluster.memory.effective
@@ -50,7 +50,7 @@ This value excludes memory from hosts that are either in maintenance mode or are
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By   | Sum         | Int        | Cumulative              | false     |
+| By | Sum | Int | Cumulative | false |
 
 ### vcenter.cluster.memory.limit
 
@@ -58,29 +58,29 @@ The available memory of the cluster.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By   | Sum         | Int        | Cumulative              | false     |
+| By | Sum | Int | Cumulative | false |
 
 ### vcenter.cluster.vm.count
 
 The number of virtual machines in the cluster.
 
-| Unit               | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ------------------ | ----------- | ---------- | ----------------------- | --------- |
-| {virtual_machines} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {virtual_machines} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name        | Description                                     | Values                                   |
-| ----------- | ----------------------------------------------- | ---------------------------------------- |
-| power_state | The current power state of the virtual machine. | Str: `on`, `off`, `suspended`, `unknown` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| power_state | The current power state of the virtual machine. | Str: ``on``, ``off``, ``suspended``, ``unknown`` |
 
 ### vcenter.cluster.vm_template.count
 
 The number of virtual machine templates in the cluster.
 
-| Unit                        | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| --------------------------- | ----------- | ---------- | ----------------------- | --------- |
-| {virtual_machine_templates} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {virtual_machine_templates} | Sum | Int | Cumulative | false |
 
 ### vcenter.datastore.disk.usage
 
@@ -88,13 +88,13 @@ The amount of space in the datastore.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By   | Sum         | Int        | Cumulative              | false     |
+| By | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name       | Description                                                       | Values                   |
-| ---------- | ----------------------------------------------------------------- | ------------------------ |
-| disk_state | The state of storage and whether it is already allocated or free. | Str: `available`, `used` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
 
 ### vcenter.datastore.disk.utilization
 
@@ -102,7 +102,7 @@ The utilization of the datastore.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| %    | Gauge       | Double     |
+| % | Gauge | Double |
 
 ### vcenter.host.cpu.capacity
 
@@ -110,7 +110,7 @@ Total CPU capacity of the host system.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz  | Sum         | Int        | Cumulative              | false     |
+| MHz | Sum | Int | Cumulative | false |
 
 ### vcenter.host.cpu.reserved
 
@@ -118,13 +118,13 @@ The CPU of the host reserved for use by virtual machines.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz  | Sum         | Int        | Cumulative              | false     |
+| MHz | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name                 | Description                               | Values               |
-| -------------------- | ----------------------------------------- | -------------------- |
-| cpu_reservation_type | The type of CPU reservation for the host. | Str: `total`, `used` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| cpu_reservation_type | The type of CPU reservation for the host. | Str: ``total``, ``used`` |
 
 ### vcenter.host.cpu.usage
 
@@ -132,7 +132,7 @@ The amount of CPU used by the host.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz  | Sum         | Int        | Cumulative              | false     |
+| MHz | Sum | Int | Cumulative | false |
 
 ### vcenter.host.cpu.utilization
 
@@ -140,7 +140,7 @@ The CPU utilization of the host system.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| %    | Gauge       | Double     |
+| % | Gauge | Double |
 
 ### vcenter.host.disk.latency.avg
 
@@ -150,14 +150,14 @@ This latency is the sum of the device and kernel read and write latencies. Requi
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms   | Gauge       | Int        |
+| ms | Gauge | Int |
 
 #### Attributes
 
-| Name      | Description                                                          | Values               |
-| --------- | -------------------------------------------------------------------- | -------------------- |
-| direction | The direction of disk latency.                                       | Str: `read`, `write` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str              |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of disk latency. | Str: ``read``, ``write`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.disk.latency.max
 
@@ -167,12 +167,12 @@ As measured over the most recent 20s interval. Requires Performance Level 3.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms   | Gauge       | Int        |
+| ms | Gauge | Int |
 
 #### Attributes
 
-| Name   | Description                                                          | Values  |
-| ------ | -------------------------------------------------------------------- | ------- |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.disk.throughput
@@ -181,16 +181,16 @@ Average number of kilobytes read from or written to the disk each second.
 
 As measured over the most recent 20s interval. Aggregated disk I/O rate. Requires Performance Level 4.
 
-| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| -------- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name      | Description                                                          | Values               |
-| --------- | -------------------------------------------------------------------- | -------------------- |
-| direction | The direction of disk latency.                                       | Str: `read`, `write` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str              |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of disk latency. | Str: ``read``, ``write`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.memory.usage
 
@@ -198,7 +198,7 @@ The amount of memory the host system is using.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.host.memory.utilization
 
@@ -206,7 +206,7 @@ The percentage of the host system's memory capacity that is being utilized.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| %    | Gauge       | Double     |
+| % | Gauge | Double |
 
 ### vcenter.host.network.packet.drop.rate
 
@@ -214,16 +214,16 @@ The rate of packets dropped across each physical NIC (network interface controll
 
 As measured over the most recent 20s interval.
 
-| Unit          | Metric Type | Value Type |
-| ------------- | ----------- | ---------- |
-| {packets/sec} | Gauge       | Double     |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {packets/sec} | Gauge | Double |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.network.packet.error.rate
 
@@ -231,16 +231,16 @@ The rate of packet errors transmitted or received on the host network.
 
 As measured over the most recent 20s interval.
 
-| Unit         | Metric Type | Value Type |
-| ------------ | ----------- | ---------- |
-| {errors/sec} | Gauge       | Double     |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {errors/sec} | Gauge | Double |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.network.packet.rate
 
@@ -248,16 +248,16 @@ The rate of packets transmitted or received across each physical NIC (network in
 
 As measured over the most recent 20s interval.
 
-| Unit          | Metric Type | Value Type |
-| ------------- | ----------- | ---------- |
-| {packets/sec} | Gauge       | Double     |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {packets/sec} | Gauge | Double |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.network.throughput
 
@@ -265,54 +265,54 @@ The amount of data that was transmitted or received over the network by the host
 
 As measured over the most recent 20s interval.
 
-| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| -------- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.host.network.usage
 
 The sum of the data transmitted and received for all the NIC instances of the host.
 
-| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| -------- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name   | Description                                                          | Values  |
-| ------ | -------------------------------------------------------------------- | ------- |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.resource_pool.cpu.shares
 
 The amount of shares of CPU in the resource pool.
 
-| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| -------- | ----------- | ---------- | ----------------------- | --------- |
-| {shares} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {shares} | Sum | Int | Cumulative | false |
 
 ### vcenter.resource_pool.cpu.usage
 
 The usage of the CPU used by the resource pool.
 
-| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ----- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum | Int | Cumulative | false |
 
 ### vcenter.resource_pool.memory.shares
 
 The amount of shares of memory in the resource pool.
 
-| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| -------- | ----------- | ---------- | ----------------------- | --------- |
-| {shares} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {shares} | Sum | Int | Cumulative | false |
 
 ### vcenter.resource_pool.memory.usage
 
@@ -320,13 +320,13 @@ The usage of the memory by the resource pool.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name | Description               | Values                           |
-| ---- | ------------------------- | -------------------------------- |
-| type | The type of memory usage. | Str: `guest`, `host`, `overhead` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| type | The type of memory usage. | Str: ``guest``, ``host``, ``overhead`` |
 
 ### vcenter.vm.cpu.readiness
 
@@ -334,7 +334,7 @@ Percentage of time that the virtual machine was ready, but could not get schedul
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| %    | Gauge       | Int        |
+| % | Gauge | Int |
 
 ### vcenter.vm.cpu.usage
 
@@ -342,7 +342,7 @@ The amount of CPU used by the VM.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz  | Sum         | Int        | Cumulative              | false     |
+| MHz | Sum | Int | Cumulative | false |
 
 ### vcenter.vm.cpu.utilization
 
@@ -350,7 +350,7 @@ The CPU utilization of the VM.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| %    | Gauge       | Double     |
+| % | Gauge | Double |
 
 ### vcenter.vm.disk.latency.avg
 
@@ -360,15 +360,15 @@ Requires Performance Counter level 2 for metric to populate. As measured over th
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms   | Gauge       | Int        |
+| ms | Gauge | Int |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                     |
-| --------- | -------------------------------------------------------------------- | -------------------------- |
-| direction | The direction of disk latency.                                       | Str: `read`, `write`       |
-| disk_type | The type of storage device that is being recorded.                   | Str: `virtual`, `physical` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                    |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of disk latency. | Str: ``read``, ``write`` |
+| disk_type | The type of storage device that is being recorded. | Str: ``virtual``, ``physical`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.disk.latency.max
 
@@ -376,12 +376,12 @@ The highest reported total latency (device and kernel times) over an interval of
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| ms   | Gauge       | Int        |
+| ms | Gauge | Int |
 
 #### Attributes
 
-| Name   | Description                                                          | Values  |
-| ------ | -------------------------------------------------------------------- | ------- |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.disk.throughput
@@ -390,16 +390,16 @@ Average number of kilobytes read from or written to the virtual disk each second
 
 As measured over the most recent 20s interval. Requires Performance Level 2.
 
-| Unit     | Metric Type | Value Type |
-| -------- | ----------- | ---------- |
-| {KiBy/s} | Gauge       | Int        |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {KiBy/s} | Gauge | Int |
 
 #### Attributes
 
-| Name      | Description                                                          | Values               |
-| --------- | -------------------------------------------------------------------- | -------------------- |
-| direction | The direction of disk latency.                                       | Str: `read`, `write` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str              |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of disk latency. | Str: ``read``, ``write`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.disk.usage
 
@@ -407,13 +407,13 @@ The amount of storage space used by the virtual machine.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By   | Sum         | Int        | Cumulative              | false     |
+| By | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name       | Description                                                       | Values                   |
-| ---------- | ----------------------------------------------------------------- | ------------------------ |
-| disk_state | The state of storage and whether it is already allocated or free. | Str: `available`, `used` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
 
 ### vcenter.vm.disk.utilization
 
@@ -421,7 +421,7 @@ The utilization of storage on the virtual machine.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| %    | Gauge       | Double     |
+| % | Gauge | Double |
 
 ### vcenter.vm.memory.ballooned
 
@@ -429,7 +429,7 @@ The amount of memory that is ballooned due to virtualization.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.vm.memory.swapped
 
@@ -437,7 +437,7 @@ The portion of memory that is granted to this VM from the host's swap space.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.vm.memory.swapped_ssd
 
@@ -445,7 +445,7 @@ The amount of memory swapped to fast disk device such as SSD.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| KiBy | Sum         | Int        | Cumulative              | false     |
+| KiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.vm.memory.usage
 
@@ -453,7 +453,7 @@ The amount of memory that is used by the virtual machine.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.vm.memory.utilization
 
@@ -461,7 +461,7 @@ The memory utilization of the VM.
 
 | Unit | Metric Type | Value Type |
 | ---- | ----------- | ---------- |
-| %    | Gauge       | Double     |
+| % | Gauge | Double |
 
 ### vcenter.vm.network.packet.drop.rate
 
@@ -469,16 +469,16 @@ The rate of transmitted or received packets dropped by each vNIC (virtual networ
 
 As measured over the most recent 20s interval.
 
-| Unit          | Metric Type | Value Type |
-| ------------- | ----------- | ---------- |
-| {packets/sec} | Gauge       | Double     |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {packets/sec} | Gauge | Double |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.network.packet.rate
 
@@ -486,16 +486,16 @@ The rate of packets transmitted or received by each vNIC (virtual network interf
 
 As measured over the most recent 20s interval.
 
-| Unit          | Metric Type | Value Type |
-| ------------- | ----------- | ---------- |
-| {packets/sec} | Gauge       | Double     |
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {packets/sec} | Gauge | Double |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.network.throughput
 
@@ -503,16 +503,16 @@ The amount of data that was transmitted or received over the network of the virt
 
 As measured over the most recent 20s interval.
 
-| Unit   | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ------ | ----------- | ---------- | ----------------------- | --------- |
-| By/sec | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| By/sec | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The direction of network throughput. | Str: ``transmitted``, ``received`` |
+| object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ### vcenter.vm.network.usage
 
@@ -520,14 +520,14 @@ The network utilization combined transmit and receive rates during an interval.
 
 As measured over the most recent 20s interval.
 
-| Unit     | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| -------- | ----------- | ---------- | ----------------------- | --------- |
-| {KiBy/s} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {KiBy/s} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name   | Description                                                          | Values  |
-| ------ | -------------------------------------------------------------------- | ------- |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
 ## Optional Metrics
@@ -544,31 +544,31 @@ metrics:
 
 The number of clusters in the datacenter.
 
-| Unit       | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---------- | ----------- | ---------- | ----------------------- | --------- |
-| {clusters} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {clusters} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name   | Description                               | Values                                |
-| ------ | ----------------------------------------- | ------------------------------------- |
-| status | The current status of the managed entity. | Str: `red`, `yellow`, `green`, `gray` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
 
 ### vcenter.datacenter.cpu.limit
 
 The total amount of CPU available to the datacenter.
 
-| Unit  | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ----- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum | Int | Cumulative | false |
 
 ### vcenter.datacenter.datastore.count
 
 The number of datastores in the datacenter.
 
-| Unit         | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ------------ | ----------- | ---------- | ----------------------- | --------- |
-| {datastores} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {datastores} | Sum | Int | Cumulative | false |
 
 ### vcenter.datacenter.disk.space
 
@@ -576,28 +576,28 @@ The amount of available and used disk space in the datacenter.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By   | Sum         | Int        | Cumulative              | false     |
+| By | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name       | Description                                                       | Values                   |
-| ---------- | ----------------------------------------------------------------- | ------------------------ |
-| disk_state | The state of storage and whether it is already allocated or free. | Str: `available`, `used` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
 
 ### vcenter.datacenter.host.count
 
 The number of hosts in the datacenter.
 
-| Unit    | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ------- | ----------- | ---------- | ----------------------- | --------- |
-| {hosts} | Sum         | Int        | Cumulative              | false     |
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {hosts} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name        | Description                               | Values                                 |
-| ----------- | ----------------------------------------- | -------------------------------------- |
-| status      | The current status of the managed entity. | Str: `red`, `yellow`, `green`, `gray`  |
-| power_state | The current power state of the host.      | Str: `on`, `off`, `standby`, `unknown` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
+| power_state | The current power state of the host. | Str: ``on``, ``off``, ``standby``, ``unknown`` |
 
 ### vcenter.datacenter.memory.limit
 
@@ -605,61 +605,22 @@ The total amount of memory available to the datacenter.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| By   | Sum         | Int        | Cumulative              | false     |
+| By | Sum | Int | Cumulative | false |
 
 ### vcenter.datacenter.vm.count
 
 The number of VM's in the datacenter.
 
-| Unit               | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ------------------ | ----------- | ---------- | ----------------------- | --------- |
-| {virtual_machines} | Sum         | Int        | Cumulative              | false     |
-
-#### Attributes
-
-| Name        | Description                                     | Values                                   |
-| ----------- | ----------------------------------------------- | ---------------------------------------- |
-| status      | The current status of the managed entity.       | Str: `red`, `yellow`, `green`, `gray`    |
-| power_state | The current power state of the virtual machine. | Str: `on`, `off`, `suspended`, `unknown` |
-
-### vcenter.host.cpu.capacity
-
-Total CPU capacity of the host system.
-
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz  | Sum         | Int        | Cumulative              | false     |
-
-### vcenter.host.cpu.reserved
-
-The CPU of the host reserved for use by virtual machines.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| MHz  | Sum         | Int        | Cumulative              | false     |
+| {virtual_machines} | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name                 | Description                               | Values               |
-| -------------------- | ----------------------------------------- | -------------------- |
-| cpu_reservation_type | The type of CPU reservation for the host. | Str: `total`, `used` |
-
-### vcenter.host.network.packet.drop.rate
-
-The rate of packets dropped across each physical NIC (network interface controller) instance on the host.
-
-As measured over the most recent 20s interval.
-
-| Unit          | Metric Type | Value Type |
-| ------------- | ----------- | ---------- |
-| {packets/sec} | Gauge       | Double     |
-
-#### Attributes
-
-| Name      | Description                                                          | Values                         |
-| --------- | -------------------------------------------------------------------- | ------------------------------ |
-| direction | The direction of network throughput.                                 | Str: `transmitted`, `received` |
-| object    | The object on the virtual machine or host that is being reported on. | Any Str                        |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
+| power_state | The current power state of the virtual machine. | Str: ``on``, ``off``, ``suspended``, ``unknown`` |
 
 ### vcenter.resource_pool.memory.ballooned
 
@@ -667,7 +628,7 @@ The amount of memory in a resource pool that is ballooned due to virtualization.
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.resource_pool.memory.granted
 
@@ -675,13 +636,13 @@ The amount of memory that is granted to VMs in the resource pool from shared and
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 #### Attributes
 
-| Name | Description                 | Values                   |
-| ---- | --------------------------- | ------------------------ |
-| type | The type of memory granted. | Str: `private`, `shared` |
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| type | The type of memory granted. | Str: ``private``, ``shared`` |
 
 ### vcenter.resource_pool.memory.swapped
 
@@ -689,21 +650,21 @@ The amount of memory that is granted to VMs in the resource pool from the host's
 
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum         | Int        | Cumulative              | false     |
+| MiBy | Sum | Int | Cumulative | false |
 
 ## Resource Attributes
 
-| Name                                 | Description                                        | Values  | Enabled |
-| ------------------------------------ | -------------------------------------------------- | ------- | ------- |
-| vcenter.cluster.name                 | The name of the vCenter cluster.                   | Any Str | true    |
-| vcenter.datacenter.name              | The name of the vCenter datacenter.                | Any Str | true    |
-| vcenter.datastore.name               | The name of the vCenter datastore.                 | Any Str | true    |
-| vcenter.host.name                    | The hostname of the vCenter ESXi host.             | Any Str | true    |
-| vcenter.resource_pool.inventory_path | The inventory path of the resource pool.           | Any Str | true    |
-| vcenter.resource_pool.name           | The name of the resource pool.                     | Any Str | true    |
-| vcenter.virtual_app.inventory_path   | The inventory path of the vApp.                    | Any Str | true    |
-| vcenter.virtual_app.name             | The name of the vApp.                              | Any Str | true    |
-| vcenter.vm.id                        | The instance UUID of the virtual machine.          | Any Str | true    |
-| vcenter.vm.name                      | The name of the virtual machine.                   | Any Str | true    |
-| vcenter.vm_template.id               | The instance UUID of the virtual machine template. | Any Str | true    |
-| vcenter.vm_template.name             | The name of the virtual machine template.          | Any Str | true    |
+| Name | Description | Values | Enabled |
+| ---- | ----------- | ------ | ------- |
+| vcenter.cluster.name | The name of the vCenter cluster. | Any Str | true |
+| vcenter.datacenter.name | The name of the vCenter datacenter. | Any Str | true |
+| vcenter.datastore.name | The name of the vCenter datastore. | Any Str | true |
+| vcenter.host.name | The hostname of the vCenter ESXi host. | Any Str | true |
+| vcenter.resource_pool.inventory_path | The inventory path of the resource pool. | Any Str | true |
+| vcenter.resource_pool.name | The name of the resource pool. | Any Str | true |
+| vcenter.virtual_app.inventory_path | The inventory path of the vApp. | Any Str | true |
+| vcenter.virtual_app.name | The name of the vApp. | Any Str | true |
+| vcenter.vm.id | The instance UUID of the virtual machine. | Any Str | true |
+| vcenter.vm.name | The name of the virtual machine. | Any Str | true |
+| vcenter.vm_template.id | The instance UUID of the virtual machine template. | Any Str | true |
+| vcenter.vm_template.name | The name of the virtual machine template. | Any Str | true |

--- a/receiver/vcenterreceiver/integration_test.go
+++ b/receiver/vcenterreceiver/integration_test.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+
 package vcenterreceiver // import github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
 
 import (

--- a/receiver/vcenterreceiver/integration_test.go
+++ b/receiver/vcenterreceiver/integration_test.go
@@ -1,8 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build integration
-
 package vcenterreceiver // import github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
 
 import (

--- a/receiver/vcenterreceiver/internal/metadata/generated_config.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_config.go
@@ -135,10 +135,10 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		VcenterHostCPUCapacity: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterHostCPUReserved: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterHostCPUUsage: MetricConfig{
 			Enabled: true,
@@ -162,7 +162,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		VcenterHostNetworkPacketDropRate: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterHostNetworkPacketErrorRate: MetricConfig{
 			Enabled: true,
@@ -198,7 +198,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		VcenterVMCPUReadiness: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterVMCPUUsage: MetricConfig{
 			Enabled: true,

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -3163,6 +3163,27 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 }
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...metricBuilderOption) *MetricsBuilder {
+	if !mbc.Metrics.VcenterDatacenterClusterCount.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cluster.count`: this metric will be enabled by default starting in release v0.106.0")
+	}
+	if !mbc.Metrics.VcenterDatacenterCPULimit.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cpu.limit`: this metric will be enabled by default starting in release v0.106.0")
+	}
+	if !mbc.Metrics.VcenterDatacenterDatastoreCount.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.datastore.count`: this metric will be enabled by default starting in release v0.106.0")
+	}
+	if !mbc.Metrics.VcenterDatacenterDiskSpace.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.disk.space`: this metric will be enabled by default starting in release v0.106.0")
+	}
+	if !mbc.Metrics.VcenterDatacenterHostCount.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.host.count`: this metric will be enabled by default starting in release v0.106.0")
+	}
+	if !mbc.Metrics.VcenterDatacenterMemoryLimit.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.memory.limit`: this metric will be enabled by default starting in release v0.106.0")
+	}
+	if !mbc.Metrics.VcenterDatacenterVMCount.enabledSetByUser {
+		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.vm.count`: this metric will be enabled by default starting in release v0.106.0")
+	}
 	if !mbc.Metrics.VcenterResourcePoolMemoryBallooned.enabledSetByUser {
 		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.ballooned`: this metric will be enabled by default starting in release v0.106.0")
 	}

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -3163,36 +3163,6 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 }
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...metricBuilderOption) *MetricsBuilder {
-	if !mbc.Metrics.VcenterDatacenterClusterCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cluster.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterCPULimit.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cpu.limit`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterDatastoreCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.datastore.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterDiskSpace.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.disk.space`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterHostCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.host.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterMemoryLimit.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.memory.limit`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterVMCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.vm.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterHostCPUCapacity.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.host.cpu.capacity`: this metric will be enabled by default starting in release v0.105.0")
-	}
-	if !mbc.Metrics.VcenterHostCPUReserved.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.host.cpu.reserved`: this metric will be enabled by default starting in release v0.105.0")
-	}
-	if !mbc.Metrics.VcenterHostNetworkPacketDropRate.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.host.network.packet.drop.rate`: this metric will be enabled by default starting in release v0.105.0")
-	}
 	if !mbc.Metrics.VcenterResourcePoolMemoryBallooned.enabledSetByUser {
 		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.ballooned`: this metric will be enabled by default starting in release v0.106.0")
 	}
@@ -3201,9 +3171,6 @@ func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, opt
 	}
 	if !mbc.Metrics.VcenterResourcePoolMemorySwapped.enabledSetByUser {
 		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.swapped`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterVMCPUReadiness.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.vm.cpu.readiness`: this metric will be enabled by default starting in release v0.105.0")
 	}
 	mb := &MetricsBuilder{
 		config:                                   mbc,

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -63,46 +63,6 @@ func TestMetricsBuilder(t *testing.T) {
 
 			expectedWarnings := 0
 			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cluster.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cpu.limit`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.datastore.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.disk.space`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.host.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.memory.limit`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.vm.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.host.cpu.capacity`: this metric will be enabled by default starting in release v0.105.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.host.cpu.reserved`: this metric will be enabled by default starting in release v0.105.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.host.network.packet.drop.rate`: this metric will be enabled by default starting in release v0.105.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
 				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.ballooned`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
 				expectedWarnings++
 			}
@@ -112,10 +72,6 @@ func TestMetricsBuilder(t *testing.T) {
 			}
 			if test.metricsSet == testDataSetDefault {
 				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.swapped`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.vm.cpu.readiness`: this metric will be enabled by default starting in release v0.105.0", observedLogs.All()[expectedWarnings].Message)
 				expectedWarnings++
 			}
 
@@ -181,9 +137,11 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordVcenterDatastoreDiskUtilizationDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterHostCPUCapacityDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterHostCPUReservedDataPoint(ts, 1, AttributeCPUReservationTypeTotal)
 
@@ -215,6 +173,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordVcenterHostMemoryUtilizationDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterHostNetworkPacketDropRateDataPoint(ts, 1, AttributeThroughputDirectionTransmitted, "object_name-val")
 
@@ -259,6 +218,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordVcenterResourcePoolMemoryUsageDataPoint(ts, 1, AttributeMemoryUsageTypeGuest)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterVMCPUReadinessDataPoint(ts, 1)
 

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -63,6 +63,34 @@ func TestMetricsBuilder(t *testing.T) {
 
 			expectedWarnings := 0
 			if test.metricsSet == testDataSetDefault {
+				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cluster.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if test.metricsSet == testDataSetDefault {
+				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cpu.limit`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if test.metricsSet == testDataSetDefault {
+				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.datastore.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if test.metricsSet == testDataSetDefault {
+				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.disk.space`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if test.metricsSet == testDataSetDefault {
+				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.host.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if test.metricsSet == testDataSetDefault {
+				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.memory.limit`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if test.metricsSet == testDataSetDefault {
+				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.vm.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
+				expectedWarnings++
+			}
+			if test.metricsSet == testDataSetDefault {
 				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.ballooned`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
 				expectedWarnings++
 			}

--- a/receiver/vcenterreceiver/internal/mockserver/responses/host-performance-counters.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/host-performance-counters.xml
@@ -471,6 +471,28 @@
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
+                        <counterId>529</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>530</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>  
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
                         <counterId>146</counterId>
                         <instance>vmnic0</instance>
                     </id>
@@ -1459,7 +1481,7 @@
                     <value>1646</value>
                     <value>1291</value>
                     <value>1058</value>
-                </value>
+                </value>  
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>435</counterId>
@@ -1559,6 +1581,28 @@
                     <value>0</value>
                     <value>0</value>
                 </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>529</counterId>
+                        <instance>vmnic2</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>530</counterId>
+                        <instance>vmnic2</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value> 
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>147</counterId>

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -319,7 +319,7 @@ metrics:
       aggregation_temporality: cumulative
     attributes: []
   vcenter.host.cpu.capacity:
-    enabled: false
+    enabled: true
     description: Total CPU capacity of the host system.
     unit: "MHz"
     sum:
@@ -327,10 +327,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: []
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.105.0"
   vcenter.host.cpu.reserved:
-    enabled: false
+    enabled: true
     description: The CPU of the host reserved for use by virtual machines.
     unit: "MHz"
     sum:
@@ -338,8 +336,6 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: [cpu_reservation_type]
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.105.0"
   vcenter.host.disk.throughput:
     enabled: true
     description: Average number of kilobytes read from or written to the disk each second.
@@ -418,15 +414,13 @@ metrics:
     attributes: [throughput_direction, object_name]
     extended_documentation: As measured over the most recent 20s interval.
   vcenter.host.network.packet.drop.rate:
-    enabled: false
+    enabled: true
     description: The rate of packets dropped across each physical NIC (network interface controller) instance on the host.
     unit: "{packets/sec}"
     gauge:
       value_type: double
     attributes: [throughput_direction, object_name]
     extended_documentation: As measured over the most recent 20s interval.
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.105.0"
   vcenter.resource_pool.memory.usage:
     enabled: true
     description: The usage of the memory by the resource pool.
@@ -624,14 +618,12 @@ metrics:
       aggregation_temporality: cumulative
     attributes: []
   vcenter.vm.cpu.readiness:
-    enabled: false
+    enabled: true
     description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
     unit: "%"
     gauge:
       value_type: int
     attributes: []
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.105.0"
   vcenter.vm.memory.utilization:
     enabled: true
     description: The memory utilization of the VM.

--- a/receiver/vcenterreceiver/scraper_test.go
+++ b/receiver/vcenterreceiver/scraper_test.go
@@ -40,10 +40,6 @@ func TestScrapeConfigsEnabled(t *testing.T) {
 	defer mockServer.Close()
 
 	optConfigs := metadata.DefaultMetricsBuilderConfig()
-	optConfigs.Metrics.VcenterVMCPUReadiness.Enabled = true
-	optConfigs.Metrics.VcenterHostCPUCapacity.Enabled = true
-	optConfigs.Metrics.VcenterHostCPUReserved.Enabled = true
-	optConfigs.Metrics.VcenterHostNetworkPacketDropRate.Enabled = true
 	setResourcePoolMemoryUsageAttrFeatureGate(t, true)
 	optConfigs.Metrics.VcenterResourcePoolMemorySwapped.Enabled = true
 	optConfigs.Metrics.VcenterResourcePoolMemoryBallooned.Enabled = true

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -83,6 +83,15 @@ resourceMetrics:
             stringValue: DC0_H0
     scopeMetrics:
       - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1707407684042820000"
+                  timeUnixNano: "1707407733803628000"
+            unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
             sum:
@@ -352,6 +361,15 @@ resourceMetrics:
             stringValue: DC0_C0
     scopeMetrics:
       - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1707407684042820000"
+                  timeUnixNano: "1707407733803628000"
+            unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
             sum:
@@ -402,6 +420,15 @@ resourceMetrics:
             stringValue: DC0_C0
     scopeMetrics:
       - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1707407684042820000"
+                  timeUnixNano: "1707407733803628000"
+            unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
             sum:
@@ -452,6 +479,15 @@ resourceMetrics:
             stringValue: DC0_C0
     scopeMetrics:
       - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1707407684042820000"
+                  timeUnixNano: "1707407733803628000"
+            unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
             sum:

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -1108,6 +1108,111 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: vcenter.host.memory.utilization
             unit: '%'
+          - description: The rate of packets dropped across each physical NIC (network interface controller) instance on the host.
+            gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+            name: vcenter.host.network.packet.drop.rate
+            unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
             gauge:
               dataPoints:
@@ -3641,6 +3746,111 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: vcenter.host.memory.utilization
             unit: '%'
+          - description: The rate of packets dropped across each physical NIC (network interface controller) instance on the host.
+            gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+            name: vcenter.host.network.packet.drop.rate
+            unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
             gauge:
               dataPoints:

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -975,6 +975,111 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: vcenter.host.memory.utilization
             unit: '%'
+          - description: The rate of packets dropped across each physical NIC (network interface controller) instance on the host.
+            gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+            name: vcenter.host.network.packet.drop.rate
+            unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
             gauge:
               dataPoints:
@@ -3508,6 +3613,111 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: vcenter.host.memory.utilization
             unit: '%'
+          - description: The rate of packets dropped across each physical NIC (network interface controller) instance on the host.
+            gauge:
+              dataPoints:
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+            name: vcenter.host.network.packet.drop.rate
+            unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
             gauge:
               dataPoints:

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -155,6 +155,91 @@ resourceMetrics:
             stringValue: esxi-111.europe-southeast1.gve.goog
     scopeMetrics:
       - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "93348"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The CPU of the host reserved for use by virtual machines.
+            name: vcenter.host.cpu.reserved
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+            unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
             sum:
@@ -2603,6 +2688,91 @@ resourceMetrics:
             stringValue: esxi-27971.cf5e88ac.australia-southeast1.gve.goog
     scopeMetrics:
       - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "93348"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The CPU of the host reserved for use by virtual machines.
+            name: vcenter.host.cpu.reserved
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "1000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "4000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "6000000"
+                  timeUnixNano: "5000000"
+            unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
             sum:
@@ -5210,6 +5380,14 @@ resourceMetrics:
             stringValue: CentOS 9
     scopeMetrics:
       - metrics:
+          - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.cpu.readiness
+            unit: '%'
           - description: The amount of CPU used by the VM.
             name: vcenter.vm.cpu.usage
             sum:
@@ -5839,6 +6017,14 @@ resourceMetrics:
             stringValue: CentOS 7
     scopeMetrics:
       - metrics:
+          - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.cpu.readiness
+            unit: '%'
           - description: The amount of CPU used by the VM.
             name: vcenter.vm.cpu.usage
             sum:
@@ -6468,6 +6654,14 @@ resourceMetrics:
             stringValue: CentOS 8
     scopeMetrics:
       - metrics:
+          - description: Percentage of time that the virtual machine was ready, but could not get scheduled to run on the physical CPU.
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.cpu.readiness
+            unit: '%'
           - description: The amount of CPU used by the VM.
             name: vcenter.vm.cpu.usage
             sum:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The following PR enables the following metrics by default
```
vcenter.vm.cpu.readiness
vcenter.host.network.packet.drop.rate
vcenter.host.cpu.capacity
vcenter.host.cpu.reserve.capacity
```
**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
Updated golden files
**Documentation:** <Describe the documentation added.>
Updated documentation using make generate