### PR TITLE
[chore] add gogenerate makefile target

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -238,9 +238,9 @@ jobs:
           git diff -s --exit-code || (echo 'Generated code is out of date, please apply this diff and commit the changes in this PR.' && git diff && exit 1)
       - name: CodeGen
         run: |
-          make -j2 generate
+          make -j2 gogenerate
           if [[ -n $(git status -s) ]]; then
-            echo 'Generated code is out of date, please run "make generate" and commit the changes in this PR.'
+            echo 'Generated code is out of date, please run "make gogenerate" and commit the changes in this PR.'
             exit 1
           fi
       - name: MultimodVerify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ When submitting a component to the community, consider breaking it down into sep
     * `make gotidy`
     * `make genotelcontribcol`
     * `make genoteltestbedcol`
-    * `make generate`
+    * `make gogenerate`
     * `make multimod-verify`
     * `make generate-gh-issue-templates`
     * `make addlicense`
@@ -236,7 +236,7 @@ When submitting a component to the community, consider breaking it down into sep
     * Add `contrib` to the list of distributions
   * Add it to the `cmd/otelcontribcol` binary by updating the `cmd/otelcontribcol/builder-config.yaml` file.
   * Please also run:
-    - `make generate`
+    - `make gogenerate`
     - `make genotelcontribcol`
   * The component's tests must also be added as a part of its respective `component_type_tests.go` file in the `cmd/otelcontribcol` directory.
   * The component must be enabled only after sufficient testing and only when it meets [`Alpha` stability requirements](https://github.com/open-telemetry/opentelemetry-collector#alpha).
@@ -431,7 +431,7 @@ To become a Code Owner, open a PR with the following changes:
 1. Add your GitHub username to the active codeowners entry in the component's `metadata.yaml` file.
 2. Run the command `make update-codeowners`.
       * Note: A GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) must be configured for this command to work.
-      * If this command is unsuccessful, manually update the component's row in the [CODEOWNERS](.github/CODEOWNERS) file, and then run `make generate` to regenerate the component's README header.
+      * If this command is unsuccessful, manually update the component's row in the [CODEOWNERS](.github/CODEOWNERS) file, and then run `make gogenerate` to regenerate the component's README header.
 
 Be sure to tag the existing Code Owners, if any, within the PR to ensure they receive a notification.
 

--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,10 @@ stability-tests: otelcontribcol
 gogci:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="gci"
 
+.PHONY: gogenerate
+gogenerate:
+	$(MAKE) $(FOR_GROUP_TARGET) TARGET="generate"
+
 .PHONY: gotidy
 gotidy:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="tidy"
@@ -280,12 +284,6 @@ docker-telemetrygen:
 	cp bin/telemetrygen_* cmd/telemetrygen/
 	cd cmd/telemetrygen && docker build --platform linux/$(GOARCH) --build-arg="TARGETOS=$(GOOS)" --build-arg="TARGETARCH=$(GOARCH)" -t telemetrygen:latest .
 	rm cmd/telemetrygen/telemetrygen_*
-
-.PHONY: generate
-generate: install-tools
-	cd ./internal/tools && go install go.opentelemetry.io/collector/cmd/mdatagen
-	$(MAKE) for-all CMD="$(GOCMD) generate ./..."
-	$(MAKE) gofmt
 
 .PHONY: githubgen-install
 githubgen-install:
@@ -529,6 +527,6 @@ checks:
 	$(MAKE) genotelcontribcol
 	$(MAKE) genoteltestbedcol
 	$(MAKE) gendistributions
-	$(MAKE) -j4 generate
+	$(MAKE) -j4 gogenerate
 	$(MAKE) multimod-verify
 	git diff --exit-code || (echo 'Some files need committing' &&  git status && exit 1)

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -224,3 +224,8 @@ moddownload:
 gci: $(TOOLS_BIN_DIR)/gci
 	@echo "running $(GCI)"
 	@$(GCI) write -s standard -s default -s "prefix(github.com/open-telemetry/opentelemetry-collector-contrib)" $(ALL_SRC_AND_DOC)
+
+.PHONY: generate
+generate: $(TOOLS_BIN_DIR)/mdatagen
+	$(GOCMD) generate ./...
+	$(MAKE) fmt


### PR DESCRIPTION
Not sure why there wasn't a `gogenerate` yet, but this allows running generate for groups the way other go* makefile targets do.
