### PR TITLE
[receiver/postgresqlreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-postgresqlreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-postgresqlreceiver.yaml
@@ -10,7 +10,7 @@ component: postgresqlreceiver
 note: Update the scope name for telemetry produced by the postgresqlreceiver from otelcol/postgresqlreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34476]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-postgresqlreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-postgresqlreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: postgresqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Update the scope name for telemetry produced by the postgresqlreceiver from otelcol/postgresqlreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/postgresqlreceiver/internal/metadata/generated_metrics.go
@@ -1792,7 +1792,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/postgresqlreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricPostgresqlBackends.emit(ils.Metrics())

--- a/receiver/postgresqlreceiver/metadata.yaml
+++ b/receiver/postgresqlreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: postgresql
-scope_name: otelcol/postgresqlreceiver
 
 status:
   class: receiver

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db.yaml
@@ -187,7 +187,7 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -255,7 +255,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -323,7 +323,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -400,7 +400,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -560,7 +560,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -720,7 +720,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -880,7 +880,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1040,7 +1040,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1074,7 +1074,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1108,7 +1108,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1142,7 +1142,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1176,7 +1176,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1210,7 +1210,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1244,5 +1244,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db_connpool.yaml
@@ -74,7 +74,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -234,7 +234,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -394,7 +394,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -471,7 +471,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -505,7 +505,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -539,7 +539,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -699,7 +699,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -859,7 +859,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -936,7 +936,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -970,7 +970,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1004,7 +1004,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1038,7 +1038,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1072,7 +1072,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource: {}
     scopeMetrics:
@@ -1262,5 +1262,5 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_all_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_all_db_schemaattr.yaml
@@ -187,7 +187,7 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -255,7 +255,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -323,7 +323,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -400,7 +400,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -563,7 +563,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -726,7 +726,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -889,7 +889,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1052,7 +1052,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1089,7 +1089,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1126,7 +1126,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1163,7 +1163,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1200,7 +1200,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1237,7 +1237,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1274,5 +1274,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db.yaml
@@ -187,7 +187,7 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -255,7 +255,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -323,7 +323,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -483,7 +483,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -643,7 +643,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -803,7 +803,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -963,7 +963,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -997,7 +997,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1031,7 +1031,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1065,7 +1065,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1099,7 +1099,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1133,7 +1133,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1167,5 +1167,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_connpool.yaml
@@ -157,7 +157,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -317,7 +317,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -394,7 +394,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -428,7 +428,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -462,7 +462,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -622,7 +622,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -782,7 +782,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -859,7 +859,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -893,7 +893,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -927,7 +927,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -961,7 +961,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -995,7 +995,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource: {}
     scopeMetrics:
@@ -1185,5 +1185,5 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_multi_db_schemaattr.yaml
@@ -187,7 +187,7 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -255,7 +255,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -323,7 +323,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -486,7 +486,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -649,7 +649,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -812,7 +812,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -975,7 +975,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1012,7 +1012,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1049,7 +1049,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1086,7 +1086,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1123,7 +1123,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1160,7 +1160,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1197,5 +1197,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db.yaml
@@ -187,7 +187,7 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -255,7 +255,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -415,7 +415,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -575,7 +575,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -609,7 +609,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -643,5 +643,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db_connpool.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db_connpool.yaml
@@ -157,7 +157,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -317,7 +317,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -394,7 +394,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -428,7 +428,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -462,7 +462,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource: {}
     scopeMetrics:
@@ -652,5 +652,5 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/integration/expected_single_db_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/integration/expected_single_db_schemaattr.yaml
@@ -187,7 +187,7 @@ resourceMetrics:
             name: postgresql.database.locks
             unit: '{lock}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -255,7 +255,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -418,7 +418,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -581,7 +581,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -618,7 +618,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -655,5 +655,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude.yaml
@@ -137,7 +137,7 @@ resourceMetrics:
             name: postgresql.wal.age
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -194,7 +194,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{table}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -251,7 +251,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{table}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -401,7 +401,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -551,7 +551,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -701,7 +701,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -851,7 +851,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -885,7 +885,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -919,7 +919,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -953,7 +953,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -987,5 +987,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/exclude_schemaattr.yaml
@@ -137,7 +137,7 @@ resourceMetrics:
             name: postgresql.wal.age
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -194,7 +194,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{table}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -251,7 +251,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{table}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -404,7 +404,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -557,7 +557,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -710,7 +710,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -863,7 +863,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -900,7 +900,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -937,7 +937,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -974,7 +974,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1011,5 +1011,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected.yaml
@@ -203,7 +203,7 @@ resourceMetrics:
             name: postgresql.wal.delay
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -280,7 +280,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -357,7 +357,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -434,7 +434,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -594,7 +594,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -754,7 +754,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -914,7 +914,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1074,7 +1074,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1234,7 +1234,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1394,7 +1394,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1428,7 +1428,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1462,7 +1462,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1496,7 +1496,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1530,7 +1530,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1564,7 +1564,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1598,5 +1598,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag.yaml
@@ -203,7 +203,7 @@ resourceMetrics:
             name: postgresql.wal.lag
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -280,7 +280,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -357,7 +357,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -434,7 +434,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -594,7 +594,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -754,7 +754,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -914,7 +914,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1074,7 +1074,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1234,7 +1234,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1394,7 +1394,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1428,7 +1428,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1462,7 +1462,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1496,7 +1496,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1530,7 +1530,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1564,7 +1564,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1598,5 +1598,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_imprecise_lag_schemaattr.yaml
@@ -203,7 +203,7 @@ resourceMetrics:
             name: postgresql.wal.lag
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -280,7 +280,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -357,7 +357,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -434,7 +434,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -597,7 +597,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -760,7 +760,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -923,7 +923,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1086,7 +1086,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1249,7 +1249,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1412,7 +1412,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1449,7 +1449,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1486,7 +1486,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1523,7 +1523,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1560,7 +1560,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1597,7 +1597,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1634,5 +1634,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/multiple/expected_schemaattr.yaml
@@ -203,7 +203,7 @@ resourceMetrics:
             name: postgresql.wal.delay
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -280,7 +280,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -357,7 +357,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -434,7 +434,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -597,7 +597,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -760,7 +760,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -923,7 +923,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1086,7 +1086,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1249,7 +1249,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1412,7 +1412,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1449,7 +1449,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1486,7 +1486,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1523,7 +1523,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1560,7 +1560,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1597,7 +1597,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -1634,5 +1634,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected.yaml
@@ -203,7 +203,7 @@ resourceMetrics:
             name: postgresql.wal.delay
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -280,7 +280,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -440,7 +440,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -600,7 +600,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -634,7 +634,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -668,5 +668,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics.yaml
@@ -137,7 +137,7 @@ resourceMetrics:
             name: postgresql.wal.age
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -194,7 +194,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{table}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -344,7 +344,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -494,7 +494,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -528,7 +528,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -562,5 +562,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_default_metrics_schemaattr.yaml
@@ -137,7 +137,7 @@ resourceMetrics:
             name: postgresql.wal.age
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -194,7 +194,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{table}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -347,7 +347,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -500,7 +500,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -537,7 +537,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -574,5 +574,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest

--- a/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
+++ b/receiver/postgresqlreceiver/testdata/scraper/otel/expected_schemaattr.yaml
@@ -203,7 +203,7 @@ resourceMetrics:
             name: postgresql.wal.delay
             unit: s
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -280,7 +280,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{temp_file}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -443,7 +443,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -606,7 +606,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{vacuums}'
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -643,7 +643,7 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest
   - resource:
       attributes:
@@ -680,5 +680,5 @@ resourceMetrics:
             name: postgresql.index.size
             unit: By
         scope:
-          name: otelcol/postgresqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the postgresqlreceiverreceiver from otelcol/postgresqlreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
