### PR TITLE
[chore] Add OS labels to common labels

### DIFF
--- a/.github/workflows/scripts/add-labels.sh
+++ b/.github/workflows/scripts/add-labels.sh
@@ -20,10 +20,13 @@ if [[ ${COMMENT:0:6} != "/label" ]]; then
 fi
 
 declare -A COMMON_LABELS
+COMMON_LABELS["arm64"]="arm64"
 COMMON_LABELS["good-first-issue"]="good first issue"
 COMMON_LABELS["help-wanted"]="help wanted"
 COMMON_LABELS["needs-discussion"]="needs discussion"
 COMMON_LABELS["needs-triage"]="needs triage"
+COMMON_LABELS["os:mac"]="os:mac"
+COMMON_LABELS["os:windows"]="os:windows"
 COMMON_LABELS["waiting-for-author"]="waiting for author"
 
 LABELS=$(echo "${COMMENT}" | sed -E 's%^/label%%')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -379,10 +379,13 @@ The following general labels are supported:
 
 | Label                | Label in Comment     |
 |----------------------|----------------------|
+| `arm64`              | `arm64`              |
 | `good first issue`   | `good-first-issue`   |
 | `help wanted`        | `help-wanted`        |
 | `discussion needed`  | `discussion-needed`  |
 | `needs triage`       | `needs-triage`       |
+| `os:mac`             | `os:mac`             |
+| `os:windows`         | `os:windows`         |
 | `waiting for author` | `waiting-for-author` |
 
 To delete a label, prepend the label with `-`. Note that you must make a new comment to modify labels; you cannot edit an existing comment.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The OS labels are pretty general labels that can be used by anyone to show when an issue may be OS-specific. I don't see any concern with opening these labels up for more people to use as there is no automation around them at this time (Adding or removing them has no impact).