### PR TITLE
[receiver/haproxyreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-haproxyreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-haproxyreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: haproxyreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the haproxyreceiver from `otelcol/haproxyreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-haproxyreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-haproxyreceiver.yaml
@@ -10,7 +10,7 @@ component: haproxyreceiver
 note: "Update the scope name for telemetry produced by the haproxyreceiver from `otelcol/haproxyreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34498]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/haproxyreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/haproxyreceiver/internal/metadata/generated_metrics.go
@@ -1533,7 +1533,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/haproxyreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricHaproxyBytesInput.emit(ils.Metrics())

--- a/receiver/haproxyreceiver/metadata.yaml
+++ b/receiver/haproxyreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: haproxy
-scope_name: otelcol/haproxyreceiver
 
 status:
   class: receiver

--- a/receiver/haproxyreceiver/testdata/integration/expected.yaml
+++ b/receiver/haproxyreceiver/testdata/integration/expected.yaml
@@ -144,5 +144,5 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest

--- a/receiver/haproxyreceiver/testdata/scraper/30252_expected.yaml
+++ b/receiver/haproxyreceiver/testdata/scraper/30252_expected.yaml
@@ -144,7 +144,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -291,7 +291,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -480,7 +480,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -659,7 +659,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -838,5 +838,5 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest

--- a/receiver/haproxyreceiver/testdata/scraper/expected.yaml
+++ b/receiver/haproxyreceiver/testdata/scraper/expected.yaml
@@ -144,7 +144,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -291,7 +291,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -480,7 +480,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -659,7 +659,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -838,7 +838,7 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest
   - resource:
       attributes:
@@ -1017,5 +1017,5 @@ resourceMetrics:
             name: haproxy.sessions.rate
             unit: '{sessions}'
         scope:
-          name: otelcol/haproxyreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the haproxyreceiverreceiver from otelcol/haproxyreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/haproxyreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
