### PR TITLE
[receiver/saphanareceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-saphanareceiver.yaml
+++ b/.chloggen/codeboten_update-scope-saphanareceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: saphanareceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the saphanareceiver from otelcol/saphanareceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-saphanareceiver.yaml
+++ b/.chloggen/codeboten_update-scope-saphanareceiver.yaml
@@ -10,7 +10,7 @@ component: saphanareceiver
 note: Update the scope name for telemetry produced by the saphanareceiver from otelcol/saphanareceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34468]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/saphanareceiver/internal/metadata/generated_metrics.go
+++ b/receiver/saphanareceiver/internal/metadata/generated_metrics.go
@@ -3110,7 +3110,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/saphanareceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSaphanaAlertCount.emit(ils.Metrics())

--- a/receiver/saphanareceiver/metadata.yaml
+++ b/receiver/saphanareceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: saphana
-scope_name: otelcol/saphanareceiver
 
 status:
   class: receiver

--- a/receiver/saphanareceiver/testdata/expected_metrics/full.yaml
+++ b/receiver/saphanareceiver/testdata/expected_metrics/full.yaml
@@ -174,7 +174,7 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: us
         scope:
-          name: otelcol/saphanareceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
           version: latest
   - resource:
       attributes:
@@ -1058,7 +1058,7 @@ resourceMetrics:
               isMonotonic: true
             unit: ms
         scope:
-          name: otelcol/saphanareceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
           version: latest
   - resource:
       attributes:
@@ -1893,5 +1893,5 @@ resourceMetrics:
               isMonotonic: true
             unit: ms
         scope:
-          name: otelcol/saphanareceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
           version: latest

--- a/receiver/saphanareceiver/testdata/expected_metrics/mostly_disabled.yaml
+++ b/receiver/saphanareceiver/testdata/expected_metrics/mostly_disabled.yaml
@@ -50,7 +50,7 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: '{threads}'
         scope:
-          name: otelcol/saphanareceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
           version: latest
   - resource:
       attributes:
@@ -103,5 +103,5 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: '{threads}'
         scope:
-          name: otelcol/saphanareceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the saphanareceiverreceiver from otelcol/saphanareceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/saphanareceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
