### PR TITLE
[receiver/sshcheck] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-receivers-sshcheckreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-receivers-sshcheckreceiver.yaml
@@ -10,7 +10,7 @@ component: sshcheckreceiver
 note: Update the scope name for telemetry produced by the sshcheckreceiver from otelcol/sshcheckreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34448]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-receivers-sshcheckreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-receivers-sshcheckreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sshcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the sshcheckreceiver from otelcol/sshcheckreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sshcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sshcheckreceiver/internal/metadata/generated_metrics.go
@@ -425,7 +425,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/sshcheckreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSshcheckDuration.emit(ils.Metrics())

--- a/receiver/sshcheckreceiver/metadata.yaml
+++ b/receiver/sshcheckreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: sshcheck
-scope_name: otelcol/sshcheckreceiver
 
 status:
   class: receiver

--- a/receiver/sshcheckreceiver/testdata/expected_metrics/cannot_authenticate.yaml
+++ b/receiver/sshcheckreceiver/testdata/expected_metrics/cannot_authenticate.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/sshcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
           version: latest

--- a/receiver/sshcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
+++ b/receiver/sshcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/sshcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
           version: latest

--- a/receiver/sshcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/sshcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/sshcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
           version: latest

--- a/receiver/sshcheckreceiver/testdata/expected_metrics/metrics_golden_sftp.yaml
+++ b/receiver/sshcheckreceiver/testdata/expected_metrics/metrics_golden_sftp.yaml
@@ -37,5 +37,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/sshcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the sshcheckreceiver from otelcol/sshcheckreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sshcheckreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
