### PR TITLE
[processors] updating remaining processor scope names

### DIFF
--- a/.chloggen/codeboten_update-scope-deltatocumulativeprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-deltatocumulativeprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: deltatocumulativeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the deltatocumulativeprocessor from `otelcol/deltatocumulative` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-deltatocumulativeprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-deltatocumulativeprocessor.yaml
@@ -10,7 +10,7 @@ component: deltatocumulativeprocessor
 note: "Update the scope name for telemetry produced by the deltatocumulativeprocessor from `otelcol/deltatocumulative` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-filterprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-filterprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: filterprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the filterprocessor from `otelcol/filter` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-filterprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-filterprocessor.yaml
@@ -10,7 +10,7 @@ component: filterprocessor
 note: "Update the scope name for telemetry produced by the filterprocessor from `otelcol/filter` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-groupbyattrsprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-groupbyattrsprocessor.yaml
@@ -10,7 +10,7 @@ component: groupbyattrsprocessor
 note: "Update the scope name for telemetry produced by the groupbyattrsprocessor from `otelcol/groupbyattrs` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-groupbyattrsprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-groupbyattrsprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: groupbyattrsprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the groupbyattrsprocessor from `otelcol/groupbyattrs` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-groupbytraceprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-groupbytraceprocessor.yaml
@@ -10,7 +10,7 @@ component: groupbytraceprocessor
 note: "Update the scope name for telemetry produced by the groupbytraceprocessor from `otelcol/groupbytrace` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-groupbytraceprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-groupbytraceprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: groupbytraceprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the groupbytraceprocessor from `otelcol/groupbytrace` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-k8sattributesprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-k8sattributesprocessor.yaml
@@ -10,7 +10,7 @@ component: k8sattributesprocessor
 note: "Update the scope name for telemetry produced by the k8sattributesprocessor from `otelcol/k8sattributes` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-k8sattributesprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-k8sattributesprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributesprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the k8sattributesprocessor from `otelcol/k8sattributes` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-probabilisticsamplerprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-probabilisticsamplerprocessor.yaml
@@ -10,7 +10,7 @@ component: probabilisticsamplerprocessor
 note: "Update the scope name for telemetry produced by the probabilisticsamplerprocessor from `otelcol/probabilisticsampler` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-probabilisticsamplerprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-probabilisticsamplerprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: probabilisticsamplerprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the probabilisticsamplerprocessor from `otelcol/probabilisticsampler` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-routingprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-routingprocessor.yaml
@@ -10,7 +10,7 @@ component: routingprocessor
 note: "Update the scope name for telemetry produced by the routingprocessor from `otelcol/routing` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-routingprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-routingprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the routingprocessor from `otelcol/routing` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-tailsamplingprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-tailsamplingprocessor.yaml
@@ -10,7 +10,7 @@ component: tailsamplingprocessor
 note: "Update the scope name for telemetry produced by the tailsamplingprocessor from `otelcol/tailsampling` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34429]
+issues: [34550]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-tailsamplingprocessor.yaml
+++ b/.chloggen/codeboten_update-scope-tailsamplingprocessor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the tailsamplingprocessor from `otelcol/tailsampling` to `github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34429]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/deltatocumulative")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/deltatocumulative")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/deltatocumulative", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/deltatocumulative", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/deltatocumulativeprocessor/metadata.yaml
+++ b/processor/deltatocumulativeprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: deltatocumulative
-scope_name: otelcol/deltatocumulative
 
 status:
   class: processor

--- a/processor/filterprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/filterprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/filter")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/filter")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/filterprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/filterprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/filter", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/filter", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/filterprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/filterprocessor/metadata.yaml
+++ b/processor/filterprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: filter
-scope_name: otelcol/filter
 
 status:
   class: processor

--- a/processor/groupbyattrsprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/groupbyattrsprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/groupbyattrs")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/groupbyattrs")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/groupbyattrsprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/groupbyattrsprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/groupbyattrs", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/groupbyattrs", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/groupbyattrsprocessor/metadata.yaml
+++ b/processor/groupbyattrsprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: groupbyattrs
-scope_name: otelcol/groupbyattrs
 
 status:
   class: processor

--- a/processor/groupbytraceprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/groupbytraceprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/groupbytrace")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/groupbytrace")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/groupbytraceprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/groupbytraceprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/groupbytrace", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/groupbytrace", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbytraceprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/groupbytraceprocessor/metadata.yaml
+++ b/processor/groupbytraceprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: groupbytrace
-scope_name: otelcol/groupbytrace
 
 status:
   class: processor

--- a/processor/k8sattributesprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/k8sattributesprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/k8sattributes")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/k8sattributes")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/k8sattributesprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/k8sattributesprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/k8sattributes", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/k8sattributes", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/k8sattributesprocessor/metadata.yaml
+++ b/processor/k8sattributesprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: k8sattributes
-scope_name: otelcol/k8sattributes
 
 status:
   class: processor

--- a/processor/probabilisticsamplerprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/probabilisticsamplerprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/probabilisticsampler")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/probabilisticsampler")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/probabilisticsamplerprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/probabilisticsamplerprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/probabilisticsampler", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/probabilisticsampler", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/probabilisticsamplerprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/probabilisticsamplerprocessor/metadata.yaml
+++ b/processor/probabilisticsamplerprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: probabilistic_sampler
-scope_name: otelcol/probabilisticsampler
 
 status:
   class: processor

--- a/processor/routingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/routingprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/routing")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/routing")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/routingprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/routingprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/routing", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/routing", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/routingprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/routingprocessor/metadata.yaml
+++ b/processor/routingprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: routing
-scope_name: otelcol/routing
 
 status:
   class: processor

--- a/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
@@ -14,11 +14,11 @@ import (
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {
-	return settings.MeterProvider.Meter("otelcol/tailsampling")
+	return settings.MeterProvider.Meter("github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor")
 }
 
 func Tracer(settings component.TelemetrySettings) trace.Tracer {
-	return settings.TracerProvider.Tracer("otelcol/tailsampling")
+	return settings.TracerProvider.Tracer("github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor")
 }
 
 // TelemetryBuilder provides an interface for components to report telemetry

--- a/processor/tailsamplingprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/tailsamplingprocessor/internal/metadata/generated_telemetry_test.go
@@ -49,14 +49,14 @@ func TestProviders(t *testing.T) {
 
 	meter := Meter(set)
 	if m, ok := meter.(mockMeter); ok {
-		require.Equal(t, "otelcol/tailsampling", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockMeter")
 	}
 
 	tracer := Tracer(set)
 	if m, ok := tracer.(mockTracer); ok {
-		require.Equal(t, "otelcol/tailsampling", m.name)
+		require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor", m.name)
 	} else {
 		require.Fail(t, "returned Meter not mockTracer")
 	}

--- a/processor/tailsamplingprocessor/metadata.yaml
+++ b/processor/tailsamplingprocessor/metadata.yaml
@@ -1,5 +1,4 @@
 type: tail_sampling
-scope_name: otelcol/tailsampling
 
 status:
   class: processor


### PR DESCRIPTION
Doing this in a single PR as there are no additional changes other than running the generation.

Part of open-telemetry/opentelemetry-collector#9494
