### PR TITLE
[receiver/expvarreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-expvarreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-expvarreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: expvarreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the expvarreceiver from `otelcol/expvarreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-expvarreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-expvarreceiver.yaml
@@ -10,7 +10,7 @@ component: expvarreceiver
 note: "Update the scope name for telemetry produced by the expvarreceiver from `otelcol/expvarreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34530]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/expvarreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/expvarreceiver/internal/metadata/generated_metrics.go
@@ -1465,7 +1465,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/expvarreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricProcessRuntimeMemstatsBuckHashSys.emit(ils.Metrics())

--- a/receiver/expvarreceiver/metadata.yaml
+++ b/receiver/expvarreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: expvar
-scope_name: otelcol/expvarreceiver
 
 status:
   class: receiver

--- a/receiver/expvarreceiver/testdata/metrics/expected_all_metrics.yaml
+++ b/receiver/expvarreceiver/testdata/metrics/expected_all_metrics.yaml
@@ -241,5 +241,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/expvarreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the expvarreceiverreceiver from otelcol/expvarreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/expvarreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
