### PR TITLE
[receiver/receivercreator] Make receivercreator expose its required interface

### DIFF
--- a/receiver/receivercreator/receiver.go
+++ b/receiver/receivercreator/receiver.go
@@ -34,17 +34,17 @@ func newReceiverCreator(params receiver.Settings, cfg *Config) receiver.Metrics 
 	}
 }
 
-// Host is an interface that the component.Host passed to receivercreator's Start function must implement
-type Host interface {
+// host is an interface that the component.Host passed to receivercreator's Start function must implement
+type host interface {
 	component.Host
 	GetFactory(component.Kind, component.Type) component.Factory
 }
 
 // Start receiver_creator.
-func (rc *receiverCreator) Start(_ context.Context, host component.Host) error {
-	rcHost, ok := host.(Host)
+func (rc *receiverCreator) Start(_ context.Context, h component.Host) error {
+	rcHost, ok := h.(host)
 	if !ok {
-		return fmt.Errorf("the receivercreator is not compatible with the provided component.Host")
+		return fmt.Errorf("the receivercreator is not compatible with the provided component.host")
 	}
 
 	rc.observerHandler = &observerHandler{
@@ -61,7 +61,7 @@ func (rc *receiverCreator) Start(_ context.Context, host component.Host) error {
 
 	// Match all configured observables to the extensions that are running.
 	for _, watchObserver := range rc.cfg.WatchObservers {
-		for cid, ext := range host.GetExtensions() {
+		for cid, ext := range rcHost.GetExtensions() {
 			if cid != watchObserver {
 				continue
 			}

--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -31,12 +31,12 @@ type receiverRunner struct {
 	logger      *zap.Logger
 	params      rcvr.Settings
 	idNamespace component.ID
-	host        component.Host
+	host        Host
 	receivers   map[string]*wrappedReceiver
 	lock        *sync.Mutex
 }
 
-func newReceiverRunner(params rcvr.Settings, host component.Host) *receiverRunner {
+func newReceiverRunner(params rcvr.Settings, host Host) *receiverRunner {
 	return &receiverRunner{
 		logger:      params.Logger,
 		params:      params,

--- a/receiver/receivercreator/runner.go
+++ b/receiver/receivercreator/runner.go
@@ -31,12 +31,12 @@ type receiverRunner struct {
 	logger      *zap.Logger
 	params      rcvr.Settings
 	idNamespace component.ID
-	host        Host
+	host        host
 	receivers   map[string]*wrappedReceiver
 	lock        *sync.Mutex
 }
 
-func newReceiverRunner(params rcvr.Settings, host Host) *receiverRunner {
+func newReceiverRunner(params rcvr.Settings, host host) *receiverRunner {
 	return &receiverRunner{
 		logger:      params.Logger,
 		params:      params,


### PR DESCRIPTION
**Description:**
Updates receivercreator in preparation for `component.Host.GetFactory` to be removed.

**Link to tracking Issue:** <Issue number if applicable>
Related to https://github.com/open-telemetry/opentelemetry-collector/issues/9511

**Testing:** <Describe what testing was performed and which tests were added.>
Unit tests.

I cant add a unit test yet that fails the interface check since being compliant with `component.Host` still requires the `GetFactory` method.