### PR TITLE
[exporter/datadog] Deprecate `logs::dump_payloads`

### DIFF
--- a/.chloggen/stanley.liu_deprecate-dump-payloads.yaml
+++ b/.chloggen/stanley.liu_deprecate-dump-payloads.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/datadog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecates `logs::dump_payloads` since it is invalid with the Datadog Agent logs pipeline, which will be enabled by default in the following release.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34490]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/stanley.liu_deprecate-dump-payloads.yaml
+++ b/.chloggen/stanley.liu_deprecate-dump-payloads.yaml
@@ -7,7 +7,7 @@ change_type: deprecation
 component: exporter/datadog
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecates `logs::dump_payloads` since it is invalid with the Datadog Agent logs pipeline, which will be enabled by default in the following release.
+note: Deprecates `logs::dump_payloads` since it is invalid with the Datadog Agent logs pipeline, which will be enabled by default in the v0.108.0 release.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [34490]

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -324,6 +324,7 @@ type LogsConfig struct {
 
 	// DumpPayloads report whether payloads should be dumped when logging level is debug.
 	// Note: this config option does not apply when enabling the `exporter.datadogexporter.UseLogsAgentExporter` feature flag.
+	// Deprecated: This config option is not supported in the Datadog Agent logs pipeline.
 	DumpPayloads bool `mapstructure:"dump_payloads"`
 
 	// UseCompression enables the logs agent to compress logs before sending them.
@@ -667,6 +668,9 @@ func (c *Config) Unmarshal(configMap *confmap.Conf) error {
 				enabledText = "disabled"
 			}
 			return fmt.Errorf("%v is not valid when the exporter.datadogexporter.UseLogsAgentExporter feature gate is %v", logsExporterSetting.setting, enabledText)
+		}
+		if logsExporterSetting.setting == "logs::dump_payloads" && logsExporterSetting.valid {
+			c.warnings = append(c.warnings, fmt.Errorf("%v is deprecated and will raise an error if set when the Datadog Agent logs pipeline is enabled by default in collector version v0.108.0", logsExporterSetting.setting))
 		}
 	}
 

--- a/exporter/datadogexporter/config.go
+++ b/exporter/datadogexporter/config.go
@@ -669,7 +669,7 @@ func (c *Config) Unmarshal(configMap *confmap.Conf) error {
 			}
 			return fmt.Errorf("%v is not valid when the exporter.datadogexporter.UseLogsAgentExporter feature gate is %v", logsExporterSetting.setting, enabledText)
 		}
-		if logsExporterSetting.setting == "logs::dump_payloads" && logsExporterSetting.valid {
+		if logsExporterSetting.setting == "logs::dump_payloads" && logsExporterSetting.valid && configMap.IsSet(logsExporterSetting.setting) {
 			c.warnings = append(c.warnings, fmt.Errorf("%v is deprecated and will raise an error if set when the Datadog Agent logs pipeline is enabled by default in collector version v0.108.0", logsExporterSetting.setting))
 		}
 	}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Deprecates `logs::dump_payloads` because this config option is invalid with the Datadog Agent logs pipeline which will be enabled by default in the following release. This PR will be included in v0.107.0 and https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34420 will be included in v0.108.0.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>
The log appears as follows:
```
2024-08-07T14:49:10.514-0400    warn    datadogexporter@v0.106.1/config.go:462  logs::dump_payloads is deprecated and will raise an error if set when the Datadog Agent logs pipeline is enabled by default in collector version v0.108.0    {"kind": "exporter", "data_type": "logs", "name": "datadog"}
```

**Documentation:** <Describe the documentation added.>