### PR TITLE
[chore] nopHost for k8s cluster receivers

### DIFF
--- a/receiver/k8sclusterreceiver/factory_test.go
+++ b/receiver/k8sclusterreceiver/factory_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"k8s.io/client-go/kubernetes"
@@ -72,14 +71,14 @@ func TestFactoryDistributions(t *testing.T) {
 
 	// default
 	r := newTestReceiver(t, rCfg)
-	err := r.Start(context.Background(), componenttest.NewNopHost())
+	err := r.Start(context.Background(), newNopHost())
 	require.NoError(t, err)
 	require.Nil(t, r.resourceWatcher.osQuotaClient)
 
 	// openshift
 	rCfg.Distribution = "openshift"
 	r = newTestReceiver(t, rCfg)
-	err = r.Start(context.Background(), componenttest.NewNopHost())
+	err = r.Start(context.Background(), newNopHost())
 	require.NoError(t, err)
 	require.NotNil(t, r.resourceWatcher.osQuotaClient)
 }
@@ -105,7 +104,7 @@ type nopHostWithExporters struct {
 }
 
 func newNopHostWithExporters() component.Host {
-	return &nopHostWithExporters{Host: componenttest.NewNopHost()}
+	return &nopHostWithExporters{Host: newNopHost()}
 }
 
 func (n *nopHostWithExporters) GetExporters() map[component.DataType]map[component.ID]component.Component {

--- a/receiver/k8sclusterreceiver/receiver_test.go
+++ b/receiver/k8sclusterreceiver/receiver_test.go
@@ -28,6 +28,20 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/metadata"
 )
 
+type nopHost struct {
+	component.Host
+}
+
+func (nh *nopHost) GetExporters() map[component.DataType]map[component.ID]component.Component {
+	return nil
+}
+
+func newNopHost() component.Host {
+	return &nopHost{
+		Host: componenttest.NewNopHost(),
+	}
+}
+
 func TestReceiver(t *testing.T) {
 	tt, err := componenttest.SetupTelemetry(component.NewID(metadata.Type))
 	require.NoError(t, err)
@@ -51,7 +65,7 @@ func TestReceiver(t *testing.T) {
 	createClusterQuota(t, osQuotaClient, 2)
 
 	ctx := context.Background()
-	require.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, r.Start(ctx, newNopHost()))
 
 	// Expects metric data from nodes and pods where each metric data
 	// struct corresponds to one resource.
@@ -92,7 +106,7 @@ func TestReceiverTimesOutAfterStartup(t *testing.T) {
 	createPods(t, client, 1)
 
 	ctx := context.Background()
-	require.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, r.Start(ctx, newNopHost()))
 	require.Eventually(t, func() bool {
 		return r.resourceWatcher.initialSyncTimedOut.Load()
 	}, 10*time.Second, 100*time.Millisecond)
@@ -119,7 +133,7 @@ func TestReceiverWithManyResources(t *testing.T) {
 	createClusterQuota(t, osQuotaClient, 2)
 
 	ctx := context.Background()
-	require.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, r.Start(ctx, newNopHost()))
 
 	require.Eventually(t, func() bool {
 		// 4 points from the cluster quota.


### PR DESCRIPTION
**Description:**
See https://github.com/open-telemetry/opentelemetry-collector/pull/10717 as the original PR for this issue.

This change removes the dependency of k8sclusterreceiver tests on nopHost, which will no longer support GetExporters in the future.