### PR TITLE
[receiver/snowflakereceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-snowflakereceiver.yaml
+++ b/.chloggen/codeboten_update-scope-snowflakereceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: snowflakereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the snowflakereceiver from otelcol/snowflakereceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-snowflakereceiver.yaml
+++ b/.chloggen/codeboten_update-scope-snowflakereceiver.yaml
@@ -10,7 +10,7 @@ component: snowflakereceiver
 note: Update the scope name for telemetry produced by the snowflakereceiver from otelcol/snowflakereceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34467]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/snowflakereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/snowflakereceiver/internal/metadata/generated_metrics.go
@@ -2072,7 +2072,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/snowflakereceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSnowflakeBillingCloudServiceTotal.emit(ils.Metrics())

--- a/receiver/snowflakereceiver/metadata.yaml
+++ b/receiver/snowflakereceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: snowflake
-scope_name: otelcol/snowflakereceiver
 
 status:
   class: receiver

--- a/receiver/snowflakereceiver/testdata/scraper/expected.yaml
+++ b/receiver/snowflakereceiver/testdata/scraper/expected.yaml
@@ -371,5 +371,5 @@ resourceMetrics:
             name: snowflake.total_elapsed_time.avg
             unit: s
         scope:
-          name: otelcol/snowflakereceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the snowflakereceiverreceiver from otelcol/snowflakereceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snowflakereceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
