### PR TITLE
[receiver/aerospikereceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-aerospikereceiver.yaml
+++ b/.chloggen/codeboten_update-scope-aerospikereceiver.yaml
@@ -10,7 +10,7 @@ component: aerospikereceiver
 note: "Update the scope name for telemetry produced by the aerospikereceiver from `otelcol/aerospikereceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34518]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-aerospikereceiver.yaml
+++ b/.chloggen/codeboten_update-scope-aerospikereceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: aerospikereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the aerospikereceiver from `otelcol/aerospikereceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
+++ b/receiver/aerospikereceiver/internal/metadata/generated_metrics.go
@@ -1200,7 +1200,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/aerospikereceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricAerospikeNamespaceDiskAvailable.emit(ils.Metrics())

--- a/receiver/aerospikereceiver/metadata.yaml
+++ b/receiver/aerospikereceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: aerospike
-scope_name: otelcol/aerospikereceiver
 
 status:
   class: receiver

--- a/receiver/aerospikereceiver/testdata/integration/expected.yaml
+++ b/receiver/aerospikereceiver/testdata/integration/expected.yaml
@@ -109,7 +109,7 @@ resourceMetrics:
             name: aerospike.node.memory.free
             unit: '%'
         scope:
-          name: otelcol/aerospikereceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
           version: latest
   - resource:
       attributes:
@@ -734,5 +734,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{transactions}'
         scope:
-          name: otelcol/aerospikereceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the aerospikereceiverreceiver from otelcol/aerospikereceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/aerospikereceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
