### PR TITLE
[receiver/k8sclusterreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-k8sclusterreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-k8sclusterreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the k8sclusterreceiver from `otelcol/k8sclusterreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-k8sclusterreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-k8sclusterreceiver.yaml
@@ -10,7 +10,7 @@ component: k8sclusterreceiver
 note: "Update the scope name for telemetry produced by the k8sclusterreceiver from `otelcol/k8sclusterreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34536]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/clusterresourcequota/testdata/expected.yaml
@@ -74,5 +74,5 @@ resourceMetrics:
             name: openshift.appliedclusterquota.used
             unit: "{resource}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/cronjob/testdata/expected.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
             name: k8s.cronjob.active_jobs
             unit: "{job}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/demonset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/demonset/testdata/expected.yaml
@@ -38,5 +38,5 @@ resourceMetrics:
             name: k8s.daemonset.ready_nodes
             unit: "{node}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/deployment/testdata/expected.yaml
@@ -30,5 +30,5 @@ resourceMetrics:
             name: k8s.deployment.desired
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected.yaml
@@ -44,6 +44,6 @@ resourceMetrics:
             name: k8s.job.max_parallel_pods
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
 

--- a/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
+++ b/receiver/k8sclusterreceiver/internal/jobs/testdata/expected_empty.yaml
@@ -32,6 +32,6 @@ resourceMetrics:
             name: k8s.job.successful_pods
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
 

--- a/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/generated_metrics.go
@@ -2585,7 +2585,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.SetSchemaUrl(conventions.SchemaURL)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/k8sclusterreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricK8sContainerCPULimit.emit(ils.Metrics())

--- a/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/namespace/testdata/expected.yaml
@@ -17,5 +17,5 @@ resourceMetrics:
             name: k8s.namespace.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/node/nodes.go
+++ b/receiver/k8sclusterreceiver/internal/node/nodes.go
@@ -106,7 +106,7 @@ func CustomMetrics(set receiver.Settings, rb *metadata.ResourceBuilder, node *co
 
 	// TODO: Generate a schema URL for the node metrics in the metadata package and use them here.
 	rm.SetSchemaUrl(conventions.SchemaURL)
-	sm.Scope().SetName("otelcol/k8sclusterreceiver")
+	sm.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver")
 	sm.Scope().SetVersion(set.BuildInfo.Version)
 
 	rb.SetK8sNodeUID(string(node.UID))

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected.yaml
@@ -83,5 +83,5 @@ resourceMetrics:
             name: k8s.node.allocatable_hugepages_2_mi
             unit: "{hugepages-2Mi}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected_mdatagen.yaml
@@ -43,5 +43,5 @@ resourceMetrics:
             unit: "{condition}"
 
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/node/testdata/expected_optional.yaml
+++ b/receiver/k8sclusterreceiver/internal/node/testdata/expected_optional.yaml
@@ -39,5 +39,5 @@ resourceMetrics:
             name: k8s.node.allocatable_memory
             unit: By
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected.yaml
@@ -23,7 +23,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -79,5 +79,5 @@ resourceMetrics:
             name: k8s.container.cpu_limit
             unit: "{cpu}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
+++ b/receiver/k8sclusterreceiver/internal/pod/testdata/expected_evicted.yaml
@@ -32,7 +32,7 @@ resourceMetrics:
             name: k8s.pod.status_reason
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -91,5 +91,5 @@ resourceMetrics:
             name: k8s.container.cpu_limit
             unit: "{cpu}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicaset/testdata/expected.yaml
@@ -27,6 +27,6 @@ resourceMetrics:
             unit: "{pod}"
 
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
 

--- a/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/replicationcontroller/testdata/expected.yaml
@@ -26,5 +26,5 @@ resourceMetrics:
             name: k8s.replication_controller.desired
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
+++ b/receiver/k8sclusterreceiver/internal/resourcequota/testdata/expected.yaml
@@ -34,5 +34,5 @@ resourceMetrics:
             name: k8s.resource_quota.used
             unit: "{resource}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest

--- a/receiver/k8sclusterreceiver/metadata.yaml
+++ b/receiver/k8sclusterreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: k8s_cluster
-scope_name: otelcol/k8sclusterreceiver
 
 status:
   class: receiver

--- a/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
+++ b/receiver/k8sclusterreceiver/testdata/e2e/expected.yaml
@@ -18,7 +18,7 @@ resourceMetrics:
             name: k8s.namespace.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -39,7 +39,7 @@ resourceMetrics:
             name: k8s.namespace.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -60,7 +60,7 @@ resourceMetrics:
             name: k8s.namespace.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -81,7 +81,7 @@ resourceMetrics:
             name: k8s.namespace.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -102,7 +102,7 @@ resourceMetrics:
             name: k8s.namespace.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -123,7 +123,7 @@ resourceMetrics:
             name: k8s.node.condition_ready
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -168,7 +168,7 @@ resourceMetrics:
             name: k8s.daemonset.ready_nodes
             unit: "{node}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -213,7 +213,7 @@ resourceMetrics:
             name: k8s.daemonset.ready_nodes
             unit: "{node}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -244,7 +244,7 @@ resourceMetrics:
             name: k8s.deployment.available
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -275,7 +275,7 @@ resourceMetrics:
             name: k8s.deployment.available
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -306,7 +306,7 @@ resourceMetrics:
             name: k8s.deployment.available
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -337,7 +337,7 @@ resourceMetrics:
             name: k8s.replicaset.available
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -368,7 +368,7 @@ resourceMetrics:
             name: k8s.replicaset.available
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -399,7 +399,7 @@ resourceMetrics:
             name: k8s.replicaset.available
             unit: "{pod}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -426,7 +426,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -453,7 +453,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -480,7 +480,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -507,7 +507,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -534,7 +534,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -561,7 +561,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -588,7 +588,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -615,7 +615,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -642,7 +642,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -669,7 +669,7 @@ resourceMetrics:
             name: k8s.pod.phase
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -729,7 +729,7 @@ resourceMetrics:
             name: k8s.container.memory_request
             unit: "By"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -803,7 +803,7 @@ resourceMetrics:
             name: k8s.container.memory_limit
             unit: "By"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -856,7 +856,7 @@ resourceMetrics:
             name: k8s.container.cpu_request
             unit: "{cpu}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -909,7 +909,7 @@ resourceMetrics:
             name: k8s.container.cpu_request
             unit: "{cpu}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -962,7 +962,7 @@ resourceMetrics:
             name: k8s.container.cpu_request
             unit: "{cpu}"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -1008,7 +1008,7 @@ resourceMetrics:
             name: k8s.container.ready
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -1075,7 +1075,7 @@ resourceMetrics:
             name: k8s.container.memory_limit
             unit: "By"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -1149,7 +1149,7 @@ resourceMetrics:
             name: k8s.container.memory_limit
             unit: "By"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -1195,7 +1195,7 @@ resourceMetrics:
             name: k8s.container.ready
             unit: ""
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest
   - resource:
       attributes:
@@ -1262,5 +1262,5 @@ resourceMetrics:
             name: k8s.container.memory_limit
             unit: "By"
         scope:
-          name: otelcol/k8sclusterreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the k8sclusterreceiverreceiver from otelcol/k8sclusterreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
