### PR TITLE
[chore] remove unused configuration

### DIFF
--- a/connector/countconnector/metadata.yaml
+++ b/connector/countconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: count
-scope_name: otelcol/countconnector
 
 status:
   class: connector

--- a/connector/datadogconnector/metadata.yaml
+++ b/connector/datadogconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: datadog
-scope_name: otelcol/datadog
 
 status:
   class: connector

--- a/connector/exceptionsconnector/metadata.yaml
+++ b/connector/exceptionsconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: exceptions
-scope_name: otelcol/exceptions
 
 status:
   class: connector

--- a/connector/failoverconnector/metadata.yaml
+++ b/connector/failoverconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: failover
-scope_name: otelcol/failover
 
 status:
   class: connector

--- a/connector/otlpjsonconnector/metadata.yaml
+++ b/connector/otlpjsonconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: otlpjson
-scope_name: otelcol/otlpjson
 
 status:
   class: connector

--- a/connector/roundrobinconnector/metadata.yaml
+++ b/connector/roundrobinconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: roundrobin
-scope_name: otelcol/roundrobinconnector
 
 status:
   class: connector

--- a/connector/routingconnector/metadata.yaml
+++ b/connector/routingconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: routing
-scope_name: otelcol/routing
 
 status:
   class: connector

--- a/connector/spanmetricsconnector/metadata.yaml
+++ b/connector/spanmetricsconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: spanmetrics
-scope_name: otelcol/spanmetrics
 
 status:
   class: connector

--- a/connector/sumconnector/metadata.yaml
+++ b/connector/sumconnector/metadata.yaml
@@ -1,5 +1,4 @@
 type: sum
-scope_name: otelcol/sumconnector
 
 status:
   class: connector


### PR DESCRIPTION
This is the same as was done for receivers/exporters but for connectors.

Part of open-telemetry/opentelemetry-collector#9494
