### PR TITLE
[connector/datadog] Move feature gate connector.datadogconnector.NativeIngest to beta

### DIFF
--- a/.chloggen/dd-conn-fg.yaml
+++ b/.chloggen/dd-conn-fg.yaml
@@ -10,7 +10,7 @@ component: datadogconnector
 note: "Move feature gate `connector.datadogconnector.NativeIngest` to beta"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34549]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/dd-conn-fg.yaml
+++ b/.chloggen/dd-conn-fg.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Move feature gate `connector.datadogconnector.NativeIngest` to beta"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: When this feature gate is enabled (default), the datadog connector uses the new API to produce APM stats under the hood.
+  | The new API has better throughput when your spans have many attributes (especially container related attributes). Funtional-wise the new API should have no user-facing change compared to the old API.
+  | However if you observe any unexpected behaviors, you can disable this feature gate to revert to the old stats processing APIs.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/datadogconnector/connector_native_test.go
+++ b/connector/datadogconnector/connector_native_test.go
@@ -17,7 +17,6 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
-	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
 	"go.uber.org/zap"
@@ -29,12 +28,6 @@ var _ component.Component = (*traceToMetricConnectorNative)(nil) // testing that
 
 // create test to create a connector, check that basic code compiles
 func TestNewConnectorNative(t *testing.T) {
-	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
-	assert.NoError(t, err)
-	defer func() {
-		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
-	}()
-
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings()
@@ -48,12 +41,6 @@ func TestNewConnectorNative(t *testing.T) {
 }
 
 func TestTraceToTraceConnectorNative(t *testing.T) {
-	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
-	assert.NoError(t, err)
-	defer func() {
-		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
-	}()
-
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings()
@@ -73,12 +60,6 @@ func creteConnectorNative(t *testing.T) (*traceToMetricConnectorNative, *consume
 }
 
 func creteConnectorNativeWithCfg(t *testing.T, cfg *Config) (*traceToMetricConnectorNative, *consumertest.MetricsSink) {
-	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
-	assert.NoError(t, err)
-	defer func() {
-		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
-	}()
-
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings()

--- a/connector/datadogconnector/connector_test.go
+++ b/connector/datadogconnector/connector_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
@@ -29,6 +30,12 @@ var _ component.Component = (*traceToMetricConnector)(nil) // testing that the c
 
 // create test to create a connector, check that basic code compiles
 func TestNewConnector(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
+	assert.NoError(t, err)
+	defer func() {
+		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
+	}()
+
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings()
@@ -42,6 +49,12 @@ func TestNewConnector(t *testing.T) {
 }
 
 func TestTraceToTraceConnector(t *testing.T) {
+	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
+	assert.NoError(t, err)
+	defer func() {
+		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
+	}()
+
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings()
@@ -101,6 +114,12 @@ func fillSpanOne(span ptrace.Span) {
 }
 
 func creteConnector(t *testing.T) (*traceToMetricConnector, *consumertest.MetricsSink) {
+	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
+	assert.NoError(t, err)
+	defer func() {
+		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
+	}()
+
 	factory := NewFactory()
 
 	creationParams := connectortest.NewNopSettings()

--- a/connector/datadogconnector/factory.go
+++ b/connector/datadogconnector/factory.go
@@ -24,7 +24,7 @@ const nativeIngestFeatureGateName = "connector.datadogconnector.NativeIngest"
 // NativeIngestFeatureGate is the feature gate that controls native OTel spans ingestion in Datadog APM stats
 var NativeIngestFeatureGate = featuregate.GlobalRegistry().MustRegister(
 	nativeIngestFeatureGateName,
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, datadogconnector uses the native OTel API to ingest OTel spans and produce APM stats."),
 	featuregate.WithRegisterFromVersion("v0.104.0"),
 )
@@ -53,10 +53,10 @@ func createDefaultConfig() component.Config {
 func createTracesToMetricsConnector(_ context.Context, params connector.Settings, cfg component.Config, nextConsumer consumer.Metrics) (c connector.Traces, err error) {
 	metricsClient := metricsclient.InitializeMetricClient(params.MeterProvider, metricsclient.ConnectorSourceTag)
 	if NativeIngestFeatureGate.IsEnabled() {
-		params.Logger.Info("Datadog connector using the native OTel API to ingest OTel spans and produce APM stats")
+		params.Logger.Info("Datadog connector using the native OTel API to ingest OTel spans and produce APM stats. To revert to the legacy processing pipeline, disable the feature gate", zap.String("feature gate", nativeIngestFeatureGateName))
 		c, err = newTraceToMetricConnectorNative(params.TelemetrySettings, cfg, nextConsumer, metricsClient)
 	} else {
-		params.Logger.Info("Datadog connector using the old processing pipelines to ingest OTel spans and produce APM stats. To opt in the new native OTel APM stats API, enable the feature gate", zap.String("feature gate", nativeIngestFeatureGateName))
+		params.Logger.Info("Datadog connector using the old processing pipelines to ingest OTel spans and produce APM stats.")
 		c, err = newTraceToMetricConnector(params.TelemetrySettings, cfg, nextConsumer, metricsClient, timing.New(metricsClient))
 	}
 	if err != nil {


### PR DESCRIPTION
When this feature gate is enabled (default), the datadog connector uses the new API to produce APM stats under the hood. The new API has better throughput when your spans have many attributes (especially container related attributes). Funtional-wise the new API should have no user-facing change compared to the old API. However if you observe any unexpected behaviors, you can disable this feature gate to revert to the old stats processing APIs.