### PR TITLE
[receiver/nsxtreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-nsxtreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-nsxtreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: nsxtreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the nsxtreceiver from `otelcol/nsxtreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/nsxtreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nsxtreceiver/internal/metadata/generated_metrics.go
@@ -609,7 +609,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/nsxtreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricNsxtNodeCPUUtilization.emit(ils.Metrics())

--- a/receiver/nsxtreceiver/metadata.yaml
+++ b/receiver/nsxtreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: nsxt
-scope_name: otelcol/nsxtreceiver
 
 status:
   class: receiver

--- a/receiver/nsxtreceiver/testdata/metrics/expected_metrics.yaml
+++ b/receiver/nsxtreceiver/testdata/metrics/expected_metrics.yaml
@@ -78,7 +78,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: KBy
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -159,7 +159,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: KBy
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -240,7 +240,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: KBy
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -347,7 +347,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{packets}'
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -454,7 +454,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{packets}'
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -561,7 +561,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{packets}'
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -668,7 +668,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{packets}'
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -775,7 +775,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{packets}'
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest
   - resource:
       attributes:
@@ -882,5 +882,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{packets}'
         scope:
-          name: otelcol/nsxtreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the nsxtreceiverreceiver from otelcol/nsxtreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nsxtreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
