### PR TITLE
[receiver/statsdreceiver] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-statsdreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-statsdreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: statsdreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the statsdreceiver from `otelcol/statsdreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-statsdreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-statsdreceiver.yaml
@@ -10,7 +10,7 @@ component: statsdreceiver
 note: "Update the scope name for telemetry produced by the statsdreceiver from `otelcol/statsdreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34547]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/statsdreceiver/internal/metadata/generated_telemetry.go
+++ b/receiver/statsdreceiver/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/statsdreceiver")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/statsdreceiver")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/receiver/statsdreceiver/internal/metadata/generated_telemetry_test.go
+++ b/receiver/statsdreceiver/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/statsdreceiver", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/statsdreceiver", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser.go
@@ -54,7 +54,7 @@ const (
 
 	DefaultObserverType = DisableObserver
 
-	receiverName = "otelcol/statsdreceiver"
+	receiverName = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiver"
 )
 
 type TimerHistogramMapping struct {

--- a/receiver/statsdreceiver/metadata.yaml
+++ b/receiver/statsdreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: statsd
-scope_name: otelcol/statsdreceiver
 
 status:
   class: receiver


### PR DESCRIPTION
Update the scope name for telemetry produced by the statsdreceiverreceiver from otelcol/statsdreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/statsdreceiverreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
