### PR TITLE
[receiver/hostmetrics] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-hostmetrics.yaml
+++ b/.chloggen/codeboten_update-scope-hostmetrics.yaml
@@ -10,7 +10,7 @@ component: hostmetricsreceiver
 note: "Update the scope name for telemetry produced by the hostmetrics receiver's scrapers from `otelcol/hostmetricsreceiver/*` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/*`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34526]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-hostmetrics.yaml
+++ b/.chloggen/codeboten_update-scope-hostmetrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the hostmetrics receiver's scrapers from `otelcol/hostmetricsreceiver/*` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/*`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/elasticsearchexporter/testdata/metrics-cpu.json
+++ b/exporter/elasticsearchexporter/testdata/metrics-cpu.json
@@ -20,7 +20,7 @@
       "scopeMetrics": [
         {
           "scope": {
-            "name": "otelcol/hostmetricsreceiver/cpu",
+            "name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper",
             "version": "0.102.0-dev"
           },
           "metrics": [

--- a/exporter/signalfxexporter/testdata/hostmetrics.yaml
+++ b/exporter/signalfxexporter/testdata/hostmetrics.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
             name: system.cpu.load_average.5m
             unit: "1"
         scope:
-          name: otelcol/hostmetricsreceiver/load
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/loadscraper
           version: v0.55.0-341-gf787ff695
   - resource: {}
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
@@ -62,7 +62,7 @@ resourceMetrics:
                   timeUnixNano: "1660943983792184000"
             unit: By
         scope:
-          name: otelcol/hostmetricsreceiver/memory
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper
           version: v0.55.0-341-gf787ff695
   - resource: {}
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
@@ -1583,7 +1583,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{packets}'
         scope:
-          name: otelcol/hostmetricsreceiver/network
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper
           version: v0.55.0-341-gf787ff695
   - resource: {}
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
@@ -1694,7 +1694,7 @@ resourceMetrics:
                   timeUnixNano: "1660943984119168000"
             unit: By
         scope:
-          name: otelcol/hostmetricsreceiver/paging
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper
           version: v0.55.0-341-gf787ff695
   - resource: {}
     schemaUrl: https://opentelemetry.io/schemas/1.9.0
@@ -2378,5 +2378,5 @@ resourceMetrics:
                   timeUnixNano: "1660943984125836000"
             unit: By
         scope:
-          name: otelcol/hostmetricsreceiver/filesystem
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
           version: v0.55.0-341-gf787ff695

--- a/exporter/signalfxexporter/testdata/hostmetrics_system_cpu_time_1.yaml
+++ b/exporter/signalfxexporter/testdata/hostmetrics_system_cpu_time_1.yaml
@@ -91,5 +91,5 @@ resourceMetrics:
               isMonotonic: true
             unit: s
         scope:
-          name: otelcol/hostmetricsreceiver/cpu
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper
           version: latest

--- a/exporter/signalfxexporter/testdata/hostmetrics_system_cpu_time_2.yaml
+++ b/exporter/signalfxexporter/testdata/hostmetrics_system_cpu_time_2.yaml
@@ -91,5 +91,5 @@ resourceMetrics:
               isMonotonic: true
             unit: s
         scope:
-          name: otelcol/hostmetricsreceiver/cpu
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper
           version: latest

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -412,7 +412,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/cpu")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemCPUFrequency.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/cpu
-scope_name: otelcol/hostmetricsreceiver/cpu
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
@@ -508,7 +508,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/disk")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/diskscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemDiskIo.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/disk
-scope_name: otelcol/hostmetricsreceiver/disk
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
@@ -297,7 +297,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/filesystem")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemFilesystemInodesUsage.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/filesystem
-scope_name: otelcol/hostmetricsreceiver/filesystem
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
@@ -246,7 +246,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/load")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/loadscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemCPULoadAverage15m.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/load
-scope_name: otelcol/hostmetricsreceiver/load
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -353,7 +353,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/memory")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/memoryscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemLinuxMemoryAvailable.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/memory
-scope_name: otelcol/hostmetricsreceiver/memory
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -527,7 +527,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/network")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/networkscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemNetworkConnections.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/network
-scope_name: otelcol/hostmetricsreceiver/network
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
@@ -396,7 +396,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/paging")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/pagingscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemPagingFaults.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/paging
-scope_name: otelcol/hostmetricsreceiver/paging
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
@@ -271,7 +271,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/processes")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processesscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricSystemProcessesCount.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/processes
-scope_name: otelcol/hostmetricsreceiver/processes
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -956,7 +956,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/hostmetricsreceiver/process")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricProcessContextSwitches.emit(ils.Metrics())

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -1,5 +1,4 @@
 type: hostmetricsreceiver/process
-scope_name: otelcol/hostmetricsreceiver/process
 
 parent: hostmetrics
 

--- a/receiver/hostmetricsreceiver/testdata/e2e/expected_process.yaml
+++ b/receiver/hostmetricsreceiver/testdata/e2e/expected_process.yaml
@@ -72,7 +72,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/hostmetricsreceiver/process
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper
           version: latest
   - resource:
       attributes:
@@ -147,5 +147,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/hostmetricsreceiver/process
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper
           version: latest

--- a/receiver/hostmetricsreceiver/testdata/e2e/expected_process_separate_proc.yaml
+++ b/receiver/hostmetricsreceiver/testdata/e2e/expected_process_separate_proc.yaml
@@ -72,5 +72,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/hostmetricsreceiver/process
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the hostmetrics receiver's scrapers from `otelcol/hostmetricsreceiver/*` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/*`

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
