### PR TITLE
[chore][internal/otelarrow] Unskip test

### DIFF
--- a/internal/otelarrow/compression/zstd/mru_test.go
+++ b/internal/otelarrow/compression/zstd/mru_test.go
@@ -4,7 +4,6 @@
 package zstd
 
 import (
-	"runtime"
 	"testing"
 	"time"
 
@@ -64,10 +63,6 @@ func TestMRUPut(t *testing.T) {
 }
 
 func TestMRUReset(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping test on Windows, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34252")
-	}
-
 	defer resetTest()
 
 	var m mru[*gint]


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This reverts https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34362 as https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34260 was merged to resolve the test. The flakiness should be resolved so we no longer need to skip this test.