### PR TITLE
[chore] removing unused configuration

### DIFF
--- a/extension/ackextension/metadata.yaml
+++ b/extension/ackextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: ack
-scope_name: otelcol/ack
 
 status:
   class: extension

--- a/extension/asapauthextension/metadata.yaml
+++ b/extension/asapauthextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: asapclient
-scope_name: otelcol/asapauth
 
 status:
   class: extension

--- a/extension/awsproxy/metadata.yaml
+++ b/extension/awsproxy/metadata.yaml
@@ -1,5 +1,4 @@
 type: awsproxy
-scope_name: otelcol/awsproxy
 
 status:
   class: extension

--- a/extension/basicauthextension/metadata.yaml
+++ b/extension/basicauthextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: basicauth
-scope_name: otelcol/basicauth
 
 status:
   class: extension

--- a/extension/bearertokenauthextension/metadata.yaml
+++ b/extension/bearertokenauthextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: bearertokenauth
-scope_name: otelcol/bearertokenauth
 
 status:
   class: extension

--- a/extension/encoding/avrologencodingextension/metadata.yaml
+++ b/extension/encoding/avrologencodingextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: avro_log_encoding
-scope_name: otelcol/avrologencoding
 
 status:
   class: extension

--- a/extension/encoding/jaegerencodingextension/metadata.yaml
+++ b/extension/encoding/jaegerencodingextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: jaeger_encoding
-scope_name: otelcol/jaegerencoding
 
 status:
   class: extension

--- a/extension/encoding/jsonlogencodingextension/metadata.yaml
+++ b/extension/encoding/jsonlogencodingextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: json_log_encoding
-scope_name: otelcol/jsonlogencoding
 
 status:
   class: extension

--- a/extension/encoding/otlpencodingextension/metadata.yaml
+++ b/extension/encoding/otlpencodingextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: otlp_encoding
-scope_name: otelcol/otlpencoding
 
 status:
   class: extension

--- a/extension/encoding/textencodingextension/metadata.yaml
+++ b/extension/encoding/textencodingextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: text_encoding
-scope_name: otelcol/textencoding
 
 status:
   class: extension

--- a/extension/encoding/zipkinencodingextension/metadata.yaml
+++ b/extension/encoding/zipkinencodingextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: zipkin_encoding
-scope_name: otelcol/zipkinencoding
 
 status:
   class: extension

--- a/extension/headerssetterextension/metadata.yaml
+++ b/extension/headerssetterextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: headers_setter
-scope_name: otelcol/headerssetter
 
 status:
   class: extension

--- a/extension/healthcheckextension/metadata.yaml
+++ b/extension/healthcheckextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: health_check
-scope_name: otelcol/healthcheck
 
 status:
   class: extension

--- a/extension/httpforwarderextension/metadata.yaml
+++ b/extension/httpforwarderextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: http_forwarder
-scope_name: otelcol/httpforwarder
 
 status:
   class: extension

--- a/extension/jaegerremotesampling/metadata.yaml
+++ b/extension/jaegerremotesampling/metadata.yaml
@@ -1,5 +1,4 @@
 type: jaegerremotesampling
-scope_name: otelcol/jaegerremotesampling
 
 status:
   class: extension

--- a/extension/oauth2clientauthextension/metadata.yaml
+++ b/extension/oauth2clientauthextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: oauth2client
-scope_name: otelcol/oauth2clientauth
 
 status:
   class: extension

--- a/extension/observer/cfgardenobserver/metadata.yaml
+++ b/extension/observer/cfgardenobserver/metadata.yaml
@@ -1,5 +1,4 @@
 type: cfgarden_observer
-scope_name: otelcol/cfgardenobserver
 
 status:
   class: extension

--- a/extension/observer/dockerobserver/metadata.yaml
+++ b/extension/observer/dockerobserver/metadata.yaml
@@ -1,5 +1,4 @@
 type: docker_observer
-scope_name: otelcol/dockerobserver
 
 status:
   class: extension

--- a/extension/observer/ecsobserver/metadata.yaml
+++ b/extension/observer/ecsobserver/metadata.yaml
@@ -1,5 +1,4 @@
 type: ecs_observer
-scope_name: otelcol/ecsobserver
 
 status:
   class: extension

--- a/extension/observer/ecstaskobserver/metadata.yaml
+++ b/extension/observer/ecstaskobserver/metadata.yaml
@@ -1,5 +1,4 @@
 type: ecs_task_observer
-scope_name: otelcol/ecstaskobserver
 
 status:
   class: extension

--- a/extension/observer/hostobserver/metadata.yaml
+++ b/extension/observer/hostobserver/metadata.yaml
@@ -1,5 +1,4 @@
 type: host_observer
-scope_name: otelcol/hostobserver
 
 status:
   class: extension

--- a/extension/observer/k8sobserver/metadata.yaml
+++ b/extension/observer/k8sobserver/metadata.yaml
@@ -1,5 +1,4 @@
 type: k8s_observer
-scope_name: otelcol/k8sobserver
 
 status:
   class: extension

--- a/extension/oidcauthextension/metadata.yaml
+++ b/extension/oidcauthextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: oidc
-scope_name: otelcol/oidcauth
 
 status:
   class: extension

--- a/extension/opampextension/metadata.yaml
+++ b/extension/opampextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: opamp
-scope_name: otelcol/opamp
 
 status:
   class: extension

--- a/extension/pprofextension/metadata.yaml
+++ b/extension/pprofextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: pprof
-scope_name: otelcol/pprof
 
 status:
   class: extension

--- a/extension/remotetapextension/metadata.yaml
+++ b/extension/remotetapextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: remotetap
-scope_name: otelcol/remotetap
 
 status:
   class: extension

--- a/extension/sigv4authextension/metadata.yaml
+++ b/extension/sigv4authextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: sigv4auth
-scope_name: otelcol/sigv4auth
 
 status:
   class: extension

--- a/extension/solarwindsapmsettingsextension/metadata.yaml
+++ b/extension/solarwindsapmsettingsextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: solarwindsapmsettings
-scope_name: otelcol/solarwindsapmsettings
 
 status:
   class: extension

--- a/extension/storage/dbstorage/metadata.yaml
+++ b/extension/storage/dbstorage/metadata.yaml
@@ -1,5 +1,4 @@
 type: db_storage
-scope_name: otelcol/dbstorage
 
 status:
   class: extension

--- a/extension/storage/filestorage/metadata.yaml
+++ b/extension/storage/filestorage/metadata.yaml
@@ -1,5 +1,4 @@
 type: file_storage
-scope_name: otelcol/filestorage
 
 status:
   class: extension

--- a/extension/sumologicextension/metadata.yaml
+++ b/extension/sumologicextension/metadata.yaml
@@ -1,5 +1,4 @@
 type: sumologic
-scope_name: otelcol/sumologic
 
 status:
   class: extension


### PR DESCRIPTION
The scope_name fields in these metadata.yaml files were not being used anywhere, removing them.

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
