### PR TITLE
[receiver/datadog] add sampling.priority attribute

### DIFF
--- a/.chloggen/datadogreceiver-samplingprio.yaml
+++ b/.chloggen/datadogreceiver-samplingprio.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add sampling.priority attribute for Probabilistic Sampling Processor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34267]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -103,7 +104,9 @@ func ToTraces(payload *pb.TracerPayload, req *http.Request) ptrace.Traces {
 			newSpan.SetName(span.Name)
 			newSpan.Status().SetCode(ptrace.StatusCodeOk)
 			newSpan.Attributes().PutStr("dd.span.Resource", span.Resource)
-
+			if samplingPriority, ok := span.Metrics["_sampling_priority_v1"]; ok {
+				newSpan.Attributes().PutStr("sampling.priority", fmt.Sprintf("%f", samplingPriority))
+			}
 			if span.Error > 0 {
 				newSpan.Status().SetCode(ptrace.StatusCodeError)
 			}

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -29,7 +29,7 @@ var data = [2]any{
 		5:  "X",
 		6:  "my-service",
 		7:  "my-resource",
-		8:  "_dd.sampling_rate_whatever",
+		8:  "_sampling_priority_v1",
 		9:  "value whatever",
 		10: "sql",
 		11: "service.name",
@@ -57,6 +57,7 @@ var data = [2]any{
 				},
 				map[any]float64{
 					5: 1.2,
+					8: 1,
 				},
 				10,
 			},
@@ -92,7 +93,7 @@ func TestTracePayloadV05Unmarshalling(t *testing.T) {
 	assert.Equal(t, 1, translated.SpanCount(), "Span Count wrong")
 	span := translated.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 	assert.NotNil(t, span)
-	assert.Equal(t, 8, span.Attributes().Len(), "missing attributes")
+	assert.Equal(t, 9, span.Attributes().Len(), "missing attributes")
 	value, exists := span.Attributes().Get("service.name")
 	serviceVersionValue, _ := span.Attributes().Get("service.version")
 	assert.True(t, exists, "service.name missing")
@@ -101,6 +102,8 @@ func TestTracePayloadV05Unmarshalling(t *testing.T) {
 	assert.Equal(t, "1.0.1", serviceVersionValue.AsString())
 	spanResource, _ := span.Attributes().Get("dd.span.Resource")
 	assert.Equal(t, "my-resource", spanResource.Str())
+	spanResource1, _ := span.Attributes().Get("sampling.priority")
+	assert.Equal(t, fmt.Sprintf("%f", 1.0), spanResource1.Str())
 }
 
 func TestTracePayloadV07Unmarshalling(t *testing.T) {


### PR DESCRIPTION
**Description:** 
Add sampling.priority attribute based on metrics _sampling_priority_v1  for probabilistic_sampler processor


**Link to tracking Issue:** 
resolve https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34267


**Testing:** 
Have a demo app with Datadog SDK
OTEL collector with probabilistic_sampler processor like this config : 
```
receivers:
  datadog:
    endpoint: 0.0.0.0:8080 
    read_timeout: 60s

processors:
  probabilistic_sampler:
    sampling_percentage: 0

exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    traces:
      receivers: [datadog]
      processors: [probabilistic_sampler]
      exporters: [debug]
```
Perform a test curl on demo app to generate traces
```curl mydemoapp:8080/actuator/metrics -H 'x-datadog-sampling-priority: 1' -H 'x-datadog-parent-id: 0' -H 'x-datadog-trace-id: 123’```
We see the traces in stdout of OTEL collector

**Documentation:** <Describe the documentation added.>