### PR TITLE
[connector/servicegraph] Fix histogram metrics miss unit

### DIFF
--- a/.chloggen/fix-hisgogram-metrics-miss-unit.yaml
+++ b/.chloggen/fix-hisgogram-metrics-miss-unit.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: servicegraphconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix histogram metrics miss unit
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34511]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+  All metrics will remove the suffix `_seconds`. It will not introduce breaking change if users use
+  | `prometheusexporter` or `prometheusremotewriteexporter` to exporter metrics in pipeline. 
+  | In some cases, like using `clickhouseexporter`(save data in native OTLP format), it will be a breaking change.
+  | Users can use `transformprocessor` to add back this suffix.
+
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -31,6 +31,8 @@ const (
 	clientKind         = "client"
 	serverKind         = "server"
 	virtualNodeLabel   = "virtual_node"
+	millisecondsUnit   = "ms"
+	secondsUnit        = "s"
 )
 
 var (
@@ -522,10 +524,10 @@ func (p *serviceGraphConnector) collectCountMetrics(ilm pmetric.ScopeMetrics) er
 func (p *serviceGraphConnector) collectLatencyMetrics(ilm pmetric.ScopeMetrics) error {
 	// TODO: Remove this once legacy metric names are removed
 	if legacyMetricNamesFeatureGate.IsEnabled() {
-		return p.collectServerLatencyMetrics(ilm, "traces_service_graph_request_duration_seconds")
+		return p.collectServerLatencyMetrics(ilm, "traces_service_graph_request_duration")
 	}
 
-	if err := p.collectServerLatencyMetrics(ilm, "traces_service_graph_request_server_seconds"); err != nil {
+	if err := p.collectServerLatencyMetrics(ilm, "traces_service_graph_request_server"); err != nil {
 		return err
 	}
 
@@ -535,7 +537,11 @@ func (p *serviceGraphConnector) collectLatencyMetrics(ilm pmetric.ScopeMetrics) 
 func (p *serviceGraphConnector) collectClientLatencyMetrics(ilm pmetric.ScopeMetrics) error {
 	if len(p.reqServerDurationSecondsCount) > 0 {
 		mDuration := ilm.Metrics().AppendEmpty()
-		mDuration.SetName("traces_service_graph_request_client_seconds")
+		mDuration.SetName("traces_service_graph_request_client")
+		mDuration.SetUnit(secondsUnit)
+		if legacyLatencyUnitMsFeatureGate.IsEnabled() {
+			mDuration.SetUnit(millisecondsUnit)
+		}
 		// TODO: Support other aggregation temporalities
 		mDuration.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 		timestamp := pcommon.NewTimestampFromTime(time.Now())
@@ -565,6 +571,10 @@ func (p *serviceGraphConnector) collectServerLatencyMetrics(ilm pmetric.ScopeMet
 	if len(p.reqServerDurationSecondsCount) > 0 {
 		mDuration := ilm.Metrics().AppendEmpty()
 		mDuration.SetName(mName)
+		mDuration.SetUnit(secondsUnit)
+		if legacyLatencyUnitMsFeatureGate.IsEnabled() {
+			mDuration.SetUnit(millisecondsUnit)
+		}
 		// TODO: Support other aggregation temporalities
 		mDuration.SetEmptyHistogram().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 		timestamp := pcommon.NewTimestampFromTime(time.Now())

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -163,7 +163,7 @@ func TestConnectorConsume(t *testing.T) {
 			},
 			sampleTraces:  buildSampleTrace(t, "val"),
 			gates:         []*featuregate.Gate{legacyLatencyUnitMsFeatureGate},
-			verifyMetrics: verifyHappyCaseMetricsWithDuration(2000, 1000),
+			verifyMetrics: verifyHappyCaseLatencyMetrics(),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -226,12 +226,19 @@ func verifyHappyCaseMetricsWithDuration(serverDurationSum, clientDurationSum flo
 		verifyCount(t, mCount)
 
 		mServerDuration := ms.At(1)
-		assert.Equal(t, "traces_service_graph_request_server_seconds", mServerDuration.Name())
+		assert.Equal(t, "traces_service_graph_request_server", mServerDuration.Name())
 		verifyDuration(t, mServerDuration, serverDurationSum, []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0})
 
 		mClientDuration := ms.At(2)
-		assert.Equal(t, "traces_service_graph_request_client_seconds", mClientDuration.Name())
+		assert.Equal(t, "traces_service_graph_request_client", mClientDuration.Name())
 		verifyDuration(t, mClientDuration, clientDurationSum, []uint64{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0})
+	}
+}
+
+func verifyHappyCaseLatencyMetrics() func(t *testing.T, md pmetric.Metrics) {
+	return func(t *testing.T, md pmetric.Metrics) {
+		verifyHappyCaseMetricsWithDuration(2000, 1000)(t, md)
+		verifyUnit(t, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(1).Unit(), millisecondsUnit)
 	}
 }
 
@@ -279,6 +286,10 @@ func verifyAttr(t *testing.T, attrs pcommon.Map, k, expected string) {
 	v, ok := attrs.Get(k)
 	assert.True(t, ok)
 	assert.Equal(t, expected, v.AsString())
+}
+
+func verifyUnit(t *testing.T, expected, actual string) {
+	assert.Equal(t, expected, actual)
 }
 
 func buildSampleTrace(t *testing.T, attrValue string) ptrace.Traces {

--- a/connector/servicegraphconnector/testdata/extra-dimensions-queue-db-expected-metrics.yaml
+++ b/connector/servicegraphconnector/testdata/extra-dimensions-queue-db-expected-metrics.yaml
@@ -11,6 +11,9 @@ resourceMetrics:
                     - key: client
                       value:
                         stringValue: foo-server
+                    - key: client_messaging.system
+                      value:
+                        stringValue: kafka
                     - key: connection_type
                       value:
                         stringValue: ""
@@ -20,9 +23,6 @@ resourceMetrics:
                     - key: server
                       value:
                         stringValue: bar-requester
-                    - key: client_messaging.system
-                      value:
-                        stringValue: kafka
                     - key: server_db.system
                       value:
                         stringValue: postgresql
@@ -36,6 +36,9 @@ resourceMetrics:
                     - key: client
                       value:
                         stringValue: foo-server
+                    - key: client_messaging.system
+                      value:
+                        stringValue: kafka
                     - key: connection_type
                       value:
                         stringValue: ""
@@ -45,9 +48,6 @@ resourceMetrics:
                     - key: server
                       value:
                         stringValue: bar-requester
-                    - key: client_messaging.system
-                      value:
-                        stringValue: kafka
                     - key: server_db.system
                       value:
                         stringValue: postgresql
@@ -62,9 +62,10 @@ resourceMetrics:
                     - 1
                     - 10
                   startTimeUnixNano: "1000000"
-                  sum: 0.000001
+                  sum: 1e-06
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_server_seconds
+            name: traces_service_graph_request_server
+            unit: s
           - histogram:
               aggregationTemporality: 2
               dataPoints:
@@ -72,6 +73,9 @@ resourceMetrics:
                     - key: client
                       value:
                         stringValue: foo-server
+                    - key: client_messaging.system
+                      value:
+                        stringValue: kafka
                     - key: connection_type
                       value:
                         stringValue: ""
@@ -81,9 +85,6 @@ resourceMetrics:
                     - key: server
                       value:
                         stringValue: bar-requester
-                    - key: client_messaging.system
-                      value:
-                        stringValue: kafka
                     - key: server_db.system
                       value:
                         stringValue: postgresql
@@ -98,8 +99,9 @@ resourceMetrics:
                     - 1
                     - 10
                   startTimeUnixNano: "1000000"
-                  sum: 0.000001
+                  sum: 1e-06
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_client_seconds
+            name: traces_service_graph_request_client
+            unit: s
         scope:
           name: traces_service_graph

--- a/connector/servicegraphconnector/testdata/failed-label-not-work-expect-metrics.yaml
+++ b/connector/servicegraphconnector/testdata/failed-label-not-work-expect-metrics.yaml
@@ -72,58 +72,6 @@ resourceMetrics:
                         stringValue: ""
                     - key: failed
                       value:
-                        boolValue: true
-                    - key: server
-                      value:
-                        stringValue: bar
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                  count: "1"
-                  explicitBounds:
-                    - 0.002
-                    - 0.004
-                    - 0.006
-                    - 0.008
-                    - 0.01
-                    - 0.05
-                    - 0.1
-                    - 0.2
-                    - 0.4
-                    - 0.8
-                    - 1
-                    - 1.4
-                    - 2
-                    - 5
-                    - 10
-                    - 15
-                  startTimeUnixNano: "1000000"
-                  sum: 1
-                  timeUnixNano: "2000000"
-                - attributes:
-                    - key: client
-                      value:
-                        stringValue: foo
-                    - key: connection_type
-                      value:
-                        stringValue: ""
-                    - key: failed
-                      value:
                         boolValue: false
                     - key: server
                       value:
@@ -167,7 +115,60 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   sum: 2
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_server_seconds
+                - attributes:
+                    - key: client
+                      value:
+                        stringValue: foo
+                    - key: connection_type
+                      value:
+                        stringValue: ""
+                    - key: failed
+                      value:
+                        boolValue: true
+                    - key: server
+                      value:
+                        stringValue: bar
+                  bucketCounts:
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 0.002
+                    - 0.004
+                    - 0.006
+                    - 0.008
+                    - 0.01
+                    - 0.05
+                    - 0.1
+                    - 0.2
+                    - 0.4
+                    - 0.8
+                    - 1
+                    - 1.4
+                    - 2
+                    - 5
+                    - 10
+                    - 15
+                  startTimeUnixNano: "1000000"
+                  sum: 1
+                  timeUnixNano: "2000000"
+            name: traces_service_graph_request_server
+            unit: s
           - histogram:
               aggregationTemporality: 2
               dataPoints:
@@ -180,58 +181,6 @@ resourceMetrics:
                         stringValue: ""
                     - key: failed
                       value:
-                        boolValue: true
-                    - key: server
-                      value:
-                        stringValue: bar
-                  bucketCounts:
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "1"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                    - "0"
-                  count: "1"
-                  explicitBounds:
-                    - 0.002
-                    - 0.004
-                    - 0.006
-                    - 0.008
-                    - 0.01
-                    - 0.05
-                    - 0.1
-                    - 0.2
-                    - 0.4
-                    - 0.8
-                    - 1
-                    - 1.4
-                    - 2
-                    - 5
-                    - 10
-                    - 15
-                  startTimeUnixNano: "1000000"
-                  sum: 1
-                  timeUnixNano: "2000000"
-                - attributes:
-                    - key: client
-                      value:
-                        stringValue: foo
-                    - key: connection_type
-                      value:
-                        stringValue: ""
-                    - key: failed
-                      value:
                         boolValue: false
                     - key: server
                       value:
@@ -275,6 +224,59 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   sum: 2
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_client_seconds
+                - attributes:
+                    - key: client
+                      value:
+                        stringValue: foo
+                    - key: connection_type
+                      value:
+                        stringValue: ""
+                    - key: failed
+                      value:
+                        boolValue: true
+                    - key: server
+                      value:
+                        stringValue: bar
+                  bucketCounts:
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "1"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                    - "0"
+                  count: "1"
+                  explicitBounds:
+                    - 0.002
+                    - 0.004
+                    - 0.006
+                    - 0.008
+                    - 0.01
+                    - 0.05
+                    - 0.1
+                    - 0.2
+                    - 0.4
+                    - 0.8
+                    - 1
+                    - 1.4
+                    - 2
+                    - 5
+                    - 10
+                    - 15
+                  startTimeUnixNano: "1000000"
+                  sum: 1
+                  timeUnixNano: "2000000"
+            name: traces_service_graph_request_client
+            unit: s
         scope:
           name: traces_service_graph

--- a/connector/servicegraphconnector/testdata/virtual-node-label-client-expected-metrics.yaml
+++ b/connector/servicegraphconnector/testdata/virtual-node-label-client-expected-metrics.yaml
@@ -64,7 +64,8 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   sum: 1e-06
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_server_seconds
+            name: traces_service_graph_request_server
+            unit: s
           - histogram:
               aggregationTemporality: 2
               dataPoints:
@@ -100,6 +101,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   sum: 0
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_client_seconds
+            name: traces_service_graph_request_client
+            unit: s
         scope:
           name: traces_service_graph

--- a/connector/servicegraphconnector/testdata/virtual-node-label-server-expected-metrics.yaml
+++ b/connector/servicegraphconnector/testdata/virtual-node-label-server-expected-metrics.yaml
@@ -58,7 +58,8 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   sum: 0
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_server_seconds
+            name: traces_service_graph_request_server
+            unit: s
           - histogram:
               aggregationTemporality: 2
               dataPoints:
@@ -91,6 +92,7 @@ resourceMetrics:
                   startTimeUnixNano: "1000000"
                   sum: 1e-06
                   timeUnixNano: "2000000"
-            name: traces_service_graph_request_client_seconds
+            name: traces_service_graph_request_client
+            unit: s
         scope:
           name: traces_service_graph


### PR DESCRIPTION
**Description:** <Describe what has changed.>

I found the servicegraph histogram metrics missing unit.
This PR will add a proper unit to metrics like [spanmetrics connector does.](			metric.SetUnit(p.config.Histogram.Unit.String()))

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>