### PR TITLE
[receiver/azureeventhub] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_more-scope-5.yaml
+++ b/.chloggen/codeboten_more-scope-5.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureeventhubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the azureeventhubreceiver from `otelcol/azureeventhubreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34611]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
@@ -17,11 +17,12 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver/internal/metadata"
 )
 
 const (
 	azureResourceID = "azure.resource.id"
-	scopeName       = "otelcol/azureresourcemetrics"
 )
 
 type azureResourceMetricsUnmarshaler struct {
@@ -75,7 +76,7 @@ func (r azureResourceMetricsUnmarshaler) UnmarshalMetrics(event *eventhub.Event)
 
 	resourceMetrics := md.ResourceMetrics().AppendEmpty()
 	resource := resourceMetrics.Resource()
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, receiverScopeName)
+	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, metadata.ScopeName)
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, conventions.AttributeTelemetrySDKLanguageGo)
 	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, r.buildInfo.Version)
 	resource.Attributes().PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAzure)

--- a/receiver/azureeventhubreceiver/factory.go
+++ b/receiver/azureeventhubreceiver/factory.go
@@ -16,11 +16,6 @@ import (
 )
 
 var (
-	// The receiver scope name
-	receiverScopeName = "otelcol/" + metadata.Type.String() + "receiver"
-)
-
-var (
 	errUnexpectedConfigurationType = errors.New("failed to cast configuration to azure event hub config")
 )
 


### PR DESCRIPTION
Update the scope name for telemetry produced by the azureeventhubreceiver from otelcol/azureeventhubreceiver to

github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver

Part of
open-telemetry/opentelemetry-collector#9494
