### PR TITLE
[receiver/cloudflare] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_more-scope-7.yaml
+++ b/.chloggen/codeboten_more-scope-7.yaml
@@ -10,7 +10,7 @@ component: cloudflarereceiver
 note: "Update the scope name for telemetry produced by the cloudflarereceiver from `otelcol/cloudflare` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34613]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/codeboten_more-scope-7.yaml
+++ b/.chloggen/codeboten_more-scope-7.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cloudflarereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the cloudflarereceiver from `otelcol/cloudflare` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/cloudflarereceiver/logs.go
+++ b/receiver/cloudflarereceiver/logs.go
@@ -39,8 +39,6 @@ type logsReceiver struct {
 
 const secretHeaderName = "X-CF-Secret"
 
-var receiverScopeName = "otelcol/" + metadata.Type.String()
-
 func newLogsReceiver(params rcvr.Settings, cfg *Config, consumer consumer.Logs) (*logsReceiver, error) {
 	recv := &logsReceiver{
 		cfg:               &cfg.Logs,
@@ -233,7 +231,7 @@ func (l *logsReceiver) processLogs(now pcommon.Timestamp, logs []map[string]any)
 			resource.Attributes().PutStr("cloudflare.zone", zone)
 		}
 		scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
-		scopeLogs.Scope().SetName(receiverScopeName)
+		scopeLogs.Scope().SetName(metadata.ScopeName)
 
 		for _, log := range logGroup {
 			logRecord := scopeLogs.LogRecords().AppendEmpty()

--- a/receiver/cloudflarereceiver/logs_test.go
+++ b/receiver/cloudflarereceiver/logs_test.go
@@ -48,7 +48,7 @@ func TestPayloadToLogRecord(t *testing.T) {
 				logs := plog.NewLogs()
 				rl := logs.ResourceLogs().AppendEmpty()
 				sl := rl.ScopeLogs().AppendEmpty()
-				sl.Scope().SetName(receiverScopeName)
+				sl.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver")
 
 				for idx, line := range strings.Split(payload, "\n") {
 					lr := sl.LogRecords().AppendEmpty()
@@ -86,7 +86,7 @@ func TestPayloadToLogRecord(t *testing.T) {
 				}))
 
 				sl := rl.ScopeLogs().AppendEmpty()
-				sl.Scope().SetName(receiverScopeName)
+				sl.Scope().SetName("github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver")
 				lr := sl.LogRecords().AppendEmpty()
 
 				require.NoError(t, lr.Attributes().FromRaw(map[string]any{

--- a/receiver/cloudflarereceiver/testdata/processed/all_fields.yaml
+++ b/receiver/cloudflarereceiver/testdata/processed/all_fields.yaml
@@ -284,4 +284,4 @@ resourceLogs:
             timeUnixNano: "1677821346000000000"
             traceId: ""
         scope:
-          name: otelcol/cloudflare
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver

--- a/receiver/cloudflarereceiver/testdata/processed/multiple_log_payload.yaml
+++ b/receiver/cloudflarereceiver/testdata/processed/multiple_log_payload.yaml
@@ -83,7 +83,7 @@ resourceLogs:
             timeUnixNano: "1677821345000000000"
             traceId: ""
         scope:
-          name: otelcol/cloudflare
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
   - resource:
       attributes:
         - key: cloudflare.zone
@@ -178,7 +178,7 @@ resourceLogs:
             timeUnixNano: "1677821345000000000"
             traceId: ""
         scope:
-          name: otelcol/cloudflare
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver
   - resource:
       attributes:
         - key: cloudflare.zone
@@ -230,4 +230,4 @@ resourceLogs:
             timeUnixNano: "1677821345000000000"
             traceId: ""
         scope:
-          name: otelcol/cloudflare
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver


### PR DESCRIPTION
Update the scope name for telemetry produced by the cloudflarereceiver from otelcol/cloudflare to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/cloudflarereceiver

Part of open-telemetry/opentelemetry-collector#9494
