### PR TITLE
[chore] remove unused configuration

### DIFF
--- a/receiver/awscloudwatchmetricsreceiver/metadata.yaml
+++ b/receiver/awscloudwatchmetricsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: awscloudwatchmetrics
-scope_name: otelcol/awscloudwatchmetricsreceiver
 
 status:
   class: receiver

--- a/receiver/awscloudwatchreceiver/metadata.yaml
+++ b/receiver/awscloudwatchreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: awscloudwatch
-scope_name: otelcol/awscloudwatchreceiver
 
 status:
   class: receiver

--- a/receiver/awscontainerinsightreceiver/metadata.yaml
+++ b/receiver/awscontainerinsightreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: awscontainerinsightreceiver
-scope_name: otelcol/awscontainerinsightreceiver
 
 status:
   class: receiver

--- a/receiver/awsecscontainermetricsreceiver/metadata.yaml
+++ b/receiver/awsecscontainermetricsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: awsecscontainermetrics
-scope_name: otelcol/awsecscontainermetricsreceiver
 
 status:
   class: receiver

--- a/receiver/awsfirehosereceiver/metadata.yaml
+++ b/receiver/awsfirehosereceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: awsfirehose
-scope_name: otelcol/awsfirehosereceiver
 
 status:
   class: receiver

--- a/receiver/awsxrayreceiver/metadata.yaml
+++ b/receiver/awsxrayreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: awsxray
-scope_name: otelcol/awsxrayreceiver
 
 status:
   class: receiver

--- a/receiver/azureblobreceiver/metadata.yaml
+++ b/receiver/azureblobreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: azureblob
-scope_name: otelcol/azureblobreceiver
 
 status:
   class: receiver

--- a/receiver/azureeventhubreceiver/metadata.yaml
+++ b/receiver/azureeventhubreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: azureeventhub
-scope_name: otelcol/azureeventhubreceiver
 
 status:
   class: receiver

--- a/receiver/azuremonitorreceiver/metadata.yaml
+++ b/receiver/azuremonitorreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: azuremonitor
-scope_name: otelcol/azuremonitorreceiver
 
 status:
   class: receiver

--- a/receiver/carbonreceiver/metadata.yaml
+++ b/receiver/carbonreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: carbon
-scope_name: otelcol/carbonreceiver
 
 status:
   class: receiver

--- a/receiver/cloudflarereceiver/metadata.yaml
+++ b/receiver/cloudflarereceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: cloudflare
-scope_name: otelcol/cloudflarereceiver
 
 status:
   class: receiver

--- a/receiver/cloudfoundryreceiver/metadata.yaml
+++ b/receiver/cloudfoundryreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: cloudfoundry
-scope_name: otelcol/cloudfoundryreceiver
 
 status:
   class: receiver

--- a/receiver/collectdreceiver/metadata.yaml
+++ b/receiver/collectdreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: collectd
-scope_name: otelcol/collectdreceiver
 
 status:
   class: receiver

--- a/receiver/datadogreceiver/metadata.yaml
+++ b/receiver/datadogreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: datadog
-scope_name: otelcol/datadogreceiver
 
 status:
   class: receiver

--- a/receiver/filelogreceiver/metadata.yaml
+++ b/receiver/filelogreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: filelog
-scope_name: otelcol/filelogreceiver
 
 status:
   class: receiver

--- a/receiver/googlecloudpubsubreceiver/metadata.yaml
+++ b/receiver/googlecloudpubsubreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: googlecloudpubsub
-scope_name: otelcol/googlecloudpubsubreceiver
 
 status:
   class: receiver

--- a/receiver/googlecloudspannerreceiver/metadata.yaml
+++ b/receiver/googlecloudspannerreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: googlecloudspanner
-scope_name: otelcol/googlecloudspannerreceiver
 
 status:
   class: receiver

--- a/receiver/hostmetricsreceiver/metadata.yaml
+++ b/receiver/hostmetricsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetrics
-scope_name: otelcol/hostmetricsreceiver
 
 status:
   class: receiver

--- a/receiver/influxdbreceiver/metadata.yaml
+++ b/receiver/influxdbreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: influxdb
-scope_name: otelcol/influxdbreceiver
 
 status:
   class: receiver

--- a/receiver/jaegerreceiver/metadata.yaml
+++ b/receiver/jaegerreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: jaeger
-scope_name: otelcol/jaegerreceiver
 
 status:
   class: receiver

--- a/receiver/jmxreceiver/metadata.yaml
+++ b/receiver/jmxreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: jmx
-scope_name: otelcol/jmxreceiver
 
 status:
   class: receiver

--- a/receiver/journaldreceiver/metadata.yaml
+++ b/receiver/journaldreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: journald
-scope_name: otelcol/journaldreceiver
 
 status:
   class: receiver

--- a/receiver/k8seventsreceiver/metadata.yaml
+++ b/receiver/k8seventsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: k8s_events
-scope_name: otelcol/k8seventsreceiver
 
 status:
   class: receiver

--- a/receiver/k8sobjectsreceiver/metadata.yaml
+++ b/receiver/k8sobjectsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: k8sobjects
-scope_name: otelcol/k8sobjectsreceiver
 
 status:
   class: receiver

--- a/receiver/lokireceiver/metadata.yaml
+++ b/receiver/lokireceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: loki
-scope_name: otelcol/lokireceiver
 
 status:
   class: receiver

--- a/receiver/namedpipereceiver/metadata.yaml
+++ b/receiver/namedpipereceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: namedpipe
-scope_name: otelcol/namedpipereceiver
 
 status:
   class: receiver

--- a/receiver/opencensusreceiver/metadata.yaml
+++ b/receiver/opencensusreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: opencensus
-scope_name: otelcol/opencensusreceiver
 
 status:
   class: receiver

--- a/receiver/osqueryreceiver/metadata.yaml
+++ b/receiver/osqueryreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: osquery
-scope_name: otelcol/osqueryreceiver
 
 status:
   class: receiver

--- a/receiver/otlpjsonfilereceiver/metadata.yaml
+++ b/receiver/otlpjsonfilereceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: otlpjsonfile
-scope_name: otelcol/otlpjsonfilereceiver
 
 status:
   class: receiver

--- a/receiver/prometheusreceiver/metadata.yaml
+++ b/receiver/prometheusreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: prometheus
-scope_name: otelcol/prometheusreceiver
 
 status:
   class: receiver

--- a/receiver/pulsarreceiver/metadata.yaml
+++ b/receiver/pulsarreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: pulsar
-scope_name: otelcol/pulsarreceiver
 
 status:
   class: receiver

--- a/receiver/purefareceiver/metadata.yaml
+++ b/receiver/purefareceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: purefa
-scope_name: otelcol/purefareceiver
 
 status:
   class: receiver

--- a/receiver/purefbreceiver/metadata.yaml
+++ b/receiver/purefbreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: purefb
-scope_name: otelcol/purefbreceiver
 
 status:
   class: receiver

--- a/receiver/receivercreator/metadata.yaml
+++ b/receiver/receivercreator/metadata.yaml
@@ -1,5 +1,4 @@
 type: receiver_creator
-scope_name: otelcol/receivercreator
 
 status:
   class: receiver

--- a/receiver/sapmreceiver/metadata.yaml
+++ b/receiver/sapmreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: sapm
-scope_name: otelcol/sapmreceiver
 
 status:
   class: receiver

--- a/receiver/signalfxreceiver/metadata.yaml
+++ b/receiver/signalfxreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: signalfx
-scope_name: otelcol/signalfxreceiver
 
 status:
   class: receiver

--- a/receiver/simpleprometheusreceiver/metadata.yaml
+++ b/receiver/simpleprometheusreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: prometheus_simple
-scope_name: otelcol/simpleprometheusreceiver
 
 status:
   class: receiver

--- a/receiver/skywalkingreceiver/metadata.yaml
+++ b/receiver/skywalkingreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: skywalking
-scope_name: otelcol/skywalkingreceiver
 
 status:
   class: receiver

--- a/receiver/snmpreceiver/metadata.yaml
+++ b/receiver/snmpreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: snmp
-scope_name: otelcol/snmpreceiver
 
 status:
   class: receiver

--- a/receiver/splunkhecreceiver/metadata.yaml
+++ b/receiver/splunkhecreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: splunk_hec
-scope_name: otelcol/splunkhecreceiver
 
 status:
   class: receiver

--- a/receiver/sqlqueryreceiver/metadata.yaml
+++ b/receiver/sqlqueryreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: sqlquery
-scope_name: otelcol/sqlqueryreceiver
 
 status:
   class: receiver

--- a/receiver/syslogreceiver/metadata.yaml
+++ b/receiver/syslogreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: syslog
-scope_name: otelcol/syslogreceiver
 
 status:
   class: receiver

--- a/receiver/tcplogreceiver/metadata.yaml
+++ b/receiver/tcplogreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: tcplog
-scope_name: otelcol/tcplogreceiver
 
 status:
   class: receiver

--- a/receiver/udplogreceiver/metadata.yaml
+++ b/receiver/udplogreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: udplog
-scope_name: otelcol/udplogreceiver
 
 status:
   class: receiver

--- a/receiver/wavefrontreceiver/metadata.yaml
+++ b/receiver/wavefrontreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: wavefront
-scope_name: otelcol/wavefrontreceiver
 
 status:
   class: receiver

--- a/receiver/webhookeventreceiver/metadata.yaml
+++ b/receiver/webhookeventreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: webhookevent
-scope_name: otelcol/webhookeventreceiver
 
 status:
   class: receiver

--- a/receiver/windowseventlogreceiver/metadata.yaml
+++ b/receiver/windowseventlogreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: windowseventlog
-scope_name: otelcol/windowseventlogreceiver
 
 status:
   class: receiver

--- a/receiver/windowsperfcountersreceiver/metadata.yaml
+++ b/receiver/windowsperfcountersreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: windowsperfcounters
-scope_name: otelcol/windowsperfcountersreceiver
 
 status:
   class: receiver

--- a/receiver/zipkinreceiver/metadata.yaml
+++ b/receiver/zipkinreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: zipkin
-scope_name: otelcol/zipkinreceiver
 
 status:
   class: receiver


### PR DESCRIPTION
The scope_name fields in these metadata.yaml files were not being used anywhere, removing them.

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494

Same as https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34441 but for receivers
