### PR TITLE
[receiver/mysqlreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-mysqlreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-mysqlreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: mysqlreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the mysqlreceiver from `otelcol/mysqlreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-mysqlreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-mysqlreceiver.yaml
@@ -10,7 +10,7 @@ component: mysqlreceiver
 note: "Update the scope name for telemetry produced by the mysqlreceiver from `otelcol/mysqlreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34545]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/mysqlreceiver/internal/metadata/generated_metrics.go
@@ -3644,7 +3644,7 @@ func WithStartTimeOverride(start pcommon.Timestamp) ResourceMetricsOption {
 func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/mysqlreceiver")
+	ils.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver")
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.metricMysqlBufferPoolDataPages.emit(ils.Metrics())

--- a/receiver/mysqlreceiver/metadata.yaml
+++ b/receiver/mysqlreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: mysql
-scope_name: otelcol/mysqlreceiver
 
 status:
   class: receiver

--- a/receiver/mysqlreceiver/testdata/integration/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/integration/expected.yaml
@@ -676,5 +676,5 @@ resourceMetrics:
               isMonotonic: true
             unit: "s"
         scope:
-          name: otelcol/mysqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
           version: latest

--- a/receiver/mysqlreceiver/testdata/scraper/expected.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected.yaml
@@ -1743,5 +1743,5 @@ resourceMetrics:
               isMonotonic: true
             unit: s
         scope:
-          name: otelcol/mysqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
           version: latest

--- a/receiver/mysqlreceiver/testdata/scraper/expected_partial.yaml
+++ b/receiver/mysqlreceiver/testdata/scraper/expected_partial.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             unit: "1"
         scope:
-          name: otelcol/mysqlreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the mysqlreceiverreceiver from otelcol/mysqlreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mysqlreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
