### PR TITLE
[exporter/otelarrow] add metadata wrapper around exporter

### DIFF
--- a/exporter/otelarrowexporter/README.md
+++ b/exporter/otelarrowexporter/README.md
@@ -115,6 +115,17 @@ streams.
 
 - `prioritizer` (default: "leastloaded"): policy for distributing load across multiple streams.
 
+### Matching Metadata Per Stream
+
+The following configuration values allow for separate streams per unique 
+metadata combinations:
+- `metadata_keys` (default = empty): When set, this exporter will create one
+  arrow exporter instance per distinct combination of values in the 
+  client.Metadata.
+- `metadata_cardinality_limit` (default = 1000): When metadata_keys is not empty, 
+ this setting limits the number of unique combinations of metadata key values 
+  that will be processed over the lifetime of the exporter.
+
 ### Network Configuration
 
 This component uses `round_robin` by default as the gRPC load

--- a/exporter/otelarrowexporter/factory.go
+++ b/exporter/otelarrowexporter/factory.go
@@ -67,14 +67,14 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func (exp *baseExporter) helperOptions() []exporterhelper.Option {
+func (e *baseExporter) helperOptions() []exporterhelper.Option {
 	return []exporterhelper.Option{
 		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
-		exporterhelper.WithTimeout(exp.config.TimeoutSettings),
-		exporterhelper.WithRetry(exp.config.RetryConfig),
-		exporterhelper.WithQueue(exp.config.QueueSettings),
-		exporterhelper.WithStart(exp.start),
-		exporterhelper.WithShutdown(exp.shutdown),
+		exporterhelper.WithTimeout(e.config.TimeoutSettings),
+		exporterhelper.WithRetry(e.config.RetryConfig),
+		exporterhelper.WithQueue(e.config.QueueSettings),
+		exporterhelper.WithStart(e.start),
+		exporterhelper.WithShutdown(e.shutdown),
 	}
 }
 
@@ -97,11 +97,11 @@ func createTracesExporter(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Traces, error) {
-	exp, err := newExporter(cfg, set, createArrowTracesStream)
+	exp, err := newMetadataExporter(cfg, set, createArrowTracesStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewTracesExporter(ctx, exp.settings, exp.config,
+	return exporterhelper.NewTracesExporter(ctx, exp.getSettings(), exp.getConfig(),
 		exp.pushTraces,
 		exp.helperOptions()...,
 	)
@@ -116,11 +116,11 @@ func createMetricsExporter(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Metrics, error) {
-	exp, err := newExporter(cfg, set, createArrowMetricsStream)
+	exp, err := newMetadataExporter(cfg, set, createArrowMetricsStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewMetricsExporter(ctx, exp.settings, exp.config,
+	return exporterhelper.NewMetricsExporter(ctx, exp.getSettings(), exp.getConfig(),
 		exp.pushMetrics,
 		exp.helperOptions()...,
 	)
@@ -135,11 +135,11 @@ func createLogsExporter(
 	set exporter.Settings,
 	cfg component.Config,
 ) (exporter.Logs, error) {
-	exp, err := newExporter(cfg, set, createArrowLogsStream)
+	exp, err := newMetadataExporter(cfg, set, createArrowLogsStream)
 	if err != nil {
 		return nil, err
 	}
-	return exporterhelper.NewLogsExporter(ctx, exp.settings, exp.config,
+	return exporterhelper.NewLogsExporter(ctx, exp.getSettings(), exp.getConfig(),
 		exp.pushLogs,
 		exp.helperOptions()...,
 	)

--- a/exporter/otelarrowexporter/metadata.go
+++ b/exporter/otelarrowexporter/metadata.go
@@ -1,0 +1,237 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package otelarrowexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter"
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"go.opentelemetry.io/collector/client"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"go.opentelemetry.io/otel/attribute"
+	"go.uber.org/multierr"
+)
+
+var (
+	// errTooManyBatchers is returned when the MetadataCardinalityLimit has been reached.
+	errTooManyBatchers = consumererror.NewPermanent(errors.New("too many batcher metadata-value combinations"))
+	// errUnexpectedType is returned when the object in the map isn't the expected type
+	errUnexpectedType = errors.New("unexpected type in map")
+)
+
+type MetadataConfig struct {
+	*Config
+
+	// MetadataKeys is a list of client.Metadata keys that will be
+	// used to form distinct batchers.  If this setting is empty,
+	// a single batcher instance will be used.  When this setting
+	// is not empty, one batcher will be used per distinct
+	// combination of values for the listed metadata keys.
+	//
+	// Empty value and unset metadata are treated as distinct cases.
+	//
+	// Entries are case-insensitive.  Duplicated entries will
+	// trigger a validation error.
+	MetadataKeys []string `mapstructure:"metadata_keys"`
+
+	// MetadataCardinalityLimit indicates the maximum number of
+	// batcher instances that will be created through a distinct
+	// combination of MetadataKeys.
+	MetadataCardinalityLimit uint32 `mapstructure:"metadata_cardinality_limit"`
+}
+
+var _ component.Config = (*MetadataConfig)(nil)
+
+// Validate checks if the exporter configuration is valid
+func (cfg *MetadataConfig) Validate() error {
+	uniq := map[string]bool{}
+	for _, k := range cfg.MetadataKeys {
+		l := strings.ToLower(k)
+		if _, has := uniq[l]; has {
+			return fmt.Errorf("duplicate entry in metadata_keys: %q (case-insensitive)", l)
+		}
+		uniq[l] = true
+	}
+	return nil
+}
+
+func createMetadataDefaultConfig() component.Config {
+	return &MetadataConfig{
+		Config: createDefaultConfig().(*Config),
+	}
+}
+
+type metadataExporter struct {
+	config   *MetadataConfig
+	settings exporter.Settings
+	scf      streamClientFactory
+	host     component.Host
+
+	metadataKeys []string
+	exporters    sync.Map
+
+	// Guards the size and the storing logic to ensure no more than limit items are stored.
+	// If we are willing to allow "some" extra items than the limit this can be removed and size can be made atomic.
+	lock sync.Mutex
+	size int
+}
+
+var _ exp = (*metadataExporter)(nil)
+
+func newMetadataExporter(cfg component.Config, set exporter.Settings, streamClientFactory streamClientFactory) (exp, error) {
+	oCfg := cfg.(*MetadataConfig)
+	// use lower-case, to be consistent with http/2 headers.
+	mks := make([]string, len(oCfg.MetadataKeys))
+	for i, k := range oCfg.MetadataKeys {
+		mks[i] = strings.ToLower(k)
+	}
+	sort.Strings(mks)
+	if len(mks) == 0 {
+		return newExporter(cfg, set, streamClientFactory)
+	}
+	return &metadataExporter{
+		config:       oCfg,
+		settings:     set,
+		scf:          streamClientFactory,
+		metadataKeys: mks,
+	}, nil
+}
+
+func (e *metadataExporter) getSettings() exporter.Settings {
+	return e.settings
+}
+
+func (e *metadataExporter) getConfig() component.Config {
+	return e.config
+}
+
+func (e *metadataExporter) helperOptions() []exporterhelper.Option {
+	return []exporterhelper.Option{
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exporterhelper.WithTimeout(e.config.Config.TimeoutSettings),
+		exporterhelper.WithRetry(e.config.Config.RetryConfig),
+		exporterhelper.WithQueue(e.config.Config.QueueSettings),
+		exporterhelper.WithStart(e.start),
+		exporterhelper.WithShutdown(e.shutdown),
+	}
+}
+
+func (e *metadataExporter) start(ctx context.Context, host component.Host) (err error) {
+	e.host = host
+	return nil
+}
+
+func (e *metadataExporter) shutdown(ctx context.Context) error {
+	var err error
+	e.exporters.Range(func(key any, value any) bool {
+		be, ok := value.(exp)
+		if !ok {
+			err = multierr.Append(err, fmt.Errorf("%w: %T", errUnexpectedType, value))
+			return true
+		}
+		err = multierr.Append(err, be.shutdown(ctx))
+		return true
+	})
+	return err
+}
+
+func (e *metadataExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
+	s := getSet(ctx, e.metadataKeys)
+
+	be, err := e.getOrCreateExporter(ctx, s)
+	if err != nil {
+		return err
+	}
+	return be.pushTraces(ctx, td)
+}
+
+func (e *metadataExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
+	s := getSet(ctx, e.metadataKeys)
+
+	be, err := e.getOrCreateExporter(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	return be.(exp).pushMetrics(ctx, md)
+}
+
+func (e *metadataExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
+	s := getSet(ctx, e.metadataKeys)
+
+	be, err := e.getOrCreateExporter(ctx, s)
+	if err != nil {
+		return err
+	}
+
+	return be.(exp).pushLogs(ctx, ld)
+}
+
+func (e *metadataExporter) getOrCreateExporter(ctx context.Context, s attribute.Set) (exp, error) {
+	v, ok := e.exporters.Load(s)
+	if !ok {
+		e.lock.Lock()
+		if e.config.MetadataCardinalityLimit != 0 && e.size >= int(e.config.MetadataCardinalityLimit) {
+			e.lock.Unlock()
+			return nil, errTooManyBatchers
+		}
+
+		newExp, err := newExporter(e.config, e.settings, e.scf)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create exporter: %w", err)
+		}
+
+		// aset.ToSlice() returns the sorted, deduplicated,
+		// and name-downcased list of attributes.
+		var loaded bool
+		v, loaded = e.exporters.LoadOrStore(s, newExp)
+		if !loaded {
+			// Start the goroutine only if we added the object to the map, otherwise is already started.
+			err = newExp.start(ctx, e.host)
+			if err != nil {
+				e.exporters.Delete(s)
+				return nil, fmt.Errorf("failed to start exporter: %w", err)
+			}
+			e.size++
+		}
+		e.lock.Unlock()
+	}
+	val, ok := v.(exp)
+	if !ok {
+		return nil, fmt.Errorf("%w: %T", errUnexpectedType, v)
+	}
+	return val, nil
+}
+
+func getSet(ctx context.Context, keys []string) attribute.Set {
+	// Get each metadata key value, form the corresponding
+	// attribute set for use as a map lookup key.
+	info := client.FromContext(ctx)
+	md := map[string][]string{}
+	var attrs []attribute.KeyValue
+	for _, k := range keys {
+		// Lookup the value in the incoming metadata, copy it
+		// into the outgoing metadata, and create a unique
+		// value for the attributeSet.
+		vs := info.Metadata.Get(k)
+		md[k] = vs
+		if len(vs) == 1 {
+			attrs = append(attrs, attribute.String(k, vs[0]))
+		} else {
+			attrs = append(attrs, attribute.StringSlice(k, vs))
+		}
+	}
+	return attribute.NewSet(attrs...)
+}

--- a/exporter/otelarrowexporter/metadata.go
+++ b/exporter/otelarrowexporter/metadata.go
@@ -193,8 +193,6 @@ func (e *metadataExporter) getOrCreateExporter(ctx context.Context, s attribute.
 			return nil, fmt.Errorf("failed to create exporter: %w", err)
 		}
 
-		// aset.ToSlice() returns the sorted, deduplicated,
-		// and name-downcased list of attributes.
 		var loaded bool
 		v, loaded = e.exporters.LoadOrStore(s, newExp)
 		if !loaded {


### PR DESCRIPTION
**Description:** Add the ability to send on Arrow streams where specified metadata sent per stream message all match on a per stream basis, similar to configuring metadata_keys in the [batch processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor). The maximum possible number of open streams would be `metadata_cardinality_limit * num_streams`.

This functionality is kept as separate as possible from the arrow exporter logic as it's not unique to the arrow exporter. 

**Link to tracking Issue:** #34178

**Testing:** WIP: testing needs to be added

**Documentation:** Added configuration explanation in readme.