### PR TITLE
[receiver/mongodbreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-mongodbreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-mongodbreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mongodbreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the mongodbreceiver from `otelcol/mongodbreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-mongodbreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-mongodbreceiver.yaml
@@ -10,7 +10,7 @@ component: mongodbreceiver
 note: "Update the scope name for telemetry produced by the mongodbreceiver from `otelcol/mongodbreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34544]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mongodbreceiver/internal/metadata/generated_metrics.go
@@ -1973,7 +1973,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/mongodbreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricMongodbCacheOperations.emit(ils.Metrics())

--- a/receiver/mongodbreceiver/metadata.yaml
+++ b/receiver/mongodbreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: mongodb
-scope_name: otelcol/mongodbreceiver
 
 status:
   class: receiver

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_0.yaml
@@ -196,7 +196,7 @@ resourceMetrics:
                   timeUnixNano: "1682363210513475000"
             unit: '{sessions}'
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -360,7 +360,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -521,7 +521,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -669,7 +669,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -830,5 +830,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/integration/expected.4_4lpu.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.4_4lpu.yaml
@@ -196,7 +196,7 @@ resourceMetrics:
                   timeUnixNano: "1682363222253814000"
             unit: '{sessions}'
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -335,7 +335,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -474,7 +474,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -613,7 +613,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -765,5 +765,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/integration/expected.5_0.yaml
+++ b/receiver/mongodbreceiver/testdata/integration/expected.5_0.yaml
@@ -196,7 +196,7 @@ resourceMetrics:
                   timeUnixNano: "1682363210542990000"
             unit: '{sessions}'
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -348,7 +348,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -500,7 +500,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -639,7 +639,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -791,5 +791,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/scraper/db_count_only.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/db_count_only.yaml
@@ -16,5 +16,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: '{databases}'
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/expected.yaml
@@ -292,7 +292,7 @@ resourceMetrics:
               isMonotonic: true
             unit: ms
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest
   - resource:
       attributes:
@@ -463,5 +463,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest

--- a/receiver/mongodbreceiver/testdata/scraper/partial_scrape.yaml
+++ b/receiver/mongodbreceiver/testdata/scraper/partial_scrape.yaml
@@ -243,5 +243,5 @@ resourceMetrics:
               isMonotonic: true
             unit: ms
         scope:
-          name: otelcol/mongodbreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the mongodbreceiverreceiver from otelcol/mongodbreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
