### PR TITLE
[receiver/sqlserver] update scope name for consistency

### DIFF
--- a/.chloggen/update-scope-receivers-sqlserver.yaml
+++ b/.chloggen/update-scope-receivers-sqlserver.yaml
@@ -10,7 +10,7 @@ component: sqlserverreceiver
 note: Update the scope name for telemetry produced by the sqlserverreceiver from otelcol/sqlserverreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34451]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/update-scope-receivers-sqlserver.yaml
+++ b/.chloggen/update-scope-receivers-sqlserver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlserverreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the sqlserverreceiver from otelcol/sqlserverreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/sqlserverreceiver/internal/metadata/generated_metrics.go
@@ -1621,7 +1621,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/sqlserverreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSqlserverBatchRequestRate.emit(ils.Metrics())

--- a/receiver/sqlserverreceiver/metadata.yaml
+++ b/receiver/sqlserverreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: sqlserver
-scope_name: otelcol/sqlserverreceiver
 
 status:
   class: receiver

--- a/receiver/sqlserverreceiver/testdata/expectedDatabaseIO.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedDatabaseIO.yaml
@@ -1471,5 +1471,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{operations}'
         scope:
-          name: otelcol/sqlserverreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
@@ -85,5 +85,5 @@ resourceMetrics:
             name: sqlserver.user.connection.count
             unit: '{connections}'
         scope:
-          name: otelcol/sqlserverreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest

--- a/receiver/sqlserverreceiver/testdata/expectedProperties.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedProperties.yaml
@@ -54,5 +54,5 @@ resourceMetrics:
             name: sqlserver.database.count
             unit: '{databases}'
         scope:
-          name: otelcol/sqlserverreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest

--- a/receiver/sqlserverreceiver/testdata/golden_named_instance_scrape.yaml
+++ b/receiver/sqlserverreceiver/testdata/golden_named_instance_scrape.yaml
@@ -188,5 +188,5 @@ resourceMetrics:
             name: sqlserver.user.connection.count
             unit: '{connections}'
         scope:
-          name: otelcol/sqlserverreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest

--- a/receiver/sqlserverreceiver/testdata/golden_scrape.yaml
+++ b/receiver/sqlserverreceiver/testdata/golden_scrape.yaml
@@ -182,5 +182,5 @@ resourceMetrics:
             name: sqlserver.user.connection.count
             unit: '{connections}'
         scope:
-          name: otelcol/sqlserverreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the sqlserverreceiver from otelcol/sqlserverreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
