### PR TITLE
[receiver/sqlserver] Properly scrape DB when metrics are enabled

### DIFF
--- a/.chloggen/sqlserver_default_metrics.yaml
+++ b/.chloggen/sqlserver_default_metrics.yaml
@@ -10,7 +10,7 @@ component: sqlserverreceiver
 note: Enable default metrics to properly trigger SQL Server scrape
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34065]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/sqlserver_default_metrics.yaml
+++ b/.chloggen/sqlserver_default_metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlserverreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable default metrics to properly trigger SQL Server scrape
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -43,10 +43,15 @@ func setupQueries(cfg *Config) []string {
 		queries = append(queries, getSQLServerDatabaseIOQuery(cfg.InstanceName))
 	}
 
-	if cfg.MetricsBuilderConfig.Metrics.SqlserverResourcePoolDiskThrottledReadRate.Enabled ||
+	if cfg.MetricsBuilderConfig.Metrics.SqlserverBatchRequestRate.Enabled ||
+		cfg.MetricsBuilderConfig.Metrics.SqlserverPageBufferCacheHitRatio.Enabled ||
+		cfg.MetricsBuilderConfig.Metrics.SqlserverResourcePoolDiskThrottledReadRate.Enabled ||
 		cfg.MetricsBuilderConfig.Metrics.SqlserverResourcePoolDiskThrottledWriteRate.Enabled ||
 		cfg.MetricsBuilderConfig.Metrics.SqlserverLockWaitRate.Enabled ||
-		cfg.MetricsBuilderConfig.Metrics.SqlserverProcessesBlocked.Enabled {
+		cfg.MetricsBuilderConfig.Metrics.SqlserverProcessesBlocked.Enabled ||
+		cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLRecompilationRate.Enabled ||
+		cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLCompilationRate.Enabled ||
+		cfg.MetricsBuilderConfig.Metrics.SqlserverUserConnectionCount.Enabled {
 
 		queries = append(queries, getSQLServerPerformanceCounterQuery(cfg.InstanceName))
 	}

--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -21,15 +21,27 @@ import (
 )
 
 func enableAllScraperMetrics(cfg *Config) {
+	// Some of these metrics are enabled by default, but it's still helpful to include
+	// in the case of using a config that may have previously disabled a metric.
+	cfg.MetricsBuilderConfig.Metrics.SqlserverBatchRequestRate.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLCompilationRate.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLRecompilationRate.Enabled = true
+
+	cfg.MetricsBuilderConfig.Metrics.SqlserverDatabaseCount.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.SqlserverDatabaseIo.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.SqlserverDatabaseLatency.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.SqlserverDatabaseOperations.Enabled = true
-	cfg.MetricsBuilderConfig.Metrics.SqlserverDatabaseIo.Enabled = true
+
+	cfg.MetricsBuilderConfig.Metrics.SqlserverLockWaitRate.Enabled = true
+
+	cfg.MetricsBuilderConfig.Metrics.SqlserverPageBufferCacheHitRatio.Enabled = true
+
+	cfg.MetricsBuilderConfig.Metrics.SqlserverProcessesBlocked.Enabled = true
 
 	cfg.MetricsBuilderConfig.Metrics.SqlserverResourcePoolDiskThrottledReadRate.Enabled = true
 	cfg.MetricsBuilderConfig.Metrics.SqlserverResourcePoolDiskThrottledWriteRate.Enabled = true
-	cfg.MetricsBuilderConfig.Metrics.SqlserverProcessesBlocked.Enabled = true
 
-	cfg.MetricsBuilderConfig.Metrics.SqlserverDatabaseCount.Enabled = true
+	cfg.MetricsBuilderConfig.Metrics.SqlserverUserConnectionCount.Enabled = true
 }
 
 func TestEmptyScrape(t *testing.T) {
@@ -42,10 +54,13 @@ func TestEmptyScrape(t *testing.T) {
 	assert.NoError(t, cfg.Validate())
 
 	// Ensure there aren't any scrapers when all metrics are disabled.
-	// The lock metric is the only scraper metric enabled by default, as it is reusing
-	// a performance counter metric and can be gathered either by perf counters or
-	// by scraping.
+	// Disable all metrics manually that are enabled by default
+	cfg.MetricsBuilderConfig.Metrics.SqlserverBatchRequestRate.Enabled = false
+	cfg.MetricsBuilderConfig.Metrics.SqlserverPageBufferCacheHitRatio.Enabled = false
 	cfg.MetricsBuilderConfig.Metrics.SqlserverLockWaitRate.Enabled = false
+	cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLRecompilationRate.Enabled = false
+	cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLCompilationRate.Enabled = false
+	cfg.MetricsBuilderConfig.Metrics.SqlserverUserConnectionCount.Enabled = false
 	scrapers := setupSQLServerScrapers(receivertest.NewNopSettings(), cfg)
 	assert.Empty(t, scrapers)
 }


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The bug here is in the `setupQueries` method. The goal is to only scrape a SQL Server instance if metrics gathered from that scrape are enabled. However, for the performance counter query, I found that some metrics weren't properly checked. This means that if `sqlserver.lock.wait.rate` is disabled, none of the other metrics will be scraped, even if they're enabled. This resolves the issue so that all metrics being gathered from this query can trigger this scrape.

To confirm all required metrics are checked here, view [this method](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6a5b9e673a433ad2c6ed7ef2526a8920fd18cf0d/receiver/sqlserverreceiver/scraper.go#L171) to see which metrics are being scraped using the perf counter query.

**Testing:** <Describe what testing was performed and which tests were added.>
Updated tests, double checked manually to ensure all metrics are properly being scraped.

**Documentation:** <Describe the documentation added.>