### PR TITLE
[receiver/dockerstatsreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-dockerstatsreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-dockerstatsreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: dockerstatsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the dockerstatsreceiver from `otelcol/dockerstatsreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-dockerstatsreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-dockerstatsreceiver.yaml
@@ -10,7 +10,7 @@ component: dockerstatsreceiver
 note: "Update the scope name for telemetry produced by the dockerstatsreceiver from `otelcol/dockerstatsreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34528]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -3946,7 +3946,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/dockerstatsreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricContainerBlockioIoMergedRecursive.emit(ils.Metrics())

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: docker_stats
-scope_name: otelcol/dockerstatsreceiver
 
 status:
   class: receiver

--- a/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
@@ -423,5 +423,5 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest

--- a/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
@@ -483,5 +483,5 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest

--- a/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
@@ -824,5 +824,5 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest

--- a/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
@@ -475,5 +475,5 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
@@ -837,5 +837,5 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
@@ -839,5 +839,5 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
@@ -782,7 +782,7 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1567,5 +1567,5 @@ resourceMetrics:
             name: container.uptime
             unit: s
         scope:
-          name: otelcol/dockerstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the dockerstatsreceiverreceiver from otelcol/dockerstatsreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/dockerstatsreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
