### PR TITLE
Use "${DOCKER_HOST}" when available instead of a hard-coded "/var/run" path for the Docker UNIX socket

### DIFF
--- a/receiver/dockerstatsreceiver/config.go
+++ b/receiver/dockerstatsreceiver/config.go
@@ -19,7 +19,9 @@ var _ component.Config = (*Config)(nil)
 
 type Config struct {
 	scraperhelper.ControllerConfig `mapstructure:",squash"`
-	// The URL of the docker server.  Default is "unix:///var/run/docker.sock"
+	// The URL of the docker server.  Default is derived from
+	// the environment variable ${DOCKER_HOST}, with a fallback
+	// to "unix:///var/run/docker.sock" if no ${DOCKER_HOST}.
 	Endpoint string `mapstructure:"endpoint"`
 
 	// A mapping of container label names to MetricDescriptor label keys.

--- a/receiver/dockerstatsreceiver/factory.go
+++ b/receiver/dockerstatsreceiver/factory.go
@@ -5,6 +5,7 @@ package dockerstatsreceiver // import "github.com/open-telemetry/opentelemetry-c
 
 import (
 	"context"
+	"os"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -22,13 +23,21 @@ func NewFactory() receiver.Factory {
 		receiver.WithMetrics(createMetricsReceiver, metadata.MetricsStability))
 }
 
+func defaultDockerEndpoint() string {
+	endpoint := os.Getenv("DOCKER_HOST")
+	if endpoint != "" {
+		return endpoint
+	}
+	return "unix:///var/run/docker.sock"
+}
+
 func createDefaultConfig() component.Config {
 	scs := scraperhelper.NewDefaultControllerConfig()
 	scs.CollectionInterval = 10 * time.Second
 	scs.Timeout = 5 * time.Second
 	return &Config{
 		ControllerConfig:     scs,
-		Endpoint:             "unix:///var/run/docker.sock",
+		Endpoint:             defaultDockerEndpoint(),
 		DockerAPIVersion:     defaultDockerAPIVersion,
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}


### PR DESCRIPTION
**Description:**

It is most common to run the Docker daemon as root, in which case the UNIX socket is indeed in `/var/run`;  _however_,  there are situations in which it may  not be possible to run Docker as root. In those cases, the environment variable `${DOCKER_HOST}` is used to indicate the location of the Docker unix socket. This fix aims to allow the use of the build system in environments where Docker is being run in an alternative deployment/location.

**Testing:**

Ran standard build and test with `make` in a context in which `/var/run/docker.sock` does not exist but in which `${DOCKER_HOST}` was correctly defined; verified that unit tests pass.

**Documentation:**

Updated comments in the affected files. Uncertain if additional documentation changes are required.
