### PR TITLE
[chore] Don't mark PRs with "never stale" label as stale

### DIFF
--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -26,6 +26,7 @@ jobs:
           exempt-issue-labels: 'never stale'
           ascending: true
           operations-per-run: 6000
+          exempt-pr-labels: 'never stale'
       - name: Check rate_limit after
         run: gh api /rate_limit
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This PR makes the `never stale` label respected on PRs. I noticed on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32486 that I had added the `never stale` label, but `Stale` was still added. This is because we need to set the [`exempt-pr-labels` option](https://github.com/actions/stale?tab=readme-ov-file#exempt-pr-labels) in the [stale action](https://github.com/actions/stale) workflow.