### PR TITLE
[receiver/mongodbatlasreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-mongodbatlasreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-mongodbatlasreceiver.yaml
@@ -10,7 +10,7 @@ component: mongodbatlasreceiver
 note: "Update the scope name for telemetry produced by the mongodbatlasreceiver from `otelcol/mongodbatlasreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34543]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-mongodbatlasreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-mongodbatlasreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbatlasreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the mongodbatlasreceiver from `otelcol/mongodbatlasreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbatlasreceiver/internal/metadata/generated_metrics.go
@@ -4172,7 +4172,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/mongodbatlasreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricMongodbatlasDbCounts.emit(ils.Metrics())

--- a/receiver/mongodbatlasreceiver/metadata.yaml
+++ b/receiver/mongodbatlasreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: mongodbatlas
-scope_name: otelcol/mongodbatlasreceiver
 
 status:
   class: receiver


### PR DESCRIPTION
Update the scope name for telemetry produced by the mongodbatlasreceiverreceiver from otelcol/mongodbatlasreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbatlasreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
