### PR TITLE
[connector/count] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-countconnector.yaml
+++ b/.chloggen/codeboten_update-scope-countconnector.yaml
@@ -10,7 +10,7 @@ component: countconnector
 note: "Update the scope name for telemetry produced by the countconnector from `otelcol/countconnector` to `github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34583]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_update-scope-countconnector.yaml
+++ b/.chloggen/codeboten_update-scope-countconnector.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: countconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the countconnector from `otelcol/countconnector` to `github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/countconnector/connector.go
+++ b/connector/countconnector/connector.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlspanevent"
 )
 
-const scopeName = "otelcol/countconnector"
+const scopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector"
 
 // count can count spans, span event, metrics, data points, or log records
 // and emit the counts onto a metrics pipeline.

--- a/connector/countconnector/testdata/logs/condition_and_attribute.yaml
+++ b/connector/countconnector/testdata/logs/condition_and_attribute.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948399018000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -58,4 +58,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948399021000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/logs/default_attribute_value.yaml
+++ b/connector/countconnector/testdata/logs/default_attribute_value.yaml
@@ -43,7 +43,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948398365000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -88,7 +88,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948398368000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -130,7 +130,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948398371000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -168,4 +168,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948398373000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/logs/multiple_attributes.yaml
+++ b/connector/countconnector/testdata/logs/multiple_attributes.yaml
@@ -34,7 +34,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948397879000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -70,7 +70,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948397882000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -103,7 +103,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948397884000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -132,4 +132,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948397886000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/logs/multiple_conditions.yaml
+++ b/connector/countconnector/testdata/logs/multiple_conditions.yaml
@@ -18,7 +18,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948395853000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -38,7 +38,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948395856000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -55,7 +55,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948395858000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -68,4 +68,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948395859000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/logs/multiple_metrics.yaml
+++ b/connector/countconnector/testdata/logs/multiple_metrics.yaml
@@ -26,7 +26,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948396984000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -54,7 +54,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948396988000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -71,7 +71,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948396990000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -84,4 +84,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948396992000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/logs/one_attribute.yaml
+++ b/connector/countconnector/testdata/logs/one_attribute.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948397419000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -58,7 +58,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948397423000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -85,7 +85,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948397425000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -108,4 +108,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948397427000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/logs/one_condition.yaml
+++ b/connector/countconnector/testdata/logs/one_condition.yaml
@@ -18,7 +18,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948395244000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -38,4 +38,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948395279000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/logs/zero_conditions.yaml
+++ b/connector/countconnector/testdata/logs/zero_conditions.yaml
@@ -18,7 +18,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948393725000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -38,7 +38,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948393759000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -55,7 +55,7 @@ resourceMetrics:
                   timeUnixNano: "1678390948393760000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -68,4 +68,4 @@ resourceMetrics:
                   timeUnixNano: "1678390948393761000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/condition_and_attribute.yaml
+++ b/connector/countconnector/testdata/metrics/condition_and_attribute.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923823222000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -58,4 +58,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923823233000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/default_attribute_value.yaml
+++ b/connector/countconnector/testdata/metrics/default_attribute_value.yaml
@@ -43,7 +43,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923822404000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -88,7 +88,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923822416000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -130,7 +130,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923822426000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -168,4 +168,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923822435000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/default_int_attribute_value.yaml
+++ b/connector/countconnector/testdata/metrics/default_int_attribute_value.yaml
@@ -49,4 +49,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923821179000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/int_attribute_value.yaml
+++ b/connector/countconnector/testdata/metrics/int_attribute_value.yaml
@@ -28,4 +28,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923821179000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/multiple_attributes.yaml
+++ b/connector/countconnector/testdata/metrics/multiple_attributes.yaml
@@ -34,7 +34,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923821783000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -70,7 +70,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923821792000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -103,7 +103,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923821800000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -132,4 +132,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923821807000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/multiple_conditions.yaml
+++ b/connector/countconnector/testdata/metrics/multiple_conditions.yaml
@@ -26,7 +26,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923819487000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -54,7 +54,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923819499000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -79,7 +79,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923819510000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -100,7 +100,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923819529000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.int
@@ -120,4 +120,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923819487000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/multiple_metrics.yaml
+++ b/connector/countconnector/testdata/metrics/multiple_metrics.yaml
@@ -42,7 +42,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923820453000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -86,7 +86,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923820468000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -127,7 +127,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923820480000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -164,7 +164,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923820491000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.int
@@ -200,4 +200,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923820480000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/one_attribute.yaml
+++ b/connector/countconnector/testdata/metrics/one_attribute.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923821179000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -58,7 +58,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923821189000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -85,7 +85,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923821196000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -108,4 +108,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923821203000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/one_condition.yaml
+++ b/connector/countconnector/testdata/metrics/one_condition.yaml
@@ -26,7 +26,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923818482000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -54,4 +54,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923818549000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/metrics/zero_conditions.yaml
+++ b/connector/countconnector/testdata/metrics/zero_conditions.yaml
@@ -26,7 +26,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923815881000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -54,7 +54,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923815923000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -79,7 +79,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923815929000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -100,7 +100,7 @@ resourceMetrics:
                   timeUnixNano: "1678391923815933000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.int
@@ -128,4 +128,4 @@ resourceMetrics:
                   timeUnixNano: "1678391923815929000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/condition_and_attribute.yaml
+++ b/connector/countconnector/testdata/traces/condition_and_attribute.yaml
@@ -46,7 +46,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127929006000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -94,4 +94,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127929018000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/default_attribute_value.yaml
+++ b/connector/countconnector/testdata/traces/default_attribute_value.yaml
@@ -76,7 +76,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127927843000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -154,7 +154,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127927856000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -229,7 +229,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127927865000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -300,4 +300,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127927874000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/multiple_attributes.yaml
+++ b/connector/countconnector/testdata/traces/multiple_attributes.yaml
@@ -58,7 +58,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127926637000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -118,7 +118,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127926647000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -175,7 +175,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127926654000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -228,4 +228,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127926661000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/multiple_conditions.yaml
+++ b/connector/countconnector/testdata/traces/multiple_conditions.yaml
@@ -26,7 +26,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127923826000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -54,7 +54,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127923836000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -79,7 +79,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127923843000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -100,4 +100,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127923849000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/multiple_metrics.yaml
+++ b/connector/countconnector/testdata/traces/multiple_metrics.yaml
@@ -42,7 +42,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127924753000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -86,7 +86,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127924764000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -127,7 +127,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127924772000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -164,4 +164,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127924780000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/one_attribute.yaml
+++ b/connector/countconnector/testdata/traces/one_attribute.yaml
@@ -46,7 +46,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127925459000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -94,7 +94,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127925468000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -139,7 +139,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127925474000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -180,4 +180,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127925497000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/one_condition.yaml
+++ b/connector/countconnector/testdata/traces/one_condition.yaml
@@ -26,7 +26,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127922310000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -54,4 +54,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127922364000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

--- a/connector/countconnector/testdata/traces/zero_conditions.yaml
+++ b/connector/countconnector/testdata/traces/zero_conditions.yaml
@@ -26,7 +26,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127920605000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -54,7 +54,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127920632000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource:
       attributes:
         - key: resource.required
@@ -79,7 +79,7 @@ resourceMetrics:
                   timeUnixNano: "1678392127920635000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector
   - resource: {}
     scopeMetrics:
       - metrics:
@@ -100,4 +100,4 @@ resourceMetrics:
                   timeUnixNano: "1678392127920638000"
               isMonotonic: true
         scope:
-          name: otelcol/countconnector
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector


### PR DESCRIPTION
Update the scope name for telemetry produced by the countconnector from otelcol/countconnector to
github.com/open-telemetry/opentelemetry-collector-contrib/connector/countconnector

Part of
https://github.com/open-telemetry/opentelemetry-collector/issues/9494
