### PR TITLE
[receiver/googlespanner] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_update-scope-googlespannerreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-googlespannerreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlespannerreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the googlespannerreceiver from `otelcol/googlecloudspannermetrics` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlespannerreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34552]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-googlespannerreceiver.yaml
+++ b/.chloggen/codeboten_update-scope-googlespannerreceiver.yaml
@@ -10,7 +10,7 @@ component: googlespannerreceiver
 note: "Update the scope name for telemetry produced by the googlespannerreceiver from `otelcol/googlecloudspannermetrics` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlespannerreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [34552]
+issues: [34593]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
@@ -9,8 +9,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/filter"
 )
 
-const instrumentationLibraryName = "otelcol/googlecloudspannermetrics"
-
 type MetricsBuilder interface {
 	Build(dataPoints []*MetricsDataPoint) (pmetric.Metrics, error)
 	Shutdown() error
@@ -44,7 +42,7 @@ func (b *metricsFromDataPointBuilder) Build(dataPoints []*MetricsDataPoint) (pme
 
 	ilms := rm.ScopeMetrics()
 	ilm := ilms.AppendEmpty()
-	ilm.Scope().SetName(instrumentationLibraryName)
+	ilm.Scope().SetName(ScopeName)
 
 	for key, points := range groupedDataPoints {
 		metric := ilm.Metrics().AppendEmpty()

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
@@ -121,7 +121,7 @@ func testMetricsFromDataPointBuilderBuild(t *testing.T, metricDataType pmetric.M
 	assert.Equal(t, len(dataForTesting.expectedGroups), metric.MetricCount())
 	assert.Equal(t, 1, metric.ResourceMetrics().At(0).ScopeMetrics().Len())
 	assert.Equal(t, len(dataForTesting.expectedGroups), metric.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
-	require.Equal(t, instrumentationLibraryName, metric.ResourceMetrics().At(0).ScopeMetrics().At(0).Scope().Name())
+	require.Equal(t, "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver", metric.ResourceMetrics().At(0).ScopeMetrics().At(0).Scope().Name())
 
 	for i := 0; i < len(dataForTesting.expectedGroups); i++ {
 		ilMetric := metric.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(i)


### PR DESCRIPTION
Update the scope name for telemetry produced by the googlespannerreceiver from otelcol/googlecloudspannermetrics to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannermetrics

Part of open-telemetry/opentelemetry-collector#9494
