### PR TITLE
[receiver/filelog] check for invalid strptime format

### DIFF
--- a/.chloggen/time-format-validation.yaml
+++ b/.chloggen/time-format-validation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filelogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Check for unsupported fractional seconds directive when converting strptime time layout to native format
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34390]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
@@ -18,6 +18,7 @@ import (
 
 var ctimeRegexp = regexp.MustCompile(`%.`)
 var decimalsRegexp = regexp.MustCompile(`\d`)
+var invalidFractionalSeconds = regexp.MustCompile(`[^.,]%[Lfs]`)
 
 var ctimeSubstitutes = map[string]string{
 	"%Y": "2006",
@@ -123,6 +124,10 @@ func Parse(format, value string) (time.Time, error) {
 func ToNative(format string) (string, error) {
 	if match := decimalsRegexp.FindString(format); match != "" {
 		return "", errors.New("format string should not contain decimals")
+	}
+
+	if match := invalidFractionalSeconds.FindString(format); match != "" {
+		return "", fmt.Errorf("invalid fractional seconds directive: '%s'. must be preceded with '.' or ','", match)
 	}
 
 	var errs []error

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
@@ -18,7 +18,6 @@ import (
 
 var ctimeRegexp = regexp.MustCompile(`%.`)
 var decimalsRegexp = regexp.MustCompile(`\d`)
-var invalidFractionalSeconds = regexp.MustCompile(`[^.,]%[Lfs]`)
 
 var ctimeSubstitutes = map[string]string{
 	"%Y": "2006",
@@ -124,10 +123,6 @@ func Parse(format, value string) (time.Time, error) {
 func ToNative(format string) (string, error) {
 	if match := decimalsRegexp.FindString(format); match != "" {
 		return "", errors.New("format string should not contain decimals")
-	}
-
-	if match := invalidFractionalSeconds.FindString(format); match != "" {
-		return "", fmt.Errorf("invalid fractional seconds directive: '%s'. must be preceded with '.' or ','", match)
 	}
 
 	var errs []error

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
@@ -17,6 +17,8 @@ import (
 )
 
 var ctimeRegexp = regexp.MustCompile(`%.`)
+var invalidFractionalSecondsStrptime = regexp.MustCompile(`[^.,]%[Lfs]`)
+var decimalsRegexp = regexp.MustCompile(`\d`)
 
 var ctimeSubstitutes = map[string]string{
 	"%Y": "2006",
@@ -135,4 +137,27 @@ func ToNative(format string) (string, error) {
 	}
 
 	return replaced, nil
+}
+
+func Validate(format string) error {
+	if match := decimalsRegexp.FindString(format); match != "" {
+		return errors.New("format string should not contain decimals")
+	}
+
+	if match := invalidFractionalSecondsStrptime.FindString(format); match != "" {
+		return fmt.Errorf("invalid fractional seconds directive: '%s'. must be preceded with '.' or ','", match)
+	}
+
+	directives := ctimeRegexp.FindAllString(format, -1)
+
+	var errs []error
+	for _, directive := range directives {
+		if _, ok := ctimeSubstitutes[directive]; !ok {
+			errs = append(errs, errors.New("unsupported ctimefmt.ToNative() directive: "+directive))
+		}
+	}
+	if len(errs) != 0 {
+		return fmt.Errorf("invalid strptime format: %v", errs)
+	}
+	return nil
 }

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
@@ -17,7 +17,6 @@ import (
 )
 
 var ctimeRegexp = regexp.MustCompile(`%.`)
-var decimalsRegexp = regexp.MustCompile(`\d`)
 
 var ctimeSubstitutes = map[string]string{
 	"%Y": "2006",
@@ -121,10 +120,6 @@ func Parse(format, value string) (time.Time, error) {
 // ToNative converts ctime-like format string to Go native layout
 // (which is used by time.Time.Format() and time.Parse() functions).
 func ToNative(format string) (string, error) {
-	if match := decimalsRegexp.FindString(format); match != "" {
-		return "", errors.New("format string should not contain decimals")
-	}
-
 	var errs []error
 	replaceFunc := func(directive string) string {
 		if subst, ok := ctimeSubstitutes[directive]; ok {

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
@@ -10,9 +10,10 @@
 package ctimefmt
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 var format1 = "%Y-%m-%d %H:%M:%S.%f"

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
@@ -12,8 +12,6 @@ package ctimefmt
 import (
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
 var format1 = "%Y-%m-%d %H:%M:%S.%f"
@@ -74,67 +72,6 @@ func TestZulu(t *testing.T) {
 				// The former returns a Time with the UTC timezone, the latter returns a Time with a 0000 time zone offset.
 				// (See Go's documentation for `time.Parse`.)
 				t.Errorf("Given: %v, expected: %v", dt, dt1)
-			}
-		})
-	}
-}
-
-func TestToNative(t *testing.T) {
-	type args struct {
-		format string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    string
-		wantErr string
-	}{
-		{
-			name: "valid format 1",
-			args: args{
-				format: "%Y-%m-%d %H:%M:%S.%f",
-			},
-			want: "2006-01-02 15:04:05.999999",
-		},
-		{
-			name: "valid format 2",
-			args: args{
-				format: "%Y-%m-%d %l:%M:%S.%L %P, %a",
-			},
-			want: "2006-01-02 3:04:05.999 pm, Mon",
-		},
-		{
-			name: "invalid fractional second directive",
-			args: args{
-				format: "%Y-%m-%d-%H-%M-%S:%L",
-			},
-			wantErr: "invalid fractional seconds directive: ':%L'. must be preceded with '.' or ','",
-		},
-		{
-			name: "format containing decimal",
-			args: args{
-				format: "%Y-%m-%d-%H-%M-%S:%L10.0",
-			},
-			wantErr: "format string should not contain decimals",
-		},
-		{
-			name: "format containing unsupported directive",
-			args: args{
-				format: "%C-%m-%d-%H-%M-%S:.%L",
-			},
-			wantErr: "convert to go time format: [unsupported ctimefmt.ToNative() directive: %C]",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := ToNative(tt.args.format)
-
-			require.Equal(t, tt.want, got)
-
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-			} else {
-				require.Nil(t, err)
 			}
 		})
 	}

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
@@ -10,6 +10,7 @@
 package ctimefmt
 
 import (
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 )
@@ -72,6 +73,57 @@ func TestZulu(t *testing.T) {
 				// The former returns a Time with the UTC timezone, the latter returns a Time with a 0000 time zone offset.
 				// (See Go's documentation for `time.Parse`.)
 				t.Errorf("Given: %v, expected: %v", dt, dt1)
+			}
+		})
+	}
+}
+
+func TestValidate(t *testing.T) {
+	type args struct {
+		layout string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr string
+	}{
+		{
+			name: "valid format",
+			args: args{
+				layout: "%Y-%m-%d %H:%M:%S.%f",
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid fractional second",
+			args: args{
+				layout: "%Y-%m-%d-%H-%M-%S:%L",
+			},
+			wantErr: "invalid fractional seconds directive: ':%L'. must be preceded with '.' or ','",
+		},
+		{
+			name: "format including decimal",
+			args: args{
+				layout: "2006-%m-%d-%H-%M-%S:%L",
+			},
+			wantErr: "format string should not contain decimals",
+		},
+		{
+			name: "unsupported directive",
+			args: args{
+				layout: "%C-%m-%d-%H-%M-%S.%L",
+			},
+			wantErr: "invalid strptime format: [unsupported ctimefmt.ToNative() directive: %C]",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := Validate(tt.args.layout)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/internal/coreinternal/timeutils/parser.go
+++ b/internal/coreinternal/timeutils/parser.go
@@ -4,6 +4,7 @@
 package timeutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -13,6 +14,7 @@ import (
 )
 
 var invalidFractionalSecondsStrptime = regexp.MustCompile(`[^.,]%[Lfs]`)
+var decimalsRegexp = regexp.MustCompile(`\d`)
 
 // TODO this regex still seems weird - need to double check if there is a more precise alternative
 var invalidFractionalSecondsGoTime = regexp.MustCompile(`[^.,9]9+`)
@@ -113,6 +115,10 @@ func SetTimestampYear(t time.Time) time.Time {
 // ValidateStrptime checks the given strptime layout and returns an error if it detects any known issues
 // that prevent it from being parsed.
 func ValidateStrptime(layout string) error {
+	if match := decimalsRegexp.FindString(layout); match != "" {
+		return errors.New("format string should not contain decimals")
+	}
+
 	if match := invalidFractionalSecondsStrptime.FindString(layout); match != "" {
 		return fmt.Errorf("invalid fractional seconds directive: '%s'. must be preceded with '.' or ','", match)
 	}

--- a/internal/coreinternal/timeutils/parser.go
+++ b/internal/coreinternal/timeutils/parser.go
@@ -13,6 +13,8 @@ import (
 )
 
 var invalidFractionalSecondsStrptime = regexp.MustCompile(`[^.,]%[Lfs]`)
+
+// TODO this regex still seems weird - need to double check if there is a more precise alternative
 var invalidFractionalSecondsGoTime = regexp.MustCompile(`[^.,9]9+`)
 
 func StrptimeToGotime(layout string) (string, error) {

--- a/internal/coreinternal/timeutils/parser.go
+++ b/internal/coreinternal/timeutils/parser.go
@@ -13,7 +13,7 @@ import (
 )
 
 var invalidFractionalSecondsStrptime = regexp.MustCompile(`[^.,]%[Lfs]`)
-var invalidFractionalSecondsGoTime = regexp.MustCompile(`[^.,](999|999999|999999999)`)
+var invalidFractionalSecondsGoTime = regexp.MustCompile(`[^.,9]9+`)
 
 func StrptimeToGotime(layout string) (string, error) {
 	return strptime.ToNative(layout)

--- a/internal/coreinternal/timeutils/parser.go
+++ b/internal/coreinternal/timeutils/parser.go
@@ -12,7 +12,6 @@ import (
 	strptime "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils/internal/ctimefmt"
 )
 
-// TODO this regex still seems weird - need to double check if there is a more precise alternative
 var invalidFractionalSecondsGoTime = regexp.MustCompile(`[^.,9]9+`)
 
 func StrptimeToGotime(layout string) (string, error) {

--- a/internal/coreinternal/timeutils/parser.go
+++ b/internal/coreinternal/timeutils/parser.go
@@ -4,7 +4,6 @@
 package timeutils // import "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils"
 
 import (
-	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -12,9 +11,6 @@ import (
 
 	strptime "github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/timeutils/internal/ctimefmt"
 )
-
-var invalidFractionalSecondsStrptime = regexp.MustCompile(`[^.,]%[Lfs]`)
-var decimalsRegexp = regexp.MustCompile(`\d`)
 
 // TODO this regex still seems weird - need to double check if there is a more precise alternative
 var invalidFractionalSecondsGoTime = regexp.MustCompile(`[^.,9]9+`)
@@ -115,15 +111,7 @@ func SetTimestampYear(t time.Time) time.Time {
 // ValidateStrptime checks the given strptime layout and returns an error if it detects any known issues
 // that prevent it from being parsed.
 func ValidateStrptime(layout string) error {
-	if match := decimalsRegexp.FindString(layout); match != "" {
-		return errors.New("format string should not contain decimals")
-	}
-
-	if match := invalidFractionalSecondsStrptime.FindString(layout); match != "" {
-		return fmt.Errorf("invalid fractional seconds directive: '%s'. must be preceded with '.' or ','", match)
-	}
-
-	return nil
+	return strptime.Validate(layout)
 }
 
 func ValidateGotime(layout string) error {

--- a/internal/coreinternal/timeutils/parser_test.go
+++ b/internal/coreinternal/timeutils/parser_test.go
@@ -62,50 +62,6 @@ func Test_setTimestampYear(t *testing.T) {
 	})
 }
 
-func TestValidateStrptime(t *testing.T) {
-	type args struct {
-		layout string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		wantErr string
-	}{
-		{
-			name: "valid format",
-			args: args{
-				layout: "%Y-%m-%d %H:%M:%S.%f",
-			},
-			wantErr: "",
-		},
-		{
-			name: "invalid fractional second",
-			args: args{
-				layout: "%Y-%m-%d-%H-%M-%S:%L",
-			},
-			wantErr: "invalid fractional seconds directive: ':%L'. must be preceded with '.' or ','",
-		},
-		{
-			name: "format including decimal",
-			args: args{
-				layout: "2006-%m-%d-%H-%M-%S:%L",
-			},
-			wantErr: "format string should not contain decimals",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			err := ValidateStrptime(tt.args.layout)
-
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
 func TestValidateGotime(t *testing.T) {
 	type args struct {
 		layout string

--- a/internal/coreinternal/timeutils/parser_test.go
+++ b/internal/coreinternal/timeutils/parser_test.go
@@ -85,6 +85,13 @@ func TestValidateStrptime(t *testing.T) {
 			},
 			wantErr: "invalid fractional seconds directive: ':%L'. must be preceded with '.' or ','",
 		},
+		{
+			name: "format including decimal",
+			args: args{
+				layout: "2006-%m-%d-%H-%M-%S:%L",
+			},
+			wantErr: "format string should not contain decimals",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/coreinternal/timeutils/parser_test.go
+++ b/internal/coreinternal/timeutils/parser_test.go
@@ -61,3 +61,77 @@ func Test_setTimestampYear(t *testing.T) {
 		require.Equal(t, expected, yearAdded)
 	})
 }
+
+func TestValidateStrptime(t *testing.T) {
+	type args struct {
+		layout string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr string
+	}{
+		{
+			name: "valid format",
+			args: args{
+				layout: "%Y-%m-%d %H:%M:%S.%f",
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid fractional second",
+			args: args{
+				layout: "%Y-%m-%d-%H-%M-%S:%L",
+			},
+			wantErr: "invalid fractional seconds directive: ':%L'. must be preceded with '.' or ','",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateStrptime(tt.args.layout)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateGotime(t *testing.T) {
+	type args struct {
+		layout string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr string
+	}{
+		{
+			name: "valid format",
+			args: args{
+				layout: "2006-01-02 15:04:05.999999",
+			},
+			wantErr: "",
+		},
+		{
+			name: "invalid fractional second",
+			args: args{
+				layout: "2006-01-02 15:04:05:999999",
+			},
+			wantErr: "som error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateGotime(tt.args.layout)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/coreinternal/timeutils/parser_test.go
+++ b/internal/coreinternal/timeutils/parser_test.go
@@ -79,6 +79,13 @@ func TestValidateGotime(t *testing.T) {
 			wantErr: "",
 		},
 		{
+			name: "valid format 2",
+			args: args{
+				layout: "2006-01-02 15:04:05,999999",
+			},
+			wantErr: "",
+		},
+		{
 			name: "invalid fractional second",
 			args: args{
 				layout: "2006-01-02 15:04:05:999999",

--- a/internal/coreinternal/timeutils/parser_test.go
+++ b/internal/coreinternal/timeutils/parser_test.go
@@ -120,7 +120,7 @@ func TestValidateGotime(t *testing.T) {
 			args: args{
 				layout: "2006-01-02 15:04:05:999999",
 			},
-			wantErr: "som error",
+			wantErr: "invalid fractional seconds directive: ':999999'. must be preceded with '.' or ','",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -79,10 +79,10 @@ func (t *TimeParser) Validate() error {
 			return errors.Wrap(err, "invalid gotime layout")
 		}
 	case StrptimeKey:
-		var err error
 		if err := timeutils.ValidateStrptime(t.Layout); err != nil {
 			return errors.Wrap(err, "invalid strptime layout")
 		}
+		var err error
 		t.Layout, err = timeutils.StrptimeToGotime(t.Layout)
 		if err != nil {
 			return errors.Wrap(err, "parse strptime layout")

--- a/pkg/stanza/operator/helper/time.go
+++ b/pkg/stanza/operator/helper/time.go
@@ -73,9 +73,16 @@ func (t *TimeParser) Validate() error {
 	}
 
 	switch t.LayoutType {
-	case NativeKey, GotimeKey: // ok
+	case NativeKey: // ok
+	case GotimeKey:
+		if err := timeutils.ValidateGotime(t.Layout); err != nil {
+			return errors.Wrap(err, "invalid gotime layout")
+		}
 	case StrptimeKey:
 		var err error
+		if err := timeutils.ValidateStrptime(t.Layout); err != nil {
+			return errors.Wrap(err, "invalid strptime layout")
+		}
 		t.Layout, err = timeutils.StrptimeToGotime(t.Layout)
 		if err != nil {
 			return errors.Wrap(err, "parse strptime layout")


### PR DESCRIPTION
**Description:** Check for unsupported fractional seconds directive when converting strptime time layout to native format. This is done to prevent parsing errors which occur due to a limitation of how timestamps are being parsed in go - for more context see this comment in the related issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34390#issuecomment-2268882664

**Link to tracking Issue:** #34390

**Testing:** Added additional unit tests

**Documentation:** TODO, probably will require a note in `regex_parser.md`
