### PR TITLE
[receiver/zookeeper] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-receivers-zookeeper.yaml
+++ b/.chloggen/codeboten_update-scope-receivers-zookeeper.yaml
@@ -10,7 +10,7 @@ component: zookeeperreceiver
 note: Update the scope name for telemetry produced by the zookeeperreceiver from otelcol/zookeeper to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34450]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-receivers-zookeeper.yaml
+++ b/.chloggen/codeboten_update-scope-receivers-zookeeper.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: zookeeperreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the zookeeperreceiver from otelcol/zookeeper to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/zookeeperreceiver/internal/metadata/generated_metrics.go
@@ -1007,7 +1007,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/zookeeperreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricZookeeperConnectionActive.emit(ils.Metrics())

--- a/receiver/zookeeperreceiver/metadata.yaml
+++ b/receiver/zookeeperreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: zookeeper
-scope_name: otelcol/zookeeperreceiver
 
 status:
   class: receiver

--- a/receiver/zookeeperreceiver/testdata/integration/expected-3.4.13.yaml
+++ b/receiver/zookeeperreceiver/testdata/integration/expected-3.4.13.yaml
@@ -144,5 +144,5 @@ resourceMetrics:
                   timeUnixNano: "1684779363308697000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/integration/expected-3.5.10-standalone.yaml
+++ b/receiver/zookeeperreceiver/testdata/integration/expected-3.5.10-standalone.yaml
@@ -134,5 +134,5 @@ resourceMetrics:
                   timeUnixNano: "1684780475969536000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/integration/expected-3.5.10.yaml
+++ b/receiver/zookeeperreceiver/testdata/integration/expected-3.5.10.yaml
@@ -163,5 +163,5 @@ resourceMetrics:
                   timeUnixNano: "1684779392577522000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.4.14.yaml
@@ -144,5 +144,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/correctness-v3.5.5.yaml
@@ -163,5 +163,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/scraper/disable-watches.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/disable-watches.yaml
@@ -135,5 +135,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-closing-connection.yaml
@@ -144,5 +144,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/error-setting-connection-deadline.yaml
@@ -144,5 +144,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/scraper/invalid-ruok.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/invalid-ruok.yaml
@@ -136,5 +136,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest

--- a/receiver/zookeeperreceiver/testdata/scraper/null-ruok.yaml
+++ b/receiver/zookeeperreceiver/testdata/scraper/null-ruok.yaml
@@ -144,5 +144,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{znodes}'
         scope:
-          name: otelcol/zookeeperreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the zookeeperreceiver from otelcol/zookeeper to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
