### PR TITLE
[receiver/elasticsearch] Enable more index metrics by default

### DIFF
--- a/.chloggen/es_add_default_metrics.yaml
+++ b/.chloggen/es_add_default_metrics.yaml
@@ -18,7 +18,7 @@ issues: [34396]
 subtext: |
   This enables the following metrics by default: 
   `elasticsearch.index.documents`
-  `elasticsearch.index.operations.merge.count`
+  `elasticsearch.index.operations.merge.current`
   `elasticsearch.index.segments.count`
   To preserve previous behavior, update your Elasticsearch receiver configuration to disable these metrics.
 

--- a/.chloggen/es_add_default_metrics.yaml
+++ b/.chloggen/es_add_default_metrics.yaml
@@ -1,0 +1,33 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable more index metrics by default
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34396]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This enables the following metrics by default: 
+  `elasticsearch.index.documents`
+  `elasticsearch.index.operations.merge.count`
+  `elasticsearch.index.segments.count`
+  To preserve previous behavior, update your Elasticsearch receiver configuration to disable these metrics.
+
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/elasticsearchreceiver/documentation.md
+++ b/receiver/elasticsearchreceiver/documentation.md
@@ -181,6 +181,21 @@ The cumulative amount of time updating the cluster state since the node started.
 | state | State of cluster state update | Any Str |
 | type | Type of cluster state update | Str: ``computation``, ``context_construction``, ``commit``, ``completion``, ``master_apply``, ``notification`` |
 
+### elasticsearch.index.documents
+
+The number of documents for an index.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {documents} | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| state | The state of the document. | Str: ``active``, ``deleted`` |
+| aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
+
 ### elasticsearch.index.operations.completed
 
 The number of operations completed for an index.
@@ -196,6 +211,20 @@ The number of operations completed for an index.
 | operation | The type of operation. | Str: ``index``, ``delete``, ``get``, ``query``, ``fetch``, ``scroll``, ``suggest``, ``merge``, ``refresh``, ``flush``, ``warmer`` |
 | aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
 
+### elasticsearch.index.operations.merge.current
+
+The number of currently active segment merges
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| {merges} | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
+
 ### elasticsearch.index.operations.time
 
 Time spent on operations for an index.
@@ -209,6 +238,20 @@ Time spent on operations for an index.
 | Name | Description | Values |
 | ---- | ----------- | ------ |
 | operation | The type of operation. | Str: ``index``, ``delete``, ``get``, ``query``, ``fetch``, ``scroll``, ``suggest``, ``merge``, ``refresh``, ``flush``, ``warmer`` |
+| aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
+
+### elasticsearch.index.segments.count
+
+Number of segments of an index.
+
+| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
+| ---- | ----------- | ---------- | ----------------------- | --------- |
+| {segments} | Sum | Int | Cumulative | false |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
 | aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
 
 ### elasticsearch.index.shards.size
@@ -837,35 +880,6 @@ The number of elements of the query cache for an index.
 | ---- | ----------- | ------ |
 | aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
 
-### elasticsearch.index.documents
-
-The number of documents for an index.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {documents} | Sum | Int | Cumulative | false |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| state | The state of the document. | Str: ``active``, ``deleted`` |
-| aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
-
-### elasticsearch.index.operations.merge.current
-
-The number of currently active segment merges
-
-| Unit | Metric Type | Value Type |
-| ---- | ----------- | ---------- |
-| {merges} | Gauge | Int |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
-
 ### elasticsearch.index.operations.merge.docs_count
 
 The total number of documents in merge operations for an index.
@@ -887,20 +901,6 @@ The total size of merged segments for an index.
 | Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
 | ---- | ----------- | ---------- | ----------------------- | --------- |
 | By | Sum | Int | Cumulative | true |
-
-#### Attributes
-
-| Name | Description | Values |
-| ---- | ----------- | ------ |
-| aggregation | Type of shard aggregation for index statistics | Str: ``primary_shards``, ``total`` |
-
-### elasticsearch.index.segments.count
-
-Number of segments of an index.
-
-| Unit | Metric Type | Value Type | Aggregation Temporality | Monotonic |
-| ---- | ----------- | ---------- | ----------------------- | --------- |
-| {segments} | Sum | Int | Cumulative | false |
 
 #### Attributes
 

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_config.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_config.go
@@ -179,13 +179,13 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: false,
 		},
 		ElasticsearchIndexDocuments: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		ElasticsearchIndexOperationsCompleted: MetricConfig{
 			Enabled: true,
 		},
 		ElasticsearchIndexOperationsMergeCurrent: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		ElasticsearchIndexOperationsMergeDocsCount: MetricConfig{
 			Enabled: false,
@@ -197,7 +197,7 @@ func DefaultMetricsConfig() MetricsConfig {
 			Enabled: true,
 		},
 		ElasticsearchIndexSegmentsCount: MetricConfig{
-			Enabled: false,
+			Enabled: true,
 		},
 		ElasticsearchIndexSegmentsMemory: MetricConfig{
 			Enabled: false,

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics_test.go
@@ -136,6 +136,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordElasticsearchIndexCacheSizeDataPoint(ts, 1, AttributeIndexAggregationTypePrimaryShards)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordElasticsearchIndexDocumentsDataPoint(ts, 1, AttributeDocumentStateActive, AttributeIndexAggregationTypePrimaryShards)
 
@@ -143,6 +144,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordElasticsearchIndexOperationsCompletedDataPoint(ts, 1, AttributeOperationIndex, AttributeIndexAggregationTypePrimaryShards)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordElasticsearchIndexOperationsMergeCurrentDataPoint(ts, 1, AttributeIndexAggregationTypePrimaryShards)
 
@@ -156,6 +158,7 @@ func TestMetricsBuilder(t *testing.T) {
 			allMetricsCount++
 			mb.RecordElasticsearchIndexOperationsTimeDataPoint(ts, 1, AttributeOperationIndex, AttributeIndexAggregationTypePrimaryShards)
 
+			defaultMetricsCount++
 			allMetricsCount++
 			mb.RecordElasticsearchIndexSegmentsCountDataPoint(ts, 1, AttributeIndexAggregationTypePrimaryShards)
 

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -896,7 +896,7 @@ metrics:
     gauge:
       value_type: int
     attributes: [ index_aggregation_type ]
-    enabled: false
+    enabled: true
   elasticsearch.index.segments.count:
     description: Number of segments of an index.
     unit: "{segments}"
@@ -905,7 +905,7 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     attributes: [index_aggregation_type]
-    enabled: false
+    enabled: true
   elasticsearch.index.segments.size:
     description: Size of segments of an index.
     unit: By
@@ -977,7 +977,7 @@ metrics:
       aggregation_temporality: cumulative
       value_type: int
     attributes: [document_state, index_aggregation_type]
-    enabled: false
+    enabled: true
   elasticsearch.process.cpu.usage:
     description: CPU usage in percent.
     unit: "1"

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
@@ -9,6 +9,32 @@ resourceMetrics:
             stringValue: .geoip_databases
     scopeMetrics:
       - metrics:
+          - description: The number of documents for an index.
+            name: elasticsearch.index.documents
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{documents}'
           - description: The number of operations completed for an index.
             name: elasticsearch.index.operations.completed
             sum:
@@ -236,6 +262,18 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
+          - description: The number of currently active segment merges
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: elasticsearch.index.operations.merge.current
+            unit: '{merges}'
           - description: Time spent on operations for an index.
             name: elasticsearch.index.operations.time
             sum:
@@ -463,6 +501,26 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
+          - description: Number of segments of an index.
+            name: elasticsearch.index.segments.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{segments}'
           - description: The size of the shards assigned to this index.
             name: elasticsearch.index.shards.size
             sum:
@@ -489,6 +547,32 @@ resourceMetrics:
             stringValue: _all
     scopeMetrics:
       - metrics:
+          - description: The number of documents for an index.
+            name: elasticsearch.index.documents
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{documents}'
           - description: The number of operations completed for an index.
             name: elasticsearch.index.operations.completed
             sum:
@@ -716,6 +800,18 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
+          - description: The number of currently active segment merges
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: elasticsearch.index.operations.merge.current
+            unit: '{merges}'
           - description: Time spent on operations for an index.
             name: elasticsearch.index.operations.time
             sum:
@@ -943,6 +1039,26 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
+          - description: Number of segments of an index.
+            name: elasticsearch.index.segments.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{segments}'
           - description: The size of the shards assigned to this index.
             name: elasticsearch.index.shards.size
             sum:
@@ -1539,8 +1655,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "15746158592"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The amount of disk space across all file stores for this node.
             name: elasticsearch.node.fs.disk.total
@@ -1548,8 +1664,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "67371577344"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The number of HTTP connections to the node.
             name: elasticsearch.node.http.connections

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
@@ -130,6 +130,32 @@ resourceMetrics:
             stringValue: .geoip_databases
     scopeMetrics:
       - metrics:
+          - description: The number of documents for an index.
+            name: elasticsearch.index.documents
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{documents}'
           - description: The number of operations completed for an index.
             name: elasticsearch.index.operations.completed
             sum:
@@ -357,6 +383,18 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
+          - description: The number of currently active segment merges
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: elasticsearch.index.operations.merge.current
+            unit: '{merges}'
           - description: Time spent on operations for an index.
             name: elasticsearch.index.operations.time
             sum:
@@ -584,6 +622,26 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
+          - description: Number of segments of an index.
+            name: elasticsearch.index.segments.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{segments}'
           - description: The size of the shards assigned to this index.
             name: elasticsearch.index.shards.size
             sum:
@@ -610,6 +668,32 @@ resourceMetrics:
             stringValue: _all
     scopeMetrics:
       - metrics:
+          - description: The number of documents for an index.
+            name: elasticsearch.index.documents
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{documents}'
           - description: The number of operations completed for an index.
             name: elasticsearch.index.operations.completed
             sum:
@@ -837,6 +921,18 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
+          - description: The number of currently active segment merges
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: elasticsearch.index.operations.merge.current
+            unit: '{merges}'
           - description: Time spent on operations for an index.
             name: elasticsearch.index.operations.time
             sum:
@@ -1064,6 +1160,26 @@ resourceMetrics:
                   timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
+          - description: Number of segments of an index.
+            name: elasticsearch.index.segments.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{segments}'
           - description: The size of the shards assigned to this index.
             name: elasticsearch.index.shards.size
             sum:

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.yaml
@@ -4,9 +4,1214 @@ resourceMetrics:
         - key: elasticsearch.cluster.name
           value:
             stringValue: docker-cluster
+    scopeMetrics:
+      - metrics:
+          - description: The number of data nodes in the cluster.
+            name: elasticsearch.cluster.data_nodes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{nodes}'
+          - description: The health status of the cluster.
+            name: elasticsearch.cluster.health
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: green
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: red
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: yellow
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{status}'
+          - description: The number of unfinished fetches.
+            name: elasticsearch.cluster.in_flight_fetch
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{fetches}'
+          - description: The total number of nodes in the cluster.
+            name: elasticsearch.cluster.nodes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{nodes}'
+          - description: The number of cluster-level changes that have not yet been executed.
+            name: elasticsearch.cluster.pending_tasks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{tasks}'
+          - description: The number of shards in the cluster.
+            name: elasticsearch.cluster.shards
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active_primary
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: initializing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: relocating
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unassigned
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unassigned_delayed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{shards}'
+          - description: The current heap memory usage
+            gauge:
+              dataPoints:
+                - asInt: "282742592"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: jvm.memory.heap.used
+            unit: By
+        scope:
+          name: otelcol/elasticsearchreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: elasticsearch.cluster.name
+          value:
+            stringValue: docker-cluster
+        - key: elasticsearch.index.name
+          value:
+            stringValue: .geoip_databases
+    scopeMetrics:
+      - metrics:
+          - description: The number of documents for an index.
+            name: elasticsearch.index.documents
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{documents}'
+          - description: The number of operations completed for an index.
+            name: elasticsearch.index.operations.completed
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The number of currently active segment merges
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: elasticsearch.index.operations.merge.current
+            unit: '{merges}'
+          - description: Time spent on operations for an index.
+            name: elasticsearch.index.operations.time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "64"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "186"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "718"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "62"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "58"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "53"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "64"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "186"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "718"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "62"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "58"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "53"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of segments of an index.
+            name: elasticsearch.index.segments.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{segments}'
+          - description: The size of the shards assigned to this index.
+            name: elasticsearch.index.shards.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "32473664"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+        scope:
+          name: otelcol/elasticsearchreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: elasticsearch.cluster.name
+          value:
+            stringValue: docker-cluster
+        - key: elasticsearch.index.name
+          value:
+            stringValue: _all
+    scopeMetrics:
+      - metrics:
+          - description: The number of documents for an index.
+            name: elasticsearch.index.documents
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{documents}'
+          - description: The number of operations completed for an index.
+            name: elasticsearch.index.operations.completed
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "33"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The number of currently active segment merges
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: elasticsearch.index.operations.merge.current
+            unit: '{merges}'
+          - description: Time spent on operations for an index.
+            name: elasticsearch.index.operations.time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "64"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "186"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "718"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "62"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "58"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "53"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "64"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "186"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "718"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "62"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "58"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "53"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of segments of an index.
+            name: elasticsearch.index.segments.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "4"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{segments}'
+          - description: The size of the shards assigned to this index.
+            name: elasticsearch.index.shards.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "32473664"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+        scope:
+          name: otelcol/elasticsearchreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: elasticsearch.cluster.name
+          value:
+            stringValue: docker-cluster
         - key: elasticsearch.node.name
           value:
-            stringValue: 085693db869f
+            stringValue: 8e63c4f981ab
         - key: elasticsearch.node.version
           value:
             stringValue: 7.16.3
@@ -15,55 +1220,55 @@ resourceMetrics:
           - description: Estimated memory used for the operation.
             gauge:
               dataPoints:
-                - asInt: "0"
+                - asInt: "8196"
                   attributes:
                     - key: name
                       value:
-                        stringValue: in_flight_requests
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: model_inference
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: accounting
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: eql_sequence
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "7088"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: accounting
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "282641608"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: parent
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: request
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: in_flight_requests
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: model_inference
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "282742592"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: parent
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.breaker.memory.estimated
             unit: By
           - description: Memory limit for the circuit breaker.
@@ -75,51 +1280,51 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: in_flight_requests
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "268435456"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: model_inference
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: accounting
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "268435456"
                   attributes:
                     - key: name
                       value:
                         stringValue: eql_sequence
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "536870912"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: accounting
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "510027366"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: parent
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "322122547"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: request
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "214748364"
                   attributes:
                     - key: name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "536870912"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: in_flight_requests
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "268435456"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: model_inference
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "510027366"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: parent
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "322122547"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Total number of times the circuit breaker has been triggered and prevented an out of memory error.
             name: elasticsearch.breaker.tripped
@@ -130,51 +1335,51 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: in_flight_requests
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: model_inference
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: accounting
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: eql_sequence
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: accounting
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: parent
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: request
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: in_flight_requests
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: model_inference
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: parent
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Number of differences between published cluster states.
@@ -182,20 +1387,20 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "53"
+                - asInt: "55"
                   attributes:
                     - key: state
                       value:
                         stringValue: compatible
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: incompatible
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: "1"
           - description: Number of published cluster states.
             name: elasticsearch.cluster.published_states.full
@@ -203,8 +1408,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: "1"
           - description: Number of cluster states in queue.
             name: elasticsearch.cluster.state_queue
@@ -216,42 +1421,42 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: committed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: pending
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: "1"
           - description: The number of cluster state update attempts that changed the cluster state since the node started.
             name: elasticsearch.cluster.state_update.count
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "46"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unchanged
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "55"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: failure
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "57"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "45"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unchanged
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: The cumulative amount of time updating the cluster state since the node started.
@@ -259,116 +1464,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "22"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unchanged
-                    - key: type
-                      value:
-                        stringValue: computation
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unchanged
-                    - key: type
-                      value:
-                        stringValue: notification
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "875"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: computation
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "8"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: notification
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "47"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: context_construction
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1043"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: commit
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1119"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: completion
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "872"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: success
-                    - key: type
-                      value:
-                        stringValue: master_apply
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: computation
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: notification
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: failure
-                    - key: type
-                      value:
-                        stringValue: context_construction
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
                 - asInt: "0"
                   attributes:
                     - key: state
@@ -377,8 +1472,8 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: commit
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
@@ -387,8 +1482,28 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: completion
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: computation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: context_construction
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
@@ -397,16 +1512,106 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: master_apply
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: failure
+                    - key: type
+                      value:
+                        stringValue: notification
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1041"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: commit
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1094"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: completion
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "727"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: computation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "45"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: context_construction
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "844"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: master_apply
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "6"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: success
+                    - key: type
+                      value:
+                        stringValue: notification
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "14"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unchanged
+                    - key: type
+                      value:
+                        stringValue: computation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unchanged
+                    - key: type
+                      value:
+                        stringValue: notification
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
           - description: Configured memory limit, in bytes, for the indexing requests.
             gauge:
               dataPoints:
                 - asInt: "53687091"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.indexing_pressure.memory.limit
             unit: By
           - description: Cumulative number of indexing requests rejected in the primary stage.
@@ -415,8 +1620,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Number of indexing requests rejected in the replica stage.
@@ -425,8 +1630,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Memory consumed, in bytes, by indexing requests in the specified stage.
@@ -438,23 +1643,23 @@ resourceMetrics:
                   attributes:
                     - key: stage
                       value:
-                        stringValue: primary
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: coordinating
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: stage
                       value:
-                        stringValue: coordinating
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: primary
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: stage
                       value:
                         stringValue: replica
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Total count of query cache misses across all shards assigned to selected nodes.
             name: elasticsearch.node.cache.count
@@ -466,15 +1671,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: hit
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: type
                       value:
                         stringValue: miss
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{count}'
           - description: The number of evictions from the cache on a node.
             name: elasticsearch.node.cache.evictions
@@ -486,15 +1691,15 @@ resourceMetrics:
                     - key: cache_name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: cache_name
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{evictions}'
           - description: The size in bytes of the cache on a node.
@@ -507,15 +1712,15 @@ resourceMetrics:
                     - key: cache_name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: cache_name
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The number of open tcp connections for internal cluster communication.
             name: elasticsearch.node.cluster.connections
@@ -523,8 +1728,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{connections}'
           - description: The number of bytes sent and received on the network for internal cluster communication.
             name: elasticsearch.node.cluster.io
@@ -536,15 +1741,15 @@ resourceMetrics:
                     - key: direction
                       value:
                         stringValue: received
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: sent
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: By
           - description: The total number of kilobytes read across all file stores for this node.
@@ -553,8 +1758,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The total number of kilobytes written across all file stores for this node.
             name: elasticsearch.node.disk.io.write
@@ -562,55 +1767,55 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The number of documents on the node.
             name: elasticsearch.node.documents
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "14"
+                - asInt: "34"
                   attributes:
                     - key: state
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: deleted
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.
             name: elasticsearch.node.fs.disk.available
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "175194710016"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "25508925440"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The amount of unallocated disk space across all file stores for this node.
             name: elasticsearch.node.fs.disk.free
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "186807754752"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "28725641216"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The amount of disk space across all file stores for this node.
             name: elasticsearch.node.fs.disk.total
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "228220321792"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "62671097856"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The number of HTTP connections to the node.
             name: elasticsearch.node.http.connections
@@ -618,8 +1823,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{connections}'
           - description: Total number of documents ingested during the lifetime of this node.
             name: elasticsearch.node.ingest.documents
@@ -627,8 +1832,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{documents}'
           - description: Total number of documents currently being ingested.
@@ -637,8 +1842,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: Total number of failed ingest operations during the lifetime of this node.
             name: elasticsearch.node.ingest.operations.failed
@@ -646,8 +1851,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operation}'
           - description: The number of open file descriptors held by the node.
@@ -655,92 +1860,92 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "305"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "321"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{files}'
           - description: The number of operations completed by a node.
             name: elasticsearch.node.operations.completed
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "14"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: get
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "6"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "34"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "6"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: merge
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "9"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "36"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "12"
                   attributes:
                     - key: operation
                       value:
                         stringValue: refresh
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: flush
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "6"
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "7"
                   attributes:
                     - key: operation
                       value:
                         stringValue: warmer
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
           - description: Time spent on operations by a node.
@@ -748,83 +1953,83 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "320"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: delete
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "64"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "186"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: get
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "37"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "727"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: query
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "23"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "48"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: merge
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "56"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "62"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "76"
                   attributes:
                     - key: operation
                       value:
                         stringValue: refresh
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "72"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "53"
                   attributes:
                     - key: operation
                       value:
-                        stringValue: flush
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: operation
+                      value:
                         stringValue: warmer
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
           - description: Total number of documents currently being ingested by a pipeline.
@@ -837,15 +2042,15 @@ resourceMetrics:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_6
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_7
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: Number of documents preprocessed by the ingest pipeline.
             name: elasticsearch.node.pipeline.ingest.documents.preprocessed
@@ -857,15 +2062,15 @@ resourceMetrics:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_6
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_7
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: Total number of failed operations for the ingest pipeline.
             name: elasticsearch.node.pipeline.ingest.operations.failed
@@ -877,15 +2082,15 @@ resourceMetrics:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_6
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_7
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operation}'
           - description: Total number of times the script cache has evicted old data.
@@ -894,8 +2099,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Total number of times the script compilation circuit breaker has limited inline script compilations.
@@ -904,8 +2109,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Total number of inline script compilations performed by the node.
@@ -914,17 +2119,17 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{compilations}'
           - description: Total data set size of all shards assigned to the node. This includes the size of shards not stored fully on the node, such as the cache for partially mounted indices.
             name: elasticsearch.node.shards.data_set.size
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "12739449"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "32484333"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.
             name: elasticsearch.node.shards.reserved.size
@@ -932,17 +2137,17 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The size of the shards assigned to this node.
             name: elasticsearch.node.shards.size
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "12739449"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "32484333"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The number of tasks finished by the thread pool.
             name: elasticsearch.node.thread_pool.tasks.finished
@@ -951,684 +2156,684 @@ resourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: transform_indexing
                     - key: state
                       value:
                         stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: auto_complete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ccr
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "370"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "40"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_job_comms
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "7"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "9"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_coordination
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_fetch_async
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_prewarming
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot_meta
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "72"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "64"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
                     - key: thread_pool_name
                       value:
                         stringValue: transform_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: vector_tile_generation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "4"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
                     - key: thread_pool_name
                       value:
                         stringValue: write
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: auto_complete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ccr
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_job_comms
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_coordination
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_fetch_async
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_prewarming
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot_meta
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: transform_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: vector_tile_generation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
                     - key: thread_pool_name
                       value:
                         stringValue: write
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "11"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_fetch_async
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_fetch_async
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_coordination
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_coordination
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: vector_tile_generation
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: vector_tile_generation
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "12"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_read
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_read
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "26"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_write
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_write
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "359"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_prewarming
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_prewarming
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: auto_complete
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: auto_complete
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "18"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot_meta
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot_meta
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_write
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_write
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_job_comms
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_job_comms
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "12"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_read
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_read
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: analyze
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: analyze
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ccr
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ccr
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tasks}'
           - description: The number of queued tasks in the thread pool.
@@ -1640,240 +2845,240 @@ resourceMetrics:
                   attributes:
                     - key: thread_pool_name
                       value:
-                        stringValue: transform_indexing
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_fetch_async
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_coordination
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: vector_tile_generation
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_read
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_write
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_prewarming
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: auto_complete
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot_meta
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_write
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_job_comms
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_read
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: analyze
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: ccr
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: fetch_shard_store
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_job_comms
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_coordination
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_fetch_async
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_prewarming
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot_meta
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: transform_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: vector_tile_generation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{tasks}'
           - description: The number of threads in the thread pool.
             name: elasticsearch.node.thread_pool.threads
@@ -1882,693 +3087,693 @@ resourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: transform_indexing
                     - key: state
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: transform_indexing
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "4"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_fetch_async
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_fetch_async
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_coordination
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_coordination
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: vector_tile_generation
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: vector_tile_generation
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_read
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "4"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_read
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_write
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "4"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_write
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "6"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_prewarming
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: searchable_snapshots_cache_prewarming
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: auto_complete
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: auto_complete
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot_meta
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot_meta
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_write
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_write
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_job_comms
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_job_comms
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_read
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: system_critical_read
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: auto_complete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ccr
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_job_comms
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_coordination
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_fetch_async
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_prewarming
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot_meta
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: transform_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: vector_tile_generation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
                     - key: thread_pool_name
                       value:
                         stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: auto_complete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
                     - key: thread_pool_name
                       value:
                         stringValue: ccr
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ccr
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
-                        stringValue: fetch_shard_store
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_job_comms
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_coordination
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_fetch_async
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: searchable_snapshots_cache_prewarming
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot_meta
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_critical_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_read
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "5"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: system_write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: transform_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: vector_tile_generation
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{threads}'
           - description: Number of transaction log operations.
             name: elasticsearch.node.translog.operations
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "9"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
           - description: Size of the transaction log.
@@ -2576,76 +3781,76 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "8390990"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "1318"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Size of uncommitted transaction log operations.
             name: elasticsearch.node.translog.uncommitted.size
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "8390990"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "1318"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).
             gauge:
               dataPoints:
-                - asDouble: 0.67
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asDouble: 0.35
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.load_avg.15m
             unit: "1"
           - description: One-minute load average on the system (field is not present if one-minute load average is not available).
             gauge:
               dataPoints:
-                - asDouble: 2.82
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asDouble: 2.55
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.load_avg.1m
             unit: "1"
           - description: Five-minute load average on the system (field is not present if five-minute load average is not available).
             gauge:
               dataPoints:
-                - asDouble: 1.22
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asDouble: 0.94
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.load_avg.5m
             unit: "1"
           - description: Recent CPU usage for the whole system, or -1 if not supported.
             gauge:
               dataPoints:
-                - asInt: "37"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "17"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.usage
             unit: '%'
           - description: Amount of physical memory.
             gauge:
               dataPoints:
-                - asInt: "2519531520"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "7927848960"
+                - asInt: "5588905984"
                   attributes:
                     - key: state
                       value:
                         stringValue: free
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2630254592"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.memory
             unit: By
           - description: The number of loaded classes
             gauge:
               dataPoints:
-                - asInt: "23957"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "23934"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.classes.loaded
             unit: "1"
           - description: The total number of garbage collections that have occurred
@@ -2653,20 +3858,20 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "14"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: The approximate accumulated collection elapsed time
@@ -2674,1211 +3879,122 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "277"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "150"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
           - description: The amount of memory that is guaranteed to be available for the heap
             gauge:
               dataPoints:
                 - asInt: "536870912"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.heap.committed
             unit: By
           - description: The maximum amount of memory can be used for the heap
             gauge:
               dataPoints:
                 - asInt: "536870912"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.heap.max
             unit: By
           - description: The current heap memory usage
             gauge:
               dataPoints:
-                - asInt: "282641608"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "282742592"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.heap.used
             unit: By
           - description: The amount of memory that is guaranteed to be available for non-heap purposes
             gauge:
               dataPoints:
-                - asInt: "149880832"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "154271744"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.nonheap.committed
             unit: By
           - description: The current non-heap memory usage
             gauge:
               dataPoints:
-                - asInt: "146738880"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "151509440"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.nonheap.used
             unit: By
           - description: The maximum amount of memory can be used for the memory pool
             gauge:
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: survivor
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
                 - asInt: "536870912"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: survivor
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.pool.max
             unit: By
           - description: The current memory pool memory usage
             gauge:
               dataPoints:
-                - asInt: "192937984"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "25655496"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: survivor
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "64048128"
+                - asInt: "70178304"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "28014912"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: survivor
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "184549376"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.pool.used
             unit: By
           - description: The current number of threads
             gauge:
               dataPoints:
-                - asInt: "52"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
+                - asInt: "54"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.threads.count
             unit: "1"
-        scope:
-          name: otelcol/elasticsearchreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: elasticsearch.cluster.name
-          value:
-            stringValue: docker-cluster
-    scopeMetrics:
-      - metrics:
-          - description: The number of data nodes in the cluster.
-            name: elasticsearch.cluster.data_nodes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-            unit: '{nodes}'
-          - description: The health status of the cluster.
-            name: elasticsearch.cluster.health
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: green
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: yellow
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: red
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-            unit: '{status}'
-          - description: The number of unfinished fetches.
-            name: elasticsearch.cluster.in_flight_fetch
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-            unit: '{fetches}'
-          - description: The total number of nodes in the cluster.
-            name: elasticsearch.cluster.nodes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1662755394888825000"
-                  timeUnixNano: "1662755404890529000"
-            unit: '{nodes}'
-          - description: The number of cluster-level changes that have not yet been executed.
-            name: elasticsearch.cluster.pending_tasks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-            unit: '{tasks}'
-          - description: The number of shards in the cluster.
-            name: elasticsearch.cluster.shards
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "45"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: initializing
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: relocating
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unassigned
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "23"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active_primary
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unassigned_delayed
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-            unit: '{shards}'
-          - description: The current heap memory usage
-            gauge:
-              dataPoints:
-                - asInt: "285158912"
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-            name: jvm.memory.heap.used
-            unit: By
-        scope:
-          name: otelcol/elasticsearchreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: elasticsearch.index.name
-          value:
-            stringValue: .geoip_databases
-        - key: elasticsearch.cluster.name
-          value:
-            stringValue: docker-cluster
-    scopeMetrics:
-      - metrics:
-          - description: The number of operations completed for an index.
-            name: elasticsearch.index.operations.completed
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "13"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "5"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "6"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "13"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "5"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "6"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-              isMonotonic: true
-            unit: '{operations}'
-          - description: Time spent on operations for an index.
-            name: elasticsearch.index.operations.time
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "82"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "52"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "30"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "82"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "52"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "30"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-              isMonotonic: true
-            unit: ms
-          - description: The size of the shards assigned to this index.
-            name: elasticsearch.index.shards.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "40230884"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-            unit: By
-        scope:
-          name: otelcol/elasticsearchreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: elasticsearch.index.name
-          value:
-            stringValue: _all
-        - key: elasticsearch.cluster.name
-          value:
-            stringValue: docker-cluster
-    scopeMetrics:
-      - metrics:
-          - description: The number of operations completed for an index.
-            name: elasticsearch.index.operations.completed
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "13"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "5"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "6"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "13"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "5"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "6"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-              isMonotonic: true
-            unit: '{operations}'
-          - description: Time spent on operations for an index.
-            name: elasticsearch.index.operations.time
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "82"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "52"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "30"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "82"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "52"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "30"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-              isMonotonic: true
-            unit: ms
-          - description: The size of the shards assigned to this index.
-            name: elasticsearch.index.shards.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "40230884"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-            unit: By
         scope:
           name: otelcol/elasticsearchreceiver
           version: latest

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.yaml
@@ -4,9 +4,676 @@ resourceMetrics:
         - key: elasticsearch.cluster.name
           value:
             stringValue: docker-cluster
+    scopeMetrics:
+      - metrics:
+          - description: The number of data nodes in the cluster.
+            name: elasticsearch.cluster.data_nodes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{nodes}'
+          - description: The health status of the cluster.
+            name: elasticsearch.cluster.health
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: green
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: red
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: status
+                      value:
+                        stringValue: yellow
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{status}'
+          - description: The number of unfinished fetches.
+            name: elasticsearch.cluster.in_flight_fetch
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{fetches}'
+          - description: The total number of nodes in the cluster.
+            name: elasticsearch.cluster.nodes
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{nodes}'
+          - description: The number of cluster-level changes that have not yet been executed.
+            name: elasticsearch.cluster.pending_tasks
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{tasks}'
+          - description: The number of shards in the cluster.
+            name: elasticsearch.cluster.shards
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active_primary
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: initializing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: relocating
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unassigned
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: unassigned_delayed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{shards}'
+          - description: The current heap memory usage
+            gauge:
+              dataPoints:
+                - asInt: "100044384"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: jvm.memory.heap.used
+            unit: By
+        scope:
+          name: otelcol/elasticsearchreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: elasticsearch.cluster.name
+          value:
+            stringValue: docker-cluster
+        - key: elasticsearch.index.name
+          value:
+            stringValue: _all
+    scopeMetrics:
+      - metrics:
+          - description: The number of documents for an index.
+            name: elasticsearch.index.documents
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: state
+                      value:
+                        stringValue: active
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{documents}'
+          - description: The number of operations completed for an index.
+            name: elasticsearch.index.operations.completed
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+          - description: The number of currently active segment merges
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: elasticsearch.index.operations.merge.current
+            unit: '{merges}'
+          - description: Time spent on operations for an index.
+            name: elasticsearch.index.operations.time
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: delete
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: fetch
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                    - key: operation
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: ms
+          - description: Number of segments of an index.
+            name: elasticsearch.index.segments.count
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: primary_shards
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{segments}'
+          - description: The size of the shards assigned to this index.
+            name: elasticsearch.index.shards.size
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "0"
+                  attributes:
+                    - key: aggregation
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+        scope:
+          name: otelcol/elasticsearchreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: elasticsearch.cluster.name
+          value:
+            stringValue: docker-cluster
         - key: elasticsearch.node.name
           value:
-            stringValue: a3fd1f595e8a
+            stringValue: 94a9f21181ef
         - key: elasticsearch.node.version
           value:
             stringValue: 7.9.3
@@ -19,44 +686,44 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: request
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                        stringValue: accounting
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: in_flight_requests
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: model_inference
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: accounting
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "275730616"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "100044384"
                   attributes:
                     - key: name
                       value:
                         stringValue: parent
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.breaker.memory.estimated
             unit: By
           - description: Memory limit for the circuit breaker.
@@ -64,48 +731,48 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "322122547"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: request
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "214748364"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: fielddata
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "536870912"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: in_flight_requests
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "268435456"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: model_inference
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
                 - asInt: "536870912"
                   attributes:
                     - key: name
                       value:
                         stringValue: accounting
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "214748364"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: fielddata
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "536870912"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: in_flight_requests
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "268435456"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: model_inference
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "510027366"
                   attributes:
                     - key: name
                       value:
                         stringValue: parent
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "322122547"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Total number of times the circuit breaker has been triggered and prevented an out of memory error.
             name: elasticsearch.breaker.tripped
@@ -116,44 +783,44 @@ resourceMetrics:
                   attributes:
                     - key: name
                       value:
-                        stringValue: request
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                        stringValue: accounting
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: in_flight_requests
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: model_inference
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: accounting
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: parent
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: request
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Number of differences between published cluster states.
@@ -166,15 +833,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: compatible
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: incompatible
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: "1"
           - description: Number of published cluster states.
             name: elasticsearch.cluster.published_states.full
@@ -182,8 +849,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "2"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: "1"
           - description: Number of cluster states in queue.
             name: elasticsearch.cluster.state_queue
@@ -195,15 +862,15 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: committed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: pending
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: "1"
           - description: Cumulative number of indexing requests rejected in the primary stage.
             name: elasticsearch.indexing_pressure.memory.total.primary_rejections
@@ -211,8 +878,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Number of indexing requests rejected in the replica stage.
@@ -221,8 +888,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Memory consumed, in bytes, by indexing requests in the specified stage.
@@ -234,23 +901,23 @@ resourceMetrics:
                   attributes:
                     - key: stage
                       value:
-                        stringValue: primary
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                        stringValue: coordinating
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: stage
                       value:
-                        stringValue: coordinating
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                        stringValue: primary
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: stage
                       value:
                         stringValue: replica
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Total count of query cache misses across all shards assigned to selected nodes.
             name: elasticsearch.node.cache.count
@@ -262,15 +929,15 @@ resourceMetrics:
                     - key: type
                       value:
                         stringValue: hit
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: type
                       value:
                         stringValue: miss
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{count}'
           - description: The number of evictions from the cache on a node.
             name: elasticsearch.node.cache.evictions
@@ -282,15 +949,15 @@ resourceMetrics:
                     - key: cache_name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: cache_name
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{evictions}'
           - description: The size in bytes of the cache on a node.
@@ -303,15 +970,15 @@ resourceMetrics:
                     - key: cache_name
                       value:
                         stringValue: fielddata
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: cache_name
                       value:
                         stringValue: query
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The number of open tcp connections for internal cluster communication.
             name: elasticsearch.node.cluster.connections
@@ -319,8 +986,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{connections}'
           - description: The number of bytes sent and received on the network for internal cluster communication.
             name: elasticsearch.node.cluster.io
@@ -332,15 +999,15 @@ resourceMetrics:
                     - key: direction
                       value:
                         stringValue: received
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
                       value:
                         stringValue: sent
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: By
           - description: The total number of kilobytes read across all file stores for this node.
@@ -349,8 +1016,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The total number of kilobytes written across all file stores for this node.
             name: elasticsearch.node.disk.io.write
@@ -358,8 +1025,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: KiBy
           - description: The number of documents on the node.
             name: elasticsearch.node.documents
@@ -371,42 +1038,42 @@ resourceMetrics:
                     - key: state
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: state
                       value:
                         stringValue: deleted
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: The amount of disk space available to the JVM across all file stores for this node. Depending on OS or process level restrictions, this might appear less than free. This is the actual amount of free disk space the Elasticsearch node can utilise.
             name: elasticsearch.node.fs.disk.available
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "176129617920"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "25607843840"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The amount of unallocated disk space across all file stores for this node.
             name: elasticsearch.node.fs.disk.free
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "187742662656"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "28824559616"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The amount of disk space across all file stores for this node.
             name: elasticsearch.node.fs.disk.total
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "228220321792"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "62671097856"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The number of HTTP connections to the node.
             name: elasticsearch.node.http.connections
@@ -414,8 +1081,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{connections}'
           - description: Total number of documents ingested during the lifetime of this node.
             name: elasticsearch.node.ingest.documents
@@ -423,8 +1090,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{documents}'
           - description: Total number of documents currently being ingested.
@@ -433,8 +1100,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: Total number of failed ingest operations during the lifetime of this node.
             name: elasticsearch.node.ingest.operations.failed
@@ -442,8 +1109,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operation}'
           - description: The number of open file descriptors held by the node.
@@ -451,9 +1118,9 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "262"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "286"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{files}'
           - description: The number of operations completed by a node.
             name: elasticsearch.node.operations.completed
@@ -464,79 +1131,79 @@ resourceMetrics:
                   attributes:
                     - key: operation
                       value:
-                        stringValue: index
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
                         stringValue: delete
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: fetch
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: flush
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: warmer
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
           - description: Time spent on operations by a node.
@@ -548,79 +1215,79 @@ resourceMetrics:
                   attributes:
                     - key: operation
                       value:
-                        stringValue: index
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
                         stringValue: delete
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: fetch
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: flush
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: index
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: query
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: scroll
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: operation
+                      value:
+                        stringValue: suggest
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: operation
                       value:
                         stringValue: warmer
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
           - description: Total number of documents currently being ingested by a pipeline.
@@ -633,15 +1300,15 @@ resourceMetrics:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_6
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_7
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: Number of documents preprocessed by the ingest pipeline.
             name: elasticsearch.node.pipeline.ingest.documents.preprocessed
@@ -653,15 +1320,15 @@ resourceMetrics:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_6
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_7
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{documents}'
           - description: Total number of failed operations for the ingest pipeline.
             name: elasticsearch.node.pipeline.ingest.operations.failed
@@ -673,15 +1340,15 @@ resourceMetrics:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_6
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: xpack_monitoring_7
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operation}'
           - description: Total number of times the script cache has evicted old data.
@@ -690,8 +1357,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Total number of times the script compilation circuit breaker has limited inline script compilations.
@@ -700,8 +1367,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: Total number of inline script compilations performed by the node.
@@ -710,8 +1377,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "1"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{compilations}'
           - description: A prediction of how much larger the shard stores on this node will eventually grow due to ongoing peer recoveries, restoring snapshots, and similar activities. A value of -1 indicates that this is not available.
             name: elasticsearch.node.shards.reserved.size
@@ -719,8 +1386,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The size of the shards assigned to this node.
             name: elasticsearch.node.shards.size
@@ -728,8 +1395,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: The number of tasks finished by the thread pool.
             name: elasticsearch.node.thread_pool.tasks.finished
@@ -738,484 +1405,484 @@ resourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: analyze
                     - key: state
                       value:
                         stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ccr
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "216"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "4"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
                     - key: thread_pool_name
                       value:
                         stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
                         stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_job_comms
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "7"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: transform_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: completed
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ccr
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
                     - key: thread_pool_name
                       value:
                         stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
                         stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: ml_datafeed
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
                     - key: state
                       value:
                         stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "11"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ccr
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ccr
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "222"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
-                    - key: state
-                      value:
-                        stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: ml_job_comms
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_job_comms
                     - key: state
                       value:
                         stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
                     - key: thread_pool_name
                       value:
                         stringValue: search
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search
                     - key: state
                       value:
                         stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
                     - key: thread_pool_name
                       value:
                         stringValue: snapshot
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot
                     - key: state
                       value:
                         stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: transform_indexing
-                    - key: state
-                      value:
-                        stringValue: completed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: transform_indexing
                     - key: state
                       value:
                         stringValue: rejected
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: rejected
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{tasks}'
           - description: The number of queued tasks in the thread pool.
@@ -1228,169 +1895,169 @@ resourceMetrics:
                     - key: thread_pool_name
                       value:
                         stringValue: analyze
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: ccr
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: generic
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: get
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: ml_job_comms
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: search
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: snapshot
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: transform_indexing
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{tasks}'
           - description: The number of threads in the thread pool.
             name: elasticsearch.node.thread_pool.threads
@@ -1399,484 +2066,484 @@ resourceMetrics:
               dataPoints:
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: active
                     - key: thread_pool_name
                       value:
                         stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
                         stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ccr
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: generic
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: get
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_job_comms
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: snapshot
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: transform_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: active
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
                     - key: thread_pool_name
                       value:
                         stringValue: analyze
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: management
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_datafeed
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: refresh
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: write
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_store
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: flush
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: force_merge
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "1"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_utility
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-token-key
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: fetch_shard_started
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: listener
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: rollup_indexing
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search_throttled
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: security-crypto
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: warmer
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: watcher
-                    - key: state
-                      value:
-                        stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: ccr
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ccr
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_started
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: fetch_shard_store
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: flush
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: force_merge
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "7"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
                     - key: thread_pool_name
                       value:
                         stringValue: generic
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "9"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: generic
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: get
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: get
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: listener
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: management
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_datafeed
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
                     - key: thread_pool_name
                       value:
                         stringValue: ml_job_comms
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: ml_job_comms
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: ml_utility
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: refresh
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: rollup_indexing
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
                     - key: thread_pool_name
                       value:
                         stringValue: search
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: search
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: search_throttled
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-crypto
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: security-token-key
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
                     - key: thread_pool_name
                       value:
                         stringValue: snapshot
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: snapshot
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
                     - key: thread_pool_name
                       value:
                         stringValue: transform_indexing
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
-                    - key: thread_pool_name
-                      value:
-                        stringValue: transform_indexing
                     - key: state
                       value:
                         stringValue: idle
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                    - key: thread_pool_name
+                      value:
+                        stringValue: warmer
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: watcher
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: idle
+                    - key: thread_pool_name
+                      value:
+                        stringValue: write
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: '{threads}'
           - description: Number of transaction log operations.
             name: elasticsearch.node.translog.operations
@@ -1884,8 +2551,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: '{operations}'
           - description: Size of the transaction log.
@@ -1894,8 +2561,8 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Size of uncommitted transaction log operations.
             name: elasticsearch.node.translog.uncommitted.size
@@ -1903,66 +2570,66 @@ resourceMetrics:
               aggregationTemporality: 2
               dataPoints:
                 - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             unit: By
           - description: Fifteen-minute load average on the system (field is not present if fifteen-minute load average is not available).
             gauge:
               dataPoints:
-                - asDouble: 0.96
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asDouble: 0.22
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.load_avg.15m
             unit: "1"
           - description: One-minute load average on the system (field is not present if one-minute load average is not available).
             gauge:
               dataPoints:
-                - asDouble: 6.13
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asDouble: 1.71
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.load_avg.1m
             unit: "1"
           - description: Five-minute load average on the system (field is not present if five-minute load average is not available).
             gauge:
               dataPoints:
-                - asDouble: 1.98
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asDouble: 0.6
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.load_avg.5m
             unit: "1"
           - description: Recent CPU usage for the whole system, or -1 if not supported.
             gauge:
               dataPoints:
-                - asInt: "55"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "12"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.cpu.usage
             unit: '%'
           - description: Amount of physical memory.
             gauge:
               dataPoints:
-                - asInt: "10171203584"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "276176896"
+                - asInt: "5924163584"
                   attributes:
                     - key: state
                       value:
                         stringValue: free
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2294996992"
+                  attributes:
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: elasticsearch.os.memory
             unit: By
           - description: The number of loaded classes
             gauge:
               dataPoints:
-                - asInt: "19069"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "19088"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.classes.loaded
             unit: "1"
           - description: The total number of garbage collections that have occurred
@@ -1970,20 +2637,20 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "11"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "13"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: "1"
           - description: The approximate accumulated collection elapsed time
@@ -1991,731 +2658,122 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "586"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
                 - asInt: "0"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "135"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
               isMonotonic: true
             unit: ms
           - description: The amount of memory that is guaranteed to be available for the heap
             gauge:
               dataPoints:
                 - asInt: "536870912"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.heap.committed
             unit: By
           - description: The maximum amount of memory can be used for the heap
             gauge:
               dataPoints:
                 - asInt: "536870912"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.heap.max
             unit: By
           - description: The current heap memory usage
             gauge:
               dataPoints:
-                - asInt: "275730616"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "100044384"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.heap.used
             unit: By
           - description: The amount of memory that is guaranteed to be available for non-heap purposes
             gauge:
               dataPoints:
-                - asInt: "125550592"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "130859008"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.nonheap.committed
             unit: By
           - description: The current non-heap memory usage
             gauge:
               dataPoints:
-                - asInt: "119346480"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "122883152"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.nonheap.used
             unit: By
           - description: The maximum amount of memory can be used for the memory pool
             gauge:
               dataPoints:
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: survivor
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
                 - asInt: "536870912"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: survivor
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.pool.max
             unit: By
           - description: The current memory pool memory usage
             gauge:
               dataPoints:
-                - asInt: "196083712"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: young
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "22865592"
-                  attributes:
-                    - key: name
-                      value:
-                        stringValue: survivor
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "56781312"
+                - asInt: "66904064"
                   attributes:
                     - key: name
                       value:
                         stringValue: old
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "15314528"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: survivor
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17825792"
+                  attributes:
+                    - key: name
+                      value:
+                        stringValue: young
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.memory.pool.used
             unit: By
           - description: The current number of threads
             gauge:
               dataPoints:
-                - asInt: "38"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
+                - asInt: "34"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
             name: jvm.threads.count
             unit: "1"
-        scope:
-          name: otelcol/elasticsearchreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: elasticsearch.cluster.name
-          value:
-            stringValue: docker-cluster
-    scopeMetrics:
-      - metrics:
-          - description: The number of data nodes in the cluster.
-            name: elasticsearch.cluster.data_nodes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-            unit: '{nodes}'
-          - description: The health status of the cluster.
-            name: elasticsearch.cluster.health
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: green
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: yellow
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-                - asInt: "0"
-                  attributes:
-                    - key: status
-                      value:
-                        stringValue: red
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-            unit: '{status}'
-          - description: The number of unfinished fetches.
-            name: elasticsearch.cluster.in_flight_fetch
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-            unit: '{fetches}'
-          - description: The total number of nodes in the cluster.
-            name: elasticsearch.cluster.nodes
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "1"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-            unit: '{nodes}'
-          - description: The number of cluster-level changes that have not yet been executed.
-            name: elasticsearch.cluster.pending_tasks
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "0"
-                  startTimeUnixNano: "1663084088275038000"
-                  timeUnixNano: "1663084098275677000"
-            unit: '{tasks}'
-          - description: The number of shards in the cluster.
-            name: elasticsearch.cluster.shards
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "45"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: initializing
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: relocating
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unassigned
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "23"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: active_primary
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: state
-                      value:
-                        stringValue: unassigned_delayed
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-            unit: '{shards}'
-          - description: The current heap memory usage
-            gauge:
-              dataPoints:
-                - asInt: "285158912"
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-            name: jvm.memory.heap.used
-            unit: By
-        scope:
-          name: otelcol/elasticsearchreceiver
-          version: latest
-  - resource:
-      attributes:
-        - key: elasticsearch.index.name
-          value:
-            stringValue: _all
-        - key: elasticsearch.cluster.name
-          value:
-            stringValue: docker-cluster
-    scopeMetrics:
-      - metrics:
-          - description: The number of operations completed for an index.
-            name: elasticsearch.index.operations.completed
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "13"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "5"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "6"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "43"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "40"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "13"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "5"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "8"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "10"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "6"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-              isMonotonic: true
-            unit: '{operations}'
-          - description: Time spent on operations for an index.
-            name: elasticsearch.index.operations.time
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "82"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "52"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "30"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "82"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: fetch
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "52"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: query
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "12"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: merge
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "938"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: index
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "2"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: delete
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "3"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: get
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "30"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: scroll
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "1"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: suggest
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "169"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: refresh
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "192"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: flush
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-                - asInt: "4"
-                  attributes:
-                    - key: operation
-                      value:
-                        stringValue: warmer
-                    - key: aggregation
-                      value:
-                        stringValue: primary_shards
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-              isMonotonic: true
-            unit: ms
-          - description: The size of the shards assigned to this index.
-            name: elasticsearch.index.shards.size
-            sum:
-              aggregationTemporality: 2
-              dataPoints:
-                - asInt: "40230884"
-                  attributes:
-                    - key: aggregation
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "1661811689941624000"
-                  timeUnixNano: "1661811689943245000"
-            unit: By
         scope:
           name: otelcol/elasticsearchreceiver
           version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
This enables the following metrics by default:

```
elasticsearch.index.documents
elasticsearch.index.operations.merge.current
elasticsearch.index.segments.count
```

**Link to tracking Issue:** <Issue number if applicable>
Resolves #34396

**Testing:** <Describe what testing was performed and which tests were added.>
Tests have been updated to account for these metrics being enabled by default. One thing to note, some tests were manually enabling these metrics. This is no longer necessary, but I've left as-is since it doesn't do any harm, and can be helpful to ensure tests act the way we want. I can update though if reviewers prefer.

Testing side note: For some reason, when running integration tests locally, I had to add a `time.Sleep` call before scraping when the docker container was being spun up. Some metrics and resource attributes weren't populated fully without the delay, and caused a mismatch with the GitHub CI's results that are generated without the sleep call.