### PR TITLE
[receiver/apachereceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-apachereceiver.yaml
+++ b/.chloggen/codeboten_update-scope-apachereceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: apachereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the apachereceiver from `otelcol/apachereceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-apachereceiver.yaml
+++ b/.chloggen/codeboten_update-scope-apachereceiver.yaml
@@ -10,7 +10,7 @@ component: apachereceiver
 note: "Update the scope name for telemetry produced by the apachereceiver from `otelcol/apachereceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34517]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/apachereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/apachereceiver/internal/metadata/generated_metrics.go
@@ -894,7 +894,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/apachereceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricApacheCPULoad.emit(ils.Metrics())

--- a/receiver/apachereceiver/metadata.yaml
+++ b/receiver/apachereceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: apache
-scope_name: otelcol/apachereceiver
 
 status:
   class: receiver

--- a/receiver/apachereceiver/testdata/integration/expected.yaml
+++ b/receiver/apachereceiver/testdata/integration/expected.yaml
@@ -215,5 +215,5 @@ resourceMetrics:
                   timeUnixNano: "1632495518500962000"
             unit: '{workers}'
         scope:
-          name: otelcol/apachereceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
           version: latest

--- a/receiver/apachereceiver/testdata/scraper/expected.yaml
+++ b/receiver/apachereceiver/testdata/scraper/expected.yaml
@@ -215,5 +215,5 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: '{workers}'
         scope:
-          name: otelcol/apachereceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the apachereceiverreceiver from otelcol/apachereceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachereceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
