### PR TITLE
[receiver/flinkmetricsreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-flinkmetricsreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-flinkmetricsreceiver.yaml
@@ -10,7 +10,7 @@ component: flinkmetricsreceiver
 note: "Update the scope name for telemetry produced by the flinkmetricsreceiver from `otelcol/flinkmetricsreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34533]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-flinkmetricsreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-flinkmetricsreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: flinkmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the flinkmetricsreceiver from `otelcol/flinkmetricsreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/flinkmetricsreceiver/internal/metadata/generated_metrics.go
@@ -1775,7 +1775,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/flinkmetricsreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricFlinkJobCheckpointCount.emit(ils.Metrics())

--- a/receiver/flinkmetricsreceiver/metadata.yaml
+++ b/receiver/flinkmetricsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: flinkmetrics
-scope_name: otelcol/flinkmetricsreceiver
 
 status:
   class: receiver

--- a/receiver/flinkmetricsreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/flinkmetricsreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -67,7 +67,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{restarts}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -137,7 +137,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{restarts}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -364,7 +364,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -594,7 +594,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -824,7 +824,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -924,5 +924,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{records}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest

--- a/receiver/flinkmetricsreceiver/testdata/expected_metrics/metrics_no_jobs_golden.yaml
+++ b/receiver/flinkmetricsreceiver/testdata/expected_metrics/metrics_no_jobs_golden.yaml
@@ -224,7 +224,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -454,7 +454,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -684,5 +684,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest

--- a/receiver/flinkmetricsreceiver/testdata/expected_metrics/partial_metrics_no_jobs.yaml
+++ b/receiver/flinkmetricsreceiver/testdata/expected_metrics/partial_metrics_no_jobs.yaml
@@ -224,7 +224,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -454,7 +454,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -684,5 +684,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest

--- a/receiver/flinkmetricsreceiver/testdata/expected_metrics/partial_metrics_no_subtasks.yaml
+++ b/receiver/flinkmetricsreceiver/testdata/expected_metrics/partial_metrics_no_subtasks.yaml
@@ -67,7 +67,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{restarts}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -137,7 +137,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{restarts}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -364,7 +364,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -594,7 +594,7 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -824,5 +824,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest

--- a/receiver/flinkmetricsreceiver/testdata/expected_metrics/partial_metrics_no_taskmanagers.yaml
+++ b/receiver/flinkmetricsreceiver/testdata/expected_metrics/partial_metrics_no_taskmanagers.yaml
@@ -224,5 +224,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest

--- a/receiver/flinkmetricsreceiver/testdata/integration/expected.yaml
+++ b/receiver/flinkmetricsreceiver/testdata/integration/expected.yaml
@@ -164,7 +164,7 @@ resourceMetrics:
                   timeUnixNano: "1656013053528397000"
             unit: '{threads}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -394,7 +394,7 @@ resourceMetrics:
                   timeUnixNano: "1656013053528397000"
             unit: By
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -464,7 +464,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{restarts}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -547,7 +547,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{records}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest
   - resource:
       attributes:
@@ -657,5 +657,5 @@ resourceMetrics:
               isMonotonic: true
             unit: '{records}'
         scope:
-          name: otelcol/flinkmetricsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the flinkmetricsreceiverreceiver from otelcol/flinkmetricsreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/flinkmetricsreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
