### PR TITLE
[chore][extensions/jaegerremotesampling]: replace `github.com/tilinna/clock` with `github.com/jonboulle/clockwork`

### DIFF
--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -562,6 +562,7 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901 // indirect
+	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/extension/jaegerremotesampling/go.mod
+++ b/extension/jaegerremotesampling/go.mod
@@ -5,9 +5,9 @@ go 1.21.0
 require (
 	github.com/fortytw2/leaktest v1.3.0
 	github.com/jaegertracing/jaeger v1.59.0
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.105.0
 	github.com/stretchr/testify v1.9.0
-	github.com/tilinna/clock v1.1.0
 	go.opentelemetry.io/collector/component v0.105.1-0.20240717163034-43ed6184f9fe
 	go.opentelemetry.io/collector/config/configgrpc v0.105.1-0.20240717163034-43ed6184f9fe
 	go.opentelemetry.io/collector/config/confighttp v0.105.1-0.20240717163034-43ed6184f9fe

--- a/extension/jaegerremotesampling/go.sum
+++ b/extension/jaegerremotesampling/go.sum
@@ -43,6 +43,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jaegertracing/jaeger v1.59.0 h1:p9/nJxdoCxq4NSgVN8P0aDqlGSfxFaggpNfLwhqQZRc=
 github.com/jaegertracing/jaeger v1.59.0/go.mod h1:IZeUGtxNIYWGD3PVI4mqAn2IWVrfGdfswB8XK0mzZ0w=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -119,8 +121,6 @@ github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsT
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
-github.com/tilinna/clock v1.1.0 h1:6IQQQCo6KoBxVudv6gwtY8o4eDfhHo8ojA5dP0MfhSs=
-github.com/tilinna/clock v1.1.0/go.mod h1:ZsP7BcY7sEEz7ktc0IVy8Us6boDrK8VradlKRUGfOao=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opentelemetry.io/collector v0.105.1-0.20240717163034-43ed6184f9fe h1:ZjgqZsb2G6DekoePCEUmr1Mh3dbiSo5fTODlsCwyhPg=

--- a/extension/jaegerremotesampling/internal/remote_strategy_cache_test.go
+++ b/extension/jaegerremotesampling/internal/remote_strategy_cache_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/fortytw2/leaktest"
 	"github.com/jaegertracing/jaeger/proto-gen/api_v2"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
-	"github.com/tilinna/clock"
 )
 
 const cacheTestItemTTL = 50 * time.Millisecond
@@ -48,9 +48,11 @@ var testStrategyResponseB = &api_v2.SamplingStrategyResponse{
 
 func Test_serviceStrategyCache_ReadWriteSequence(t *testing.T) {
 	testTime := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
-	mock := clock.NewMock(testTime)
-	ctx, cfn := mock.DeadlineContext(context.Background(), testTime.Add(3*time.Minute))
-	defer cfn()
+	mock := clockwork.NewFakeClockAt(testTime)
+	_ = mock.After(3 * time.Minute)
+
+	ctx, cancel := context.WithCancel(clockwork.AddToContext(context.Background(), mock))
+	defer cancel()
 
 	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
 	defer func() {
@@ -91,7 +93,7 @@ func Test_serviceStrategyCache_ReadWriteSequence(t *testing.T) {
 	}, cache.items["fooSvc"])
 
 	// advance time (still within TTL time range)
-	mock.Add(20 * time.Millisecond)
+	mock.Advance(20 * time.Millisecond)
 
 	// the written item is still available
 	result, ok = cache.get(ctx, "fooSvc")
@@ -102,7 +104,7 @@ func Test_serviceStrategyCache_ReadWriteSequence(t *testing.T) {
 	assert.Nil(t, result)
 
 	// advance time (just before end of TTL time range)
-	mock.Add(30 * time.Millisecond)
+	mock.Advance(30 * time.Millisecond)
 
 	// the written item is still available
 	result, ok = cache.get(ctx, "fooSvc")
@@ -113,7 +115,7 @@ func Test_serviceStrategyCache_ReadWriteSequence(t *testing.T) {
 	assert.Nil(t, result)
 
 	// advance time (across TTL range)
-	mock.Add(1 * time.Millisecond)
+	mock.Advance(1 * time.Millisecond)
 
 	// the (now stale) cached item is no longer available
 	result, ok = cache.get(ctx, "fooSvc")
@@ -131,9 +133,11 @@ func Test_serviceStrategyCache_ReadWriteSequence(t *testing.T) {
 
 func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 	startTime := time.Date(2023, 1, 1, 10, 0, 0, 0, time.UTC)
-	mock := clock.NewMock(startTime)
-	ctx, cfn := mock.DeadlineContext(context.Background(), startTime.Add(3*time.Minute))
-	defer cfn()
+	mock := clockwork.NewFakeClockAt(startTime)
+	_ = mock.After(3 * time.Minute)
+
+	ctx, cancel := context.WithCancel(clockwork.AddToContext(context.Background(), mock))
+	defer cancel()
 
 	cache := newServiceStrategyCache(cacheTestItemTTL).(*serviceStrategyTTLCache)
 	defer func() {
@@ -149,12 +153,12 @@ func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 	assert.Nil(t, result)
 
 	// perform a write for barSvc at startTime + 10ms
-	firstWriteTime := mock.Add(10 * time.Millisecond)
+	mock.Advance(10 * time.Millisecond)
 	cache.put(ctx, "barSvc", testStrategyResponseA)
 
 	// whitebox assert for internal timestamp tracking
 	assert.Equal(t, serviceStrategyCacheEntry{
-		retrievedAt:      firstWriteTime,
+		retrievedAt:      mock.Now(),
 		strategyResponse: testStrategyResponseA,
 	}, cache.items["barSvc"])
 
@@ -167,7 +171,7 @@ func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 	assert.Equal(t, testStrategyResponseA, result)
 
 	// advance time (still within TTL time range)
-	mock.Add(10 * time.Millisecond)
+	mock.Advance(10 * time.Millisecond)
 
 	// the written item is still available
 	result, ok = cache.get(ctx, "fooSvc")
@@ -178,8 +182,9 @@ func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 	assert.Equal(t, testStrategyResponseA, result)
 
 	// perform a write for barSvc at startTime + 30ms (still within TTL, but we retain this more recent data)
-	secondWriteTime := mock.Add(10 * time.Millisecond)
+	mock.Advance(10 * time.Millisecond)
 	cache.put(ctx, "barSvc", testStrategyResponseB)
+	secondWriteTime := mock.Now()
 
 	// whitebox assert for internal timestamp tracking (post-write, still-fresh cache entry replaced with newer data)
 	assert.Equal(t, serviceStrategyCacheEntry{
@@ -196,7 +201,7 @@ func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 	assert.Equal(t, testStrategyResponseB, result)
 
 	// advance time (to end of what is now a new/full TTL for the new fresh item)
-	mock.Add(cacheTestItemTTL)
+	mock.Advance(cacheTestItemTTL)
 
 	result, ok = cache.get(ctx, "fooSvc")
 	assert.False(t, ok)
@@ -206,7 +211,7 @@ func Test_serviceStrategyCache_WritesUpdateTimestamp(t *testing.T) {
 	assert.Equal(t, testStrategyResponseB, result)
 
 	// advance time beyond the newer item's TTL
-	mock.Add(1)
+	mock.Advance(1)
 
 	// the (now stale) cached item is no longer available
 	result, ok = cache.get(ctx, "fooSvc")


### PR DESCRIPTION
**Description:**
 - replaces `github.com/tilinna/clock` with `github.com/jonboulle/clockwork` in `jaegerremotesampleing extension`

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34190

**Connected PRs:**
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34221
- https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34226
