### PR TITLE
[exporter/splunkhec] asynchronous HTTP request consumption

### DIFF
--- a/.chloggen/fix_hec_body_request.yaml
+++ b/.chloggen/fix_hec_body_request.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:  only return the buffer to the pool after the HTTP request has been closed by the HTTP client
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34255]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/splunkhecexporter/buffer.go
+++ b/exporter/splunkhecexporter/buffer.go
@@ -126,7 +126,7 @@ func (c *cancellableGzipWriter) Reset() {
 }
 
 func (c *cancellableGzipWriter) Flush() error {
-	return c.innerWriter.Close()
+	return c.innerWriter.Flush()
 }
 
 func (c *cancellableGzipWriter) OnClose(onClose func() error) {
@@ -134,6 +134,9 @@ func (c *cancellableGzipWriter) OnClose(onClose func() error) {
 }
 
 func (c *cancellableGzipWriter) Close() error {
+	if err := c.innerWriter.Close(); err != nil {
+		return err
+	}
 	return c.onClose()
 }
 

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -167,7 +167,10 @@ func isProfilingData(sl plog.ScopeLogs) bool {
 // ld log records are parsed to Splunk events.
 func (c *client) pushLogDataInBatches(ctx context.Context, ld plog.Logs, headers map[string]string) error {
 	buf := c.bufferPool.get()
-	defer c.bufferPool.put(buf)
+	buf.OnClose(func() error {
+		c.bufferPool.put(buf)
+		return nil
+	})
 	is := iterState{}
 	var permanentErrors []error
 
@@ -374,7 +377,10 @@ func (c *client) fillTracesBuffer(traces ptrace.Traces, buf buffer, is iterState
 // md metrics are parsed to Splunk events.
 func (c *client) pushMultiMetricsDataInBatches(ctx context.Context, md pmetric.Metrics, headers map[string]string) error {
 	buf := c.bufferPool.get()
-	defer c.bufferPool.put(buf)
+	buf.OnClose(func() error {
+		c.bufferPool.put(buf)
+		return nil
+	})
 	is := iterState{}
 
 	var permanentErrors []error
@@ -419,7 +425,10 @@ func (c *client) pushMultiMetricsDataInBatches(ctx context.Context, md pmetric.M
 // md metrics are parsed to Splunk events.
 func (c *client) pushMetricsDataInBatches(ctx context.Context, md pmetric.Metrics, headers map[string]string) error {
 	buf := c.bufferPool.get()
-	defer c.bufferPool.put(buf)
+	buf.OnClose(func() error {
+		c.bufferPool.put(buf)
+		return nil
+	})
 	is := iterState{}
 	var permanentErrors []error
 


### PR DESCRIPTION
**Description:**
only return the buffer to the pool after the HTTP request has been closed by the HTTP client

**Link to tracking Issue:**
Fixes #34255

**Testing:**
Tests pass. Performance tests show a large performance hit.

```
                                      │  before.txt  │               after.txt               │
                                      │    sec/op    │    sec/op     vs base                 │
_pushLogData_10_10_1024-10              91.11µ ± ∞ ¹   89.49µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                76.62µ ± ∞ ¹   86.14µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                79.62µ ± ∞ ¹   88.56µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10               1.528m ± ∞ ¹   1.707m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10              14.37m ± ∞ ¹   15.10m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10              14.18m ± ∞ ¹   16.03m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10   597.9µ ± ∞ ¹   770.1µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10     136.3µ ± ∞ ¹   264.0µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10     136.1µ ± ∞ ¹   254.7µ ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10    3.064m ± ∞ ¹   3.547m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10   30.55m ± ∞ ¹   31.86m ± ∞ ¹        ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10   30.30m ± ∞ ¹   31.35m ± ∞ ¹        ~ (p=1.000 n=1) ²
geomean                                 1.152m         1.389m        +20.64%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                      │  before.txt   │                after.txt                 │
                                      │     B/op      │      B/op       vs base                  │
_pushLogData_10_10_1024-10              73.16Ki ± ∞ ¹    75.62Ki ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                63.82Ki ± ∞ ¹    84.78Ki ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                63.27Ki ± ∞ ¹   105.46Ki ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10               1.257Mi ± ∞ ¹    1.997Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10              12.60Mi ± ∞ ¹    18.51Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10              12.68Mi ± ∞ ¹    24.51Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10   2.417Mi ± ∞ ¹    3.191Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10     64.24Ki ± ∞ ¹   860.77Ki ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10     64.40Ki ± ∞ ¹   860.70Ki ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10    1.257Mi ± ∞ ¹    2.045Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10   12.54Mi ± ∞ ¹    13.42Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10   12.54Mi ± ∞ ¹    13.42Mi ± ∞ ¹         ~ (p=1.000 n=1) ²
geomean                                 848.1Ki          1.671Mi        +101.75%
¹ need >= 6 samples for confidence interval at level 0.95
² need >= 4 samples to detect a difference at alpha level 0.05

                                      │  before.txt  │              after.txt               │
                                      │  allocs/op   │  allocs/op    vs base                │
_pushLogData_10_10_1024-10               821.0 ± ∞ ¹    828.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_8K-10                 716.0 ± ∞ ¹    726.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_10_2M-10                 709.0 ± ∞ ¹    721.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_10_200_2M-10               14.02k ± ∞ ¹   14.04k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_2M-10              140.0k ± ∞ ¹   140.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_100_200_5M-10              140.0k ± ∞ ¹   140.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_1024-10    785.0 ± ∞ ¹    817.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_8K-10      709.0 ± ∞ ¹    738.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_10_2M-10      709.0 ± ∞ ¹    738.0 ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_10_200_2M-10    14.02k ± ∞ ¹   14.05k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_2M-10   140.0k ± ∞ ¹   140.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
_pushLogData_compressed_100_200_5M-10   140.0k ± ∞ ¹   140.1k ± ∞ ¹       ~ (p=1.000 n=1) ²
geomean                                 6.937k         7.033k        +1.38%


```