### PR TITLE
[receiver/httpcheckreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-httpcheckreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-httpcheckreceiver.yaml
@@ -10,7 +10,7 @@ component: httpcheckreceiver
 note: "Update the scope name for telemetry produced by the httpcheckreceiver from `otelcol/httpcheckreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34497]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-httpcheckreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-httpcheckreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: httpcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the httpcheckreceiver from `otelcol/httpcheckreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_metrics.go
@@ -258,7 +258,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/httpcheckreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricHttpcheckDuration.emit(ils.Metrics())

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: httpcheck
-scope_name: otelcol/httpcheckreceiver
 
 status:
   class: receiver

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/endpoint_404.yaml
@@ -99,5 +99,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/httpcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
           version: latest

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/invalid_endpoint.yaml
@@ -113,5 +113,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/httpcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
           version: latest

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -99,5 +99,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/httpcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
           version: latest

--- a/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
+++ b/receiver/httpcheckreceiver/testdata/expected_metrics/multiple_targets.yaml
@@ -184,5 +184,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/httpcheckreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the httpcheckreceiverreceiver from otelcol/httpcheckreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/httpcheckreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
