### PR TITLE
[chore] initialize slice variables with an empty slice

### DIFF
--- a/pkg/stanza/adapter/factory.go
+++ b/pkg/stanza/adapter/factory.go
@@ -46,7 +46,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 
 		operators := append([]operator.Config{inputCfg}, baseCfg.Operators...)
 
-		emitterOpts := []helper.EmitterOption{}
+		var emitterOpts []helper.EmitterOption
 		if baseCfg.maxBatchSize > 0 {
 			emitterOpts = append(emitterOpts, helper.WithMaxBatchSize(baseCfg.maxBatchSize))
 		}
@@ -62,7 +62,7 @@ func createLogsReceiver(logReceiverType LogReceiverType) rcvr.CreateLogsFunc {
 			return nil, err
 		}
 
-		converterOpts := []converterOption{}
+		var converterOpts []converterOption
 		if baseCfg.numWorkers > 0 {
 			converterOpts = append(converterOpts, withWorkerCount(baseCfg.numWorkers))
 		}


### PR DESCRIPTION
Small golang fix to use a `var` declaration rather than initializing an empty slice.