### PR TITLE
[chore] Temporarily skip flaky filelog test on arm64

### DIFF
--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -325,6 +325,10 @@ func TestStartAtEnd(t *testing.T) {
 // to another file, while the symlink target is changed frequently, reads all
 // the logs from all the files ever targeted by that symlink.
 func TestSymlinkedFiles(t *testing.T) {
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Failing consistently on ARM64. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34494")
+	}
+
 	if runtime.GOOS == "windows" {
 		t.Skip("Time sensitive tests disabled for now on Windows. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32715#issuecomment-2107737828")
 	}


### PR DESCRIPTION
See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34494