### PR TITLE
[chore] make httpforwarderextension use default client config for egress

### DIFF
--- a/extension/httpforwarderextension/config_test.go
+++ b/extension/httpforwarderextension/config_test.go
@@ -23,6 +23,15 @@ func TestLoadConfig(t *testing.T) {
 	maxIdleConns := 42
 	idleConnTimeout := 80 * time.Second
 
+	egressCfg := confighttp.NewDefaultClientConfig()
+	egressCfg.Endpoint = "http://target/"
+	egressCfg.Headers = map[string]configopaque.String{
+		"otel_http_forwarder": "dev",
+	}
+	egressCfg.MaxIdleConns = &maxIdleConns
+	egressCfg.IdleConnTimeout = &idleConnTimeout
+	egressCfg.Timeout = 5 * time.Second
+
 	tests := []struct {
 		id       component.ID
 		expected component.Config
@@ -37,15 +46,7 @@ func TestLoadConfig(t *testing.T) {
 				Ingress: confighttp.ServerConfig{
 					Endpoint: "http://localhost:7070",
 				},
-				Egress: confighttp.ClientConfig{
-					Endpoint: "http://target/",
-					Headers: map[string]configopaque.String{
-						"otel_http_forwarder": "dev",
-					},
-					MaxIdleConns:    &maxIdleConns,
-					IdleConnTimeout: &idleConnTimeout,
-					Timeout:         5 * time.Second,
-				},
+				Egress: egressCfg,
 			},
 		},
 	}


### PR DESCRIPTION
This PR unblocks https://github.com/open-telemetry/opentelemetry-collector/pull/10688