### PR TITLE
[receiver/iisreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-iisreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-iisreceiver.yaml
@@ -10,7 +10,7 @@ component: iisreceiver
 note: "Update the scope name for telemetry produced by the iisreceiver from `otelcol/iisreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34535]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-iisreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-iisreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: iisreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the iisreceiver from `otelcol/iisreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/iisreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/iisreceiver/internal/metadata/generated_metrics.go
@@ -823,7 +823,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/iisreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricIisConnectionActive.emit(ils.Metrics())

--- a/receiver/iisreceiver/metadata.yaml
+++ b/receiver/iisreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: iis
-scope_name: otelcol/iisreceiver
 
 status:
   class: receiver

--- a/receiver/iisreceiver/testdata/integration/expected.yaml
+++ b/receiver/iisreceiver/testdata/integration/expected.yaml
@@ -152,7 +152,7 @@ resourceMetrics:
             name: iis.uptime
             unit: s
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest
   - resource:
       attributes:
@@ -189,7 +189,7 @@ resourceMetrics:
               isMonotonic: true
             unit: "{requests}"
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest
   - resource:
       attributes:
@@ -226,7 +226,7 @@ resourceMetrics:
               isMonotonic: true
             unit: "{requests}"
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest
   - resource: {}
     scopeMetrics:
@@ -241,5 +241,5 @@ resourceMetrics:
                   timeUnixNano: "1664375533465547100"
             unit: "{threads}"
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest

--- a/receiver/iisreceiver/testdata/scraper/expected.yaml
+++ b/receiver/iisreceiver/testdata/scraper/expected.yaml
@@ -152,7 +152,7 @@ resourceMetrics:
             name: iis.uptime
             unit: s
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest
   - resource:
       attributes:
@@ -189,7 +189,7 @@ resourceMetrics:
               isMonotonic: true
             unit: '{requests}'
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest
   - resource: {}
     scopeMetrics:
@@ -204,5 +204,5 @@ resourceMetrics:
                   timeUnixNano: "1664375532831495700"
             unit: '{threads}'
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest

--- a/receiver/iisreceiver/testdata/scraper/expected_negative_denominator.yaml
+++ b/receiver/iisreceiver/testdata/scraper/expected_negative_denominator.yaml
@@ -15,5 +15,5 @@ resourceMetrics:
             name: iis.request.queue.age.max
             unit: ms
         scope:
-          name: otelcol/iisreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the iisreceiverreceiver from otelcol/iisreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/iisreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
