### PR TITLE
[receiver/couchdbreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-couchdbreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-couchdbreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: couchdbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the couchdbreceiver from `otelcol/couchdbreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-couchdbreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-couchdbreceiver.yaml
@@ -10,7 +10,7 @@ component: couchdbreceiver
 note: "Update the scope name for telemetry produced by the couchdbreceiver from `otelcol/couchdbreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34525]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/couchdbreceiver/internal/metadata/generated_metrics.go
@@ -635,7 +635,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/couchdbreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricCouchdbAverageRequestTime.emit(ils.Metrics())

--- a/receiver/couchdbreceiver/metadata.yaml
+++ b/receiver/couchdbreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: couchdb
-scope_name: otelcol/couchdbreceiver
 
 status:
   class: receiver

--- a/receiver/couchdbreceiver/testdata/scraper/expected.yaml
+++ b/receiver/couchdbreceiver/testdata/scraper/expected.yaml
@@ -316,5 +316,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{views}'
         scope:
-          name: otelcol/couchdbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
           version: latest

--- a/receiver/couchdbreceiver/testdata/scraper/only_db_ops.yaml
+++ b/receiver/couchdbreceiver/testdata/scraper/only_db_ops.yaml
@@ -28,5 +28,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{operations}'
         scope:
-          name: otelcol/couchdbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the couchdbreceiverreceiver from otelcol/couchdbreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/couchdbreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
