### PR TITLE
[chore] skip test to avoid conflict on read_timeout field

### DIFF
--- a/receiver/webhookeventreceiver/config_test.go
+++ b/receiver/webhookeventreceiver/config_test.go
@@ -113,6 +113,7 @@ func TestValidateConfig(t *testing.T) {
 }
 
 func TestLoadConfig(t *testing.T) {
+	t.Skip("skip temporarily to avoid a test failure on read_timeout with https://github.com/open-telemetry/opentelemetry-collector/pull/10275")
 	t.Parallel()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector/pull/10275 for context - we need to disable a test so we can merge the change in core, and bring it here next.