### PR TITLE
[otelarrow/netstats] prefix metrics with otelcol_

### DIFF
--- a/exporter/otelarrowexporter/README.md
+++ b/exporter/otelarrowexporter/README.md
@@ -173,17 +173,17 @@ metrics, this component provides network-level measurement instruments
 which we anticipate will become part of `exporterhelper` and/or
 `obsreport` in the future.  At the `normal` level of metrics detail:
 
-- `exporter_sent`: uncompressed bytes sent, prior to compression
-- `exporter_sent_wire`: compressed bytes sent, on the wire.
+- `otelcol_exporter_sent`: uncompressed bytes sent, prior to compression
+- `otelcol_exporter_sent_wire`: compressed bytes sent, on the wire.
 
 Arrow's compression performance can be derived by dividing the average
-`exporter_sent` value by the average `exporter_sent_wire` value.
+`otelcol_exporter_sent` value by the average `otelcol_exporter_sent_wire` value.
 
 At the `detailed` metrics detail level, information about the stream
 of data being returned to the exporter will be instrumented:
 
-- `exporter_recv`: uncompressed bytes received, prior to compression
-- `exporter_recv_wire`: compressed bytes received, on the wire.
+- `otelcol_exporter_recv`: uncompressed bytes received, prior to compression
+- `otelcol_exporter_recv_wire`: compressed bytes received, on the wire.
 
 ### Compression Configuration
 

--- a/internal/otelarrow/netstats/netstats.go
+++ b/internal/otelarrow/netstats/netstats.go
@@ -144,17 +144,17 @@ func NewExporterNetworkReporter(settings exporter.Settings) (*NetworkReporter, e
 
 	var errors, err error
 	if level > configtelemetry.LevelNormal {
-		rep.compSizeHisto, err = meter.Int64Histogram(ExporterKey+"_"+CompSize, metric.WithDescription(compSizeDescription), metric.WithUnit(bytesUnit))
+		rep.compSizeHisto, err = meter.Int64Histogram("otelcol_"+ExporterKey+"_"+CompSize, metric.WithDescription(compSizeDescription), metric.WithUnit(bytesUnit))
 		errors = multierr.Append(errors, err)
 	}
 
-	rep.sentBytes, rep.sentWireBytes, err = makeSentMetrics(ExporterKey, meter, true)
+	rep.sentBytes, rep.sentWireBytes, err = makeSentMetrics("otelcol_"+ExporterKey, meter, true)
 	errors = multierr.Append(errors, err)
 
 	// Normally, an exporter counts sent bytes, and skips received
 	// bytes.  LevelDetailed will reveal exporter-received bytes.
 	if level > configtelemetry.LevelNormal {
-		rep.recvBytes, rep.recvWireBytes, err = makeRecvMetrics(ExporterKey, meter, false)
+		rep.recvBytes, rep.recvWireBytes, err = makeRecvMetrics("otelcol_"+ExporterKey, meter, false)
 		errors = multierr.Append(errors, err)
 	}
 
@@ -179,17 +179,17 @@ func NewReceiverNetworkReporter(settings receiver.Settings) (*NetworkReporter, e
 
 	var errors, err error
 	if level > configtelemetry.LevelNormal {
-		rep.compSizeHisto, err = meter.Int64Histogram(ReceiverKey+"_"+CompSize, metric.WithDescription(compSizeDescription), metric.WithUnit(bytesUnit))
+		rep.compSizeHisto, err = meter.Int64Histogram("otelcol_"+ReceiverKey+"_"+CompSize, metric.WithDescription(compSizeDescription), metric.WithUnit(bytesUnit))
 		errors = multierr.Append(errors, err)
 	}
 
-	rep.recvBytes, rep.recvWireBytes, err = makeRecvMetrics(ReceiverKey, meter, true)
+	rep.recvBytes, rep.recvWireBytes, err = makeRecvMetrics("otelcol_"+ReceiverKey, meter, true)
 	errors = multierr.Append(errors, err)
 
 	// Normally, a receiver counts received bytes, and skips sent
 	// bytes.  LevelDetailed will reveal receiver-sent bytes.
 	if level > configtelemetry.LevelNormal {
-		rep.sentBytes, rep.sentWireBytes, err = makeSentMetrics(ReceiverKey, meter, false)
+		rep.sentBytes, rep.sentWireBytes, err = makeSentMetrics("otelcol_"+ReceiverKey, meter, false)
 		errors = multierr.Append(errors, err)
 	}
 

--- a/internal/otelarrow/netstats/netstats_test.go
+++ b/internal/otelarrow/netstats/netstats_test.go
@@ -58,17 +58,17 @@ func TestNetStatsExporterNone(t *testing.T) {
 
 func TestNetStatsExporterNormal(t *testing.T) {
 	testNetStatsExporter(t, configtelemetry.LevelNormal, map[string]any{
-		"exporter_sent":      int64(1000),
-		"exporter_sent_wire": int64(100),
+		"otelcol_exporter_sent":      int64(1000),
+		"otelcol_exporter_sent_wire": int64(100),
 	})
 }
 
 func TestNetStatsExporterDetailed(t *testing.T) {
 	testNetStatsExporter(t, configtelemetry.LevelDetailed, map[string]any{
-		"exporter_sent":            int64(1000),
-		"exporter_sent_wire":       int64(100),
-		"exporter_recv_wire":       int64(10),
-		"exporter_compressed_size": int64(100), // same as sent_wire b/c sum metricValue uses histogram sum
+		"otelcol_exporter_sent":            int64(1000),
+		"otelcol_exporter_sent_wire":       int64(100),
+		"otelcol_exporter_recv_wire":       int64(10),
+		"otelcol_exporter_compressed_size": int64(100), // same as sent_wire b/c sum metricValue uses histogram sum
 	})
 }
 
@@ -198,17 +198,17 @@ func TestNetStatsReceiverNone(t *testing.T) {
 
 func TestNetStatsReceiverNormal(t *testing.T) {
 	testNetStatsReceiver(t, configtelemetry.LevelNormal, map[string]any{
-		"receiver_recv":      int64(1000),
-		"receiver_recv_wire": int64(100),
+		"otelcol_receiver_recv":      int64(1000),
+		"otelcol_receiver_recv_wire": int64(100),
 	})
 }
 
 func TestNetStatsReceiverDetailed(t *testing.T) {
 	testNetStatsReceiver(t, configtelemetry.LevelDetailed, map[string]any{
-		"receiver_recv":            int64(1000),
-		"receiver_recv_wire":       int64(100),
-		"receiver_sent_wire":       int64(10),
-		"receiver_compressed_size": int64(100), // same as recv_wire b/c sum metricValue uses histogram sum
+		"otelcol_receiver_recv":            int64(1000),
+		"otelcol_receiver_recv_wire":       int64(100),
+		"otelcol_receiver_sent_wire":       int64(10),
+		"otelcol_receiver_compressed_size": int64(100), // same as recv_wire b/c sum metricValue uses histogram sum
 	})
 }
 
@@ -317,10 +317,10 @@ func TestUncompressedSizeBypass(t *testing.T) {
 	require.NoError(t, err)
 
 	expect := map[string]any{
-		"exporter_sent":            int64(1000),
-		"exporter_sent_wire":       int64(100),
-		"exporter_recv_wire":       int64(10),
-		"exporter_compressed_size": int64(100),
+		"otelcol_exporter_sent":            int64(1000),
+		"otelcol_exporter_sent_wire":       int64(100),
+		"otelcol_exporter_recv_wire":       int64(10),
+		"otelcol_exporter_compressed_size": int64(100),
 	}
 	require.Equal(t, expect, metricValues(t, rm, "my.arrow.v1.method"))
 }

--- a/receiver/otelarrowreceiver/README.md
+++ b/receiver/otelarrowreceiver/README.md
@@ -173,17 +173,17 @@ metrics, this component provides network-level measurement instruments
 which we anticipate will become part of `obsreport` in the future.  At
 the `normal` level of metrics detail:
 
-- `receiver_recv`: uncompressed bytes received, prior to compression
-- `receiver_recv_wire`: compressed bytes received, on the wire.
+- `otelcol_receiver_recv`: uncompressed bytes received, prior to compression
+- `otelcol_receiver_recv_wire`: compressed bytes received, on the wire.
 
 Arrow's compression performance can be derived by dividing the average
-`receiver_recv` value by the average `receiver_recv_wire` value.
+`otelcol_receiver_recv` value by the average `otelcol_receiver_recv_wire` value.
 
 At the `detailed` metrics detail level, information about the stream
 of data being returned from the receiver will be instrumented:
 
-- `receiver_sent`: uncompressed bytes sent, prior to compression
-- `receiver_sent_wire`: compressed bytes sent, on the wire.
+- `otelcol_receiver_sent`: uncompressed bytes sent, prior to compression
+- `otelcol_receiver_sent_wire`: compressed bytes sent, on the wire.
 
 There several OpenTelemetry Protocol with Apache Arrow-consumer
 related metrics available to help diagnose internal performance.


### PR DESCRIPTION
This used to be automatically added previously via the prometheus exporter's WithNamespace configuration. That has been removed in https://github.com/open-telemetry/opentelemetry-collector/pull/9759
