### PR TITLE
[receiver/filestatsreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-filestatsreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-filestatsreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filestatsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the filestatsreceiver from `otelcol/filestatsreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/filestatsreceiver/internal/metadata/generated_metrics.go
@@ -376,7 +376,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/filestatsreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricFileAtime.emit(ils.Metrics())

--- a/receiver/filestatsreceiver/metadata.yaml
+++ b/receiver/filestatsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: filestats
-scope_name: otelcol/filestatsreceiver
 
 status:
   class: receiver

--- a/receiver/filestatsreceiver/testdata/integration/expected.yaml
+++ b/receiver/filestatsreceiver/testdata/integration/expected.yaml
@@ -27,7 +27,7 @@ resourceMetrics:
             name: file.size
             unit: b
         scope:
-          name: otelcol/filestatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
           version: latest
   - resource:
       attributes:
@@ -57,5 +57,5 @@ resourceMetrics:
             name: file.size
             unit: b
         scope:
-          name: otelcol/filestatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the filestatsreceiverreceiver from otelcol/filestatsreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/filestatsreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
