### PR TITLE
[exporter/elasticsearch] add support for `batcher` config

### DIFF
--- a/.chloggen/elasticsearch-sync-bulkindexer.yaml
+++ b/.chloggen/elasticsearch-sync-bulkindexer.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add opt-in support for the experimental `batcher` config
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32377]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  By enabling (or explicitly disabling) the batcher, the Elasticsearch exporter's
+  existing batching/buffering logic will be disabled, and the batch sender will be used.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -81,6 +81,32 @@ All other defaults are as defined by [confighttp].
 
 The Elasticsearch exporter supports the common [`sending_queue` settings][exporterhelper]. However, the sending queue is currently disabled by default.
 
+### Batching
+
+> [!WARNING]
+> The `batcher` config is experimental and may change without notice.
+
+The Elasticsearch exporter supports the [common `batcher` settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterbatcher/config.go).
+The `batcher` config is currently disabled by default.
+
+- `batcher`:
+  - `enabled` (default=unset): Enable batching of requests into a single bulk request.
+  - `min_size_items` (default=5000): Minimum number of log records / spans in the buffer to trigger a flush immediately.
+  - `max_size_items` (default=10000): Maximum number of log records / spans in a request.
+  - `flush_timeout` (default=30s): Maximum time of the oldest item spent inside the buffer, aka "max age of buffer". A flush will happen regardless of the size of content in buffer.
+
+By setting `batcher::enabled` to either `true` or `false`, the exporter will not perform any of its own buffering or batching,
+and the `flush` config will be ignored. In a future release when the `batcher` config is stable,
+and has feature parity with the exporter's existing `flush` config, it will be enabled by default.
+
+Using the common `batcher` functionality provides several benefits over the default behavior:
+ - Combined with a persistent queue, or no queue at all, `batcher` enables at least once delivery.
+   With the default behavior, the exporter will accept data and process it asynchronously,
+   which interacts poorly with queuing.
+ - By ensuring the exporter makes requests to Elasticsearch synchronously,
+   client metadata can be passed through to Elasticsearch requests,
+   e.g. by using the [`headers_setter` extension](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/extension/headerssetterextension/README.md).
+
 ### Elasticsearch document routing
 
 Telemetry data will be written to signal specific data streams by default:
@@ -168,6 +194,9 @@ The behaviour of this bulk indexing can be configured with the following setting
   - `initial_interval` (default=100ms): Initial waiting time if a HTTP request failed.
   - `max_interval` (default=1m): Max waiting time if a HTTP request failed.
   - `retry_on_status` (default=[429, 500, 502, 503, 504]): Status codes that trigger request or document level retries. Request level retry and document level retry status codes are shared and cannot be configured separately. To avoid duplicates, it is recommended to set it to `[429]`. WARNING: The default will be changed to `[429]` in the future.
+
+> [!NOTE]
+> The `flush` config will be ignored when `batcher::enabled` config is explicitly set to `true` or `false`.
 
 ### Elasticsearch node discovery
 

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -87,7 +87,6 @@ The Elasticsearch exporter supports the common [`sending_queue` settings][export
 > The `batcher` config is experimental and may change without notice.
 
 The Elasticsearch exporter supports the [common `batcher` settings](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterbatcher/config.go).
-The `batcher` config is currently disabled by default.
 
 - `batcher`:
   - `enabled` (default=unset): Enable batching of requests into a single bulk request.
@@ -95,9 +94,11 @@ The `batcher` config is currently disabled by default.
   - `max_size_items` (default=10000): Maximum number of log records / spans in a request.
   - `flush_timeout` (default=30s): Maximum time of the oldest item spent inside the buffer, aka "max age of buffer". A flush will happen regardless of the size of content in buffer.
 
-By setting `batcher::enabled` to either `true` or `false`, the exporter will not perform any of its own buffering or batching,
-and the `flush` config will be ignored. In a future release when the `batcher` config is stable,
-and has feature parity with the exporter's existing `flush` config, it will be enabled by default.
+By default, the exporter will perform its own buffering and batching, as configured through the
+`flush` config, and `batcher` will be unused. By setting `batcher::enabled` to either `true` or
+`false`, the exporter will not perform any of its own buffering or batching, and the `flush` config
+will be ignored. In a future release when the `batcher` config is stable, and has feature parity
+with the exporter's existing `flush` config, it will be enabled by default.
 
 Using the common `batcher` functionality provides several benefits over the default behavior:
  - Combined with a persistent queue, or no queue at all, `batcher` enables at least once delivery.

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/metadata"
@@ -107,6 +108,15 @@ func TestConfig(t *testing.T) {
 					PrefixSeparator: "-",
 					DateFormat:      "%Y.%m.%d",
 				},
+				Batcher: BatcherConfig{
+					FlushTimeout: 30 * time.Second,
+					MinSizeConfig: exporterbatcher.MinSizeConfig{
+						MinSizeItems: 5000,
+					},
+					MaxSizeConfig: exporterbatcher.MaxSizeConfig{
+						MaxSizeItems: 10000,
+					},
+				},
 			},
 		},
 		{
@@ -167,6 +177,15 @@ func TestConfig(t *testing.T) {
 					Enabled:         false,
 					PrefixSeparator: "-",
 					DateFormat:      "%Y.%m.%d",
+				},
+				Batcher: BatcherConfig{
+					FlushTimeout: 30 * time.Second,
+					MinSizeConfig: exporterbatcher.MinSizeConfig{
+						MinSizeItems: 5000,
+					},
+					MaxSizeConfig: exporterbatcher.MaxSizeConfig{
+						MaxSizeItems: 10000,
+					},
 				},
 			},
 		},
@@ -229,6 +248,15 @@ func TestConfig(t *testing.T) {
 					PrefixSeparator: "-",
 					DateFormat:      "%Y.%m.%d",
 				},
+				Batcher: BatcherConfig{
+					FlushTimeout: 30 * time.Second,
+					MinSizeConfig: exporterbatcher.MinSizeConfig{
+						MinSizeItems: 5000,
+					},
+					MaxSizeConfig: exporterbatcher.MaxSizeConfig{
+						MaxSizeItems: 10000,
+					},
+				},
 			},
 		},
 		{
@@ -261,6 +289,16 @@ func TestConfig(t *testing.T) {
 			configFile: "config.yaml",
 			expected: withDefaultConfig(func(cfg *Config) {
 				cfg.Endpoint = "https://elastic.example.com:9200"
+			}),
+		},
+		{
+			id:         component.NewIDWithName(metadata.Type, "batcher_disabled"),
+			configFile: "config.yaml",
+			expected: withDefaultConfig(func(cfg *Config) {
+				cfg.Endpoint = "https://elastic.example.com:9200"
+
+				enabled := false
+				cfg.Batcher.Enabled = &enabled
 			}),
 		},
 	}

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -31,6 +32,7 @@ type elasticsearchExporter struct {
 	dynamicIndex   bool
 	model          mappingModel
 
+	wg          sync.WaitGroup // active sessions
 	bulkIndexer bulkIndexer
 }
 
@@ -84,12 +86,28 @@ func (e *elasticsearchExporter) Start(ctx context.Context, host component.Host) 
 
 func (e *elasticsearchExporter) Shutdown(ctx context.Context) error {
 	if e.bulkIndexer != nil {
-		return e.bulkIndexer.Close(ctx)
+		if err := e.bulkIndexer.Close(ctx); err != nil {
+			return err
+		}
 	}
-	return nil
+
+	doneCh := make(chan struct{})
+	go func() {
+		e.wg.Wait()
+		close(doneCh)
+	}()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-doneCh:
+		return nil
+	}
 }
 
 func (e *elasticsearchExporter) pushLogsData(ctx context.Context, ld plog.Logs) error {
+	e.wg.Add(1)
+	defer e.wg.Done()
+
 	session, err := e.bulkIndexer.StartSession(ctx)
 	if err != nil {
 		return err
@@ -158,6 +176,9 @@ func (e *elasticsearchExporter) pushMetricsData(
 	ctx context.Context,
 	metrics pmetric.Metrics,
 ) error {
+	e.wg.Add(1)
+	defer e.wg.Done()
+
 	session, err := e.bulkIndexer.StartSession(ctx)
 	if err != nil {
 		return err
@@ -296,6 +317,9 @@ func (e *elasticsearchExporter) pushTraceData(
 	ctx context.Context,
 	td ptrace.Traces,
 ) error {
+	e.wg.Add(1)
+	defer e.wg.Done()
+
 	session, err := e.bulkIndexer.StartSession(ctx)
 	if err != nil {
 		return err

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -912,6 +912,42 @@ func TestExporterAuth(t *testing.T) {
 	<-done
 }
 
+func TestExporterBatcher(t *testing.T) {
+	var requests []*http.Request
+	testauthID := component.NewID(component.MustNewType("authtest"))
+	batcherEnabled := false // sync bulk indexer is used without batching
+	exporter := newUnstartedTestLogsExporter(t, "http://testing.invalid", func(cfg *Config) {
+		cfg.Batcher = BatcherConfig{Enabled: &batcherEnabled}
+		cfg.Auth = &configauth.Authentication{AuthenticatorID: testauthID}
+	})
+	err := exporter.Start(context.Background(), &mockHost{
+		extensions: map[component.ID]component.Component{
+			testauthID: &authtest.MockClient{
+				ResultRoundTripper: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+					requests = append(requests, req)
+					return nil, errors.New("nope")
+				}),
+			},
+		},
+	})
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, exporter.Shutdown(context.Background()))
+	}()
+
+	logs := plog.NewLogs()
+	resourceLogs := logs.ResourceLogs().AppendEmpty()
+	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
+	scopeLogs.LogRecords().AppendEmpty().Body().SetStr("log record body")
+
+	_ = exporter.ConsumeLogs(context.WithValue(context.Background(), "key", "value1"), logs)
+	_ = exporter.ConsumeLogs(context.WithValue(context.Background(), "key", "value2"), logs)
+	require.Len(t, requests, 2) // flushed immediately by Consume
+
+	assert.Equal(t, "value1", requests[0].Context().Value("key"))
+	assert.Equal(t, "value2", requests[1].Context().Value("key"))
+}
+
 func newTestTracesExporter(t *testing.T, url string, fns ...func(*Config)) exporter.Traces {
 	f := NewFactory()
 	cfg := withDefaultConfig(append([]func(*Config){func(cfg *Config) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -940,12 +940,13 @@ func TestExporterBatcher(t *testing.T) {
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
 	scopeLogs.LogRecords().AppendEmpty().Body().SetStr("log record body")
 
-	_ = exporter.ConsumeLogs(context.WithValue(context.Background(), "key", "value1"), logs)
-	_ = exporter.ConsumeLogs(context.WithValue(context.Background(), "key", "value2"), logs)
+	type key struct{}
+	_ = exporter.ConsumeLogs(context.WithValue(context.Background(), key{}, "value1"), logs)
+	_ = exporter.ConsumeLogs(context.WithValue(context.Background(), key{}, "value2"), logs)
 	require.Len(t, requests, 2) // flushed immediately by Consume
 
-	assert.Equal(t, "value1", requests[0].Context().Value("key"))
-	assert.Equal(t, "value2", requests[1].Context().Value("key"))
+	assert.Equal(t, "value1", requests[0].Context().Value(key{}))
+	assert.Equal(t, "value2", requests[1].Context().Value(key{}))
 }
 
 func newTestTracesExporter(t *testing.T, url string, fns ...func(*Config)) exporter.Traces {

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -191,7 +191,12 @@ func exporterhelperOptions(
 			MaxSizeConfig: cfg.Batcher.MaxSizeConfig,
 		}
 		opts = append(opts, exporterhelper.WithBatcher(batcherConfig))
-		opts = append(opts, exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0})) // effectively disable timeout_sender because timeout is enforced in bulk indexer
+
+		// Effectively disable timeout_sender because timeout is enforced in bulk indexer.
+		//
+		// We keep timeout_sender enabled in the async mode (Batcher.Enabled == nil),
+		// to ensure sending data to the background workers will not block indefinitely.
+		opts = append(opts, exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}))
 	}
 	return opts
 }

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -191,6 +191,7 @@ func exporterhelperOptions(
 			MaxSizeConfig: cfg.Batcher.MaxSizeConfig,
 		}
 		opts = append(opts, exporterhelper.WithBatcher(batcherConfig))
+		opts = append(opts, exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0})) // effectively disable timeout_sender because timeout is enforced in bulk indexer
 	}
 	return opts
 }

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterbatcher"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/metadata"
@@ -87,6 +88,15 @@ func createDefaultConfig() component.Config {
 			LogRequestBody:  false,
 			LogResponseBody: false,
 		},
+		Batcher: BatcherConfig{
+			FlushTimeout: 30 * time.Second,
+			MinSizeConfig: exporterbatcher.MinSizeConfig{
+				MinSizeItems: 5000,
+			},
+			MaxSizeConfig: exporterbatcher.MaxSizeConfig{
+				MaxSizeItems: 10000,
+			},
+		},
 	}
 }
 
@@ -117,10 +127,7 @@ func createLogsExporter(
 		set,
 		cfg,
 		exporter.pushLogsData,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
-		exporterhelper.WithStart(exporter.Start),
-		exporterhelper.WithShutdown(exporter.Shutdown),
-		exporterhelper.WithQueue(cf.QueueSettings),
+		exporterhelperOptions(cf, exporter.Start, exporter.Shutdown)...,
 	)
 }
 
@@ -141,10 +148,7 @@ func createMetricsExporter(
 		set,
 		cfg,
 		exporter.pushMetricsData,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
-		exporterhelper.WithStart(exporter.Start),
-		exporterhelper.WithShutdown(exporter.Shutdown),
-		exporterhelper.WithQueue(cf.QueueSettings),
+		exporterhelperOptions(cf, exporter.Start, exporter.Shutdown)...,
 	)
 }
 
@@ -164,9 +168,29 @@ func createTracesExporter(ctx context.Context,
 		set,
 		cfg,
 		exporter.pushTraceData,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
-		exporterhelper.WithStart(exporter.Start),
-		exporterhelper.WithShutdown(exporter.Shutdown),
-		exporterhelper.WithQueue(cf.QueueSettings),
+		exporterhelperOptions(cf, exporter.Start, exporter.Shutdown)...,
 	)
+}
+
+func exporterhelperOptions(
+	cfg *Config,
+	start component.StartFunc,
+	shutdown component.ShutdownFunc,
+) []exporterhelper.Option {
+	opts := []exporterhelper.Option{
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
+		exporterhelper.WithStart(start),
+		exporterhelper.WithShutdown(shutdown),
+		exporterhelper.WithQueue(cfg.QueueSettings),
+	}
+	if cfg.Batcher.Enabled != nil {
+		batcherConfig := exporterbatcher.Config{
+			Enabled:       *cfg.Batcher.Enabled,
+			FlushTimeout:  cfg.Batcher.FlushTimeout,
+			MinSizeConfig: cfg.Batcher.MinSizeConfig,
+			MaxSizeConfig: cfg.Batcher.MaxSizeConfig,
+		}
+		opts = append(opts, exporterhelper.WithBatcher(batcherConfig))
+	}
+	return opts
 }

--- a/exporter/elasticsearchexporter/integrationtest/datareceiver.go
+++ b/exporter/elasticsearchexporter/integrationtest/datareceiver.go
@@ -47,15 +47,34 @@ type esDataReceiver struct {
 	receiver          receiver.Logs
 	endpoint          string
 	decodeBulkRequest bool
+	batcherEnabled    *bool
 	t                 testing.TB
 }
 
-func newElasticsearchDataReceiver(t testing.TB, decodeBulkRequest bool) *esDataReceiver {
-	return &esDataReceiver{
+type dataReceiverOption func(*esDataReceiver)
+
+func newElasticsearchDataReceiver(t testing.TB, opts ...dataReceiverOption) *esDataReceiver {
+	r := &esDataReceiver{
 		DataReceiverBase:  testbed.DataReceiverBase{},
 		endpoint:          fmt.Sprintf("http://%s:%d", testbed.DefaultHost, testutil.GetAvailablePort(t)),
-		decodeBulkRequest: decodeBulkRequest,
+		decodeBulkRequest: true,
 		t:                 t,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+func withDecodeBulkRequest(decode bool) dataReceiverOption {
+	return func(r *esDataReceiver) {
+		r.decodeBulkRequest = decode
+	}
+}
+
+func withBatcherEnabled(enabled bool) dataReceiverOption {
+	return func(r *esDataReceiver) {
+		r.batcherEnabled = &enabled
 	}
 }
 
@@ -102,20 +121,32 @@ func (es *esDataReceiver) Stop() error {
 
 func (es *esDataReceiver) GenConfigYAMLStr() string {
 	// Note that this generates an exporter config for agent.
-	cfgFormat := `
+	cfgFormat := fmt.Sprintf(`
   elasticsearch:
     endpoints: [%s]
     logs_index: %s
     traces_index: %s
-    flush:
-      interval: 1s
     sending_queue:
       enabled: true
     retry:
       enabled: true
-      max_requests: 10000
-`
-	return fmt.Sprintf(cfgFormat, es.endpoint, TestLogsIndex, TestTracesIndex)
+      max_requests: 10000`,
+		es.endpoint, TestLogsIndex, TestTracesIndex,
+	)
+
+	if es.batcherEnabled == nil {
+		cfgFormat += `
+    flush:
+      interval: 1s`
+	} else {
+		cfgFormat += fmt.Sprintf(`
+    batcher:
+      flush_timeout: 1s
+      enabled: %v`,
+			*es.batcherEnabled,
+		)
+	}
+	return cfgFormat + "\n"
 }
 
 func (es *esDataReceiver) ProtocolName() string {

--- a/exporter/elasticsearchexporter/integrationtest/datareceiver.go
+++ b/exporter/elasticsearchexporter/integrationtest/datareceiver.go
@@ -130,6 +130,8 @@ func (es *esDataReceiver) GenConfigYAMLStr() string {
       enabled: true
     retry:
       enabled: true
+      initial_interval: 100ms
+      max_interval: 1s
       max_requests: 10000`,
 		es.endpoint, TestLogsIndex, TestTracesIndex,
 	)

--- a/exporter/elasticsearchexporter/integrationtest/exporter_bench_test.go
+++ b/exporter/elasticsearchexporter/integrationtest/exporter_bench_test.go
@@ -125,7 +125,7 @@ func prepareBenchmark(
 
 	cfg := &benchRunnerCfg{}
 	// Benchmarks don't decode the bulk requests to avoid allocations to pollute the results.
-	receiver := newElasticsearchDataReceiver(b, false /* DecodeBulkRequest */)
+	receiver := newElasticsearchDataReceiver(b, withDecodeBulkRequest(false))
 	cfg.provider = testbed.NewPerfTestDataProvider(testbed.LoadOptions{ItemsPerBatch: batchSize})
 	cfg.provider.SetLoadGeneratorCounters(&cfg.generatedCount)
 

--- a/exporter/elasticsearchexporter/integrationtest/exporter_test.go
+++ b/exporter/elasticsearchexporter/integrationtest/exporter_test.go
@@ -20,6 +20,13 @@ func TestExporter(t *testing.T) {
 	for _, eventType := range []string{"logs", "traces"} {
 		for _, tc := range []struct {
 			name string
+
+			// batcherEnabled enables/disables the batch sender. If this is
+			// nil, then the exporter buffers data itself (legacy behaviour),
+			// whereas if it is non-nil then the exporter will not perform
+			// any buffering itself.
+			batcherEnabled *bool
+
 			// restartCollector restarts the OTEL collector. Restarting
 			// the collector allows durability testing of the ES exporter
 			// based on the OTEL config used for testing.
@@ -27,20 +34,27 @@ func TestExporter(t *testing.T) {
 			mockESFailure    bool
 		}{
 			{name: "basic"},
+			{name: "batcher_enabled", batcherEnabled: ptrTo(true)},
+			{name: "batcher_disabled", batcherEnabled: ptrTo(false)},
 			{name: "es_intermittent_failure", mockESFailure: true},
+
 			/* TODO: Below tests should be enabled after https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30792 is fixed
 			{name: "collector_restarts", restartCollector: true},
 			{name: "collector_restart_with_es_intermittent_failure", mockESFailure: true, restartCollector: true},
 			*/
 		} {
 			t.Run(fmt.Sprintf("%s/%s", eventType, tc.name), func(t *testing.T) {
-				runner(t, eventType, tc.restartCollector, tc.mockESFailure)
+				var opts []dataReceiverOption
+				if tc.batcherEnabled != nil {
+					opts = append(opts, withBatcherEnabled(*tc.batcherEnabled))
+				}
+				runner(t, eventType, tc.restartCollector, tc.mockESFailure, opts...)
 			})
 		}
 	}
 }
 
-func runner(t *testing.T, eventType string, restartCollector, mockESFailure bool) {
+func runner(t *testing.T, eventType string, restartCollector, mockESFailure bool, opts ...dataReceiverOption) {
 	t.Helper()
 
 	var (
@@ -57,7 +71,7 @@ func runner(t *testing.T, eventType string, restartCollector, mockESFailure bool
 		t.Fatalf("failed to create data sender for type: %s", eventType)
 	}
 
-	receiver := newElasticsearchDataReceiver(t, true)
+	receiver := newElasticsearchDataReceiver(t, opts...)
 	loadOpts := testbed.LoadOptions{
 		DataItemsPerSecond: 1_000,
 		ItemsPerBatch:      10,
@@ -122,4 +136,8 @@ func runner(t *testing.T, eventType string, restartCollector, mockESFailure bool
 		"backend should receive all sent items",
 	)
 	tc.ValidateData()
+}
+
+func ptrTo[T any](t T) *T {
+	return &t
 }

--- a/exporter/elasticsearchexporter/integrationtest/exporter_test.go
+++ b/exporter/elasticsearchexporter/integrationtest/exporter_test.go
@@ -34,9 +34,12 @@ func TestExporter(t *testing.T) {
 			mockESFailure    bool
 		}{
 			{name: "basic"},
-			{name: "batcher_enabled", batcherEnabled: ptrTo(true)},
-			{name: "batcher_disabled", batcherEnabled: ptrTo(false)},
 			{name: "es_intermittent_failure", mockESFailure: true},
+
+			{name: "batcher_enabled", batcherEnabled: ptrTo(true)},
+			{name: "batcher_enabled_es_intermittent_failure", batcherEnabled: ptrTo(true), mockESFailure: true},
+			{name: "batcher_disabled", batcherEnabled: ptrTo(false)},
+			{name: "batcher_disabled_es_intermittent_failure", batcherEnabled: ptrTo(false), mockESFailure: true},
 
 			/* TODO: Below tests should be enabled after https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/30792 is fixed
 			{name: "collector_restarts", restartCollector: true},

--- a/exporter/elasticsearchexporter/integrationtest/exporter_test.go
+++ b/exporter/elasticsearchexporter/integrationtest/exporter_test.go
@@ -22,7 +22,7 @@ func TestExporter(t *testing.T) {
 			name string
 
 			// batcherEnabled enables/disables the batch sender. If this is
-			// nil, then the exporter buffers data itself (legacy behaviour),
+			// nil, then the exporter buffers data itself (legacy behavior),
 			// whereas if it is non-nil then the exporter will not perform
 			// any buffering itself.
 			batcherEnabled *bool

--- a/exporter/elasticsearchexporter/testdata/config.yaml
+++ b/exporter/elasticsearchexporter/testdata/config.yaml
@@ -82,3 +82,7 @@ elasticsearch/deprecated_index:
   index: my_log_index
 elasticsearch/confighttp_endpoint:
   endpoint: https://elastic.example.com:9200
+elasticsearch/batcher_disabled:
+  endpoint: https://elastic.example.com:9200
+  batcher:
+    enabled: false


### PR DESCRIPTION
**Description:**

Add opt-in support for the experimental batch sender (https://github.com/open-telemetry/opentelemetry-collector/issues/8122). When opting into this functionality the exporter's `Consume*` methods will make synchronous bulk requests to Elasticsearch, without additional batching/buffering in the exporter.

By default the exporter continues to use its own buffering, which supports thresholds for time, number of documents, and size of encoded documents in bytes. The batch sender does not currently support a bytes-based threshold, and is experimental, hence why we are not yet making it the default for the Elasticsearch exporter.

This PR is based on https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32632, but made to be non-breaking.

**Link to tracking Issue:**

#32377

**Testing:**

Added unit and integration tests.

Manually tested with Elasticsearch, using the following config to highlight that client metadata can now flow through all the way:

```yaml
receivers:
  otlp:
    protocols:
      http:
        endpoint: 0.0.0.0:4318
        include_metadata: true

exporters:
  elasticsearch:
    endpoint: "http://localhost:9200"
    auth:
      authenticator: headers_setter
    batcher:
      enabled: false

extensions:
  headers_setter:
    headers:
      - action: insert
        key: Authorization
        from_context: authorization

service:
  extensions: [headers_setter]
  pipelines:
    traces:
      receivers: [otlp]
      processors: []
      exporters: [elasticsearch]
```

I have Elasticsearch running locally, with an "admin" user with the password "changeme". Sending OTLP/HTTP to the collector with `telemetrygen traces --otlp-http --otlp-insecure http://localhost:4318 --otlp-header "Authorization=\"Basic YWRtaW46Y2hhbmdlbWU=\""`, I observe the following:
 - Without the `batcher` config, the exporter fails to index data into Elasticsearch due to an auth error. That's because the exporter is buffering and dropping the context with client metadata, so there's no Authorization header attached to the requests going out.
 - With `batcher: {enabled: true}`, same behaviour as above. Unlike the [`batch` processor](https://github.com/open-telemetry/opentelemetry-collector/tree/main/processor/batchprocessor), the batch sender does not maintain client metadata.
 - With `batcher: {enabled: false}`, the exporter successfully indexes data into Elasticsearch.

**Documentation:**

Updated the README.