### PR TITLE
[receiver/vcenter] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-receivers-vcenter.yaml
+++ b/.chloggen/codeboten_update-scope-receivers-vcenter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the vcenterreceiver from otelcol/vcenter to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-receivers-vcenter.yaml
+++ b/.chloggen/codeboten_update-scope-receivers-vcenter.yaml
@@ -10,7 +10,7 @@ component: vcenterreceiver
 note: Update the scope name for telemetry produced by the vcenterreceiver from otelcol/vcenter to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34449]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/vcenterreceiver/internal/metadata/generated_metrics.go
@@ -4067,7 +4067,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/vcenterreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricVcenterClusterCPUEffective.emit(ils.Metrics())

--- a/receiver/vcenterreceiver/metadata.yaml
+++ b/receiver/vcenterreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: vcenter
-scope_name: otelcol/vcenterreceiver
 
 status:
   class: receiver

--- a/receiver/vcenterreceiver/testdata/integration/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/integration/expected.yaml
@@ -120,7 +120,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{virtual_machines}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -225,7 +225,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{virtual_machine_templates}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -266,7 +266,7 @@ resourceMetrics:
             name: vcenter.datastore.disk.utilization
             unit: '%'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -322,7 +322,7 @@ resourceMetrics:
             name: vcenter.host.memory.utilization
             unit: '%'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -381,7 +381,7 @@ resourceMetrics:
             name: vcenter.host.memory.utilization
             unit: '%'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -440,7 +440,7 @@ resourceMetrics:
             name: vcenter.host.memory.utilization
             unit: '%'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -499,7 +499,7 @@ resourceMetrics:
             name: vcenter.host.memory.utilization
             unit: '%'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -536,7 +536,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{shares}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -573,7 +573,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{shares}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -662,7 +662,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -751,7 +751,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -843,7 +843,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -935,5 +935,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -130,7 +130,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{virtual_machines}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -345,7 +345,7 @@ resourceMetrics:
             name: vcenter.cluster.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -386,7 +386,7 @@ resourceMetrics:
             name: vcenter.datastore.disk.utilization
             unit: '%'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -3142,7 +3142,7 @@ resourceMetrics:
             name: vcenter.host.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -5901,7 +5901,7 @@ resourceMetrics:
             name: vcenter.host.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -6012,7 +6012,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -6123,7 +6123,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -6165,7 +6165,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -6799,7 +6799,7 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: '{KiBy/s}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -7535,7 +7535,7 @@ resourceMetrics:
             name: vcenter.vm.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -8271,5 +8271,5 @@ resourceMetrics:
             name: vcenter.vm.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -130,7 +130,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{virtual_machines}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -345,7 +345,7 @@ resourceMetrics:
             name: vcenter.cluster.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -386,7 +386,7 @@ resourceMetrics:
             name: vcenter.datastore.disk.utilization
             unit: '%'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -3142,7 +3142,7 @@ resourceMetrics:
             name: vcenter.host.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -5901,7 +5901,7 @@ resourceMetrics:
             name: vcenter.host.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -5993,7 +5993,7 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -6085,7 +6085,7 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: MiBy
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -6127,7 +6127,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -6761,7 +6761,7 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: '{KiBy/s}'
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -7497,7 +7497,7 @@ resourceMetrics:
             name: vcenter.vm.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest
   - resource:
       attributes:
@@ -8233,5 +8233,5 @@ resourceMetrics:
             name: vcenter.vm.vsan.throughput
             unit: By/s
         scope:
-          name: otelcol/vcenterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the vcenterreceiver from otelcol/vcenter to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/vcenterreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
