### PR TITLE
awsfirehosereceiver: fix: if no key is configured, allow any key

### DIFF
--- a/receiver/awsfirehosereceiver/README.md
+++ b/receiver/awsfirehosereceiver/README.md
@@ -56,6 +56,8 @@ See the [Record Types](#record-types) section for all available options.
 The access key to be checked on each request received. This can be set when creating or updating the delivery stream.
 See [documentation](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http) for details.
 
+If a key is configured in the receiver, it is checked in all incoming requests.  If no key is configured or it is the empty string, any incoming key is accepted, including no key.
+
 ## Record Types
 
 ### cwmetrics

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -233,8 +233,10 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // validate checks the Firehose access key in the header against
 // the one passed into the Config
 func (fmr *firehoseReceiver) validate(r *http.Request) (int, error) {
-	if accessKey := r.Header.Get(headerFirehoseAccessKey); accessKey != "" && accessKey != string(fmr.config.AccessKey) {
-		return http.StatusUnauthorized, errInvalidAccessKey
+	if fmr.config.AccessKey != "" {
+		if accessKey := r.Header.Get(headerFirehoseAccessKey); accessKey != "" && accessKey != string(fmr.config.AccessKey) {
+			return http.StatusUnauthorized, errInvalidAccessKey
+		}
 	}
 	return http.StatusAccepted, nil
 }


### PR DESCRIPTION
**Description:**

The configuration for the `awsfirehosereceiver` allows configuring an authentication key, that is compared to the incoming request.  Currently, if that is not configured in the receiver but is provided in the AWS sender, authentication fails.

This makes it difficult to support a multi-tenant model where the incoming key is used to differentiate customer sources.  While the ARN could be used as it is also in a header, this isn't as useful as a key we provide to the customer, as they might use many source ARNs and we don't want to care about them.

This will make it work like this:

* If a key is configured in the receiver, it must be present in the request and must match.
* If a key is not configured, it it optional, and if present in the request, is ignored.

I'm able to use a standard authenticator extension to validate the request if I choose.

**Link to tracking Issue:**

N/A

**Testing:** 

Added unit tests, tested in our test environment.

**Documentation:**

Will add docs about this in the README.