### PR TITLE
[processor/logdedup] Process pending aggregated logs on shutdown

### DIFF
--- a/.chloggen/logdedup-process-on-shutdown.yaml
+++ b/.chloggen/logdedup-process-on-shutdown.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: logdedupprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensures any pending aggregated logs are processed and sent to the next consumer before shutting down.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34615]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/logdedupprocessor/processor.go
+++ b/processor/logdedupprocessor/processor.go
@@ -106,6 +106,8 @@ func (p *logDedupProcessor) handleExportInterval(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
+			// Export any remaining logs
+			p.exportLogs(ctx)
 			if err := ctx.Err(); err != context.Canceled {
 				p.logger.Error("context error", zap.Error(err))
 			}


### PR DESCRIPTION
**Description:**

Updates shutdown behaviour to ensure pending aggregated logs are processed and passed to the next consumer on shutdown.

**Link to tracking Issue:**

- Closes #34615

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>