### PR TITLE
[chore][receiver/elasticsearch] Update reference to `metrics` config option

### DIFF
--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -63,5 +63,5 @@ The following metric are available with versions:
 - `elasticsearch.cluster.state_update.time` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml).
-Refer to [documentation.md](./documentation.md) for information on how to enable and disable metrics scraped by this
+Refer to [documentation.md](./documentation.md) for information on how to enable and disable metrics produced by this
 receiver.

--- a/receiver/elasticsearchreceiver/README.md
+++ b/receiver/elasticsearchreceiver/README.md
@@ -25,7 +25,6 @@ See the [Elasticsearch docs](https://www.elastic.co/guide/en/elasticsearch/refer
 
 The following settings are optional:
 
-- `metrics` (default: see `DefaultMetricsSettings` [here](./internal/metadata/generated_metrics.go): Allows enabling and disabling specific metrics from being collected in this receiver.
 - `nodes` (default: `["_all"]`): Allows specifying node filters that define which nodes are scraped for node-level and cluster-level metrics. See [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/7.9/cluster.html#cluster-nodes) for allowed filters. If this option is left explicitly empty, then no node-level metrics will be scraped and cluster-level metrics will scrape only metrics related to cluster's health.
 - `skip_cluster_metrics` (default: `false`): If true, cluster-level metrics will not be scraped.
 - `indices` (default: `["_all"]`): Allows specifying index filters that define which indices are scraped for index-level metrics. See [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-stats.html#index-stats-api-path-params) for allowed filters. If this option is left explicitly empty, then no index-level metrics will be scraped.
@@ -63,4 +62,6 @@ The following metric are available with versions:
 - `elasticsearch.cluster.state_update.count` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
 - `elasticsearch.cluster.state_update.time` >= [7.16.0](https://www.elastic.co/guide/en/elasticsearch/reference/7.16/release-notes-7.16.0.html)
 
-Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml)
+Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml).
+Refer to [documentation.md](./documentation.md) for information on how to enable and disable metrics scraped by this
+receiver.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The current README information on the `metrics` config option is out of date, as there's no longer any `DefaultMetricsSettings` information in the referenced file. Since this config option is available across receivers in `contrib`, I think it's enough to simply reference the `documentation.md` file in the `Metrics` section, and not include a specific config option entry in the `Configuration` section.