### PR TITLE
[exporter/prometheusremotewrite] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-5.yaml
+++ b/.chloggen/codeboten_update-scope-5.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the prometheusremotewriteexporter from otelcol/prometheusremotewrite to github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-5.yaml
+++ b/.chloggen/codeboten_update-scope-5.yaml
@@ -10,7 +10,7 @@ component: prometheusremotewriteexporter
 note: Update the scope name for telemetry produced by the prometheusremotewriteexporter from otelcol/prometheusremotewrite to github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34440]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/prometheusremotewrite")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/prometheusremotewrite")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry_test.go
+++ b/exporter/prometheusremotewriteexporter/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/prometheusremotewrite", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/prometheusremotewrite", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -1,5 +1,4 @@
 type: prometheusremotewrite
-scope_name: otelcol/prometheusremotewrite
 
 status:
   class: exporter


### PR DESCRIPTION
Update the scope name for telemetry produced by the prometheusremotewriteexporter from `otelcol/prometheusremotewrite` to `github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter`

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
