### PR TITLE
[receiver/nginxreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-nginxreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-nginxreceiver.yaml
@@ -10,7 +10,7 @@ component: nginxreceiver
 note: "Update the scope name for telemetry produced by the nginxreceiver from `otelcol/nginxreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34493]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-nginxreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-nginxreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: nginxreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the nginxreceiver from `otelcol/nginxreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/nginxreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/nginxreceiver/internal/metadata/generated_metrics.go
@@ -339,7 +339,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/nginxreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricNginxConnectionsAccepted.emit(ils.Metrics())

--- a/receiver/nginxreceiver/metadata.yaml
+++ b/receiver/nginxreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: nginx
-scope_name: otelcol/nginxreceiver
 
 status:
   class: receiver

--- a/receiver/nginxreceiver/testdata/integration/expected.yaml
+++ b/receiver/nginxreceiver/testdata/integration/expected.yaml
@@ -61,5 +61,5 @@ resourceMetrics:
               isMonotonic: true
             unit: requests
         scope:
-          name: otelcol/nginxreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
           version: latest

--- a/receiver/nginxreceiver/testdata/scraper/expected.yaml
+++ b/receiver/nginxreceiver/testdata/scraper/expected.yaml
@@ -60,5 +60,5 @@ resourceMetrics:
               isMonotonic: true
             unit: requests
         scope:
-          name: otelcol/nginxreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
           version: latest

--- a/receiver/nginxreceiver/testdata/scraper/expected_with_connections_as_gauge.yaml
+++ b/receiver/nginxreceiver/testdata/scraper/expected_with_connections_as_gauge.yaml
@@ -59,5 +59,5 @@ resourceMetrics:
               isMonotonic: true
             unit: requests
         scope:
-          name: otelcol/nginxreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the nginxreceiverreceiver from otelcol/nginxreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/nginxreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
