### PR TITLE
[receiver/postgresql] Don't error when unix sockets are used for postgresql replication 

### DIFF
--- a/.chloggen/postgres-null-client.yaml
+++ b/.chloggen/postgres-null-client.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support unix socket based replication by handling null values in the client_addr field
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33107]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/postgresqlreceiver/client.go
+++ b/receiver/postgresqlreceiver/client.go
@@ -501,7 +501,7 @@ type replicationStats struct {
 
 func (c *postgreSQLClient) getDeprecatedReplicationStats(ctx context.Context) ([]replicationStats, error) {
 	query := `SELECT
-	client_addr,
+	coalesce(cast(client_addr as varchar), 'unix') AS client_addr,
 	coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), -1) AS replication_bytes_pending,
 	extract('epoch' from coalesce(write_lag, '-1 seconds'))::integer,
 	extract('epoch' from coalesce(flush_lag, '-1 seconds'))::integer,
@@ -543,7 +543,7 @@ func (c *postgreSQLClient) getReplicationStats(ctx context.Context) ([]replicati
 	}
 
 	query := `SELECT
-	client_addr,
+	coalesce(cast(client_addr as varchar), 'unix') AS client_addr,
 	coalesce(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), -1) AS replication_bytes_pending,
 	extract('epoch' from coalesce(write_lag, '-1 seconds'))::decimal AS write_lag_fractional,
 	extract('epoch' from coalesce(flush_lag, '-1 seconds'))::decimal AS flush_lag_fractional,


### PR DESCRIPTION
**Description:**
When monitoring a postgresql system with replication over unix sockets, the receiver was failing to scrape metrics due to an unexpected null value. As the postgres [documentation](https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-REPLICATION-VIEW) states, the client_addr will have a null value if replication is being done over unix sockets.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33107

**Testing:** Local testing was done. The existing tests do not cover replication metrics, and after some time attempting to update the integration tests to provide a dockerized replication setup using unix sockets in testcontainers I had to admit defeat. I found two sources online for others setting up dockerized replication but I was not able to get it fully functioning using unix sockets (https://stackoverflow.com/questions/75524147/create-postgres-replica-container and https://github.com/eremeykin/pg-primary-replica/blob/main/docker-compose.yaml)

**Documentation:** Documentation already claimed that unix sockets would show the work 'unix' for the replication_client attribute. This was previously incorrect (as it would break collection), but now will be accurate.