### PR TITLE
[chore] [receiver/datadog] Refactor translation files into internal package

### DIFF
--- a/receiver/datadogreceiver/internal/translator/batcher.go
+++ b/receiver/datadogreceiver/internal/translator/batcher.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
+package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"

--- a/receiver/datadogreceiver/internal/translator/batcher.go
+++ b/receiver/datadogreceiver/internal/translator/batcher.go
@@ -10,7 +10,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 )
 
-type Batcher struct {
+type batcher struct {
 	pmetric.Metrics
 
 	resourceMetrics map[identity.Resource]pmetric.ResourceMetrics
@@ -18,8 +18,8 @@ type Batcher struct {
 	metrics         map[identity.Metric]pmetric.Metric
 }
 
-func newBatcher() Batcher {
-	return Batcher{
+func newBatcher() batcher {
+	return batcher{
 		Metrics:         pmetric.NewMetrics(),
 		resourceMetrics: make(map[identity.Resource]pmetric.ResourceMetrics),
 		scopeMetrics:    make(map[identity.Scope]pmetric.ScopeMetrics),
@@ -30,7 +30,7 @@ func newBatcher() Batcher {
 // Dimensions stores the properties of the series that are needed in order
 // to unique identify the series. This is needed in order to batch metrics by
 // resource, scope, and datapoint attributes
-type Dimensions struct {
+type dimensions struct {
 	name          string
 	metricType    pmetric.MetricType
 	resourceAttrs pcommon.Map
@@ -47,9 +47,9 @@ var metricTypeMap = map[string]pmetric.MetricType{
 	"sketch":        pmetric.MetricTypeExponentialHistogram,
 }
 
-func parseSeriesProperties(name string, metricType string, tags []string, host string, version string, stringPool *StringPool) Dimensions {
+func parseSeriesProperties(name string, metricType string, tags []string, host string, version string, stringPool *StringPool) dimensions {
 	resourceAttrs, scopeAttrs, dpAttrs := tagsToAttributes(tags, host, stringPool)
-	return Dimensions{
+	return dimensions{
 		name:          name,
 		metricType:    metricTypeMap[metricType],
 		buildInfo:     version,
@@ -59,7 +59,7 @@ func parseSeriesProperties(name string, metricType string, tags []string, host s
 	}
 }
 
-func (b Batcher) Lookup(dim Dimensions) (pmetric.Metric, identity.Metric) {
+func (b batcher) Lookup(dim dimensions) (pmetric.Metric, identity.Metric) {
 	resource := dim.Resource()
 	resourceID := identity.OfResource(resource)
 	resourceMetrics, ok := b.resourceMetrics[resourceID]
@@ -90,13 +90,13 @@ func (b Batcher) Lookup(dim Dimensions) (pmetric.Metric, identity.Metric) {
 	return metric, metricID
 }
 
-func (d Dimensions) Resource() pcommon.Resource {
+func (d dimensions) Resource() pcommon.Resource {
 	resource := pcommon.NewResource()
 	d.resourceAttrs.CopyTo(resource.Attributes()) // TODO(jesus.vazquez) review this copy
 	return resource
 }
 
-func (d Dimensions) Scope() pcommon.InstrumentationScope {
+func (d dimensions) Scope() pcommon.InstrumentationScope {
 	scope := pcommon.NewInstrumentationScope()
 	scope.SetName("otelcol/datadogreceiver")
 	scope.SetVersion(d.buildInfo)
@@ -104,7 +104,7 @@ func (d Dimensions) Scope() pcommon.InstrumentationScope {
 	return scope
 }
 
-func (d Dimensions) Metric() pmetric.Metric {
+func (d dimensions) Metric() pmetric.Metric {
 	metric := pmetric.NewMetric()
 	metric.SetName(d.name)
 	switch d.metricType {

--- a/receiver/datadogreceiver/internal/translator/batcher_test.go
+++ b/receiver/datadogreceiver/internal/translator/batcher_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver
+package translator
 
 import (
 	"testing"
@@ -275,13 +275,13 @@ func TestMetricBatcher(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mt := newMetricsTranslator()
-			mt.buildInfo = component.BuildInfo{
+			mt := NewMetricsTranslator()
+			mt.BuildInfo = component.BuildInfo{
 				Command:     "otelcol",
 				Description: "OpenTelemetry Collector",
 				Version:     "latest",
 			}
-			result := mt.translateMetricsV1(tt.series)
+			result := mt.TranslateSeriesV1(tt.series)
 
 			tt.expect(t, result)
 		})

--- a/receiver/datadogreceiver/internal/translator/batcher_test.go
+++ b/receiver/datadogreceiver/internal/translator/batcher_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
@@ -275,12 +274,7 @@ func TestMetricBatcher(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mt := NewMetricsTranslator()
-			mt.BuildInfo = component.BuildInfo{
-				Command:     "otelcol",
-				Description: "OpenTelemetry Collector",
-				Version:     "latest",
-			}
+			mt := createMetricsTranslator()
 			result := mt.TranslateSeriesV1(tt.series)
 
 			tt.expect(t, result)

--- a/receiver/datadogreceiver/internal/translator/metrics_translator.go
+++ b/receiver/datadogreceiver/internal/translator/metrics_translator.go
@@ -12,13 +12,14 @@ import (
 
 type MetricsTranslator struct {
 	sync.RWMutex
-	BuildInfo  component.BuildInfo
+	buildInfo  component.BuildInfo
 	lastTs     map[identity.Stream]pcommon.Timestamp
 	stringPool *StringPool
 }
 
-func NewMetricsTranslator() *MetricsTranslator {
+func NewMetricsTranslator(buildInfo component.BuildInfo) *MetricsTranslator {
 	return &MetricsTranslator{
+		buildInfo:  buildInfo,
 		lastTs:     make(map[identity.Stream]pcommon.Timestamp),
 		stringPool: newStringPool(),
 	}

--- a/receiver/datadogreceiver/internal/translator/metrics_translator.go
+++ b/receiver/datadogreceiver/internal/translator/metrics_translator.go
@@ -4,10 +4,12 @@
 package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+	"sync"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	"sync"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 )
 
 type MetricsTranslator struct {

--- a/receiver/datadogreceiver/internal/translator/metrics_translator.go
+++ b/receiver/datadogreceiver/internal/translator/metrics_translator.go
@@ -1,0 +1,38 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"sync"
+)
+
+type MetricsTranslator struct {
+	sync.RWMutex
+	BuildInfo  component.BuildInfo
+	lastTs     map[identity.Stream]pcommon.Timestamp
+	stringPool *StringPool
+}
+
+func NewMetricsTranslator() *MetricsTranslator {
+	return &MetricsTranslator{
+		lastTs:     make(map[identity.Stream]pcommon.Timestamp),
+		stringPool: newStringPool(),
+	}
+}
+
+func (mt *MetricsTranslator) streamHasTimestamp(stream identity.Stream) (pcommon.Timestamp, bool) {
+	mt.RLock()
+	defer mt.RUnlock()
+	ts, ok := mt.lastTs[stream]
+	return ts, ok
+}
+
+func (mt *MetricsTranslator) updateLastTsForStream(stream identity.Stream, ts pcommon.Timestamp) {
+	mt.Lock()
+	defer mt.Unlock()
+	mt.lastTs[stream] = ts
+}

--- a/receiver/datadogreceiver/internal/translator/series.go
+++ b/receiver/datadogreceiver/internal/translator/series.go
@@ -29,7 +29,7 @@ func (mt *MetricsTranslator) TranslateSeriesV1(series SeriesList) pmetric.Metric
 	for _, serie := range series.Series {
 		var dps pmetric.NumberDataPointSlice
 
-		dimensions := parseSeriesProperties(serie.Metric, serie.GetType(), serie.GetTags(), serie.GetHost(), mt.BuildInfo.Version, mt.stringPool)
+		dimensions := parseSeriesProperties(serie.Metric, serie.GetType(), serie.GetTags(), serie.GetHost(), mt.buildInfo.Version, mt.stringPool)
 		metric, metricID := bt.Lookup(dimensions)
 
 		switch serie.GetType() {

--- a/receiver/datadogreceiver/internal/translator/series.go
+++ b/receiver/datadogreceiver/internal/translator/series.go
@@ -1,46 +1,17 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
+package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 
 import (
-	"sync"
 	"time"
 
 	datadogV1 "github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 )
-
-type MetricsTranslator struct {
-	sync.RWMutex
-	buildInfo  component.BuildInfo
-	lastTs     map[identity.Stream]pcommon.Timestamp
-	stringPool *StringPool
-}
-
-func newMetricsTranslator() *MetricsTranslator {
-	return &MetricsTranslator{
-		lastTs:     make(map[identity.Stream]pcommon.Timestamp),
-		stringPool: newStringPool(),
-	}
-}
-
-func (mt *MetricsTranslator) streamHasTimestamp(stream identity.Stream) (pcommon.Timestamp, bool) {
-	mt.RLock()
-	defer mt.RUnlock()
-	ts, ok := mt.lastTs[stream]
-	return ts, ok
-}
-
-func (mt *MetricsTranslator) updateLastTsForStream(stream identity.Stream, ts pcommon.Timestamp) {
-	mt.Lock()
-	defer mt.Unlock()
-	mt.lastTs[stream] = ts
-}
 
 const (
 	TypeGauge string = "gauge"
@@ -52,13 +23,13 @@ type SeriesList struct {
 	Series []datadogV1.Series `json:"series"`
 }
 
-func (mt *MetricsTranslator) translateMetricsV1(series SeriesList) pmetric.Metrics {
+func (mt *MetricsTranslator) TranslateSeriesV1(series SeriesList) pmetric.Metrics {
 	bt := newBatcher()
 
 	for _, serie := range series.Series {
 		var dps pmetric.NumberDataPointSlice
 
-		dimensions := parseSeriesProperties(serie.Metric, serie.GetType(), serie.GetTags(), serie.GetHost(), mt.buildInfo.Version, mt.stringPool)
+		dimensions := parseSeriesProperties(serie.Metric, serie.GetType(), serie.GetTags(), serie.GetHost(), mt.BuildInfo.Version, mt.stringPool)
 		metric, metricID := bt.Lookup(dimensions)
 
 		switch serie.GetType() {

--- a/receiver/datadogreceiver/internal/translator/series_test.go
+++ b/receiver/datadogreceiver/internal/translator/series_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver
+package translator
 
 import (
 	"testing"
@@ -152,7 +152,7 @@ func TestTranslateMetricsV1(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mt := createMetricsTranslator()
-			result := mt.translateMetricsV1(tt.series)
+			result := mt.TranslateSeriesV1(tt.series)
 
 			tt.expect(t, result)
 		})

--- a/receiver/datadogreceiver/internal/translator/series_test.go
+++ b/receiver/datadogreceiver/internal/translator/series_test.go
@@ -28,7 +28,7 @@ func testPointsToDatadogPoints(points []testPoint) [][]*float64 {
 
 }
 
-func TestTranslateMetricsV1(t *testing.T) {
+func TestTranslateSeriesV1(t *testing.T) {
 	tests := []struct {
 		name string
 

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
+package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 
 import (
 	"fmt"

--- a/receiver/datadogreceiver/internal/translator/tags_test.go
+++ b/receiver/datadogreceiver/internal/translator/tags_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver
+package translator
 
 import (
 	"testing"

--- a/receiver/datadogreceiver/internal/translator/testutil.go
+++ b/receiver/datadogreceiver/internal/translator/testutil.go
@@ -13,12 +13,11 @@ import (
 )
 
 func createMetricsTranslator() *MetricsTranslator {
-	mt := NewMetricsTranslator()
-	mt.BuildInfo = component.BuildInfo{
+	mt := NewMetricsTranslator(component.BuildInfo{
 		Command:     "otelcol",
 		Description: "OpenTelemetry Collector",
 		Version:     "latest",
-	}
+	})
 	return mt
 }
 

--- a/receiver/datadogreceiver/internal/translator/testutil.go
+++ b/receiver/datadogreceiver/internal/translator/testutil.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
+package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 
 import (
 	"testing"
@@ -13,8 +13,8 @@ import (
 )
 
 func createMetricsTranslator() *MetricsTranslator {
-	mt := newMetricsTranslator()
-	mt.buildInfo = component.BuildInfo{
+	mt := NewMetricsTranslator()
+	mt.BuildInfo = component.BuildInfo{
 		Command:     "otelcol",
 		Description: "OpenTelemetry Collector",
 		Version:     "latest",

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package datadogreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
+package translator // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver"
 
 import (
 	"bytes"
@@ -83,7 +83,7 @@ func TestTracePayloadV05Unmarshalling(t *testing.T) {
 	require.NoError(t, traces.UnmarshalMsgDictionary(payload), "Must not error when marshaling content")
 	req, _ := http.NewRequest(http.MethodPost, "/v0.5/traces", io.NopCloser(bytes.NewReader(payload)))
 
-	translated := toTraces(&pb.TracerPayload{
+	translated := ToTraces(&pb.TracerPayload{
 		LanguageName:    req.Header.Get("Datadog-Meta-Lang"),
 		LanguageVersion: req.Header.Get("Datadog-Meta-Lang-Version"),
 		TracerVersion:   req.Header.Get("Datadog-Meta-Tracer-Version"),
@@ -115,7 +115,7 @@ func TestTracePayloadV07Unmarshalling(t *testing.T) {
 	bytez, _ := apiPayload.MarshalMsg(reqBytes)
 	req, _ := http.NewRequest(http.MethodPost, "/v0.7/traces", io.NopCloser(bytes.NewReader(bytez)))
 
-	translatedPayloads, _ := handleTracesPayload(req)
+	translatedPayloads, _ := HandleTracesPayload(req)
 	assert.Equal(t, len(translatedPayloads), 1, "Expected one translated payload")
 	translated := translatedPayloads[0]
 	span := translated.GetChunks()[0].GetSpans()[0]
@@ -151,7 +151,7 @@ func TestTracePayloadApiV02Unmarshalling(t *testing.T) {
 	bytez, _ := proto.Marshal(&agentPayload)
 	req, _ := http.NewRequest(http.MethodPost, "/api/v0.2/traces", io.NopCloser(bytes.NewReader(bytez)))
 
-	translatedPayloads, _ := handleTracesPayload(req)
+	translatedPayloads, _ := HandleTracesPayload(req)
 	assert.Equal(t, len(translatedPayloads), 2, "Expected two translated payload")
 	for _, translated := range translatedPayloads {
 		assert.NotNil(t, translated)

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 	"io"
 	"net/http"
 
@@ -18,6 +17,8 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator"
 )
 
 type datadogReceiver struct {

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -66,8 +66,7 @@ func (ddr *datadogReceiver) Start(ctx context.Context, host component.Host) erro
 	}
 
 	if ddr.nextMetricsConsumer != nil {
-		ddr.metricsTranslator = translator.NewMetricsTranslator()
-		ddr.metricsTranslator.BuildInfo = ddr.params.BuildInfo
+		ddr.metricsTranslator = translator.NewMetricsTranslator(ddr.params.BuildInfo)
 
 		ddmux.HandleFunc("/api/v1/series", ddr.handleV1Series)
 		ddmux.HandleFunc("/api/v2/series", ddr.handleV2Series)


### PR DESCRIPTION
**Description:**
This PR is a follow-up to #33957. It refactors the Datadog receiver files to remove internal methods and structures from the public API and into an internal directory.

**Link to tracking Issue:** 
#18278 

**Testing:** 
This is a refactor, so no new unit tests have been added.