### PR TITLE
[chore] Update OTTL hash function recommendations

### DIFF
--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -1185,7 +1185,7 @@ Examples:
 
 - `SHA1("name")`
 
-**Note:** According to the National Institute of Standards and Technology (NIST), SHA1 is no longer a recommended hash function. It should be avoided except when required for compatibility. New uses should prefer FNV whenever possible.
+**Note:** [According to the National Institute of Standards and Technology (NIST)](https://csrc.nist.gov/projects/hash-functions), SHA1 is no longer a recommended hash function. It should be avoided except when required for compatibility. New uses should prefer a SHA-2 family function (such as SHA-256 or SHA-512) whenever possible.
 
 ### SHA256
 
@@ -1205,8 +1205,6 @@ Examples:
 
 
 - `SHA256("name")`
-
-**Note:** According to the National Institute of Standards and Technology (NIST), SHA256 is no longer a recommended hash function. It should be avoided except when required for compatibility. New uses should prefer FNV whenever possible.
 
 ### SpanID
 


### PR DESCRIPTION
**Description:**

* FNV is a non-cryptographic hash function, which makes it inadequate to replace cryptographic hash functions like SHA-1.
* SHA-256 is still a recommended hash function by NIST. I've added a link to the official list of recommended hash functions as a citation.