### PR TITLE
[chore] Temporarily remove @evan-bradley from PR auto-assignment

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -24,7 +24,8 @@ assigneeGroups:
     - codeboten
     - djaglowski
     - dmitryax
-    - evan-bradley
+    # Unavailable 2024-08-12 -- 2024-08-23, 2024-09-06 -- 2024-09-30
+    # - evan-bradley
     - jpkrohling
     - MovieStoreGuy
     - mx-psi


### PR DESCRIPTION
I will be unavailable 2024-08-12 -- 2024-08-23 and 2024-09-06 -- 2024-09-30. I'm removing myself from auto-assignment so contributors can have an available approver assigned to their PRs.