### PR TITLE
[receiver/prometheus] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-prometheusreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-prometheusreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the prometheusreceiver from `otelcol/prometheusreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-prometheusreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-prometheusreceiver.yaml
@@ -10,7 +10,7 @@ component: prometheusreceiver
 note: "Update the scope name for telemetry produced by the prometheusreceiver from `otelcol/prometheusreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34589]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -26,9 +26,8 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+	mdata "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 )
-
-const receiverName = "otelcol/prometheusreceiver"
 
 type transaction struct {
 	isNew                  bool
@@ -320,7 +319,7 @@ func (t *transaction) getMetrics(resource pcommon.Resource) (pmetric.Metrics, er
 		// If metrics don't include otel_scope_name or otel_scope_version
 		// labels, use the receiver name and version.
 		if scope == emptyScopeID {
-			ils.Scope().SetName(receiverName)
+			ils.Scope().SetName(mdata.ScopeName)
 			ils.Scope().SetVersion(t.buildInfo.Version)
 		} else {
 			// Otherwise, use the scope that was provided with the metrics.

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -204,7 +204,7 @@ func testReceiverVersionAndNameAreAttached(t *testing.T, enableNativeHistograms 
 	require.Equal(t, expectedResource, gotResource)
 
 	gotScope := mds[0].ResourceMetrics().At(0).ScopeMetrics().At(0).Scope()
-	require.Equal(t, receiverName, gotScope.Name())
+	require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver", gotScope.Name())
 	require.Equal(t, component.NewDefaultBuildInfo().Version, gotScope.Version())
 }
 

--- a/receiver/prometheusreceiver/metrics_receiver_labels_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_labels_test.go
@@ -777,7 +777,7 @@ func verifyMultipleScopes(t *testing.T, td *testData, rms []pmetric.ResourceMetr
 	require.Equal(t, sms.At(0).Scope().Name(), "fake.scope.name")
 	require.Equal(t, sms.At(0).Scope().Version(), "v0.1.0")
 	require.Equal(t, sms.At(0).Scope().Attributes().Len(), 0)
-	require.Equal(t, sms.At(1).Scope().Name(), "otelcol/prometheusreceiver")
+	require.Equal(t, sms.At(1).Scope().Name(), "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver")
 	require.Equal(t, sms.At(1).Scope().Attributes().Len(), 0)
 	require.Equal(t, sms.At(2).Scope().Name(), "scope.with.attributes")
 	require.Equal(t, sms.At(2).Scope().Version(), "v1.5.0")


### PR DESCRIPTION
Update the scope name for telemetry produced by the prometheusreceiver from otelcol/prometheusreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver

Part of https://github.com/open-telemetry/opentelemetry-collector/issues/9494
