### PR TITLE
[processor/logdeup] Add scope aggregator

### DIFF
--- a/.chloggen/logdedup-scope-aggregator.yaml
+++ b/.chloggen/logdedup-scope-aggregator.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: logdedupprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a scope aggregator to the logdedup processor enabling the aggregation of logs per scope.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34606]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/logdedupprocessor/counter.go
+++ b/processor/logdedupprocessor/counter.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/cespare/xxhash/v2"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
 )
 

--- a/processor/logdedupprocessor/counter.go
+++ b/processor/logdedupprocessor/counter.go
@@ -10,7 +10,6 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 
 	"github.com/cespare/xxhash/v2"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
 )
 

--- a/processor/logdedupprocessor/counter.go
+++ b/processor/logdedupprocessor/counter.go
@@ -6,10 +6,10 @@ package logdedupprocessor // import "github.com/open-telemetry/opentelemetry-col
 import (
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 
-	"github.com/cespare/xxhash/v2"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
 )
 

--- a/processor/logdedupprocessor/counter.go
+++ b/processor/logdedupprocessor/counter.go
@@ -165,11 +165,10 @@ func (a *logCounter) Increment() {
 }
 
 // getResourceKey creates a unique hash for the resource to use as a map key
-/* #nosec G104 -- According to Hash interface write can never return an error */
 func getResourceKey(resource pcommon.Resource) hashedKey {
 	hasher := xxhash.New()
 	attrsHash := pdatautil.MapHash(resource.Attributes())
-	hasher.Write(attrsHash[:])
+	_, _ = hasher.Write(attrsHash[:])
 	hash := hasher.Sum(nil)
 
 	// convert from slice to fixed size array to use as key
@@ -179,13 +178,12 @@ func getResourceKey(resource pcommon.Resource) hashedKey {
 }
 
 // getScopeKey creates a unique hash for the scope to use as a map key
-/* #nosec G104 -- According to Hash interface write can never return an error */
 func getScopeKey(scope pcommon.InstrumentationScope) hashedKey {
 	hasher := xxhash.New()
 	attrsHash := pdatautil.MapHash(scope.Attributes())
-	hasher.Write(attrsHash[:])
-	hasher.Write([]byte(scope.Name()))
-	hasher.Write([]byte(scope.Version()))
+	_, _ = hasher.Write(attrsHash[:])
+	_, _ = hasher.Write([]byte(scope.Name()))
+	_, _ = hasher.Write([]byte(scope.Version()))
 	hash := hasher.Sum(nil)
 
 	// convert from slice to fixed size array to use as key
@@ -195,15 +193,14 @@ func getScopeKey(scope pcommon.InstrumentationScope) hashedKey {
 }
 
 // getLogKey creates a unique hash for the log record to use as a map key
-/* #nosec G104 -- According to Hash interface write can never return an error */
 func getLogKey(logRecord plog.LogRecord) hashedKey {
 	hasher := xxhash.New()
 	attrsHash := pdatautil.MapHash(logRecord.Attributes())
-	hasher.Write(attrsHash[:])
+	_, _ = hasher.Write(attrsHash[:])
 	bodyHash := pdatautil.ValueHash(logRecord.Body())
-	hasher.Write(bodyHash[:])
-	hasher.Write([]byte(logRecord.SeverityNumber().String()))
-	hasher.Write([]byte(logRecord.SeverityText()))
+	_, _ = hasher.Write(bodyHash[:])
+	_, _ = hasher.Write([]byte(logRecord.SeverityNumber().String()))
+	_, _ = hasher.Write([]byte(logRecord.SeverityText()))
 	hash := hasher.Sum(nil)
 
 	// convert from slice to fixed size array to use as key

--- a/processor/logdedupprocessor/go.mod
+++ b/processor/logdedupprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/logde
 go 1.21.0
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.106.1
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.106.2-0.20240809191011-ef07ea073562
@@ -23,7 +24,6 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0 // indirect

--- a/processor/logdedupprocessor/go.mod
+++ b/processor/logdedupprocessor/go.mod
@@ -3,7 +3,6 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/logde
 go 1.21.0
 
 require (
-	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.106.1
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.106.2-0.20240809191011-ef07ea073562
@@ -24,6 +23,7 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0 // indirect

--- a/processor/logdedupprocessor/processor.go
+++ b/processor/logdedupprocessor/processor.go
@@ -13,8 +13,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.uber.org/zap"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
 )
 
 // logDedupProcessor is a logDedupProcessor that counts duplicate instances of logs.
@@ -77,19 +75,20 @@ func (p *logDedupProcessor) ConsumeLogs(_ context.Context, pl plog.Logs) error {
 	defer p.mux.Unlock()
 
 	for i := 0; i < pl.ResourceLogs().Len(); i++ {
-		resourceLogs := pl.ResourceLogs().At(i)
-		resourceAttrs := resourceLogs.Resource().Attributes()
-		resourceKey := pdatautil.MapHash(resourceAttrs)
-		for j := 0; j < resourceLogs.ScopeLogs().Len(); j++ {
-			scope := resourceLogs.ScopeLogs().At(j)
-			logs := scope.LogRecords()
-			for k := 0; k < logs.Len(); k++ {
-				logRecord := logs.At(k)
+		rl := pl.ResourceLogs().At(i)
+		resource := rl.Resource()
+
+		for j := 0; j < rl.ScopeLogs().Len(); j++ {
+			sl := rl.ScopeLogs().At(j)
+			scope := sl.Scope()
+
+			for k := 0; k < sl.LogRecords().Len(); k++ {
+				logRecord := sl.LogRecords().At(k)
 				// Remove excluded fields if any
 				p.remover.RemoveFields(logRecord)
 
 				// Add the log to the aggregator
-				p.aggregator.Add(resourceKey, resourceAttrs, logRecord)
+				p.aggregator.Add(resource, scope, logRecord)
 			}
 		}
 	}
@@ -113,6 +112,7 @@ func (p *logDedupProcessor) handleExportInterval(ctx context.Context) {
 			return
 		case <-ticker.C:
 			p.mux.Lock()
+			defer p.mux.Unlock()
 
 			logs := p.aggregator.Export()
 			// Only send logs if we have some
@@ -123,7 +123,6 @@ func (p *logDedupProcessor) handleExportInterval(ctx context.Context) {
 				}
 			}
 			p.aggregator.Reset()
-			p.mux.Unlock()
 		}
 	}
 }


### PR DESCRIPTION
**Description:**

Adds a scope aggregator to separate log records by different scopes.

Also includes some refactor work:
- Extend pdatautil.hash with configurable options of values to hash, includes ability of returning uint64
- Add consistent hash functions for resource, scope and log records that use new hash functions
- Update aggregators to keep a copy of the original resource, scope and log record instead of just it's attributes
  - Simplifies ConsumeLogs & Export functions
- Update newLogCounter to set lastObservedTime
- Update existing and add more tests

**Link to tracking Issue:**

- Closes #34606 34606

**Testing:**

Updated existing and added more unit tests to verify behaviour.
