### PR TITLE
[receiver/vcenter] Adds vSAN metrics for Virtual Machines

### DIFF
--- a/.chloggen/vcenterreceiver-vm-vsan.yaml
+++ b/.chloggen/vcenterreceiver-vm-vsan.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'vcenterreceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a number of default disabled vSAN metrics for Virtual Machines.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33556]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ dist/
 # Miscellaneous files
 *.sw[op]
 *.DS_Store
+__debug_bin*
 
 # Coverage
 coverage/*

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -4,7 +4,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otelcontrib
 
 go 1.21.0
 
-toolchain go1.22.3
+toolchain go1.21.12
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.105.0

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -4,7 +4,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otelcontrib
 
 go 1.21.0
 
-toolchain go1.21.12
+toolchain go1.22.3
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.105.0

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -1217,6 +1217,8 @@ github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02 h1:tR3jsKPiO/mb6ntzk/dJlHZtm37CPfVp1C9KIo534+4=
+github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02/go.mod h1:7NQ3kWOx2cZOSjtcveTa5nqupVr2s6/83sG+rTlI7uA=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -7,35 +7,45 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/vmware/govmomi"
 	"github.com/vmware/govmomi/find"
 	"github.com/vmware/govmomi/object"
 	"github.com/vmware/govmomi/performance"
-	"github.com/vmware/govmomi/property"
 	"github.com/vmware/govmomi/view"
 	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
+	"github.com/vmware/govmomi/vim25/soap"
 	vt "github.com/vmware/govmomi/vim25/types"
+	"github.com/vmware/govmomi/vsan"
+	"github.com/vmware/govmomi/vsan/types"
+	"go.uber.org/zap"
 )
 
 // vcenterClient is a client that collects data from a vCenter endpoint.
 type vcenterClient struct {
-	moClient  *govmomi.Client
-	vimDriver *vim25.Client
-	finder    *find.Finder
-	pc        *property.Collector
-	pm        *performance.Manager
-	vm        *view.Manager
-	cfg       *Config
+	logger     *zap.Logger
+	moClient   *govmomi.Client
+	vimDriver  *vim25.Client
+	vsanDriver *vsan.Client
+	finder     *find.Finder
+	pm         *performance.Manager
+	vm         *view.Manager
+	cfg        *Config
 }
 
 var newVcenterClient = defaultNewVcenterClient
 
-func defaultNewVcenterClient(c *Config) *vcenterClient {
+func defaultNewVcenterClient(l *zap.Logger, c *Config) *vcenterClient {
 	return &vcenterClient{
-		cfg: c,
+		logger: l,
+		cfg:    c,
 	}
 }
 
@@ -70,10 +80,15 @@ func (vc *vcenterClient) EnsureConnection(ctx context.Context) error {
 	}
 	vc.moClient = client
 	vc.vimDriver = client.Client
-	vc.pc = property.DefaultCollector(vc.vimDriver)
 	vc.finder = find.NewFinder(vc.vimDriver)
 	vc.pm = performance.NewManager(vc.vimDriver)
 	vc.vm = view.NewManager(vc.vimDriver)
+	vsanDriver, err := vsan.NewClient(ctx, vc.vimDriver)
+	if err != nil {
+		vc.logger.Info(fmt.Errorf("could not create VSAN client: %w", err).Error())
+	} else {
+		vc.vsanDriver = vsanDriver
+	}
 	return nil
 }
 
@@ -319,4 +334,190 @@ func (vc *vcenterClient) PerfMetricsQuery(
 	return &PerfMetricsQueryResult{
 		resultsByRef: resultsByRef,
 	}, nil
+}
+
+// VSANQueryResults contains all returned vSAN metric related data
+type VSANQueryResults struct {
+	// Contains vSAN metric data keyed by UUID string
+	MetricResultsByUUID map[string]*VSANMetricResults
+}
+
+// VSANMetricResults contains vSAN metric related data for a single resource
+type VSANMetricResults struct {
+	// Contains UUID info for related resource
+	UUID string
+	// Contains returned metric value info for all metrics
+	MetricDetails []*VSANMetricDetails
+}
+
+// VSANMetricDetails contains vSAN metric data for a single metric
+type VSANMetricDetails struct {
+	// Contains the metric label
+	MetricLabel string
+	// Contains vSAN metric values keyed by timestamp
+	ValuesByTimestamp map[time.Time]int64
+}
+
+// VSANVirtualMachines returns back virtual machine vSAN performance metrics for a group of clusters
+func (vc *vcenterClient) VSANVirtualMachines(
+	ctx context.Context,
+	clusterRefs []*vt.ManagedObjectReference,
+) (*VSANQueryResults, error) {
+	allResults := VSANQueryResults{
+		MetricResultsByUUID: map[string]*VSANMetricResults{},
+	}
+
+	for _, clusterRef := range clusterRefs {
+		results, err := vc.vSANVirtualMachinesByCluster(ctx, clusterRef)
+		// Check for expected errors
+		if err != nil {
+			faultErr := errors.Unwrap(err)
+			if faultErr == nil {
+				return nil, fmt.Errorf("problem retrieving Virtual Machine vSAN metrics: %w", err)
+			}
+			if !soap.IsSoapFault(faultErr) {
+				return nil, fmt.Errorf("problem retrieving Virtual Machine vSAN metrics: %w", err)
+			}
+
+			fault := soap.ToSoapFault(faultErr)
+			msg := fault.String
+			if fault.Detail.Fault != nil {
+				msg = reflect.TypeOf(fault.Detail.Fault).Name()
+			}
+			switch msg {
+			case "NotSupported":
+				vc.logger.Info(fmt.Sprintf("problem retrieving Virtual Machine vSAN metrics: %s", err.Error()))
+				return &allResults, nil
+			case "NotFound":
+				vc.logger.Debug(fmt.Sprintf("no Virtual Machine vSAN metrics found: %s", err.Error()))
+				return &allResults, nil
+			default:
+				return nil, fmt.Errorf("problem retrieving Virtual Machine vSAN metrics: %w", err)
+			}
+		}
+
+		maps.Copy(allResults.MetricResultsByUUID, results.MetricResultsByUUID)
+	}
+
+	return &allResults, nil
+}
+
+// vSANVirtualMachinesByCluster returns back virtual machine vSAN performance metrics for a cluster
+func (vc *vcenterClient) vSANVirtualMachinesByCluster(
+	ctx context.Context,
+	clusterRef *vt.ManagedObjectReference,
+) (*VSANQueryResults, error) {
+	queryResults := VSANQueryResults{
+		MetricResultsByUUID: map[string]*VSANMetricResults{},
+	}
+	// Not all vCenters support vSAN so just return an empty result
+	if vc.vsanDriver == nil {
+		return &queryResults, nil
+	}
+
+	now := time.Now()
+	querySpec := []types.VsanPerfQuerySpec{
+		{
+			EntityRefId: "virtual-machine:*",
+			StartTime:   &now,
+			EndTime:     &now,
+			Labels: []string{
+				"iopsRead",
+				"iopsWrite",
+				"throughputRead",
+				"throughputWrite",
+				"latencyRead",
+				"latencyWrite",
+			},
+		},
+	}
+	rawResults, err := vc.vsanDriver.VsanPerfQueryPerf(ctx, clusterRef, querySpec)
+	if err != nil {
+		return nil, fmt.Errorf("problem retrieving Virtual Machine vSAN metrics for cluster %s: %w", clusterRef.Value, err)
+	}
+
+	queryResults.MetricResultsByUUID = map[string]*VSANMetricResults{}
+	for _, rawResult := range rawResults {
+		metricResults, err := convertVSANResultToMetricResults(rawResult)
+		if err != nil && metricResults != nil {
+			return &queryResults, fmt.Errorf("problem retrieving Virtual Machine [%s] vSAN metrics for cluster %s: %w", metricResults.UUID, clusterRef.Value, err)
+		}
+		if err != nil {
+			return &queryResults, fmt.Errorf("problem retrieving Virtual Machine vSAN metrics for cluster %s: %w", clusterRef.Value, err)
+		}
+
+		queryResults.MetricResultsByUUID[metricResults.UUID] = metricResults
+	}
+
+	return &queryResults, nil
+}
+
+func convertVSANResultToMetricResults(vSANResult types.VsanPerfEntityMetricCSV) (*VSANMetricResults, error) {
+	uuid, err := uuidFromEntityRefID(vSANResult.EntityRefId)
+	if err != nil {
+		return nil, err
+	}
+
+	metricResults := VSANMetricResults{
+		UUID:          uuid,
+		MetricDetails: []*VSANMetricDetails{},
+	}
+
+	// Parse all timestamps
+	timeStrings := strings.Split(vSANResult.SampleInfo, ",")
+	timestamps := []time.Time{}
+	for _, timeString := range timeStrings {
+		timestamp, err := time.Parse("2006-01-02 15:04:05", timeString)
+		if err != nil {
+			return &metricResults, fmt.Errorf("problem parsing timestamp from %s: %w", timeString, err)
+		}
+
+		timestamps = append(timestamps, timestamp)
+	}
+
+	// Parse all metrics
+	for _, vSANValue := range vSANResult.Value {
+		metricDetails, err := convertVSANValueToMetricDetails(vSANValue, timestamps)
+		if err != nil {
+			return &metricResults, err
+		}
+
+		metricResults.MetricDetails = append(metricResults.MetricDetails, metricDetails)
+	}
+	return &metricResults, nil
+}
+
+func convertVSANValueToMetricDetails(vSANValue types.VsanPerfMetricSeriesCSV, timestamps []time.Time) (*VSANMetricDetails, error) {
+	metricLabel := vSANValue.MetricId.Label
+	metricDetails := VSANMetricDetails{
+		MetricLabel:       metricLabel,
+		ValuesByTimestamp: map[time.Time]int64{},
+	}
+	valueStrings := strings.Split(vSANValue.Values, ",")
+	if len(valueStrings) != len(timestamps) {
+		return nil, fmt.Errorf("number of timestamps [%d] doesn't match number of values [%d] for metric %s", len(timestamps), len(valueStrings), metricLabel)
+	}
+
+	// Match up timestamps with metric values
+	for i, valueString := range valueStrings {
+		value, err := strconv.ParseInt(valueString, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("problem converting value [%s] for metric %s", valueString, metricLabel)
+		}
+
+		metricDetails.ValuesByTimestamp[timestamps[i]] = value
+	}
+
+	return &metricDetails, nil
+}
+
+// uuidFromEntityRefID returns the UUID portion of the EntityRefId
+func uuidFromEntityRefID(id string) (string, error) {
+	colonIndex := strings.Index(id, ":")
+	if colonIndex != -1 {
+		uuid := id[colonIndex+1:]
+		return uuid, nil
+	}
+
+	return "", fmt.Errorf("no ':' found in EntityRefId [%s] to parse UUID", id)
 }

--- a/receiver/vcenterreceiver/client.go
+++ b/receiver/vcenterreceiver/client.go
@@ -406,7 +406,7 @@ func (vc *vcenterClient) vSANQuery(
 	now := time.Now()
 	querySpec := []types.VsanPerfQuerySpec{
 		{
-			EntityRefId: "virtual-machine:*",
+			EntityRefId: string(queryType),
 			StartTime:   &now,
 			EndTime:     &now,
 			Labels:      vc.getLabelsForQueryType(queryType),
@@ -464,7 +464,7 @@ func (vc *vcenterClient) handleVSANError(
 }
 
 func (vc *vcenterClient) convertVSANResultToMetricResults(vSANResult types.VsanPerfEntityMetricCSV) (*VSANMetricResults, error) {
-	uuid, err := uuidFromEntityRefID(vSANResult.EntityRefId)
+	uuid, err := vc.uuidFromEntityRefID(vSANResult.EntityRefId)
 	if err != nil {
 		return nil, err
 	}
@@ -535,7 +535,7 @@ func (vc *vcenterClient) convertVSANValueToMetricDetails(
 }
 
 // uuidFromEntityRefID returns the UUID portion of the EntityRefId
-func uuidFromEntityRefID(id string) (string, error) {
+func (vc *vcenterClient) uuidFromEntityRefID(id string) (string, error) {
 	colonIndex := strings.Index(id, ":")
 	if colonIndex != -1 {
 		uuid := id[colonIndex+1:]

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -642,6 +642,58 @@ As measured over the most recent 20s interval.
 | ---- | ----------- | ------ |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
 
+## Optional Metrics
+
+The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
+
+```yaml
+metrics:
+  <metric_name>:
+    enabled: true
+```
+
+### vcenter.vm.vsan.latency.avg
+
+The virtual machine latency while accessing vSAN storage.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| us | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| type | The type of vSAN latency. | Str: ``read``, ``write`` |
+
+### vcenter.vm.vsan.operations
+
+The vSAN IOPs of a virtual machine.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {operations/sec} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| type | The type of vSAN operation. | Str: ``read``, ``write``, ``unmap`` |
+
+### vcenter.vm.vsan.throughput
+
+The vSAN throughput of a virtual machine.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| By/s | Gauge | Double |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| direction | The type of vSAN throughput. | Str: ``read``, ``write`` |
+
 ## Resource Attributes
 
 | Name | Description | Values | Enabled |

--- a/receiver/vcenterreceiver/generated_package_test.go
+++ b/receiver/vcenterreceiver/generated_package_test.go
@@ -3,8 +3,9 @@
 package vcenterreceiver
 
 import (
-	"go.uber.org/goleak"
 	"testing"
+
+	"go.uber.org/goleak"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/vcenterreceiver/generated_package_test.go
+++ b/receiver/vcenterreceiver/generated_package_test.go
@@ -3,9 +3,8 @@
 package vcenterreceiver
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/receiver/vcenterreceiver/go.sum
+++ b/receiver/vcenterreceiver/go.sum
@@ -37,6 +37,8 @@ github.com/docker/go-connections v0.5.0 h1:USnMq7hx7gwdVZq1L49hLXaFtUdTADjXGp+uj
 github.com/docker/go-connections v0.5.0/go.mod h1:ov60Kzw0kKElRwhNs9UlUHAE/F9Fe6GLaXnqyDdmEXc=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02 h1:tR3jsKPiO/mb6ntzk/dJlHZtm37CPfVp1C9KIo534+4=
+github.com/dougm/pretty v0.0.0-20171025230240-2ee9d7453c02/go.mod h1:7NQ3kWOx2cZOSjtcveTa5nqupVr2s6/83sG+rTlI7uA=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=

--- a/receiver/vcenterreceiver/internal/metadata/generated_config.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_config.go
@@ -82,6 +82,9 @@ type MetricsConfig struct {
 	VcenterVMNetworkPacketRate         MetricConfig `mapstructure:"vcenter.vm.network.packet.rate"`
 	VcenterVMNetworkThroughput         MetricConfig `mapstructure:"vcenter.vm.network.throughput"`
 	VcenterVMNetworkUsage              MetricConfig `mapstructure:"vcenter.vm.network.usage"`
+	VcenterVMVsanLatencyAvg            MetricConfig `mapstructure:"vcenter.vm.vsan.latency.avg"`
+	VcenterVMVsanOperations            MetricConfig `mapstructure:"vcenter.vm.vsan.operations"`
+	VcenterVMVsanThroughput            MetricConfig `mapstructure:"vcenter.vm.vsan.throughput"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
@@ -247,6 +250,15 @@ func DefaultMetricsConfig() MetricsConfig {
 		},
 		VcenterVMNetworkUsage: MetricConfig{
 			Enabled: true,
+		},
+		VcenterVMVsanLatencyAvg: MetricConfig{
+			Enabled: false,
+		},
+		VcenterVMVsanOperations: MetricConfig{
+			Enabled: false,
+		},
+		VcenterVMVsanThroughput: MetricConfig{
+			Enabled: false,
 		},
 	}
 }

--- a/receiver/vcenterreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_config_test.go
@@ -79,6 +79,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					VcenterVMNetworkPacketRate:         MetricConfig{Enabled: true},
 					VcenterVMNetworkThroughput:         MetricConfig{Enabled: true},
 					VcenterVMNetworkUsage:              MetricConfig{Enabled: true},
+					VcenterVMVsanLatencyAvg:            MetricConfig{Enabled: true},
+					VcenterVMVsanOperations:            MetricConfig{Enabled: true},
+					VcenterVMVsanThroughput:            MetricConfig{Enabled: true},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					VcenterClusterName:               ResourceAttributeConfig{Enabled: true},
@@ -154,6 +157,9 @@ func TestMetricsBuilderConfig(t *testing.T) {
 					VcenterVMNetworkPacketRate:         MetricConfig{Enabled: false},
 					VcenterVMNetworkThroughput:         MetricConfig{Enabled: false},
 					VcenterVMNetworkUsage:              MetricConfig{Enabled: false},
+					VcenterVMVsanLatencyAvg:            MetricConfig{Enabled: false},
+					VcenterVMVsanOperations:            MetricConfig{Enabled: false},
+					VcenterVMVsanThroughput:            MetricConfig{Enabled: false},
 				},
 				ResourceAttributes: ResourceAttributesConfig{
 					VcenterClusterName:               ResourceAttributeConfig{Enabled: false},

--- a/receiver/vcenterreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/vcenterreceiver/internal/metadata/testdata/config.yaml
@@ -109,6 +109,12 @@ all_set:
       enabled: true
     vcenter.vm.network.usage:
       enabled: true
+    vcenter.vm.vsan.latency.avg:
+      enabled: true
+    vcenter.vm.vsan.operations:
+      enabled: true
+    vcenter.vm.vsan.throughput:
+      enabled: true
   resource_attributes:
     vcenter.cluster.name:
       enabled: true
@@ -243,6 +249,12 @@ none_set:
     vcenter.vm.network.throughput:
       enabled: false
     vcenter.vm.network.usage:
+      enabled: false
+    vcenter.vm.vsan.latency.avg:
+      enabled: false
+    vcenter.vm.vsan.operations:
+      enabled: false
+    vcenter.vm.vsan.throughput:
       enabled: false
   resource_attributes:
     vcenter.cluster.name:

--- a/receiver/vcenterreceiver/internal/mockserver/client_mock.go
+++ b/receiver/vcenterreceiver/internal/mockserver/client_mock.go
@@ -218,9 +218,8 @@ func routeVsanPerfQueryPerf(t *testing.T, body map[string]any) ([]byte, error) {
 	if !ok {
 		return []byte{}, errNotFound
 	}
-	entityRefId := querySpecs["entityRefId"].(string)
-	switch entityRefId {
-	case "virtual-machine:*":
+	entityRefID := querySpecs["entityRefId"].(string)
+	if entityRefID == "virtual-machine:*" {
 		return loadResponse("vm-vsan.xml")
 	}
 	return []byte{}, errNotFound

--- a/receiver/vcenterreceiver/internal/mockserver/client_mock.go
+++ b/receiver/vcenterreceiver/internal/mockserver/client_mock.go
@@ -81,6 +81,10 @@ func routeBody(t *testing.T, requestType string, body map[string]any) ([]byte, e
 		return routePerformanceQuery(t, body)
 	case "CreateContainerView":
 		return loadResponse("create-container-view.xml")
+	case "DestroyView":
+		return loadResponse("destroy-view.xml")
+	case "VsanPerfQueryPerf":
+		return routeVsanPerfQueryPerf(t, body)
 	}
 
 	return []byte{}, errNotFound
@@ -203,6 +207,21 @@ func routePerformanceQuery(t *testing.T, body map[string]any) ([]byte, error) {
 		return loadResponse("host-performance-counters.xml")
 	case "VirtualMachine":
 		return loadResponse("vm-performance-counters.xml")
+	}
+	return []byte{}, errNotFound
+}
+
+func routeVsanPerfQueryPerf(t *testing.T, body map[string]any) ([]byte, error) {
+	queryPerf := body["VsanPerfQueryPerf"].(map[string]any)
+	require.NotNil(t, queryPerf)
+	querySpecs, ok := queryPerf["querySpecs"].(map[string]any)
+	if !ok {
+		return []byte{}, errNotFound
+	}
+	entityRefId := querySpecs["entityRefId"].(string)
+	switch entityRefId {
+	case "virtual-machine:*":
+		return loadResponse("vm-vsan.xml")
 	}
 	return []byte{}, errNotFound
 }

--- a/receiver/vcenterreceiver/internal/mockserver/responses/destroy-view.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/destroy-view.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+      <DestroyViewResponse/>
+   </soapenv:Body>
+</soapenv:Envelope>

--- a/receiver/vcenterreceiver/internal/mockserver/responses/vm-vsan.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/vm-vsan.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<soapenv:Envelope xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <soapenv:Body>
+        <VsanPerfQueryPerfResponse xmlns="urn:vsan">
+            <returnval xsi:type="VsanPerfEntityMetricCSV">
+                <entityRefId xsi:type="xsd:string">virtual-machine:5000bbe0-993e-5813-c56a-198eaa62fb61</entityRefId>
+                <sampleInfo xsi:type="xsd:string">2022-05-24 15:45:00,2022-05-24 15:46:00</sampleInfo>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">iopsRead</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">10,11</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">iopsWrite</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">12,13</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">throughputRead</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">20,40</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">throughputWrite</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">60,80</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">latencyRead</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">14,15</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">latencyWrite</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">16,17</values>
+                </value>
+            </returnval>
+            <returnval xsi:type="VsanPerfEntityMetricCSV">
+                <entityRefId xsi:type="xsd:string">virtual-machine:5000bbe0-993e-5813-c56a-198eaa62fb62</entityRefId>
+                <sampleInfo xsi:type="xsd:string">2022-05-24 15:45:00,2022-05-24 15:46:00</sampleInfo>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">iopsRead</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">20,21</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">iopsWrite</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">22,23</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">throughputRead</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">120,140</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">throughputWrite</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">160,180</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">latencyRead</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">24,25</values>
+                </value>
+                <value xsi:type="VsanPerfMetricSeriesCSV">
+                    <metricId xsi:type="VsanPerfMetricId">
+                        <label xsi:type="xsd:string">latencyWrite</label>
+                    </metricId>
+                    <values xsi:type="xsd:string">26,27</values>
+                </value>
+            </returnval>
+        </VsanPerfQueryPerfResponse>
+    </soapenv:Body>
+</soapenv:Envelope>

--- a/receiver/vcenterreceiver/internal/mockserver/responses/vm-vsan.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/vm-vsan.xml
@@ -8,36 +8,42 @@
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">iopsRead</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">10,11</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">iopsWrite</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">12,13</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">throughputRead</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
-                    <values xsi:type="xsd:string">20,40</values>
+                    <values xsi:type="xsd:string">300,600</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">throughputWrite</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
-                    <values xsi:type="xsd:string">60,80</values>
+                    <values xsi:type="xsd:string">900,1200</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">latencyRead</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">14,15</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">latencyWrite</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">16,17</values>
                 </value>
@@ -48,36 +54,42 @@
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">iopsRead</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">20,21</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">iopsWrite</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">22,23</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">throughputRead</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
-                    <values xsi:type="xsd:string">120,140</values>
+                    <values xsi:type="xsd:string">1800,2100</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">throughputWrite</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
-                    <values xsi:type="xsd:string">160,180</values>
+                    <values xsi:type="xsd:string">2400,2700</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">latencyRead</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">24,25</values>
                 </value>
                 <value xsi:type="VsanPerfMetricSeriesCSV">
                     <metricId xsi:type="VsanPerfMetricId">
                         <label xsi:type="xsd:string">latencyWrite</label>
+                        <metricsCollectInterval xsi:type="xsd:int">300</metricsCollectInterval>
                     </metricId>
                     <values xsi:type="xsd:string">26,27</values>
                 </value>

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -143,6 +143,28 @@ attributes:
     name_override: object
     description: The object on the virtual machine or host that is being reported on.
     type: string
+  vsan_throughput_direction:
+    name_override: direction
+    description: The type of vSAN throughput.
+    type: string
+    enum:
+      - read
+      - write
+  vsan_latency_type:
+    name_override: type
+    description: The type of vSAN latency.
+    type: string
+    enum:
+      - read
+      - write
+  vsan_operation_type:
+    name_override: type
+    description: The type of vSAN operation.
+    type: string
+    enum:
+      - read
+      - write
+      - unmap
 
 metrics:
   vcenter.datacenter.cluster.count:
@@ -611,3 +633,30 @@ metrics:
     gauge:
       value_type: double
     attributes: []
+  vcenter.vm.vsan.throughput:
+    enabled: false
+    description: The vSAN throughput of a virtual machine.
+    unit: "By/s"
+    gauge:
+      value_type: double
+    attributes: [vsan_throughput_direction]
+    warnings:
+      if_enabled_not_set: "this metric will be enabled by default starting in release v0.107.0"
+  vcenter.vm.vsan.operations:
+    enabled: false
+    description: The vSAN IOPs of a virtual machine.
+    unit: "{operations/sec}"
+    gauge:
+      value_type: int
+    attributes: [vsan_operation_type]
+    warnings:
+      if_enabled_not_set: "this metric will be enabled by default starting in release v0.107.0"
+  vcenter.vm.vsan.latency.avg:
+    enabled: false
+    description: The virtual machine latency while accessing vSAN storage.
+    unit: "us"
+    gauge:
+      value_type: int
+    attributes: [vsan_latency_type]
+    warnings:
+      if_enabled_not_set: "this metric will be enabled by default starting in release v0.107.0"

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -418,10 +418,10 @@ func (v *vcenterMetricScraper) recordVMVSANMetrics(vSANMetrics *VSANMetricResult
 			case "iopsWrite":
 				v.mb.RecordVcenterVMVsanOperationsDataPoint(pcommon.NewTimestampFromTime(*timestamp), value, metadata.AttributeVsanOperationTypeWrite)
 			case "throughputRead":
-				readRate := float64(value) / 20
+				readRate := float64(value) / float64(metric.Interval)
 				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(*timestamp), readRate, metadata.AttributeVsanThroughputDirectionRead)
 			case "throughputWrite":
-				writeRate := float64(value) / 20
+				writeRate := float64(value) / float64(metric.Interval)
 				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(*timestamp), writeRate, metadata.AttributeVsanThroughputDirectionWrite)
 			case "latencyRead":
 				v.mb.RecordVcenterVMVsanLatencyAvgDataPoint(pcommon.NewTimestampFromTime(*timestamp), value, metadata.AttributeVsanLatencyTypeRead)

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -410,22 +410,23 @@ func (v *vcenterMetricScraper) recordVMPerformanceMetrics(entityMetric *performa
 // recordVMVSANMetrics records vSAN metrics for a vSphere Virtual Machine
 func (v *vcenterMetricScraper) recordVMVSANMetrics(vSANMetrics *VSANMetricResults) {
 	for _, metric := range vSANMetrics.MetricDetails {
-		for timestamp, value := range metric.ValuesByTimestamp {
+		for i, value := range metric.Values {
+			timestamp := metric.Timestamps[i]
 			switch metric.MetricLabel {
 			case "iopsRead":
-				v.mb.RecordVcenterVMVsanOperationsDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanOperationTypeRead)
+				v.mb.RecordVcenterVMVsanOperationsDataPoint(pcommon.NewTimestampFromTime(*timestamp), value, metadata.AttributeVsanOperationTypeRead)
 			case "iopsWrite":
-				v.mb.RecordVcenterVMVsanOperationsDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanOperationTypeWrite)
+				v.mb.RecordVcenterVMVsanOperationsDataPoint(pcommon.NewTimestampFromTime(*timestamp), value, metadata.AttributeVsanOperationTypeWrite)
 			case "throughputRead":
 				readRate := float64(value) / 20
-				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(timestamp), readRate, metadata.AttributeVsanThroughputDirectionRead)
+				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(*timestamp), readRate, metadata.AttributeVsanThroughputDirectionRead)
 			case "throughputWrite":
 				writeRate := float64(value) / 20
-				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(timestamp), writeRate, metadata.AttributeVsanThroughputDirectionWrite)
+				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(*timestamp), writeRate, metadata.AttributeVsanThroughputDirectionWrite)
 			case "latencyRead":
-				v.mb.RecordVcenterVMVsanLatencyAvgDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanLatencyTypeRead)
+				v.mb.RecordVcenterVMVsanLatencyAvgDataPoint(pcommon.NewTimestampFromTime(*timestamp), value, metadata.AttributeVsanLatencyTypeRead)
 			case "latencyWrite":
-				v.mb.RecordVcenterVMVsanLatencyAvgDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanLatencyTypeWrite)
+				v.mb.RecordVcenterVMVsanLatencyAvgDataPoint(pcommon.NewTimestampFromTime(*timestamp), value, metadata.AttributeVsanLatencyTypeWrite)
 			}
 		}
 	}

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -406,3 +406,27 @@ func (v *vcenterMetricScraper) recordVMPerformanceMetrics(entityMetric *performa
 		}
 	}
 }
+
+// recordVMVSANMetrics records vSAN metrics for a vSphere Virtual Machine
+func (v *vcenterMetricScraper) recordVMVSANMetrics(vSANMetrics *VSANMetricResults) {
+	for _, metric := range vSANMetrics.MetricDetails {
+		for timestamp, value := range metric.ValuesByTimestamp {
+			switch metric.MetricLabel {
+			case "iopsRead":
+				v.mb.RecordVcenterVMVsanOperationsDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanOperationTypeRead)
+			case "iopsWrite":
+				v.mb.RecordVcenterVMVsanOperationsDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanOperationTypeWrite)
+			case "throughputRead":
+				readRate := float64(value) / 20
+				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(timestamp), readRate, metadata.AttributeVsanThroughputDirectionRead)
+			case "throughputWrite":
+				writeRate := float64(value) / 20
+				v.mb.RecordVcenterVMVsanThroughputDataPoint(pcommon.NewTimestampFromTime(timestamp), writeRate, metadata.AttributeVsanThroughputDirectionWrite)
+			case "latencyRead":
+				v.mb.RecordVcenterVMVsanLatencyAvgDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanLatencyTypeRead)
+			case "latencyWrite":
+				v.mb.RecordVcenterVMVsanLatencyAvgDataPoint(pcommon.NewTimestampFromTime(timestamp), value, metadata.AttributeVsanLatencyTypeWrite)
+			}
+		}
+	}
+}

--- a/receiver/vcenterreceiver/processors.go
+++ b/receiver/vcenterreceiver/processors.go
@@ -317,10 +317,14 @@ func (v *vcenterMetricScraper) buildVMMetrics(
 	}
 
 	// Record VM metric data points
-	perfMetrics := v.scrapeData.vmPerfMetricsByRef[vm.Reference().Value]
 	v.recordVMStats(ts, vm, hs)
+	perfMetrics := v.scrapeData.vmPerfMetricsByRef[vm.Reference().Value]
 	if perfMetrics != nil {
 		v.recordVMPerformanceMetrics(perfMetrics)
+	}
+	vSANMetrics := v.scrapeData.vmVSANMetricsByUUID[vm.Config.InstanceUuid]
+	if vSANMetrics != nil {
+		v.recordVMVSANMetrics(vSANMetrics)
 	}
 	v.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -316,14 +316,7 @@ func (v *vcenterMetricScraper) scrapeVirtualMachines(ctx context.Context, dc *mo
 	}
 
 	// Get all VirtualMachine vSAN metrics and store for later retrieval
-	clusterRefs := []*types.ManagedObjectReference{}
-	for _, compute := range v.scrapeData.computesByRef {
-		if compute.Reference().Type == "ClusterComputeResource" {
-			ref := compute.Reference()
-			clusterRefs = append(clusterRefs, &ref)
-		}
-	}
-	vSANMetrics, err := v.client.VSANVirtualMachines(ctx, clusterRefs)
+	vSANMetrics, err := v.client.VSANVirtualMachines(ctx)
 	if err != nil {
 		errs.AddPartial(1, fmt.Errorf("failed to retrieve vSAN metrics for VirtualMachines: %w", err))
 		return

--- a/receiver/vcenterreceiver/scraper_test.go
+++ b/receiver/vcenterreceiver/scraper_test.go
@@ -41,6 +41,9 @@ func TestScrapeConfigsEnabled(t *testing.T) {
 
 	optConfigs := metadata.DefaultMetricsBuilderConfig()
 	setResourcePoolMemoryUsageAttrFeatureGate(t, true)
+	optConfigs.Metrics.VcenterVMVsanLatencyAvg.Enabled = true
+	optConfigs.Metrics.VcenterVMVsanOperations.Enabled = true
+	optConfigs.Metrics.VcenterVMVsanThroughput.Enabled = true
 
 	cfg := &Config{
 		MetricsBuilderConfig: optConfigs,

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -7083,6 +7083,105 @@ resourceMetrics:
                   startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
             unit: '{KiBy/s}'
+          - description: The virtual machine latency while accessing vSAN storage.
+            gauge:
+              dataPoints:
+                - asInt: "14"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "15"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+                - asInt: "16"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "17"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.vsan.latency.avg
+            unit: us
+          - description: The vSAN IOPs of a virtual machine.
+            gauge:
+              dataPoints:
+                - asInt: "10"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "11"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+                - asInt: "12"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "13"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.vsan.operations
+            unit: '{operations/sec}'
+          - description: The vSAN throughput of a virtual machine.
+            gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 4
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.vsan.throughput
+            unit: By/s
         scope:
           name: otelcol/vcenterreceiver
           version: latest
@@ -7720,6 +7819,105 @@ resourceMetrics:
                   startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
             unit: '{KiBy/s}'
+          - description: The virtual machine latency while accessing vSAN storage.
+            gauge:
+              dataPoints:
+                - asInt: "24"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "25"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+                - asInt: "26"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "27"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.vsan.latency.avg
+            unit: us
+          - description: The vSAN IOPs of a virtual machine.
+            gauge:
+              dataPoints:
+                - asInt: "20"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "21"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+                - asInt: "22"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asInt: "23"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.vsan.operations
+            unit: '{operations/sec}'
+          - description: The vSAN throughput of a virtual machine.
+            gauge:
+              dataPoints:
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 7
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 8
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "3000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.vm.vsan.throughput
+            unit: By/s
         scope:
           name: otelcol/vcenterreceiver
           version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Adds a set of vSAN metrics for Virtual Machines.
```
vcenter.vm.vsan.throughput          (direction={read/write})
vcenter.vm.vsan.iops                (direction={read/write})
vcenter.vm.vsan.latency.avg         (direction={read/write})
```

**Link to tracking Issue:** <Issue number if applicable>
#33556 

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests added for scraper.
Could not add client tests as `govmomi` vSAN simulator currently not implemented. 
Tested against live environment.

**Documentation:** <Describe the documentation added.>
New documentation generated