### PR TITLE
[pkg/stanza] Fix when Process and Write errors are returned

### DIFF
--- a/.chloggen/fix_operators_error_handling.yaml
+++ b/.chloggen/fix_operators_error_handling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure that errors from `Process` and `Write` do not break for loops
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34295]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/operator/helper/writer.go
+++ b/pkg/stanza/operator/helper/writer.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
@@ -54,7 +55,7 @@ func (w *WriterOperator) Write(ctx context.Context, e *entry.Entry) error {
 		}
 		err := op.Process(ctx, e.Copy())
 		if err != nil {
-			return err
+			w.Logger().Error("Failed to process entry", zap.Error(err))
 		}
 	}
 	return nil

--- a/pkg/stanza/operator/helper/writer_test.go
+++ b/pkg/stanza/operator/helper/writer_test.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/operatortest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -54,6 +55,34 @@ func TestWriterOperatorWrite(t *testing.T) {
 	testEntry := entry.New()
 
 	err := writer.Write(ctx, testEntry)
+	require.NoError(t, err)
+	output1.AssertCalled(t, "Process", ctx, mock.Anything)
+	output2.AssertCalled(t, "Process", ctx, mock.Anything)
+}
+
+func TestWriterOperatorWriteAfterError(t *testing.T) {
+	output1 := testutil.NewMockOperator("output1")
+	output1.On("Process", mock.Anything, mock.Anything).Return(errors.NewError("Operator can not process logs.", ""))
+	output2 := testutil.NewMockOperator("output2")
+	output2.On("Process", mock.Anything, mock.Anything).Return(nil)
+
+	config := WriterConfig{
+		OutputIDs: []string{"output1", "output2"},
+		BasicConfig: BasicConfig{
+			OperatorType: "testtype",
+		},
+	}
+	set := componenttest.NewNopTelemetrySettings()
+	writer, err := config.Build(set)
+	require.NoError(t, err)
+
+	err = writer.SetOutputs([]operator.Operator{output1, output2})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	testEntry := entry.New()
+
+	err = writer.Write(ctx, testEntry)
 	require.NoError(t, err)
 	output1.AssertCalled(t, "Process", ctx, mock.Anything)
 	output2.AssertCalled(t, "Process", ctx, mock.Anything)

--- a/pkg/stanza/operator/parser/container/config.go
+++ b/pkg/stanza/operator/parser/container/config.go
@@ -100,7 +100,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		recombineParser:         recombineParser,
 		format:                  c.Format,
 		addMetadataFromFilepath: c.AddMetadataFromFilePath,
-		crioLogEmitter:          cLogEmitter,
+		criLogEmitter:           cLogEmitter,
 		criConsumers:            &wg,
 	}
 	return p, nil

--- a/pkg/stanza/operator/parser/container/parser.go
+++ b/pkg/stanza/operator/parser/container/parser.go
@@ -100,7 +100,7 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 				p.Logger().Error("unable to start the internal recombine operator", zap.Error(err))
 				return
 			}
-			go p.crioConsumer(ctx)
+			go p.criConsumer(ctx)
 			p.asyncConsumerStarted = true
 		})
 
@@ -151,9 +151,9 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 	return nil
 }
 
-// crioConsumer receives log entries from the crioLogEmitter and
+// criConsumer receives log entries from the crioLogEmitter and
 // writes them to the output of the main parser
-func (p *Parser) crioConsumer(ctx context.Context) {
+func (p *Parser) criConsumer(ctx context.Context) {
 	entriesChan := p.crioLogEmitter.OutChannel()
 	p.criConsumers.Add(1)
 	defer p.criConsumers.Done()
@@ -162,7 +162,6 @@ func (p *Parser) crioConsumer(ctx context.Context) {
 			err := p.Write(ctx, e)
 			if err != nil {
 				p.Logger().Error("failed to write entry", zap.Error(err))
-				return
 			}
 		}
 	}

--- a/pkg/stanza/operator/parser/container/parser.go
+++ b/pkg/stanza/operator/parser/container/parser.go
@@ -59,7 +59,7 @@ type Parser struct {
 	recombineParser         operator.Operator
 	format                  string
 	addMetadataFromFilepath bool
-	crioLogEmitter          *helper.LogEmitter
+	criLogEmitter           *helper.LogEmitter
 	asyncConsumerStarted    bool
 	criConsumerStartOnce    sync.Once
 	criConsumers            *sync.WaitGroup
@@ -90,7 +90,7 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 		}
 	case containerdFormat, crioFormat:
 		p.criConsumerStartOnce.Do(func() {
-			err = p.crioLogEmitter.Start(nil)
+			err = p.criLogEmitter.Start(nil)
 			if err != nil {
 				p.Logger().Error("unable to start the internal LogEmitter", zap.Error(err))
 				return
@@ -151,10 +151,10 @@ func (p *Parser) Process(ctx context.Context, entry *entry.Entry) (err error) {
 	return nil
 }
 
-// criConsumer receives log entries from the crioLogEmitter and
+// criConsumer receives log entries from the criLogEmitter and
 // writes them to the output of the main parser
 func (p *Parser) criConsumer(ctx context.Context) {
-	entriesChan := p.crioLogEmitter.OutChannel()
+	entriesChan := p.criLogEmitter.OutChannel()
 	p.criConsumers.Add(1)
 	defer p.criConsumers.Done()
 	for entries := range entriesChan {
@@ -167,7 +167,7 @@ func (p *Parser) criConsumer(ctx context.Context) {
 	}
 }
 
-// Stop ensures that the internal recombineParser, the internal crioLogEmitter and
+// Stop ensures that the internal recombineParser, the internal criLogEmitter and
 // the crioConsumer are stopped in the proper order without being affected by
 // any possible race conditions
 func (p *Parser) Stop() error {
@@ -181,11 +181,11 @@ func (p *Parser) Stop() error {
 	if err != nil {
 		stopErrs = append(stopErrs, fmt.Errorf("unable to stop the internal recombine operator: %w", err))
 	}
-	// the recombineParser will call the Process of the crioLogEmitter synchronously so the entries will be first
-	// written to the channel before the Stop of the recombineParser returns. Then since the crioLogEmitter handles
+	// the recombineParser will call the Process of the criLogEmitter synchronously so the entries will be first
+	// written to the channel before the Stop of the recombineParser returns. Then since the criLogEmitter handles
 	// the entries synchronously it is safe to call its Stop.
-	// After crioLogEmitter is stopped the crioConsumer will consume the remaining messages and return.
-	err = p.crioLogEmitter.Stop()
+	// After criLogEmitter is stopped the crioConsumer will consume the remaining messages and return.
+	err = p.criLogEmitter.Stop()
 	if err != nil {
 		stopErrs = append(stopErrs, fmt.Errorf("unable to stop the internal LogEmitter: %w", err))
 	}

--- a/pkg/stanza/operator/transformer/router/transformer.go
+++ b/pkg/stanza/operator/transformer/router/transformer.go
@@ -57,7 +57,6 @@ func (t *Transformer) Process(ctx context.Context, entry *entry.Entry) error {
 				err = output.Process(ctx, entry)
 				if err != nil {
 					t.Logger().Error("Failed to process entry", zap.Error(err))
-					return err
 				}
 			}
 			break

--- a/pkg/stanza/operator/transformer/router/transformer_test.go
+++ b/pkg/stanza/operator/transformer/router/transformer_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/entry"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/errors"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/testutil"
@@ -192,7 +193,11 @@ func TestTransformer(t *testing.T) {
 			var attributes map[string]any
 
 			mock1 := testutil.NewMockOperator("output1")
-			mock1.On("Process", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+			mock1.On(
+				"Process", mock.Anything, mock.Anything,
+			).Return(
+				errors.NewError("Operator can not process logs.", ""),
+			).Run(func(args mock.Arguments) {
 				results["output1"]++
 				if entry, ok := args[1].(*entry.Entry); ok {
 					attributes = entry.Attributes


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As discussed at https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34295,  error handling can be problematic in stanza package after the recent changes at https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33847. 
Specifically:
1. When [`Write`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/operator/helper/writer.go#L50) is called in a for loop, a returned error should not break the for loop. It should just be logged.
2. When [`Process`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/d78d7bb37d0c84da04ac8a83356eb669ecd75a95/pkg/stanza/operator/operator.go#L40) is called in a for loop, a returned error should not break the for loop. It should just be logged.

**Link to tracking Issue:** <Issue number if applicable> https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34295

**Testing:** <Describe what testing was performed and which tests were added.> Added

**Documentation:** <Describe the documentation added.> ~