### PR TITLE
[receiver/elasticsearchreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-elasticsearchreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-elasticsearchreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the elasticsearchreceiver from `otelcol/elasticsearchreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-elasticsearchreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-elasticsearchreceiver.yaml
@@ -10,7 +10,7 @@ component: elasticsearchreceiver
 note: "Update the scope name for telemetry produced by the elasticsearchreceiver from `otelcol/elasticsearchreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34529]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/elasticsearchreceiver/internal/metadata/generated_metrics.go
@@ -5592,7 +5592,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/elasticsearchreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricElasticsearchBreakerMemoryEstimated.emit(ils.Metrics())

--- a/receiver/elasticsearchreceiver/metadata.yaml
+++ b/receiver/elasticsearchreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: elasticsearch
-scope_name: otelcol/elasticsearchreceiver
 
 status:
   class: receiver

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/clusterSkip.yaml
@@ -535,7 +535,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -1073,7 +1073,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -2295,5 +2295,5 @@ resourceMetrics:
             name: jvm.threads.count
             unit: "1"
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full_linux.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full_linux.yaml
@@ -147,7 +147,7 @@ resourceMetrics:
             name: jvm.memory.heap.used
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -939,7 +939,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -1731,7 +1731,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -3085,5 +3085,5 @@ resourceMetrics:
             name: jvm.threads.count
             unit: "1"
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/full_other.yaml
@@ -147,7 +147,7 @@ resourceMetrics:
             name: jvm.memory.heap.used
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -939,7 +939,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -1731,7 +1731,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -3067,5 +3067,5 @@ resourceMetrics:
             name: jvm.threads.count
             unit: "1"
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest

--- a/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
+++ b/receiver/elasticsearchreceiver/testdata/expected_metrics/noNodes.yaml
@@ -118,7 +118,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{shards}'
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -656,7 +656,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -1194,5 +1194,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_16_3.yaml
@@ -126,7 +126,7 @@ resourceMetrics:
             name: jvm.memory.heap.used
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -664,7 +664,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -1202,7 +1202,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -3996,5 +3996,5 @@ resourceMetrics:
             name: jvm.threads.count
             unit: "1"
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest

--- a/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.yaml
+++ b/receiver/elasticsearchreceiver/testdata/integration/expected.7_9_3.yaml
@@ -126,7 +126,7 @@ resourceMetrics:
             name: jvm.memory.heap.used
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -664,7 +664,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest
   - resource:
       attributes:
@@ -2775,5 +2775,5 @@ resourceMetrics:
             name: jvm.threads.count
             unit: "1"
         scope:
-          name: otelcol/elasticsearchreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the elasticsearchreceiverreceiver from otelcol/elasticsearchreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/elasticsearchreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
