### PR TITLE
[internal/attraction] Add support for string pointers

### DIFF
--- a/.chloggen/attraction-support-string-pointers.yaml
+++ b/.chloggen/attraction-support-string-pointers.yaml
@@ -1,0 +1,9 @@
+change_type: enhancement
+component: internal/attraction
+note: Add support for string pointers in `client.Info.AuthData`
+issues: [34284]
+subtext: |
+  `processor/attributesprocessor` and other components using `internal/attraction` under the hood only supported string values and slices of string values.
+  
+  In some cases, such as modeling optional attributes, it can be useful to support string pointers (`*string`) and slices of string pointers (`[]*string`).
+change_logs: []


### PR DESCRIPTION
**Description:** 

`processor/attributesprocessor` and other components using `internal/attraction` under the hood only support string values and slices of string values.

In some cases, such as modeling optional attributes, it can be useful to support string pointers (`*string`) and slices of string pointers (`[]*string`) as well.

These types were silently ignored before and now a warning is emitted (log level to be discussed).

**Link to tracking Issue:** -

**Testing:** Unit tests were added to `internal/attraction`.

**Documentation:** No documentation changes were necessary that I am aware of.