### PR TITLE
[receiver/cloudfoundry] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_more-scope-6.yaml
+++ b/.chloggen/codeboten_more-scope-6.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cloudfoundryreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the cloudfoundryreceiver from `otelcol/cloudfoundry` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_more-scope-6.yaml
+++ b/.chloggen/codeboten_more-scope-6.yaml
@@ -10,7 +10,7 @@ component: cloudfoundryreceiver
 note: "Update the scope name for telemetry produced by the cloudfoundryreceiver from `otelcol/cloudfoundry` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34612]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/cloudfoundryreceiver/receiver.go
+++ b/receiver/cloudfoundryreceiver/receiver.go
@@ -17,12 +17,13 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver/internal/metadata"
 )
 
 const (
-	transport              = "http"
-	dataFormat             = "cloudfoundry"
-	instrumentationLibName = "otelcol/cloudfoundry"
+	transport  = "http"
+	dataFormat = "cloudfoundry"
 )
 
 var _ receiver.Metrics = (*cloudFoundryReceiver)(nil)
@@ -214,13 +215,13 @@ func (cfr *cloudFoundryReceiver) streamLogs(
 func createLibraryMetricsSlice(metrics pmetric.Metrics) pmetric.MetricSlice {
 	resourceMetric := metrics.ResourceMetrics().AppendEmpty()
 	libraryMetrics := resourceMetric.ScopeMetrics().AppendEmpty()
-	libraryMetrics.Scope().SetName(instrumentationLibName)
+	libraryMetrics.Scope().SetName(metadata.ScopeName)
 	return libraryMetrics.Metrics()
 }
 
 func createLibraryLogsSlice(logs plog.Logs) plog.LogRecordSlice {
 	resourceLog := logs.ResourceLogs().AppendEmpty()
 	libraryLogs := resourceLog.ScopeLogs().AppendEmpty()
-	libraryLogs.Scope().SetName(instrumentationLibName)
+	libraryLogs.Scope().SetName(metadata.ScopeName)
 	return libraryLogs.LogRecords()
 }


### PR DESCRIPTION
Update the scope name for telemetry produced by the cloudfoundryreceiver from otelcol/cloudfoundryreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudfoundryreceiver

Part of open-telemetry/opentelemetry-collector#9494
