### PR TITLE
[receiver/vcenter] Enabled vCenter Datacenter metrics by default

### DIFF
--- a/.chloggen/enable-vcenter-datacenter-resource-pool-metrics.yaml
+++ b/.chloggen/enable-vcenter-datacenter-resource-pool-metrics.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Enables various vCenter metrics that were disabled by default until v0.106.0"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33607]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The following metrics will be enabled by default "vcenter.datacenter.cluster.count", "vcenter.datacenter.vm.count", "vcenter.datacenter.datastore.count",
+  "vcenter.datacenter.host.count", "vcenter.datacenter.disk.space", "vcenter.datacenter.cpu.limit", "vcenter.datacenter.memory.limit",
+  "vcenter.resource_pool.memory.swapped", "vcenter.resource_pool.memory.ballooned", and "vcenter.resource_pool.memory.granted". The 
+  "resourcePoolMemoryUsageAttribute" has also been bumped up to release v.0.107.0
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/vcenterreceiver/README.md
+++ b/receiver/vcenterreceiver/README.md
@@ -63,4 +63,4 @@ the `vcenter.resource_pool.memory.usage` metric.
 
 This feature gate will eventually be enabled by default, and eventually the old implementation will be removed. It aims
 to give users time to migrate to the new implementation. The target release for this featuregate to be enabled by default
-is v0.106.0.
+is v0.107.0.

--- a/receiver/vcenterreceiver/documentation.md
+++ b/receiver/vcenterreceiver/documentation.md
@@ -82,6 +82,88 @@ The number of virtual machine templates in the cluster.
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | {virtual_machine_templates} | Sum | Int | Cumulative | false |
 
+### vcenter.datacenter.cluster.count
+
+The number of clusters in the datacenter.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {clusters} | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
+
+### vcenter.datacenter.cpu.limit
+
+The total amount of CPU available to the datacenter.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {MHz} | Sum | Int | Cumulative | false |
+
+### vcenter.datacenter.datastore.count
+
+The number of datastores in the datacenter.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {datastores} | Sum | Int | Cumulative | false |
+
+### vcenter.datacenter.disk.space
+
+The amount of available and used disk space in the datacenter.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| By | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
+
+### vcenter.datacenter.host.count
+
+The number of hosts in the datacenter.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {hosts} | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
+| power_state | The current power state of the host. | Str: ``on``, ``off``, ``standby``, ``unknown`` |
+
+### vcenter.datacenter.memory.limit
+
+The total amount of memory available to the datacenter.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| By | Sum | Int | Cumulative | false |
+
+### vcenter.datacenter.vm.count
+
+The number of VM's in the datacenter.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {virtual_machines} | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
+| power_state | The current power state of the virtual machine. | Str: ``on``, ``off``, ``suspended``, ``unknown`` |
+
 ### vcenter.datastore.disk.usage
 
 The amount of space in the datastore.
@@ -306,6 +388,28 @@ The usage of the CPU used by the resource pool.
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | {MHz} | Sum | Int | Cumulative | false |
 
+### vcenter.resource_pool.memory.ballooned
+
+The amount of memory in a resource pool that is ballooned due to virtualization.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| MiBy | Sum | Int | Cumulative | false |
+
+### vcenter.resource_pool.memory.granted
+
+The amount of memory that is granted to VMs in the resource pool from shared and non-shared host memory.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| MiBy | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| type | The type of memory granted. | Str: ``private``, ``shared`` |
+
 ### vcenter.resource_pool.memory.shares
 
 The amount of shares of memory in the resource pool.
@@ -313,6 +417,14 @@ The amount of shares of memory in the resource pool.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | {shares} | Sum | Int | Cumulative | false |
+
+### vcenter.resource_pool.memory.swapped
+
+The amount of memory that is granted to VMs in the resource pool from the host's swap space.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| MiBy | Sum | Int | Cumulative | false |
 
 ### vcenter.resource_pool.memory.usage
 
@@ -529,128 +641,6 @@ As measured over the most recent 20s interval.
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | object | The object on the virtual machine or host that is being reported on. | Any Str |
-
-## Optional Metrics
-
-The following metrics are not emitted by default. Each of them can be enabled by applying the following configuration:
-
-```yaml
-metrics:
-  <metric_name>:
-    enabled: true
-```
-
-### vcenter.datacenter.cluster.count
-
-The number of clusters in the datacenter.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {clusters} | Sum | Int | Cumulative | false |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
-
-### vcenter.datacenter.cpu.limit
-
-The total amount of CPU available to the datacenter.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {MHz} | Sum | Int | Cumulative | false |
-
-### vcenter.datacenter.datastore.count
-
-The number of datastores in the datacenter.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {datastores} | Sum | Int | Cumulative | false |
-
-### vcenter.datacenter.disk.space
-
-The amount of available and used disk space in the datacenter.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| disk_state | The state of storage and whether it is already allocated or free. | Str: ``available``, ``used`` |
-
-### vcenter.datacenter.host.count
-
-The number of hosts in the datacenter.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {hosts} | Sum | Int | Cumulative | false |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
-| power_state | The current power state of the host. | Str: ``on``, ``off``, ``standby``, ``unknown`` |
-
-### vcenter.datacenter.memory.limit
-
-The total amount of memory available to the datacenter.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| By | Sum | Int | Cumulative | false |
-
-### vcenter.datacenter.vm.count
-
-The number of VM's in the datacenter.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {virtual_machines} | Sum | Int | Cumulative | false |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| status | The current status of the managed entity. | Str: ``red``, ``yellow``, ``green``, ``gray`` |
-| power_state | The current power state of the virtual machine. | Str: ``on``, ``off``, ``suspended``, ``unknown`` |
-
-### vcenter.resource_pool.memory.ballooned
-
-The amount of memory in a resource pool that is ballooned due to virtualization.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
-
-### vcenter.resource_pool.memory.granted
-
-The amount of memory that is granted to VMs in the resource pool from shared and non-shared host memory.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| type | The type of memory granted. | Str: ``private``, ``shared`` |
-
-### vcenter.resource_pool.memory.swapped
-
-The amount of memory that is granted to VMs in the resource pool from the host's swap space.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| MiBy | Sum | Int | Cumulative | false |
 
 ## Resource Attributes
 

--- a/receiver/vcenterreceiver/internal/metadata/generated_config.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_config.go
@@ -108,25 +108,25 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		VcenterDatacenterClusterCount: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterDatacenterCPULimit: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterDatacenterDatastoreCount: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterDatacenterDiskSpace: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterDatacenterHostCount: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterDatacenterMemoryLimit: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterDatacenterVMCount: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterDatastoreDiskUsage: MetricConfig{
 			Enabled: true,
@@ -183,16 +183,16 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		VcenterResourcePoolMemoryBallooned: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterResourcePoolMemoryGranted: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterResourcePoolMemoryShares: MetricConfig{
 			Enabled: true,
 		},
 		VcenterResourcePoolMemorySwapped: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		VcenterResourcePoolMemoryUsage: MetricConfig{
 			Enabled: true,

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -3163,36 +3163,6 @@ func WithStartTime(startTime pcommon.Timestamp) metricBuilderOption {
 }
 
 func NewMetricsBuilder(mbc MetricsBuilderConfig, settings receiver.Settings, options ...metricBuilderOption) *MetricsBuilder {
-	if !mbc.Metrics.VcenterDatacenterClusterCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cluster.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterCPULimit.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cpu.limit`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterDatastoreCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.datastore.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterDiskSpace.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.disk.space`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterHostCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.host.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterMemoryLimit.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.memory.limit`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterDatacenterVMCount.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.vm.count`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterResourcePoolMemoryBallooned.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.ballooned`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterResourcePoolMemoryGranted.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.granted`: this metric will be enabled by default starting in release v0.106.0")
-	}
-	if !mbc.Metrics.VcenterResourcePoolMemorySwapped.enabledSetByUser {
-		settings.Logger.Warn("[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.swapped`: this metric will be enabled by default starting in release v0.106.0")
-	}
 	mb := &MetricsBuilder{
 		config:                                   mbc,
 		startTime:                                pcommon.NewTimestampFromTime(time.Now()),

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics_test.go
@@ -62,46 +62,6 @@ func TestMetricsBuilder(t *testing.T) {
 			mb := NewMetricsBuilder(loadMetricsBuilderConfig(t, test.name), settings, WithStartTime(start))
 
 			expectedWarnings := 0
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cluster.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.cpu.limit`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.datastore.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.disk.space`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.host.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.memory.limit`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.datacenter.vm.count`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.ballooned`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.granted`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
-			if test.metricsSet == testDataSetDefault {
-				assert.Equal(t, "[WARNING] Please set `enabled` field explicitly for `vcenter.resource_pool.memory.swapped`: this metric will be enabled by default starting in release v0.106.0", observedLogs.All()[expectedWarnings].Message)
-				expectedWarnings++
-			}
 
 			assert.Equal(t, expectedWarnings, observedLogs.Len())
 
@@ -136,24 +96,31 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordVcenterClusterVMTemplateCountDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterDatacenterClusterCountDataPoint(ts, 1, AttributeEntityStatusRed)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterDatacenterCPULimitDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterDatacenterDatastoreCountDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterDatacenterDiskSpaceDataPoint(ts, 1, AttributeDiskStateAvailable)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterDatacenterHostCountDataPoint(ts, 1, AttributeEntityStatusRed, AttributeHostPowerStateOn)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterDatacenterMemoryLimitDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterDatacenterVMCountDataPoint(ts, 1, AttributeEntityStatusRed, AttributeVMCountPowerStateOn)
 
@@ -229,9 +196,11 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordVcenterResourcePoolCPUUsageDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterResourcePoolMemoryBalloonedDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterResourcePoolMemoryGrantedDataPoint(ts, 1, AttributeMemoryGrantedTypePrivate)
 
@@ -239,6 +208,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordVcenterResourcePoolMemorySharesDataPoint(ts, 1)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordVcenterResourcePoolMemorySwappedDataPoint(ts, 1)
 

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -146,7 +146,7 @@ attributes:
 
 metrics:
   vcenter.datacenter.cluster.count:
-    enabled: false
+    enabled: true
     description: The number of clusters in the datacenter.
     unit: "{clusters}"
     sum:
@@ -154,10 +154,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: [entity_status]
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.datacenter.host.count:
-    enabled: false
+    enabled: true
     description: The number of hosts in the datacenter.
     unit: "{hosts}"
     sum:
@@ -165,10 +163,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: [entity_status, host_power_state]
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.datacenter.vm.count:
-    enabled: false
+    enabled: true
     description: The number of VM's in the datacenter.
     unit: "{virtual_machines}"
     sum:
@@ -176,10 +172,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: [entity_status, vm_count_power_state]
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.datacenter.datastore.count:
-    enabled: false
+    enabled: true
     description: The number of datastores in the datacenter.
     unit: "{datastores}"
     sum:
@@ -187,10 +181,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: []
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.datacenter.disk.space:
-    enabled: false
+    enabled: true
     description: The amount of available and used disk space in the datacenter.
     unit: "By"
     sum:
@@ -198,10 +190,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: [disk_state]
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.datacenter.cpu.limit:
-    enabled: false
+    enabled: true
     description: The total amount of CPU available to the datacenter.
     unit: "{MHz}"
     sum:
@@ -209,10 +199,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: []
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.datacenter.memory.limit:
-    enabled: false
+    enabled: true
     description: The total amount of memory available to the datacenter.
     unit: "By"
     sum:
@@ -220,8 +208,6 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: []
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.cluster.cpu.limit:
     enabled: true
     description: The amount of CPU available to the cluster.
@@ -440,7 +426,7 @@ metrics:
       aggregation_temporality: cumulative
     attributes: []
   vcenter.resource_pool.memory.swapped:
-    enabled: false
+    enabled: true
     description: The amount of memory that is granted to VMs in the resource pool from the host's swap space.
     unit: MiBy
     sum:
@@ -448,10 +434,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: []
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.resource_pool.memory.ballooned:
-    enabled: false
+    enabled: true 
     description: The amount of memory in a resource pool that is ballooned due to virtualization.
     unit: MiBy
     sum:
@@ -459,10 +443,8 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: []
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.resource_pool.memory.granted:
-    enabled: false
+    enabled: true
     description: The amount of memory that is granted to VMs in the resource pool from shared and non-shared host memory.
     unit: MiBy
     sum:
@@ -470,8 +452,6 @@ metrics:
       value_type: int
       aggregation_temporality: cumulative
     attributes: [memory_granted_type]
-    warnings:
-      if_enabled_not_set: "this metric will be enabled by default starting in release v0.106.0"
   vcenter.resource_pool.cpu.usage:
     enabled: true
     description: The usage of the CPU used by the resource pool.

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -18,7 +18,7 @@ var enableResourcePoolMemoryUsageAttr = featuregate.GlobalRegistry().MustRegiste
 	featuregate.StageAlpha,
 	featuregate.WithRegisterFromVersion("v0.104.0"),
 	featuregate.WithRegisterDescription("Enables the memory usage type attribute for the vcenter.resource_pool.memory.usage metric"),
-	featuregate.WithRegisterToVersion("v0.106.0"))
+	featuregate.WithRegisterToVersion("v0.107.0"))
 
 // recordDatacenterStats records stat metrics for a vSphere Datacenter
 func (v *vcenterMetricScraper) recordDatacenterStats(

--- a/receiver/vcenterreceiver/scraper_test.go
+++ b/receiver/vcenterreceiver/scraper_test.go
@@ -41,16 +41,6 @@ func TestScrapeConfigsEnabled(t *testing.T) {
 
 	optConfigs := metadata.DefaultMetricsBuilderConfig()
 	setResourcePoolMemoryUsageAttrFeatureGate(t, true)
-	optConfigs.Metrics.VcenterResourcePoolMemorySwapped.Enabled = true
-	optConfigs.Metrics.VcenterResourcePoolMemoryBallooned.Enabled = true
-	optConfigs.Metrics.VcenterResourcePoolMemoryGranted.Enabled = true
-	optConfigs.Metrics.VcenterDatacenterClusterCount.Enabled = true
-	optConfigs.Metrics.VcenterDatacenterDatastoreCount.Enabled = true
-	optConfigs.Metrics.VcenterDatacenterHostCount.Enabled = true
-	optConfigs.Metrics.VcenterDatacenterVMCount.Enabled = true
-	optConfigs.Metrics.VcenterDatacenterCPULimit.Enabled = true
-	optConfigs.Metrics.VcenterDatacenterMemoryLimit.Enabled = true
-	optConfigs.Metrics.VcenterDatacenterDiskSpace.Enabled = true
 
 	cfg := &Config{
 		MetricsBuilderConfig: optConfigs,

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -1,6 +1,129 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: DC0
+    scopeMetrics:
+      - metrics:
+          - description: The number of clusters in the datacenter.
+            name: vcenter.datacenter.cluster.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: gray
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: green
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: red
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: yellow
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{clusters}'
+          - description: The total amount of CPU available to the datacenter.
+            name: vcenter.datacenter.cpu.limit
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "18352"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{MHz}'
+          - description: The number of datastores in the datacenter.
+            name: vcenter.datacenter.datastore.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{datastores}'
+          - description: The amount of available and used disk space in the datacenter.
+            name: vcenter.datacenter.disk.space
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10952166604800"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "42949672960"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of hosts in the datacenter.
+            name: vcenter.datacenter.host.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "on"
+                    - key: status
+                      value:
+                        stringValue: gray
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{hosts}'
+          - description: The total amount of memory available to the datacenter.
+            name: vcenter.datacenter.memory.limit
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "17177722880"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of VM's in the datacenter.
+            name: vcenter.datacenter.vm.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "on"
+                    - key: status
+                      value:
+                        stringValue: green
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{virtual_machines}'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
         - key: vcenter.cluster.name
           value:
             stringValue: DC0_C0

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -1,6 +1,139 @@
 resourceMetrics:
   - resource:
       attributes:
+        - key: vcenter.datacenter.name
+          value:
+            stringValue: Datacenter
+    scopeMetrics:
+      - metrics:
+          - description: The number of clusters in the datacenter.
+            name: vcenter.datacenter.cluster.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: gray
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: green
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: red
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: yellow
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{clusters}'
+          - description: The total amount of CPU available to the datacenter.
+            name: vcenter.datacenter.cpu.limit
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "186696"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{MHz}'
+          - description: The number of datastores in the datacenter.
+            name: vcenter.datacenter.datastore.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{datastores}'
+          - description: The amount of available and used disk space in the datacenter.
+            name: vcenter.datacenter.disk.space
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "51693551508648"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: available
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5917763748696"
+                  attributes:
+                    - key: disk_state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of hosts in the datacenter.
+            name: vcenter.datacenter.host.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "on"
+                    - key: status
+                      value:
+                        stringValue: green
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{hosts}'
+          - description: The total amount of memory available to the datacenter.
+            name: vcenter.datacenter.memory.limit
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1645526253568"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: The number of VM's in the datacenter.
+            name: vcenter.datacenter.vm.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "on"
+                    - key: status
+                      value:
+                        stringValue: green
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: power_state
+                      value:
+                        stringValue: "on"
+                    - key: status
+                      value:
+                        stringValue: yellow
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{virtual_machines}'
+        scope:
+          name: otelcol/vcenterreceiver
+          version: latest
+  - resource:
+      attributes:
         - key: vcenter.cluster.name
           value:
             stringValue: Cluster
@@ -5452,6 +5585,35 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{MHz}'
+          - description: The amount of memory in a resource pool that is ballooned due to virtualization.
+            name: vcenter.resource_pool.memory.ballooned
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
+          - description: The amount of memory that is granted to VMs in the resource pool from shared and non-shared host memory.
+            name: vcenter.resource_pool.memory.granted
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "199617"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: private
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: shared
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
           - description: The amount of shares of memory in the resource pool.
             name: vcenter.resource_pool.memory.shares
             sum:
@@ -5461,6 +5623,15 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{shares}'
+          - description: The amount of memory that is granted to VMs in the resource pool from the host's swap space.
+            name: vcenter.resource_pool.memory.swapped
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
           - description: The usage of the memory by the resource pool.
             name: vcenter.resource_pool.memory.usage
             sum:
@@ -5506,6 +5677,35 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{MHz}'
+          - description: The amount of memory in a resource pool that is ballooned due to virtualization.
+            name: vcenter.resource_pool.memory.ballooned
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
+          - description: The amount of memory that is granted to VMs in the resource pool from shared and non-shared host memory.
+            name: vcenter.resource_pool.memory.granted
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "199617"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: private
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: type
+                      value:
+                        stringValue: shared
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
           - description: The amount of shares of memory in the resource pool.
             name: vcenter.resource_pool.memory.shares
             sum:
@@ -5515,6 +5715,15 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
             unit: '{shares}'
+          - description: The amount of memory that is granted to VMs in the resource pool from the host's swap space.
+            name: vcenter.resource_pool.memory.swapped
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: MiBy
           - description: The usage of the memory by the resource pool.
             name: vcenter.resource_pool.memory.usage
             sum:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue. -->
The following PR enabled all the metrics that are to be released by v.0.106.0 by default.


<!-- Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
- Ran integration test, passing
- Ran scraper test, passing.

**Documentation:** <Describe the documentation added.>
Updated documentation using `make generate`