### PR TITLE
[receiver/snmp] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-snmpreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-snmpreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: snmpreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the snmpreceiver from `otelcol/snmpreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-snmpreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-snmpreceiver.yaml
@@ -10,7 +10,7 @@ component: snmpreceiver
 note: "Update the scope name for telemetry produced by the snmpreceiver from `otelcol/snmpreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34592]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/snmpreceiver/otel_metric_helper.go
+++ b/receiver/snmpreceiver/otel_metric_helper.go
@@ -12,6 +12,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver/internal/metadata"
 )
 
 // generalResourceKey is the resource key for the no general "no attribute" resource
@@ -111,7 +113,7 @@ func (h *otelMetricHelper) createResource(resourceKey string, resourceAttributes
 		resourceMetrics.Resource().Attributes().PutStr(key, value)
 	}
 	scopeMetrics := resourceMetrics.ScopeMetrics().AppendEmpty()
-	scopeMetrics.Scope().SetName("otelcol/snmpreceiver")
+	scopeMetrics.Scope().SetName(metadata.ScopeName)
 	scopeMetrics.Scope().SetVersion(h.settings.BuildInfo.Version)
 	h.resourcesByKey[resourceKey] = &resourceMetrics
 	h.metricsByResource[resourceKey] = map[string]*pmetric.Metric{}

--- a/receiver/snmpreceiver/testdata/expected_metrics/10_indexed_scalar_metrics_same_resource_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/10_indexed_scalar_metrics_same_resource_golden.yaml
@@ -27,5 +27,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/11_indexed_multiple_metrics_same_resource_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/11_indexed_multiple_metrics_same_resource_golden.yaml
@@ -37,5 +37,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/12_indexed_metrics_w_all_attrs_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/12_indexed_metrics_w_all_attrs_golden.yaml
@@ -32,5 +32,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/13_indexed_metrics_w_column_oid_attr_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/13_indexed_metrics_w_column_oid_attr_golden.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/14_indexed_column_oid_float_attr_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/14_indexed_column_oid_float_attr_golden.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/15_indexed_column_oid_int_attr_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/15_indexed_column_oid_int_attr_golden.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/16_indexed_prefix_res_attr_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/16_indexed_prefix_res_attr_golden.yaml
@@ -21,7 +21,7 @@ resourceMetrics:
             name: metric2
             unit: '{units}'
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -45,5 +45,5 @@ resourceMetrics:
             name: metric2
             unit: '{units}'
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/17_indexed_oid_res_attr_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/17_indexed_oid_res_attr_golden.yaml
@@ -21,7 +21,7 @@ resourceMetrics:
             name: metric2
             unit: '{units}'
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -45,5 +45,5 @@ resourceMetrics:
             name: metric2
             unit: '{units}'
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/18_indexed_oid_and_prefix_res_attr_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/18_indexed_oid_and_prefix_res_attr_golden.yaml
@@ -17,7 +17,7 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -37,5 +37,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/19_scalar_ra_string_and_coid_ra_string_on_coid_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/19_scalar_ra_string_and_coid_ra_string_on_coid_metric_golden.yaml
@@ -17,7 +17,7 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -37,5 +37,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/1_scalar_metrics_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/1_scalar_metrics_golden.yaml
@@ -10,5 +10,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/20_scalar_ra_int_and_coid_ra_int_on_coid_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/20_scalar_ra_int_and_coid_ra_int_on_coid_metric_golden.yaml
@@ -17,7 +17,7 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -37,5 +37,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/21_scalar_ra_float_and_coid_ra_float_on_coid_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/21_scalar_ra_float_and_coid_ra_float_on_coid_metric_golden.yaml
@@ -17,7 +17,7 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -37,5 +37,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/22_scalar_ra_string_and_prefix_ra_on_coid_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/22_scalar_ra_string_and_prefix_ra_on_coid_metric_golden.yaml
@@ -17,7 +17,7 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -37,5 +37,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/23_multiple_scalar_oid_string_with_multiple_coid_ra_string_on_coid_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/23_multiple_scalar_oid_string_with_multiple_coid_ra_string_on_coid_metric_golden.yaml
@@ -23,7 +23,7 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -49,5 +49,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/24_scalar_ra_string_and_coid_attr_string_on_coid_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/24_scalar_ra_string_and_coid_attr_string_on_coid_metric_golden.yaml
@@ -24,5 +24,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/25_scalar_ra_string_and_ivp_attr_on_coid_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/25_scalar_ra_string_and_ivp_attr_on_coid_metric_golden.yaml
@@ -24,5 +24,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/26_scalar_ra_string_on_scalar_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/26_scalar_ra_string_on_scalar_metric_golden.yaml
@@ -14,5 +14,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/27_multiple_scalar_ra_string_on_scalar_metric_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/27_multiple_scalar_ra_string_on_scalar_metric_golden.yaml
@@ -17,5 +17,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/28_two_scalar_oid_metrics_with_same_resource_attribute_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/28_two_scalar_oid_metrics_with_same_resource_attribute_golden.yaml
@@ -21,5 +21,5 @@ resourceMetrics:
             name: metric2
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/29_metric_does_not_use_all_available_scalar_RAs_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/29_metric_does_not_use_all_available_scalar_RAs_golden.yaml
@@ -24,5 +24,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/2_scalar_metrics_sum_cumulative_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/2_scalar_metrics_sum_cumulative_golden.yaml
@@ -12,5 +12,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/3_scalar_metrics_sum_delta_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/3_scalar_metrics_sum_delta_golden.yaml
@@ -11,5 +11,5 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/4_scalar_multiple_metrics_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/4_scalar_multiple_metrics_golden.yaml
@@ -17,5 +17,5 @@ resourceMetrics:
             name: metric2
             unit: '{things}'
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/5_scalar_metric_w_attr_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/5_scalar_metric_w_attr_golden.yaml
@@ -17,5 +17,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/6_scalar_metric_w_multi_datapoint_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/6_scalar_metric_w_multi_datapoint_golden.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/7_indexed_metrics_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/7_indexed_metrics_golden.yaml
@@ -20,5 +20,5 @@ resourceMetrics:
             name: metric1
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/8_indexed_metrics_sum_cumulative_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/8_indexed_metrics_sum_cumulative_golden.yaml
@@ -22,5 +22,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/expected_metrics/9_indexed_metrics_sum_delta_golden.yaml
+++ b/receiver/snmpreceiver/testdata/expected_metrics/9_indexed_metrics_sum_delta_golden.yaml
@@ -21,5 +21,5 @@ resourceMetrics:
                   timeUnixNano: "1000000"
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/integration/v2c_config_expected_metrics.yaml
+++ b/receiver/snmpreceiver/testdata/integration/v2c_config_expected_metrics.yaml
@@ -27,7 +27,7 @@ resourceMetrics:
             name: snmp.test.metric.sysservices
             unit: by
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -53,7 +53,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -79,7 +79,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -105,5 +105,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest

--- a/receiver/snmpreceiver/testdata/integration/v3_config_expected_metrics.yaml
+++ b/receiver/snmpreceiver/testdata/integration/v3_config_expected_metrics.yaml
@@ -27,7 +27,7 @@ resourceMetrics:
             name: snmp.test.metric.sysuptime
             unit: by
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -53,7 +53,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -79,7 +79,7 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest
   - resource:
       attributes:
@@ -105,5 +105,5 @@ resourceMetrics:
               isMonotonic: true
             unit: By
         scope:
-          name: otelcol/snmpreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the snmpreceiver from otelcol/snmpreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/snmpreceiver

Part of open-telemetry/opentelemetry-collector#9494
