### PR TITLE
[chore] relax more assertions

### DIFF
--- a/exporter/datadogexporter/config_warnings_test.go
+++ b/exporter/datadogexporter/config_warnings_test.go
@@ -81,7 +81,7 @@ func TestSendAggregations(t *testing.T) {
 			cfg := f.CreateDefaultConfig().(*Config)
 			err := testInstance.cfgMap.Unmarshal(cfg)
 			if err != nil || testInstance.err != "" {
-				assert.EqualError(t, err, testInstance.err)
+				assert.ErrorContains(t, err, testInstance.err)
 			} else {
 				assert.Equal(t, testInstance.expectedAggrValue, cfg.Metrics.HistConfig.SendAggregations)
 				var warningStr []string
@@ -158,7 +158,7 @@ func TestPeerTags(t *testing.T) {
 			cfg := f.CreateDefaultConfig().(*Config)
 			err := testInstance.cfgMap.Unmarshal(cfg)
 			if err != nil || testInstance.err != "" {
-				assert.EqualError(t, err, testInstance.err)
+				assert.ErrorContains(t, err, testInstance.err)
 			} else {
 				assert.Equal(t, testInstance.expectedPeerTagsValue, cfg.Traces.PeerTagsAggregation)
 				var warningStr []string


### PR DESCRIPTION
I need to relax assertions a bit more to get tests to pass when we update mapstructure. Example: https://github.com/open-telemetry/opentelemetry-collector/actions/runs/9970721988/job/27550235163?pr=10610