### PR TITLE
[processor/metricstransform] adding option for list of strings for metricstransform processor

### DIFF
--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -21,6 +21,9 @@ const (
 	// groupResourceLabelsFieldName is the mapstructure field name for GroupResouceLabels field
 	groupResourceLabelsFieldName = "group_resource_labels"
 
+	// groupResourceLabelListFieldName is the mapstructure field name for GroupResouceLabelsList field
+	groupResourceLabelListFieldName = "group_resource_labels_list"
+
 	// aggregationTypeFieldName is the mapstructure field name for aggregationType field
 	aggregationTypeFieldName = "aggregation_type"
 
@@ -72,8 +75,11 @@ type transform struct {
 	NewName string `mapstructure:"new_name"`
 
 	// GroupResourceLabels specifes resource labels that will be appended to this group's new ResourceMetrics message
-	// REQUIRED only if Action is GROUP
 	GroupResourceLabels map[string]string `mapstructure:"group_resource_labels"`
+
+	// GroupResourceLabelsList specifes resource labels string lists that will be appended to this group's new ResourceMetrics message
+	// One of {GroupResourceLabels, GroupResourceLabelsList} REQUIRED only if Action is GROUP
+	GroupResourceLabelsList map[string][]string `mapstructure:"group_resource_labels_list"`
 
 	// AggregationType specifies how to aggregate.
 	// REQUIRED only if Action is COMBINE.

--- a/processor/metricstransformprocessor/config_test.go
+++ b/processor/metricstransformprocessor/config_test.go
@@ -138,6 +138,7 @@ func TestLoadConfig(t *testing.T) {
 						},
 						Action:              "group",
 						GroupResourceLabels: map[string]string{"metric_group": "2"},
+						GroupResourceLabelsList: map[string][]string{"metric_groups": {"2", "3"}},
 					},
 				},
 			},

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -85,8 +85,8 @@ func validateConfiguration(config *Config) error {
 			return fmt.Errorf("missing required field %q while %q is %v", newNameFieldName, actionFieldName, Insert)
 		}
 
-		if transform.Action == Group && transform.GroupResourceLabels == nil {
-			return fmt.Errorf("missing required field %q while %q is %v", groupResourceLabelsFieldName, actionFieldName, Group)
+		if transform.Action == Group && (transform.GroupResourceLabels == nil && transform.GroupResourceLabelsList == nil) {
+			return fmt.Errorf("missing required field %q or %q while %q is %v", groupResourceLabelsFieldName, groupResourceLabelsListFieldName, actionFieldName, Group)
 		}
 
 		if transform.AggregationType != "" && !transform.AggregationType.IsValid() {
@@ -142,6 +142,7 @@ func buildHelperConfig(config *Config, version string) ([]internalTransform, err
 			Action:              t.Action,
 			NewName:             t.NewName,
 			GroupResourceLabels: t.GroupResourceLabels,
+			GroupResourceLabelsList: t.GroupResourceLabelsList,
 			AggregationType:     t.AggregationType,
 			Operations:          make([]internalOperation, len(t.Operations)),
 		}

--- a/processor/metricstransformprocessor/factory_test.go
+++ b/processor/metricstransformprocessor/factory_test.go
@@ -53,7 +53,7 @@ func TestCreateProcessors(t *testing.T) {
 		{
 			configName:   "config_invalid_group.yaml",
 			succeed:      false,
-			errorMessage: fmt.Sprintf("missing required field %q while %q is %v", groupResourceLabelsFieldName, actionFieldName, Group),
+			errorMessage: fmt.Sprintf("missing required field %q or %q while %q is %v", groupResourceLabelsFieldName, groupResourceLabelsListFieldName, actionFieldName, Group),
 		},
 		{
 			configName:   "config_invalid_action.yaml",

--- a/processor/metricstransformprocessor/metrics_transform_processor.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor.go
@@ -25,6 +25,7 @@ type internalTransform struct {
 	Action              ConfigAction
 	NewName             string
 	GroupResourceLabels map[string]string
+	GroupResourceLabelsList map[string][]string
 	AggregationType     aggregateutil.AggregationType
 	SubmatchCase        submatchCase
 	Operations          []internalOperation

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -34,6 +34,7 @@ var (
 					MetricIncludeFilter: internalFilterStrict{include: "foo/metric"},
 					Action:              Group,
 					GroupResourceLabels: map[string]string{"resource.type": "foo"},
+					GroupResourceLabelsList: map[string][]string{"resource.type": {"foo", "bar"}},
 				},
 			},
 		},

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -306,6 +306,14 @@ func initResourceMetrics(dest pmetric.ResourceMetrics, resource pcommon.Resource
 		dest.Resource().Attributes().PutStr(k, v)
 	}
 
+	for k, v := range transform.GroupResourceLabelsList {
+		list := pcommon.NewSlice()
+		for _, val := range v {
+			list.AppendEmpty().SetStr(val)
+		}
+		dest.Resource().Attributes().Put(k, list)
+	}
+
 	sm := dest.ScopeMetrics().AppendEmpty()
 	scope.CopyTo(sm.Scope())
 }

--- a/processor/metricstransformprocessor/testdata/config_invalid_group.yaml
+++ b/processor/metricstransformprocessor/testdata/config_invalid_group.yaml
@@ -4,3 +4,4 @@ metricstransform:
       action: group
       match_type: strict
       # group_resource_labels: absent
+      # group_resource_labels_list: absent


### PR DESCRIPTION
**Description:** 

Adds an option to send a list of strings for metricstransform processor group labels.

this is useful to add array of strings as attributes for matching metrics

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34671

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>