### PR TITLE
[chore][CODEOWNERS] Fix order

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,7 +103,7 @@ extension/httpforwarderextension/                                   @open-teleme
 extension/jaegerremotesampling/                                     @open-telemetry/collector-contrib-approvers @yurishkuro @frzifus
 extension/oauth2clientauthextension/                                @open-telemetry/collector-contrib-approvers @pavankrish123 @jpkrohling
 extension/observer/                                                 @open-telemetry/collector-contrib-approvers @dmitryax @rmfitzpatrick
-extension/observer/cfgardenobserver/                                @open-telemetry/collector-contrib-approvers @cemdk @tomasmota @m1rp @jriguera @crobert-1
+extension/observer/cfgardenobserver/                                @open-telemetry/collector-contrib-approvers @crobert-1 @cemdk @tomasmota @m1rp @jriguera
 extension/observer/dockerobserver/                                  @open-telemetry/collector-contrib-approvers @MovieStoreGuy
 extension/observer/ecsobserver/                                     @open-telemetry/collector-contrib-approvers @dmitryax @rmfitzpatrick
 extension/observer/ecstaskobserver/                                 @open-telemetry/collector-contrib-approvers @rmfitzpatrick


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`make checks` is failing due to the order of code owners on a newly introduced component. This implements the required change to fix the check.

[Failing action](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/9936498568/job/27444980411#step:16:25)