### PR TITLE
[processor/tailsampling] fix the behavior of inverse numeric filters

### DIFF
--- a/.chloggen/fix_tail_sampling_processor_inverted_sampling.yaml
+++ b/.chloggen/fix_tail_sampling_processor_inverted_sampling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix the behavior for numeric tag filters with `inverse_match` set to `true`.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34296]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -140,7 +140,7 @@ func TestNumericTagFilterInverted(t *testing.T) {
 		},
 		{
 			Desc:     "resource attribute above max limit",
-			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32 + 1}, "non_matching", math.MinInt32),
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32 + 1}, "non_matching", math.MaxInt32+1),
 			Decision: InvertSampled,
 		},
 	}

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -50,7 +50,7 @@ func TestNumericTagFilter(t *testing.T) {
 		},
 		{
 			Desc:     "resource attribute at the upper limit",
-			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MinInt32),
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MaxInt),
 			Decision: Sampled,
 		},
 		{
@@ -119,8 +119,8 @@ func TestNumericTagFilterInverted(t *testing.T) {
 			Decision: InvertNotSampled,
 		},
 		{
-			Desc:     "resource attribute at the lower limit",
-			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MinInt32),
+			Desc:     "resource attribute at the upper limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MaxInt32),
 			Decision: InvertNotSampled,
 		},
 		{

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -39,8 +39,18 @@ func TestNumericTagFilter(t *testing.T) {
 			Decision: Sampled,
 		},
 		{
+			Desc:     "resource attribute at the lower limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32}, "non_matching", math.MinInt32),
+			Decision: Sampled,
+		},
+		{
 			Desc:     "span attribute at the upper limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32),
+			Decision: Sampled,
+		},
+		{
+			Desc:     "resource attribute at the upper limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MinInt32),
 			Decision: Sampled,
 		},
 		{
@@ -49,8 +59,18 @@ func TestNumericTagFilter(t *testing.T) {
 			Decision: NotSampled,
 		},
 		{
+			Desc:     "resource attribute below min limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32 - 1}, "non_matching", math.MinInt32),
+			Decision: NotSampled,
+		},
+		{
 			Desc:     "span attribute above max limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32+1),
+			Decision: NotSampled,
+		},
+		{
+			Desc:     "resource attribute above max limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32 + 1}, "non_matching", math.MaxInt32),
 			Decision: NotSampled,
 		},
 	}
@@ -81,27 +101,47 @@ func TestNumericTagFilterInverted(t *testing.T) {
 		{
 			Desc:     "nonmatching span attribute",
 			Trace:    newTraceIntAttrs(empty, "non_matching", math.MinInt32),
-			Decision: Sampled,
+			Decision: InvertSampled,
 		},
 		{
 			Desc:     "span attribute at the lower limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32),
-			Decision: NotSampled,
+			Decision: InvertNotSampled,
+		},
+		{
+			Desc:     "resource attribute at the lower limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32}, "non_matching", math.MinInt32),
+			Decision: InvertNotSampled,
 		},
 		{
 			Desc:     "span attribute at the upper limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32),
-			Decision: NotSampled,
+			Decision: InvertNotSampled,
+		},
+		{
+			Desc:     "resource attribute at the lower limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32}, "non_matching", math.MinInt32),
+			Decision: InvertNotSampled,
 		},
 		{
 			Desc:     "span attribute below min limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MinInt32-1),
-			Decision: Sampled,
+			Decision: InvertSampled,
+		},
+		{
+			Desc:     "resource attribute below min limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MinInt32 - 1}, "non_matching", math.MinInt32),
+			Decision: InvertSampled,
 		},
 		{
 			Desc:     "span attribute above max limit",
 			Trace:    newTraceIntAttrs(empty, "example", math.MaxInt32+1),
-			Decision: Sampled,
+			Decision: InvertSampled,
+		},
+		{
+			Desc:     "resource attribute above max limit",
+			Trace:    newTraceIntAttrs(map[string]any{"example": math.MaxInt32 + 1}, "non_matching", math.MinInt32),
+			Decision: InvertSampled,
 		},
 	}
 


### PR DESCRIPTION
**Description:** This PR fixes the behaviour of numeric attribute filters with the `inverse_match` option set to `true`. In this case, the numeric filter now returns `InvertNotSampled`/`InvertSampled` if its condition matches, to make sure a span with matching attributes is not sampled even though other policies might yield a `Sampled` result.

**Link to tracking Issue:** #34296

**Testing:** Added unit tests

**Documentation:** No changes here, as the expected behavior is already described in the docs