### PR TITLE
[receiver/redisreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-redisreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-redisreceiver.yaml
@@ -10,7 +10,7 @@ component: redisreceiver
 note: Update the scope name for telemetry produced by the redisreceiver from otelcol/redisreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34470]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-redisreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-redisreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: redisreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the redisreceiver from otelcol/redisreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/redisreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/redisreceiver/internal/metadata/generated_metrics.go
@@ -2055,7 +2055,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/redisreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricRedisClientsBlocked.emit(ils.Metrics())

--- a/receiver/redisreceiver/metadata.yaml
+++ b/receiver/redisreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: redis
-scope_name: otelcol/redisreceiver
 
 status:
   class: receiver

--- a/receiver/redisreceiver/redis_scraper_test.go
+++ b/receiver/redisreceiver/redis_scraper_test.go
@@ -33,7 +33,7 @@ func TestRedisRunnable(t *testing.T) {
 	rm := md.ResourceMetrics().At(0)
 	ilm := rm.ScopeMetrics().At(0)
 	il := ilm.Scope()
-	assert.Equal(t, "otelcol/redisreceiver", il.Name())
+	assert.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver", il.Name())
 }
 
 func TestNewReceiver_invalid_endpoint(t *testing.T) {

--- a/receiver/redisreceiver/testdata/integration/expected-cluster.yaml
+++ b/receiver/redisreceiver/testdata/integration/expected-cluster.yaml
@@ -288,5 +288,5 @@ resourceMetrics:
               isMonotonic: true
             unit: s
         scope:
-          name: otelcol/redisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
           version: latest

--- a/receiver/redisreceiver/testdata/integration/expected-old.yaml
+++ b/receiver/redisreceiver/testdata/integration/expected-old.yaml
@@ -266,5 +266,5 @@ resourceMetrics:
               isMonotonic: true
             unit: s
         scope:
-          name: otelcol/redisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the redisreceiverreceiver from otelcol/redisreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/redisreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
