### PR TITLE
[receiver/rabbitmqreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-rabbitmqreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-rabbitmqreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: rabbitmqreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the rabbitmqreceiver from otelcol/rabbitmqreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-rabbitmqreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-rabbitmqreceiver.yaml
@@ -10,7 +10,7 @@ component: rabbitmqreceiver
 note: Update the scope name for telemetry produced by the rabbitmqreceiver from otelcol/rabbitmqreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34475]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/rabbitmqreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/rabbitmqreceiver/internal/metadata/generated_metrics.go
@@ -465,7 +465,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/rabbitmqreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricRabbitmqConsumerCount.emit(ils.Metrics())

--- a/receiver/rabbitmqreceiver/metadata.yaml
+++ b/receiver/rabbitmqreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: rabbitmq
-scope_name: otelcol/rabbitmqreceiver
 
 status:
   class: receiver

--- a/receiver/rabbitmqreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/rabbitmqreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -42,7 +42,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{messages}'
         scope:
-          name: otelcol/rabbitmqreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
           version: latest
   - resource:
       attributes:
@@ -127,5 +127,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{messages}'
         scope:
-          name: otelcol/rabbitmqreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the rabbitmqreceiverreceiver from otelcol/rabbitmqreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/rabbitmqreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
