### PR TITLE
[receiver/memcachedreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-memcachedreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-memcachedreceiver.yaml
@@ -10,7 +10,7 @@ component: memcachedreceiver
 note: "Update the scope name for telemetry produced by the memcachedreceiver from `otelcol/memcachedreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34542]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-memcachedreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-memcachedreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: memcachedreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the memcachedreceiver from `otelcol/memcachedreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/memcachedreceiver/internal/metadata/generated_metrics.go
@@ -823,7 +823,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/memcachedreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricMemcachedBytes.emit(ils.Metrics())

--- a/receiver/memcachedreceiver/metadata.yaml
+++ b/receiver/memcachedreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: memcached
-scope_name: otelcol/memcachedreceiver
 
 status:
   class: receiver

--- a/receiver/memcachedreceiver/testdata/integration/expected.yaml
+++ b/receiver/memcachedreceiver/testdata/integration/expected.yaml
@@ -205,5 +205,5 @@ resourceMetrics:
                   timeUnixNano: "1639770622333015000"
             unit: '{threads}'
         scope:
-          name: otelcol/memcachedreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
           version: latest

--- a/receiver/memcachedreceiver/testdata/scraper/expected.yaml
+++ b/receiver/memcachedreceiver/testdata/scraper/expected.yaml
@@ -205,5 +205,5 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: '{threads}'
         scope:
-          name: otelcol/memcachedreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the memcachedreceiverreceiver from otelcol/memcachedreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/memcachedreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
