### PR TITLE
[receiver/apachesparkreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-apachesparkreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-apachesparkreceiver.yaml
@@ -10,7 +10,7 @@ component: apachesparkreceiver
 note: "Update the scope name for telemetry produced by the apachesparkreceiver from `otelcol/apachesparkreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34519]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-apachesparkreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-apachesparkreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: apachesparkreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the apachesparkreceiver from `otelcol/apachesparkreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/apachesparkreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/apachesparkreceiver/internal/metadata/generated_metrics.go
@@ -3779,7 +3779,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/apachesparkreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSparkDriverBlockManagerDiskUsage.emit(ils.Metrics())

--- a/receiver/apachesparkreceiver/metadata.yaml
+++ b/receiver/apachesparkreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: apachespark
-scope_name: otelcol/apachesparkreceiver
 
 status:
   class: receiver

--- a/receiver/apachesparkreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/apachesparkreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -405,7 +405,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{ event }'
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -575,7 +575,7 @@ resourceMetrics:
               isMonotonic: true
             unit: ms
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -665,7 +665,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{ task }'
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -955,7 +955,7 @@ resourceMetrics:
               isMonotonic: true
             unit: bytes
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -1245,5 +1245,5 @@ resourceMetrics:
               isMonotonic: true
             unit: bytes
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest

--- a/receiver/apachesparkreceiver/testdata/expected_metrics/metrics_partial_golden.yaml
+++ b/receiver/apachesparkreceiver/testdata/expected_metrics/metrics_partial_golden.yaml
@@ -405,5 +405,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{ event }'
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest

--- a/receiver/apachesparkreceiver/testdata/integration/expected.yaml
+++ b/receiver/apachesparkreceiver/testdata/integration/expected.yaml
@@ -405,7 +405,7 @@ resourceMetrics:
                   timeUnixNano: "1684786605037452000"
             unit: '{ event }'
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -695,7 +695,7 @@ resourceMetrics:
               isMonotonic: true
             unit: bytes
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -985,7 +985,7 @@ resourceMetrics:
               isMonotonic: true
             unit: bytes
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -1155,7 +1155,7 @@ resourceMetrics:
               isMonotonic: true
             unit: ms
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest
   - resource:
       attributes:
@@ -1245,5 +1245,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{ task }'
         scope:
-          name: otelcol/apachesparkreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the apachesparkreceiverreceiver from otelcol/apachesparkreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/apachesparkreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
