### PR TITLE
[chore] Skip TestMRUReset until #34252 is fixed

### DIFF
--- a/internal/otelarrow/compression/zstd/mru_test.go
+++ b/internal/otelarrow/compression/zstd/mru_test.go
@@ -4,6 +4,7 @@
 package zstd
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -62,6 +63,10 @@ func TestMRUPut(t *testing.T) {
 }
 
 func TestMRUReset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34252")
+	}
+
 	defer resetTest()
 
 	var m mru[*gint]


### PR DESCRIPTION
This is failing too much on Windows skipping the test until it is fixed.