### PR TITLE
[receiver/kubeletstatsreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-kubeletstatsreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-kubeletstatsreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: kubeletstatsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the kubeletstatsreceiver from `otelcol/kubeletstatsreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-kubeletstatsreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-kubeletstatsreceiver.yaml
@@ -10,7 +10,7 @@ component: kubeletstatsreceiver
 note: "Update the scope name for telemetry produced by the kubeletstatsreceiver from `otelcol/kubeletstatsreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34537]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
@@ -55,7 +55,7 @@ func requireMetricsOk(t *testing.T, mds []pmetric.Metrics) {
 			requireResourceOk(t, rm.Resource())
 			for j := 0; j < rm.ScopeMetrics().Len(); j++ {
 				ilm := rm.ScopeMetrics().At(j)
-				require.Equal(t, "otelcol/kubeletstatsreceiver", ilm.Scope().Name())
+				require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver", ilm.Scope().Name())
 				for k := 0; k < ilm.Metrics().Len(); k++ {
 					requireMetricOk(t, ilm.Metrics().At(k))
 				}

--- a/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/kubeletstatsreceiver/internal/metadata/generated_metrics.go
@@ -3318,7 +3318,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/kubeletstatsreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricContainerCPUTime.emit(ils.Metrics())

--- a/receiver/kubeletstatsreceiver/metadata.yaml
+++ b/receiver/kubeletstatsreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: kubeletstats
-scope_name: otelcol/kubeletstatsreceiver
 
 status:
   class: receiver

--- a/receiver/kubeletstatsreceiver/testdata/e2e/expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/e2e/expected.yaml
@@ -6,7 +6,7 @@ resourceMetrics:
             stringValue: kind-control-plane
     scopeMetrics:
       - scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
         metrics:
           - name: k8s.node.cpu.time

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_cpu_util_nodelimit_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_cpu_util_nodelimit_expected.yaml
@@ -21,7 +21,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -45,7 +45,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -69,7 +69,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -93,7 +93,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -117,7 +117,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -141,7 +141,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -165,7 +165,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -189,7 +189,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -213,7 +213,7 @@ resourceMetrics:
             name: k8s.pod.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -240,7 +240,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -267,7 +267,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -294,7 +294,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -321,7 +321,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -348,7 +348,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -375,7 +375,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -402,7 +402,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -429,7 +429,7 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -456,5 +456,5 @@ resourceMetrics:
             name: k8s.container.cpu.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_expected.yaml
@@ -151,7 +151,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -311,7 +311,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -471,7 +471,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -631,7 +631,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -791,7 +791,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -951,7 +951,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1111,7 +1111,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1271,7 +1271,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1431,7 +1431,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1591,7 +1591,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1700,7 +1700,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1809,7 +1809,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1918,7 +1918,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2027,7 +2027,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2136,7 +2136,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2245,7 +2245,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2354,7 +2354,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2463,7 +2463,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2572,7 +2572,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2631,7 +2631,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2690,7 +2690,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2749,7 +2749,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2808,7 +2808,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2867,7 +2867,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2926,7 +2926,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2985,7 +2985,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -3044,5 +3044,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_memory_util_nodelimit_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_memory_util_nodelimit_expected.yaml
@@ -21,7 +21,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -45,7 +45,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -69,7 +69,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -93,7 +93,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -117,7 +117,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -141,7 +141,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -165,7 +165,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -189,7 +189,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -213,7 +213,7 @@ resourceMetrics:
             name: k8s.pod.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -240,7 +240,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -267,7 +267,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -294,7 +294,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -321,7 +321,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -348,7 +348,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -375,7 +375,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -402,7 +402,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -429,7 +429,7 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -456,5 +456,5 @@ resourceMetrics:
             name: k8s.container.memory.node.utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metadata_Container_Metadata_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metadata_Container_Metadata_expected.yaml
@@ -109,7 +109,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -221,7 +221,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -333,7 +333,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -445,7 +445,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -557,7 +557,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -669,7 +669,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -781,7 +781,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -893,7 +893,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1005,5 +1005,5 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metadata_Volume_Metadata_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metadata_Volume_Metadata_expected.yaml
@@ -59,7 +59,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -121,7 +121,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -183,7 +183,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -245,7 +245,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -307,7 +307,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -372,7 +372,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -437,7 +437,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -502,5 +502,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_all_groups_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_all_groups_expected.yaml
@@ -151,7 +151,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -311,7 +311,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -471,7 +471,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -631,7 +631,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -791,7 +791,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -951,7 +951,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1111,7 +1111,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1271,7 +1271,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1431,7 +1431,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1591,7 +1591,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1650,7 +1650,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1709,7 +1709,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1768,7 +1768,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1827,7 +1827,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1886,7 +1886,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1945,7 +1945,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2004,7 +2004,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2063,7 +2063,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2175,7 +2175,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2287,7 +2287,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2399,7 +2399,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2511,7 +2511,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2623,7 +2623,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2735,7 +2735,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2847,7 +2847,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -2959,7 +2959,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -3071,5 +3071,5 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_container_group_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_container_group_expected.yaml
@@ -109,7 +109,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -221,7 +221,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -333,7 +333,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -445,7 +445,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -557,7 +557,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -669,7 +669,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -781,7 +781,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -893,7 +893,7 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1005,5 +1005,5 @@ resourceMetrics:
             name: container.memory.working_set
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_node_group_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_node_group_expected.yaml
@@ -151,5 +151,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_pod_group_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_pod_group_expected.yaml
@@ -157,7 +157,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -317,7 +317,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -477,7 +477,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -637,7 +637,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -797,7 +797,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -957,7 +957,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1117,7 +1117,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1277,7 +1277,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1437,5 +1437,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_volume_group_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_only_volume_group_expected.yaml
@@ -56,7 +56,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -115,7 +115,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -174,7 +174,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -233,7 +233,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -292,7 +292,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -351,7 +351,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -410,7 +410,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -469,5 +469,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_pod_and_node_groups_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_metric_groups_pod_and_node_groups_expected.yaml
@@ -151,7 +151,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -311,7 +311,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -471,7 +471,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -631,7 +631,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -791,7 +791,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -951,7 +951,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1111,7 +1111,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1271,7 +1271,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1431,7 +1431,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -1591,5 +1591,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_percent_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_percent_expected.yaml
@@ -45,7 +45,7 @@ resourceMetrics:
             name: k8s.pod.memory_request_utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -96,5 +96,5 @@ resourceMetrics:
             name: k8s.container.memory_request_utilization
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_do_not_collect_detailed_labels_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_do_not_collect_detailed_labels_expected.yaml
@@ -59,7 +59,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -121,7 +121,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -183,7 +183,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -245,7 +245,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -307,7 +307,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -372,7 +372,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -437,7 +437,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -502,5 +502,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_empty_volume_name_in_pvc_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_empty_volume_name_in_pvc_expected.yaml
@@ -59,7 +59,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -121,7 +121,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -183,7 +183,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -245,7 +245,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -307,7 +307,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -381,7 +381,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -455,5 +455,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_non_existent_volume_in_pvc_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_non_existent_volume_in_pvc_expected.yaml
@@ -59,7 +59,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -121,7 +121,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -183,7 +183,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -245,7 +245,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -307,7 +307,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -381,7 +381,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -455,5 +455,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_pvc_doesnot_exist_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_pvc_doesnot_exist_expected.yaml
@@ -59,7 +59,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -121,7 +121,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -183,7 +183,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -245,7 +245,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -307,5 +307,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest

--- a/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_successful_expected.yaml
+++ b/receiver/kubeletstatsreceiver/testdata/scraper/test_scraper_with_pvc_labels_successful_expected.yaml
@@ -59,7 +59,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -121,7 +121,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -183,7 +183,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -245,7 +245,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -307,7 +307,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -378,7 +378,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -452,7 +452,7 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest
   - resource:
       attributes:
@@ -526,5 +526,5 @@ resourceMetrics:
             name: k8s.volume.inodes.used
             unit: "1"
         scope:
-          name: otelcol/kubeletstatsreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the kubeletstatsreceiverreceiver from otelcol/kubeletstatsreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
