### PR TITLE
[chore] [processor/k8sattributes] Update a config doc comment

### DIFF
--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -229,7 +229,7 @@ type FieldExtractConfig struct {
 	Regex string `mapstructure:"regex"`
 
 	// From represents the source of the labels/annotations.
-	// Allowed values are "pod" and "namespace". The default is pod.
+	// Allowed values are "pod", "namespace", and "node". The default is pod.
 	From string `mapstructure:"from"`
 }
 


### PR DESCRIPTION
Annotations and labels extraction is possible from nodes as well after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/28570. Fixing a missing doc string
