### PR TITLE
[internal/otelarrow] [chore] fix TestMRUReset flakiness

### DIFF
--- a/internal/otelarrow/compression/zstd/mru_test.go
+++ b/internal/otelarrow/compression/zstd/mru_test.go
@@ -5,6 +5,7 @@ package zstd
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -73,7 +74,10 @@ func TestMRUReset(t *testing.T) {
 	})
 	require.Equal(t, 1, m.Size())
 
-	m.Reset()
+	// Ensure the monotonic clock has has advanced before resetting.
+	time.Sleep(10 * time.Millisecond)
+
+	g2 := m.Reset()
 	require.Equal(t, 0, m.Size())
 
 	// This doesn't take because its generation is before the reset.

--- a/internal/otelarrow/compression/zstd/mru_test.go
+++ b/internal/otelarrow/compression/zstd/mru_test.go
@@ -77,7 +77,7 @@ func TestMRUReset(t *testing.T) {
 	// Ensure the monotonic clock has has advanced before resetting.
 	time.Sleep(10 * time.Millisecond)
 
-	g2 := m.Reset()
+	m.Reset()
 	require.Equal(t, 0, m.Size())
 
 	// This doesn't take because its generation is before the reset.


### PR DESCRIPTION
**Description:**

Ensure the monotonic clock has advanced prior to resetting, to ensure the item generation is before the reset.
The monotonic clock is guaranteed to be non-decreasing, but may be identical in consecutive measurements.

**Link to tracking Issue:**

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34252

**Testing:**

I couldn't reproduce the issue locally - this issue would depend on the system clock frequency.

**Documentation:**

N/A