### PR TITLE
[receiver/gitproviderreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-gitproviderreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-gitproviderreceiver.yaml
@@ -10,7 +10,7 @@ component: gitproviderreceiver
 note: "Update the scope name for telemetry produced by the gitproviderreceiver from `otelcol/gitproviderreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitproviderreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34496]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-gitproviderreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-gitproviderreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: gitproviderreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the gitproviderreceiver from `otelcol/gitproviderreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitproviderreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/gitproviderreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/gitproviderreceiver/internal/metadata/generated_metrics.go
@@ -784,7 +784,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/gitproviderreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitproviderreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricGitRepositoryBranchCommitAheadbyCount.emit(ils.Metrics())

--- a/receiver/gitproviderreceiver/internal/scraper/githubscraper/testdata/scraper/expected_happy_path.yaml
+++ b/receiver/gitproviderreceiver/internal/scraper/githubscraper/testdata/scraper/expected_happy_path.yaml
@@ -161,5 +161,5 @@ resourceMetrics:
             name: git.repository.pull_request.time_to_merge
             unit: s
         scope:
-          name: otelcol/gitproviderreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitproviderreceiver
           version: latest

--- a/receiver/gitproviderreceiver/internal/scraper/githubscraper/testdata/scraper/expected_no_repos.yaml
+++ b/receiver/gitproviderreceiver/internal/scraper/githubscraper/testdata/scraper/expected_no_repos.yaml
@@ -19,5 +19,5 @@ resourceMetrics:
             name: git.repository.count
             unit: '{repository}'
         scope:
-          name: otelcol/gitproviderreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitproviderreceiver
           version: latest

--- a/receiver/gitproviderreceiver/metadata.yaml
+++ b/receiver/gitproviderreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: gitprovider
-scope_name: otelcol/gitproviderreceiver
 
 sem_conv_version: 1.9.0
 


### PR DESCRIPTION
Update the scope name for telemetry produced by the gitproviderreceiverreceiver from otelcol/gitproviderreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/gitproviderreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
