### PR TITLE
[receiver/azuremonitor] update scope name for consistency

### DIFF
--- a/.chloggen/codeboten_more-scope-8.yaml
+++ b/.chloggen/codeboten_more-scope-8.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Update the scope name for telemetry produced by the azuremonitorreceiver from `otelcol/azuremonitorreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_more-scope-8.yaml
+++ b/.chloggen/codeboten_more-scope-8.yaml
@@ -10,7 +10,7 @@ component: azuremonitorreceiver
 note: "Update the scope name for telemetry produced by the azuremonitorreceiver from `otelcol/azuremonitorreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34618]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/azuremonitorreceiver/internal/metadata/metrics.go
+++ b/receiver/azuremonitorreceiver/internal/metadata/metrics.go
@@ -135,7 +135,7 @@ func (mb *MetricsBuilder) EmitForResource(rmo ...ResourceMetricsOption) {
 	rm := pmetric.NewResourceMetrics()
 	rm.Resource().Attributes().EnsureCapacity(mb.resourceCapacity)
 	ils := rm.ScopeMetrics().AppendEmpty()
-	ils.Scope().SetName("otelcol/azuremonitorreceiver")
+	ils.Scope().SetName(ScopeName)
 	ils.Scope().SetVersion(mb.buildInfo.Version)
 	ils.Metrics().EnsureCapacity(mb.metricsCapacity)
 	mb.EmitAllMetrics(ils)

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -771,5 +771,5 @@ resourceMetrics:
             name: azure_metric6_count
             unit: unit1
         scope:
-          name: otelcol/azuremonitorreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
           version: latest

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
@@ -816,5 +816,5 @@ resourceMetrics:
             name: azure_metric4_maximum
             unit: unit1
         scope:
-          name: otelcol/azuremonitorreceiver
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
           version: latest


### PR DESCRIPTION
Update the scope name for telemetry produced by the azuremonitorreceiver from otelcol/azuremonitorreceiver to github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver

Part of open-telemetry/opentelemetry-collector#9494
