### PR TITLE
[chore][receiver/vcenter] Reworked Integration test for vCenter

### DIFF
--- a/receiver/vcenterreceiver/integration_test.go
+++ b/receiver/vcenterreceiver/integration_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/vmware/govmomi/session"
 	"github.com/vmware/govmomi/simulator"
 	"github.com/vmware/govmomi/vim25"
+	"github.com/vmware/govmomi/vim25/types"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configtls"
@@ -26,7 +27,52 @@ import (
 )
 
 func TestIntegration(t *testing.T) {
-	simulator.Test(func(_ context.Context, c *vim25.Client) {
+	model := simulator.VPX()
+
+	model.Host = 2
+	model.Machine = 2
+
+	err := model.Create()
+	require.NoError(t, err)
+
+	simulator.Test(func(ctx context.Context, c *vim25.Client) {
+		finder := find.NewFinder(c)
+
+		hosts, err := finder.HostSystemList(ctx, "/DC0/host/*")
+		require.NoError(t, err)
+		for i, host := range hosts {
+			newName := fmt.Sprintf("H%d", i)
+			simulator.Map.Get(host.Reference()).(*simulator.HostSystem).Name = newName
+		}
+
+		vms, err := finder.VirtualMachineList(ctx, "/DC0/vm/*")
+		require.NoError(t, err)
+		for i, vm := range vms {
+			newName := fmt.Sprintf("VM%d", i)
+			newUUID := fmt.Sprintf("vm-uuid-%d", i)
+			simVM := simulator.Map.Get(vm.Reference()).(*simulator.VirtualMachine)
+			simVM.Name = newName
+			simVM.Config.Uuid = newUUID
+
+			// Explicitly assign VM to a specific host
+			hostIndex := i % len(hosts) // This will alternate VMs between hosts
+			host := hosts[hostIndex]
+			hostRef := host.Reference()
+			relocateSpec := types.VirtualMachineRelocateSpec{
+				Host: &hostRef,
+			}
+			task, err := vm.Relocate(ctx, relocateSpec, types.VirtualMachineMovePriorityDefaultPriority)
+			require.NoError(t, err)
+			require.NoError(t, task.Wait(ctx))
+
+			// Reconfigure the VM to apply name and UUID changes
+			task, err = vm.Reconfigure(ctx, types.VirtualMachineConfigSpec{
+				Name: newName,
+				Uuid: newUUID,
+			})
+			require.NoError(t, err)
+			require.NoError(t, task.Wait(ctx))
+		}
 		pw, set := simulator.DefaultLogin.Password()
 		require.True(t, set)
 
@@ -51,7 +97,6 @@ func TestIntegration(t *testing.T) {
 		defer func() {
 			newVcenterClient = defaultNewVcenterClient
 		}()
-
 		scraperinttest.NewIntegrationTest(
 			NewFactory(),
 			scraperinttest.WithCustomConfig(
@@ -66,9 +111,10 @@ func TestIntegration(t *testing.T) {
 					}
 				}),
 			scraperinttest.WithCompareOptions(
-				pmetrictest.IgnoreResourceAttributeValue("vcenter.host.name"),
 				pmetrictest.IgnoreTimestamp(),
 				pmetrictest.IgnoreResourceMetricsOrder(),
+				pmetrictest.IgnoreDatapointAttributesOrder(),
+				pmetrictest.IgnoreMetricDataPointsOrder(),
 				pmetrictest.IgnoreMetricsOrder(),
 				pmetrictest.IgnoreStartTimestamp(),
 				pmetrictest.IgnoreMetricValues(),

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -1,131 +1,106 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: vcenter.datacenter.name
-          value:
-            stringValue: DC0
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_H0
-        - key: vcenter.resource_pool.name
-          value:
-            stringValue: Resources
-        - key: vcenter.resource_pool.inventory_path
-          value:
-            stringValue: /DC0/host/DC0_H0/Resources
-    scopeMetrics:
-      - metrics:
-          - description: The amount of shares of CPU in the resource pool.
-            name: vcenter.resource_pool.cpu.shares
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9000"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{shares}"
-          - description: The amount of shares of memory in the resource pool.
-            name: vcenter.resource_pool.memory.shares
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9000"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{shares}"
-        scope:
-          name: otelcol/vcenterreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: vcenter.datacenter.name
-          value:
-            stringValue: DC0
         - key: vcenter.cluster.name
           value:
             stringValue: DC0_C0
-        - key: vcenter.resource_pool.name
-          value:
-            stringValue: Resources
-        - key: vcenter.resource_pool.inventory_path
-          value:
-            stringValue: /DC0/host/DC0_C0/Resources
-    scopeMetrics:
-      - metrics:
-          - description: The amount of shares of CPU in the resource pool.
-            name: vcenter.resource_pool.cpu.shares
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9000"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{shares}"
-          - description: The amount of shares of memory in the resource pool.
-            name: vcenter.resource_pool.memory.shares
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "9000"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{shares}"
-        scope:
-          name: otelcol/vcenterreceiver
-          version: latest
-  - resource:
-      attributes:
         - key: vcenter.datacenter.name
           value:
             stringValue: DC0
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_H0
     scopeMetrics:
       - metrics:
-          - description: Total CPU capacity of the host system.
-            name: vcenter.host.cpu.capacity
+          - description: The effective CPU available to the cluster. This value excludes CPU from hosts in maintenance mode or are unresponsive.
+            name: vcenter.cluster.cpu.effective
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The amount of CPU used by the host.
-            name: vcenter.host.cpu.usage
+                - asInt: "6882"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{MHz}'
+          - description: The amount of CPU available to the cluster.
+            name: vcenter.cluster.cpu.limit
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The CPU utilization of the host system.
-            gauge:
-              dataPoints:
-                - asDouble: 1.4603312990409765
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.cpu.utilization
-            unit: "%"
-          - description: The amount of memory the host system is using.
-            name: vcenter.host.memory.usage
+                - asInt: "6882"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{MHz}'
+          - description: The number of hosts in the cluster.
+            name: vcenter.cluster.host.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "1404"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MiBy
-          - description: The percentage of the host system's memory capacity that is being utilized.
-            gauge:
+                - asInt: "0"
+                  attributes:
+                    - key: effective
+                      value:
+                        boolValue: false
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: effective
+                      value:
+                        boolValue: true
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{hosts}'
+          - description: The effective available memory of the cluster.
+            name: vcenter.cluster.memory.effective
+            sum:
+              aggregationTemporality: 2
               dataPoints:
-                - asDouble: 34.285714285714285
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.memory.utilization
-            unit: "%"
+                - asInt: "13509110959964160"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The available memory of the cluster.
+            name: vcenter.cluster.memory.limit
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "12883292160"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of virtual machines in the cluster.
+            name: vcenter.cluster.vm.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "off"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "on"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: suspended
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{virtual_machines}'
+          - description: The number of virtual machine templates in the cluster.
+            name: vcenter.cluster.vm_template.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{virtual_machine_templates}'
         scope:
           name: otelcol/vcenterreceiver
           version: latest
@@ -144,29 +119,29 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "42949672960"
-                  attributes:
-                    - key: disk_state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
                 - asInt: "10952166604800"
                   attributes:
                     - key: disk_state
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "42949672960"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The utilization of the datastore.
             gauge:
               dataPoints:
                 - asDouble: 0.390625
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: vcenter.datastore.disk.utilization
-            unit: "%"
+            unit: '%'
         scope:
           name: otelcol/vcenterreceiver
           version: latest
@@ -175,21 +150,328 @@ resourceMetrics:
         - key: vcenter.datacenter.name
           value:
             stringValue: DC0
-        - key: vcenter.vm.name
+        - key: vcenter.host.name
           value:
-            stringValue: DC0_H0_VM0
+            stringValue: H0
+    scopeMetrics:
+      - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4588"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The amount of CPU used by the host.
+            name: vcenter.host.cpu.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The CPU utilization of the host system.
+            gauge:
+              dataPoints:
+                - asDouble: 1.4603312990409765
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.cpu.utilization
+            unit: '%'
+          - description: The amount of memory the host system is using.
+            name: vcenter.host.memory.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1404"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
+          - description: The percentage of the host system's memory capacity that is being utilized.
+            gauge:
+              dataPoints:
+                - asDouble: 34.285714285714285
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.memory.utilization
+            unit: '%'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: DC0_C0
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: DC0
+        - key: vcenter.host.name
+          value:
+            stringValue: H1
+    scopeMetrics:
+      - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4588"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The amount of CPU used by the host.
+            name: vcenter.host.cpu.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The CPU utilization of the host system.
+            gauge:
+              dataPoints:
+                - asDouble: 1.4603312990409765
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.cpu.utilization
+            unit: '%'
+          - description: The amount of memory the host system is using.
+            name: vcenter.host.memory.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1404"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
+          - description: The percentage of the host system's memory capacity that is being utilized.
+            gauge:
+              dataPoints:
+                - asDouble: 34.285714285714285
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.memory.utilization
+            unit: '%'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: DC0_C0
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: DC0
+        - key: vcenter.host.name
+          value:
+            stringValue: H2
+    scopeMetrics:
+      - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4588"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The amount of CPU used by the host.
+            name: vcenter.host.cpu.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The CPU utilization of the host system.
+            gauge:
+              dataPoints:
+                - asDouble: 1.4603312990409765
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.cpu.utilization
+            unit: '%'
+          - description: The amount of memory the host system is using.
+            name: vcenter.host.memory.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1404"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
+          - description: The percentage of the host system's memory capacity that is being utilized.
+            gauge:
+              dataPoints:
+                - asDouble: 34.285714285714285
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.memory.utilization
+            unit: '%'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: DC0_C0
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: DC0
+        - key: vcenter.host.name
+          value:
+            stringValue: H3
+    scopeMetrics:
+      - metrics:
+          - description: Total CPU capacity of the host system.
+            name: vcenter.host.cpu.capacity
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4588"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The amount of CPU used by the host.
+            name: vcenter.host.cpu.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "67"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MHz
+          - description: The CPU utilization of the host system.
+            gauge:
+              dataPoints:
+                - asDouble: 1.4603312990409765
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.cpu.utilization
+            unit: '%'
+          - description: The amount of memory the host system is using.
+            name: vcenter.host.memory.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1404"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
+          - description: The percentage of the host system's memory capacity that is being utilized.
+            gauge:
+              dataPoints:
+                - asDouble: 34.285714285714285
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: vcenter.host.memory.utilization
+            unit: '%'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: DC0_C0
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: DC0
+        - key: vcenter.resource_pool.inventory_path
+          value:
+            stringValue: /DC0/host/DC0_C0/Resources
+        - key: vcenter.resource_pool.name
+          value:
+            stringValue: Resources
+    scopeMetrics:
+      - metrics:
+          - description: The amount of shares of CPU in the resource pool.
+            name: vcenter.resource_pool.cpu.shares
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{shares}'
+          - description: The amount of shares of memory in the resource pool.
+            name: vcenter.resource_pool.memory.shares
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{shares}'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: DC0
+        - key: vcenter.host.name
+          value:
+            stringValue: H0
+        - key: vcenter.resource_pool.inventory_path
+          value:
+            stringValue: /DC0/host/DC0_H0/Resources
+        - key: vcenter.resource_pool.name
+          value:
+            stringValue: Resources
+    scopeMetrics:
+      - metrics:
+          - description: The amount of shares of CPU in the resource pool.
+            name: vcenter.resource_pool.cpu.shares
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{shares}'
+          - description: The amount of shares of memory in the resource pool.
+            name: vcenter.resource_pool.memory.shares
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{shares}'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: DC0
+        - key: vcenter.host.name
+          value:
+            stringValue: H0
+        - key: vcenter.resource_pool.inventory_path
+          value:
+            stringValue: /DC0/host/DC0_H0/Resources
+        - key: vcenter.resource_pool.name
+          value:
+            stringValue: Resources
         - key: vcenter.vm.id
           value:
             stringValue: b4689bed-97f0-5bcd-8a4c-07477cc8f06f
-        - key: vcenter.resource_pool.name
+        - key: vcenter.vm.name
           value:
-            stringValue: Resources
-        - key: vcenter.resource_pool.inventory_path
-          value:
-            stringValue: /DC0/host/DC0_H0/Resources
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_H0
+            stringValue: VM0
     scopeMetrics:
       - metrics:
           - description: The amount of storage space used by the virtual machine.
@@ -197,37 +479,37 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: disk_state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
                 - asInt: "10737418240"
                   attributes:
                     - key: disk_state
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The utilization of storage on the virtual machine.
             gauge:
               dataPoints:
                 - asDouble: 0
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: vcenter.vm.disk.utilization
-            unit: "%"
+            unit: '%'
           - description: The amount of memory that is ballooned due to virtualization.
             name: vcenter.vm.memory.ballooned
             sum:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The portion of memory that is granted to this VM from the host's swap space.
             name: vcenter.vm.memory.swapped
@@ -235,8 +517,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The amount of memory swapped to fast disk device such as SSD.
             name: vcenter.vm.memory.swapped_ssd
@@ -244,8 +526,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The amount of memory that is used by the virtual machine.
             name: vcenter.vm.memory.usage
@@ -253,8 +535,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
         scope:
           name: otelcol/vcenterreceiver
@@ -264,21 +546,21 @@ resourceMetrics:
         - key: vcenter.datacenter.name
           value:
             stringValue: DC0
-        - key: vcenter.vm.name
+        - key: vcenter.host.name
           value:
-            stringValue: DC0_H0_VM1
+            stringValue: H1
+        - key: vcenter.resource_pool.inventory_path
+          value:
+            stringValue: /DC0/host/DC0_H0/Resources
+        - key: vcenter.resource_pool.name
+          value:
+            stringValue: Resources
         - key: vcenter.vm.id
           value:
             stringValue: 12f8928d-f144-5c57-89db-dd2d0902c9fa
-        - key: vcenter.resource_pool.name
+        - key: vcenter.vm.name
           value:
-            stringValue: Resources
-        - key: vcenter.resource_pool.inventory_path
-          value:
-            stringValue: /DC0/host/DC0_H0/Resources
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_H0
+            stringValue: VM1
     scopeMetrics:
       - metrics:
           - description: The amount of storage space used by the virtual machine.
@@ -286,37 +568,37 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: disk_state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
                 - asInt: "10737418240"
                   attributes:
                     - key: disk_state
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The utilization of storage on the virtual machine.
             gauge:
               dataPoints:
                 - asDouble: 0
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: vcenter.vm.disk.utilization
-            unit: "%"
+            unit: '%'
           - description: The amount of memory that is ballooned due to virtualization.
             name: vcenter.vm.memory.ballooned
             sum:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The portion of memory that is granted to this VM from the host's swap space.
             name: vcenter.vm.memory.swapped
@@ -324,8 +606,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The amount of memory swapped to fast disk device such as SSD.
             name: vcenter.vm.memory.swapped_ssd
@@ -333,8 +615,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The amount of memory that is used by the virtual machine.
             name: vcenter.vm.memory.usage
@@ -342,212 +624,35 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
         scope:
           name: otelcol/vcenterreceiver
           version: latest
   - resource:
       attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: DC0_C0
         - key: vcenter.datacenter.name
           value:
             stringValue: DC0
         - key: vcenter.host.name
           value:
-            stringValue: DC0_C0_H0
-        - key: vcenter.cluster.name
+            stringValue: H2
+        - key: vcenter.resource_pool.inventory_path
           value:
-            stringValue: DC0_C0
-    scopeMetrics:
-      - metrics:
-          - description: Total CPU capacity of the host system.
-            name: vcenter.host.cpu.capacity
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The amount of CPU used by the host.
-            name: vcenter.host.cpu.usage
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The CPU utilization of the host system.
-            gauge:
-              dataPoints:
-                - asDouble: 1.4603312990409765
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.cpu.utilization
-            unit: "%"
-          - description: The amount of memory the host system is using.
-            name: vcenter.host.memory.usage
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1404"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MiBy
-          - description: The percentage of the host system's memory capacity that is being utilized.
-            gauge:
-              dataPoints:
-                - asDouble: 34.285714285714285
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.memory.utilization
-            unit: "%"
-        scope:
-          name: otelcol/vcenterreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: vcenter.datacenter.name
+            stringValue: /DC0/host/DC0_C0/Resources
+        - key: vcenter.resource_pool.name
           value:
-            stringValue: DC0
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_C0_H1
-        - key: vcenter.cluster.name
-          value:
-            stringValue: DC0_C0
-    scopeMetrics:
-      - metrics:
-          - description: Total CPU capacity of the host system.
-            name: vcenter.host.cpu.capacity
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The amount of CPU used by the host.
-            name: vcenter.host.cpu.usage
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The CPU utilization of the host system.
-            gauge:
-              dataPoints:
-                - asDouble: 1.4603312990409765
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.cpu.utilization
-            unit: "%"
-          - description: The amount of memory the host system is using.
-            name: vcenter.host.memory.usage
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1404"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MiBy
-          - description: The percentage of the host system's memory capacity that is being utilized.
-            gauge:
-              dataPoints:
-                - asDouble: 34.285714285714285
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.memory.utilization
-            unit: "%"
-        scope:
-          name: otelcol/vcenterreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: vcenter.datacenter.name
-          value:
-            stringValue: DC0
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_C0_H2
-        - key: vcenter.cluster.name
-          value:
-            stringValue: DC0_C0
-    scopeMetrics:
-      - metrics:
-          - description: Total CPU capacity of the host system.
-            name: vcenter.host.cpu.capacity
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The amount of CPU used by the host.
-            name: vcenter.host.cpu.usage
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "67"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MHz
-          - description: The CPU utilization of the host system.
-            gauge:
-              dataPoints:
-                - asDouble: 1.4603312990409765
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.cpu.utilization
-            unit: "%"
-          - description: The amount of memory the host system is using.
-            name: vcenter.host.memory.usage
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1404"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: MiBy
-          - description: The percentage of the host system's memory capacity that is being utilized.
-            gauge:
-              dataPoints:
-                - asDouble: 34.285714285714285
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            name: vcenter.host.memory.utilization
-            unit: "%"
-        scope:
-          name: otelcol/vcenterreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: vcenter.datacenter.name
-          value:
-            stringValue: DC0
-        - key: vcenter.vm.name
-          value:
-            stringValue: DC0_C0_RP0_VM0
+            stringValue: Resources
         - key: vcenter.vm.id
           value:
             stringValue: bfff331f-7f07-572d-951e-edd3701dc061
-        - key: vcenter.cluster.name
+        - key: vcenter.vm.name
           value:
-            stringValue: DC0_C0
-        - key: vcenter.resource_pool.name
-          value:
-            stringValue: Resources
-        - key: vcenter.resource_pool.inventory_path
-          value:
-            stringValue: /DC0/host/DC0_C0/Resources
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_C0_H0
+            stringValue: VM2
     scopeMetrics:
       - metrics:
           - description: The amount of storage space used by the virtual machine.
@@ -555,37 +660,37 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: disk_state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
                 - asInt: "10737418240"
                   attributes:
                     - key: disk_state
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The utilization of storage on the virtual machine.
             gauge:
               dataPoints:
                 - asDouble: 0
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: vcenter.vm.disk.utilization
-            unit: "%"
+            unit: '%'
           - description: The amount of memory that is ballooned due to virtualization.
             name: vcenter.vm.memory.ballooned
             sum:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The portion of memory that is granted to this VM from the host's swap space.
             name: vcenter.vm.memory.swapped
@@ -593,8 +698,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The amount of memory swapped to fast disk device such as SSD.
             name: vcenter.vm.memory.swapped_ssd
@@ -602,8 +707,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The amount of memory that is used by the virtual machine.
             name: vcenter.vm.memory.usage
@@ -611,35 +716,35 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
         scope:
           name: otelcol/vcenterreceiver
           version: latest
   - resource:
       attributes:
+        - key: vcenter.cluster.name
+          value:
+            stringValue: DC0_C0
         - key: vcenter.datacenter.name
           value:
             stringValue: DC0
-        - key: vcenter.vm.name
+        - key: vcenter.host.name
           value:
-            stringValue: DC0_C0_RP0_VM1
+            stringValue: H3
+        - key: vcenter.resource_pool.inventory_path
+          value:
+            stringValue: /DC0/host/DC0_C0/Resources
+        - key: vcenter.resource_pool.name
+          value:
+            stringValue: Resources
         - key: vcenter.vm.id
           value:
             stringValue: 6132d223-1566-5921-bc3b-df91ece09a4d
-        - key: vcenter.cluster.name
+        - key: vcenter.vm.name
           value:
-            stringValue: DC0_C0
-        - key: vcenter.resource_pool.name
-          value:
-            stringValue: Resources
-        - key: vcenter.resource_pool.inventory_path
-          value:
-            stringValue: /DC0/host/DC0_C0/Resources
-        - key: vcenter.host.name
-          value:
-            stringValue: DC0_C0_H2
+            stringValue: VM3
     scopeMetrics:
       - metrics:
           - description: The amount of storage space used by the virtual machine.
@@ -647,37 +752,37 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: disk_state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
                 - asInt: "10737418240"
                   attributes:
                     - key: disk_state
                       value:
                         stringValue: available
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The utilization of storage on the virtual machine.
             gauge:
               dataPoints:
                 - asDouble: 0
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: vcenter.vm.disk.utilization
-            unit: "%"
+            unit: '%'
           - description: The amount of memory that is ballooned due to virtualization.
             name: vcenter.vm.memory.ballooned
             sum:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The portion of memory that is granted to this VM from the host's swap space.
             name: vcenter.vm.memory.swapped
@@ -685,8 +790,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
           - description: The amount of memory swapped to fast disk device such as SSD.
             name: vcenter.vm.memory.swapped_ssd
@@ -694,8 +799,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The amount of memory that is used by the virtual machine.
             name: vcenter.vm.memory.usage
@@ -703,114 +808,9 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: MiBy
-        scope:
-          name: otelcol/vcenterreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: vcenter.datacenter.name
-          value:
-            stringValue: DC0
-        - key: vcenter.cluster.name
-          value:
-            stringValue: DC0_C0
-    scopeMetrics:
-      - metrics:
-          - description: The effective CPU available to the cluster. This value excludes CPU from hosts in maintenance mode or are unresponsive.
-            name: vcenter.cluster.cpu.effective
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "6882"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{MHz}"
-          - description: The amount of CPU available to the cluster.
-            name: vcenter.cluster.cpu.limit
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "6882"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{MHz}"
-          - description: The number of hosts in the cluster.
-            name: vcenter.cluster.host.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: effective
-                      value:
-                        boolValue: false
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-                - asInt: "3"
-                  attributes:
-                    - key: effective
-                      value:
-                        boolValue: true
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{hosts}"
-          - description: The effective available memory of the cluster.
-            name: vcenter.cluster.memory.effective
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "13500061378877440"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: By
-          - description: The available memory of the cluster.
-            name: vcenter.cluster.memory.limit
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "12883292160"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: By
-          - description: The number of virtual machines in the cluster.
-            name: vcenter.cluster.vm.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "2"
-                  attributes:
-                    - key: power_state
-                      value:
-                        stringValue: "on"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-                - asInt: "0"
-                  attributes:
-                    - key: power_state
-                      value:
-                        stringValue: "off"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-                - asInt: "0"
-                  attributes:
-                    - key: power_state
-                      value:
-                        stringValue: "suspended"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{virtual_machines}"
-          - description: The number of virtual machine templates in the cluster.
-            name: vcenter.cluster.vm_template.count
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  startTimeUnixNano: "1707407684042820000"
-                  timeUnixNano: "1707407733803628000"
-            unit: "{virtual_machine_templates}"
         scope:
           name: otelcol/vcenterreceiver
           version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The following PR works to make the integration tests a bit more deterministic by taking advantage of the govmomi simulator. Previously the integration test had the following line when comparing
```
pmetrictest.IgnoreResourceAttributeValue("vcenter.host.name")
```
Which is a bit of a hacky fix that addressed an issue where the simulator had inconsistent VM to Host assignments between test runs.

Although ignoring the resource attribute value currently works, it breaks once datacenter metrics are enabled by default

This PR hopes to make the integration tests more consistent and accurate going forward.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
- Regenerated the expected.yaml using `scraperinttest.WriteExpected()`
- Passes Integration test

**Documentation:** <Describe the documentation added.>