### PR TITLE
[receiver/bigipreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-bigipreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-bigipreceiver.yaml
@@ -10,7 +10,7 @@ component: bigipreceiver
 note: "Update the scope name for telemetry produced by the bigipreceiver from `otelcol/bigipreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34520]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-bigipreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-bigipreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: bigipreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the bigipreceiver from `otelcol/bigipreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/bigipreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/bigipreceiver/internal/metadata/generated_metrics.go
@@ -1700,7 +1700,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/bigipreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricBigipNodeAvailability.emit(ils.Metrics())

--- a/receiver/bigipreceiver/metadata.yaml
+++ b/receiver/bigipreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: bigip
-scope_name: otelcol/bigipreceiver
 
 status:
   class: receiver

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -133,7 +133,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -269,7 +269,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -397,7 +397,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -525,7 +525,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -653,7 +653,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -781,7 +781,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -909,7 +909,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1031,7 +1031,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1162,7 +1162,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1284,7 +1284,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1415,7 +1415,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1546,7 +1546,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1677,7 +1677,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1808,7 +1808,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1930,7 +1930,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -2052,5 +2052,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_golden.yaml
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_golden.yaml
@@ -108,7 +108,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -219,7 +219,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -330,7 +330,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -441,5 +441,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest

--- a/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.yaml
+++ b/receiver/bigipreceiver/testdata/expected_metrics/metrics_partial_with_members_golden.yaml
@@ -133,7 +133,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -269,7 +269,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -380,7 +380,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -511,7 +511,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -622,7 +622,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -753,7 +753,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -884,7 +884,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1015,7 +1015,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1146,7 +1146,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1257,7 +1257,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1368,5 +1368,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest

--- a/receiver/bigipreceiver/testdata/integration/expected.yaml
+++ b/receiver/bigipreceiver/testdata/integration/expected.yaml
@@ -119,7 +119,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -241,7 +241,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -363,7 +363,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -485,7 +485,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -621,7 +621,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -757,7 +757,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -888,7 +888,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1019,7 +1019,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1150,7 +1150,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1281,7 +1281,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1412,7 +1412,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1540,7 +1540,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1668,7 +1668,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1796,7 +1796,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -1924,7 +1924,7 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest
   - resource:
       attributes:
@@ -2052,5 +2052,5 @@ resourceMetrics:
                   timeUnixNano: "1651862591371979000"
             unit: '{sessions}'
         scope:
-          name: otelcol/bigipreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the bigipreceiverreceiver from otelcol/bigipreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/bigipreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
