### PR TITLE
[receiver/vcenter] Change Host Perf Metric Reported Datapoints From 5 to 1

### DIFF
--- a/.chloggen/vcenter-receiver_remove_extra_host_perf_metrics.yaml
+++ b/.chloggen/vcenter-receiver_remove_extra_host_perf_metrics.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: vcenterreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Removes the ability to sent 5 historical metrics per collection for Host Resource performance metrics."
+note: Several host performance metrics now return 1 data point per time series instead of 5.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [34708]
@@ -16,11 +16,12 @@ issues: [34708]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-Sending 5 historical metrics already did not match up with what was being done with the VM performance metrics.
-It could easily lead to situations where timetamps were the tail end of these 5 datapoints would end up being
-picked up by the following collection as well. This change also fixes an issue with the googlecloud exporter
-seeing these datapoints (20s apart) as duplicates. Following is the list of affected metrics which will now only
-report a single datapoint per set of unique attribute values.
+The 5 data points previously sent represented consecutive 20s sampling periods. Depending on the collection interval 
+these could easily overlap. Sending just the latest of these data points is more in line with other performance metrics.
+
+This change also fixes an issue with the googlecloud exporter seeing these datapoints as duplicates.
+
+Following is the list of affected metrics which will now only report a single datapoint per set of unique attribute values.
 - vcenter.host.cpu.reserved
 - vcenter.host.disk.latency.avg
 - vcenter.host.disk.latency.max

--- a/.chloggen/vcenter-receiver_remove_extra_host_perf_metrics.yaml
+++ b/.chloggen/vcenter-receiver_remove_extra_host_perf_metrics.yaml
@@ -16,21 +16,21 @@ issues: [34708]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-The 5 data points previously sent represented consecutive 20s sampling periods. Depending on the collection interval 
-these could easily overlap. Sending just the latest of these data points is more in line with other performance metrics.
-
-This change also fixes an issue with the googlecloud exporter seeing these datapoints as duplicates.
-
-Following is the list of affected metrics which will now only report a single datapoint per set of unique attribute values.
-- vcenter.host.cpu.reserved
-- vcenter.host.disk.latency.avg
-- vcenter.host.disk.latency.max
-- vcenter.host.disk.throughput
-- vcenter.host.network.packet.drop.rate
-- vcenter.host.network.packet.error.rate
-- vcenter.host.network.packet.rate
-- vcenter.host.network.throughput
-- vcenter.host.network.usage
+  The 5 data points previously sent represented consecutive 20s sampling periods. Depending on the collection interval 
+  these could easily overlap. Sending just the latest of these data points is more in line with other performance metrics.
+  
+  This change also fixes an issue with the googlecloud exporter seeing these datapoints as duplicates.
+  
+  Following is the list of affected metrics which will now only report a single datapoint per set of unique attribute values.
+  - vcenter.host.cpu.reserved
+  - vcenter.host.disk.latency.avg
+  - vcenter.host.disk.latency.max
+  - vcenter.host.disk.throughput
+  - vcenter.host.network.packet.drop.rate
+  - vcenter.host.network.packet.error.rate
+  - vcenter.host.network.packet.rate
+  - vcenter.host.network.throughput
+  - vcenter.host.network.usage
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/vcenter-receiver_remove_extra_host_perf_metrics.yaml
+++ b/.chloggen/vcenter-receiver_remove_extra_host_perf_metrics.yaml
@@ -1,0 +1,41 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: vcenterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Removes the ability to sent 5 historical metrics per collection for Host Resource performance metrics."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34708]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+Sending 5 historical metrics already did not match up with what was being done with the VM performance metrics.
+It could easily lead to situations where timetamps were the tail end of these 5 datapoints would end up being
+picked up by the following collection as well. This change also fixes an issue with the googlecloud exporter
+seeing these datapoints (20s apart) as duplicates. Following is the list of affected metrics which will now only
+report a single datapoint per set of unique attribute values.
+- vcenter.host.cpu.reserved
+- vcenter.host.disk.latency.avg
+- vcenter.host.disk.latency.max
+- vcenter.host.disk.throughput
+- vcenter.host.network.packet.drop.rate
+- vcenter.host.network.packet.error.rate
+- vcenter.host.network.packet.rate
+- vcenter.host.network.throughput
+- vcenter.host.network.usage
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/vcenterreceiver/internal/mockserver/responses/host-performance-counters.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/host-performance-counters.xml
@@ -10,22 +10,6 @@
             <returnval xsi:type="PerfEntityMetric">
                 <entity type="HostSystem">host-1002</entity>
                 <sampleInfo>
-                    <timestamp>2022-05-17T17:24:40Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:25:00Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:25:20Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:25:40Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <sampleInfo>
                     <timestamp>2022-05-17T17:26:00Z</timestamp>
                     <interval>20</interval>
                 </sampleInfo>
@@ -34,10 +18,6 @@
                         <counterId>143</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>769</value>
-                    <value>773</value>
-                    <value>927</value>
-                    <value>980</value>
                     <value>864</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -45,10 +25,6 @@
                         <counterId>532</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>411</value>
-                    <value>422</value>
-                    <value>551</value>
-                    <value>617</value>
                     <value>488</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -56,10 +32,6 @@
                         <counterId>147</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>40810</value>
-                    <value>41703</value>
-                    <value>42960</value>
-                    <value>42206</value>
                     <value>41480</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -67,10 +39,6 @@
                         <counterId>146</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>42110</value>
-                    <value>42686</value>
-                    <value>44277</value>
-                    <value>43122</value>
                     <value>42703</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -79,10 +47,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -90,20 +54,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -112,10 +68,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -123,20 +75,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -145,10 +89,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -156,20 +96,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -178,10 +110,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -189,10 +117,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -200,20 +124,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -222,20 +138,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -244,20 +152,12 @@
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -266,20 +166,12 @@
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
                     <value>0</value>
-                    <value>4</value>
-                    <value>1</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -288,20 +180,12 @@
                         <instance>vmnic3</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic1</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -310,20 +194,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>2</value>
                     <value>1</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -332,20 +208,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -354,20 +222,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
-                    <value>7</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>4</value>
                     <value>2</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -376,20 +236,12 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance></instance>
                     </id>
-                    <value>928</value>
-                    <value>1120</value>
-                    <value>1646</value>
-                    <value>1291</value>
                     <value>1058</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -398,10 +250,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -409,20 +257,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>532</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>3064</value>
-                    <value>2537</value>
-                    <value>4373</value>
-                    <value>3746</value>
                     <value>2569</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -431,20 +271,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>147</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>11182</value>
-                    <value>13009</value>
-                    <value>16489</value>
-                    <value>12398</value>
                     <value>12984</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -453,20 +285,12 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>502</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -475,10 +299,6 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -486,20 +306,12 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>  
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>13316</value>
-                    <value>14473</value>
-                    <value>19662</value>
-                    <value>15478</value>
                     <value>14458</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -507,10 +319,6 @@
                         <counterId>130</counterId>
                         <instance></instance>
                     </id>
-                    <value>28</value>
-                    <value>45</value>
-                    <value>88</value>
-                    <value>92</value>
                     <value>31</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -519,20 +327,12 @@
                         <instance></instance>
                     </id>
                     <value>1840</value>
-                    <value>1840</value>
-                    <value>1840</value>
-                    <value>1840</value>
-                    <value>1840</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>501</counterId>
                         <instance></instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -541,20 +341,12 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>9</counterId>
                         <instance></instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -563,20 +355,12 @@
                         <instance></instance>
                     </id>
                     <value>4000</value>
-                    <value>4000</value>
-                    <value>4000</value>
-                    <value>4000</value>
-                    <value>4000</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance>vmnic1</instance>
                     </id>
-                    <value>116</value>
-                    <value>114</value>
-                    <value>113</value>
-                    <value>112</value>
                     <value>120</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -584,10 +368,6 @@
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
-                    <value>4</value>
-                    <value>0</value>
-                    <value>1</value>
-                    <value>2</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -596,20 +376,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>570</value>
-                    <value>768</value>
-                    <value>1269</value>
-                    <value>927</value>
                     <value>681</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -617,10 +389,6 @@
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
-                    <value>6</value>
-                    <value>6</value>
-                    <value>4</value>
-                    <value>8</value>
                     <value>19</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -629,20 +397,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>1</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>357</value>
-                    <value>351</value>
-                    <value>376</value>
-                    <value>363</value>
                     <value>376</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -650,10 +410,6 @@
                         <counterId>532</counterId>
                         <instance></instance>
                     </id>
-                    <value>3475</value>
-                    <value>2959</value>
-                    <value>4924</value>
-                    <value>4364</value>
                     <value>3058</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -662,20 +418,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -684,20 +432,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -706,20 +446,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance></instance>
                     </id>
-                    <value>55647</value>
-                    <value>57376</value>
-                    <value>64156</value>
-                    <value>58814</value>
                     <value>57390</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -728,10 +460,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -739,20 +467,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>538</counterId>
                         <instance>vmnic2</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -761,20 +481,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>147</counterId>
                         <instance></instance>
                     </id>
-                    <value>51992</value>
-                    <value>54712</value>
-                    <value>59449</value>
-                    <value>54604</value>
                     <value>54464</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -783,10 +495,6 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -794,20 +502,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance>vmnic2</instance>
                     </id>
-                    <value>105</value>
-                    <value>103</value>
-                    <value>104</value>
-                    <value>102</value>
                     <value>109</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -816,20 +516,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -838,10 +530,6 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -849,20 +537,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
-                    <value>4</value>
-                    <value>25</value>
-                    <value>76</value>
-                    <value>63</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -870,10 +550,6 @@
                         <counterId>143</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>3634</value>
-                    <value>3305</value>
-                    <value>5642</value>
-                    <value>4674</value>
                     <value>3251</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -881,10 +557,6 @@
                         <counterId>143</counterId>
                         <instance></instance>
                     </id>
-                    <value>4404</value>
-                    <value>4079</value>
-                    <value>6570</value>
-                    <value>5655</value>
                     <value>4117</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -893,10 +565,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -904,20 +572,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -926,20 +586,12 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
-                    <value>5</value>
-                    <value>10</value>
-                    <value>5</value>
-                    <value>7</value>
                     <value>6</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -948,20 +600,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>2</value>
-                    <value>0</value>
-                    <value>2</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>520</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -970,20 +614,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>516</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -992,20 +628,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>516</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1014,20 +642,12 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>133</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>899</value>
-                    <value>899</value>
-                    <value>905</value>
-                    <value>1000</value>
                     <value>1002</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1035,10 +655,6 @@
                         <counterId>124</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>499</value>
-                    <value>568</value>
-                    <value>476</value>
-                    <value>387</value>
                     <value>977</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1046,10 +662,6 @@
                         <counterId>518</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>781</value>
-                    <value>789</value>
-                    <value>645</value>
-                    <value>781</value>
                     <value>782</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1057,10 +669,6 @@
                         <counterId>522</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>781</value>
-                    <value>789</value>
-                    <value>645</value>
-                    <value>781</value>
                     <value>782</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1068,31 +676,11 @@
                         <counterId>131</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>781</value>
-                    <value>789</value>
-                    <value>645</value>
-                    <value>781</value>
                     <value>782</value>
                 </value>
             </returnval>
             <returnval xsi:type="PerfEntityMetric">
                 <entity type="HostSystem">host-1003</entity>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:24:40Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:25:00Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:25:20Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:25:40Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
                 <sampleInfo>
                     <timestamp>2022-05-17T17:26:00Z</timestamp>
                     <interval>20</interval>
@@ -1102,10 +690,6 @@
                         <counterId>143</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>769</value>
-                    <value>773</value>
-                    <value>927</value>
-                    <value>980</value>
                     <value>864</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1113,10 +697,6 @@
                         <counterId>532</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>411</value>
-                    <value>422</value>
-                    <value>551</value>
-                    <value>617</value>
                     <value>488</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1124,10 +704,6 @@
                         <counterId>147</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>40810</value>
-                    <value>41703</value>
-                    <value>42960</value>
-                    <value>42206</value>
                     <value>41480</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1135,10 +711,6 @@
                         <counterId>146</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>42110</value>
-                    <value>42686</value>
-                    <value>44277</value>
-                    <value>43122</value>
                     <value>42703</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1147,10 +719,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1158,20 +726,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1180,10 +740,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1191,20 +747,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1213,10 +761,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1224,20 +768,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1246,10 +782,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1257,10 +789,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1268,20 +796,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1290,20 +810,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1312,20 +824,12 @@
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1334,20 +838,12 @@
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
                     <value>0</value>
-                    <value>4</value>
-                    <value>1</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1356,20 +852,12 @@
                         <instance>vmnic3</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic1</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1378,20 +866,12 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>502</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1400,20 +880,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>2</value>
                     <value>1</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1422,20 +894,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1444,20 +908,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
-                    <value>7</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>4</value>
                     <value>2</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1466,20 +922,12 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance></instance>
                     </id>
-                    <value>928</value>
-                    <value>1120</value>
-                    <value>1646</value>
-                    <value>1291</value>
                     <value>1058</value>
                 </value>  
                 <value xsi:type="PerfMetricIntSeries">
@@ -1488,20 +936,12 @@
                         <instance></instance>
                     </id>
                     <value>1840</value>
-                    <value>1840</value>
-                    <value>1840</value>
-                    <value>1840</value>
-                    <value>1840</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>501</counterId>
                         <instance></instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1510,20 +950,12 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>9</counterId>
                         <instance></instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1532,20 +964,12 @@
                         <instance></instance>
                     </id>
                     <value>4000</value>
-                    <value>4000</value>
-                    <value>4000</value>
-                    <value>4000</value>
-                    <value>4000</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>516</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1554,20 +978,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>532</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>3064</value>
-                    <value>2537</value>
-                    <value>4373</value>
-                    <value>3746</value>
                     <value>2569</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1576,10 +992,6 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1587,20 +999,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>530</counterId>
                         <instance>vmnic2</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value> 
                 <value xsi:type="PerfMetricIntSeries">
@@ -1608,10 +1012,6 @@
                         <counterId>147</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>11182</value>
-                    <value>13009</value>
-                    <value>16489</value>
-                    <value>12398</value>
                     <value>12984</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1619,10 +1019,6 @@
                         <counterId>146</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>13316</value>
-                    <value>14473</value>
-                    <value>19662</value>
-                    <value>15478</value>
                     <value>14458</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1630,10 +1026,6 @@
                         <counterId>130</counterId>
                         <instance></instance>
                     </id>
-                    <value>28</value>
-                    <value>45</value>
-                    <value>88</value>
-                    <value>92</value>
                     <value>31</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1641,10 +1033,6 @@
                         <counterId>146</counterId>
                         <instance>vmnic1</instance>
                     </id>
-                    <value>116</value>
-                    <value>114</value>
-                    <value>113</value>
-                    <value>112</value>
                     <value>120</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1652,10 +1040,6 @@
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
-                    <value>4</value>
-                    <value>0</value>
-                    <value>1</value>
-                    <value>2</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1664,20 +1048,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>570</value>
-                    <value>768</value>
-                    <value>1269</value>
-                    <value>927</value>
                     <value>681</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1685,10 +1061,6 @@
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
-                    <value>6</value>
-                    <value>6</value>
-                    <value>4</value>
-                    <value>8</value>
                     <value>19</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1697,20 +1069,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>1</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>357</value>
-                    <value>351</value>
-                    <value>376</value>
-                    <value>363</value>
                     <value>376</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1718,10 +1082,6 @@
                         <counterId>532</counterId>
                         <instance></instance>
                     </id>
-                    <value>3475</value>
-                    <value>2959</value>
-                    <value>4924</value>
-                    <value>4364</value>
                     <value>3058</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1730,20 +1090,12 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1752,20 +1104,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1774,20 +1118,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance></instance>
                     </id>
-                    <value>55647</value>
-                    <value>57376</value>
-                    <value>64156</value>
-                    <value>58814</value>
                     <value>57390</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1796,10 +1132,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1807,20 +1139,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>538</counterId>
                         <instance>vmnic2</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1829,20 +1153,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>147</counterId>
                         <instance></instance>
                     </id>
-                    <value>51992</value>
-                    <value>54712</value>
-                    <value>59449</value>
-                    <value>54604</value>
                     <value>54464</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1851,10 +1167,6 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1862,20 +1174,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance>vmnic2</instance>
                     </id>
-                    <value>105</value>
-                    <value>103</value>
-                    <value>104</value>
-                    <value>102</value>
                     <value>109</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1884,20 +1188,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic3</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1906,10 +1202,6 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1917,20 +1209,12 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
-                    <value>4</value>
-                    <value>25</value>
-                    <value>76</value>
-                    <value>63</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1938,10 +1222,6 @@
                         <counterId>143</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>3634</value>
-                    <value>3305</value>
-                    <value>5642</value>
-                    <value>4674</value>
                     <value>3251</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1949,10 +1229,6 @@
                         <counterId>143</counterId>
                         <instance></instance>
                     </id>
-                    <value>4404</value>
-                    <value>4079</value>
-                    <value>6570</value>
-                    <value>5655</value>
                     <value>4117</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1961,10 +1237,6 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1972,20 +1244,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic0</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1994,20 +1258,12 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
-                    <value>5</value>
-                    <value>10</value>
-                    <value>5</value>
-                    <value>7</value>
                     <value>6</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2016,20 +1272,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>2</value>
-                    <value>0</value>
-                    <value>2</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>520</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2038,20 +1286,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>516</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2060,20 +1300,12 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>516</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2082,20 +1314,12 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
-                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>133</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>899</value>
-                    <value>899</value>
-                    <value>905</value>
-                    <value>1000</value>
                     <value>1002</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2103,10 +1327,6 @@
                         <counterId>124</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>499</value>
-                    <value>568</value>
-                    <value>476</value>
-                    <value>387</value>
                     <value>977</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2114,10 +1334,6 @@
                         <counterId>518</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>781</value>
-                    <value>789</value>
-                    <value>645</value>
-                    <value>781</value>
                     <value>782</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2125,10 +1341,6 @@
                         <counterId>522</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>781</value>
-                    <value>789</value>
-                    <value>645</value>
-                    <value>781</value>
                     <value>782</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -2136,10 +1348,6 @@
                         <counterId>131</counterId>
                         <instance>4000</instance>
                     </id>
-                    <value>781</value>
-                    <value>789</value>
-                    <value>645</value>
-                    <value>781</value>
                     <value>782</value>
                 </value>
             </returnval>

--- a/receiver/vcenterreceiver/scraper.go
+++ b/receiver/vcenterreceiver/scraper.go
@@ -270,7 +270,7 @@ func (v *vcenterMetricScraper) scrapeHosts(ctx context.Context, dc *mo.Datacente
 	}
 
 	spec := types.PerfQuerySpec{
-		MaxSample: 5,
+		MaxSample: 1,
 		Format:    string(types.PerfFormatNormal),
 		// Just grabbing real time performance metrics of the current
 		// supported metrics by this receiver. If more are added we may need

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -417,71 +417,15 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -503,46 +447,6 @@ resourceMetrics:
           - description: The latency of operations to the host system's disk.
             gauge:
               dataPoints:
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -551,48 +455,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -601,48 +465,20 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
             gauge:
               dataPoints:
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "905"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1000"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1002"
                   attributes:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -650,46 +486,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "28"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "45"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "88"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "92"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "31"
                   attributes:
                     - key: direction
@@ -698,48 +494,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "25"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "76"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "63"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -748,48 +504,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "8"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "19"
                   attributes:
                     - key: direction
@@ -798,48 +514,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "10"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "6"
                   attributes:
                     - key: direction
@@ -848,17 +524,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -868,78 +534,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2"
                   attributes:
                     - key: direction
@@ -948,48 +544,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1"
                   attributes:
                     - key: direction
@@ -998,17 +554,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1018,58 +564,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1078,37 +574,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1118,78 +584,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -1198,8 +594,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -1229,57 +625,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1289,38 +635,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -1334,57 +650,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1394,47 +660,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1444,47 +670,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1494,47 +680,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1544,47 +690,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1594,47 +700,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1644,47 +710,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1694,47 +720,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1744,47 +730,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1794,83 +740,13 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/sec}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
             gauge:
               dataPoints:
-                - asDouble: 2782.35
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 2868.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3207.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2940.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2869.5
                   attributes:
                     - key: direction
@@ -1879,48 +755,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 665.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 723.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 983.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 773.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 722.9
                   attributes:
                     - key: direction
@@ -1929,48 +765,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 6
                   attributes:
                     - key: direction
@@ -1979,48 +775,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.25
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 5.45
                   attributes:
                     - key: direction
@@ -2029,48 +785,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2105.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2134.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2213.85
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2156.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2135.15
                   attributes:
                     - key: direction
@@ -2079,48 +795,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2599.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2735.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2972.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2730.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2723.2
                   attributes:
                     - key: direction
@@ -2129,48 +805,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 559.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 650.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 824.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 619.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 649.2
                   attributes:
                     - key: direction
@@ -2179,17 +815,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -2199,47 +825,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -2249,78 +835,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2040.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2085.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2148
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2110.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2074
                   attributes:
                     - key: direction
@@ -2329,8 +845,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/sec}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -2338,46 +854,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "928"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "1120"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1646"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1291"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1058"
                   attributes:
                     - key: direction
@@ -2386,48 +862,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "570"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "768"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1269"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "927"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "681"
                   attributes:
                     - key: direction
@@ -2436,17 +872,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2456,47 +882,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2506,58 +892,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "357"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "351"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "376"
                   attributes:
                     - key: direction
@@ -2566,68 +902,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "363"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3475"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2959"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4924"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4364"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3058"
                   attributes:
                     - key: direction
@@ -2636,48 +912,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3064"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2537"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4373"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "3746"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2569"
                   attributes:
                     - key: direction
@@ -2686,17 +922,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2706,47 +932,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2756,78 +942,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "411"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "422"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "551"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "617"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "488"
                   attributes:
                     - key: direction
@@ -2836,189 +952,49 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4404"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4079"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "6570"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "5655"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "4117"
                   attributes:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3634"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "3305"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5642"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4674"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "769"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "773"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "927"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "980"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:
@@ -3176,71 +1152,15 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -3262,46 +1182,6 @@ resourceMetrics:
           - description: The latency of operations to the host system's disk.
             gauge:
               dataPoints:
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -3310,48 +1190,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -3360,48 +1200,20 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
             gauge:
               dataPoints:
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "905"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1000"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1002"
                   attributes:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -3409,46 +1221,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "28"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "45"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "88"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "92"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "31"
                   attributes:
                     - key: direction
@@ -3457,48 +1229,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "25"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "76"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "63"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -3507,48 +1239,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "8"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "19"
                   attributes:
                     - key: direction
@@ -3557,48 +1249,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "10"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "6"
                   attributes:
                     - key: direction
@@ -3607,17 +1259,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -3627,78 +1269,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2"
                   attributes:
                     - key: direction
@@ -3707,48 +1279,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1"
                   attributes:
                     - key: direction
@@ -3757,17 +1289,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -3777,58 +1299,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -3837,37 +1309,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -3877,78 +1319,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -3957,8 +1329,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -3988,57 +1360,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4048,38 +1370,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -4093,57 +1385,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4153,47 +1395,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4203,47 +1405,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4253,47 +1415,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4303,47 +1425,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4353,47 +1435,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4403,47 +1445,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4453,47 +1455,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4503,47 +1465,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4553,83 +1475,13 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/sec}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
             gauge:
               dataPoints:
-                - asDouble: 2782.35
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 2868.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3207.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2940.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2869.5
                   attributes:
                     - key: direction
@@ -4638,48 +1490,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 665.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 723.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 983.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 773.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 722.9
                   attributes:
                     - key: direction
@@ -4688,48 +1500,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 6
                   attributes:
                     - key: direction
@@ -4738,48 +1510,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.25
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 5.45
                   attributes:
                     - key: direction
@@ -4788,48 +1520,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2105.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2134.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2213.85
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2156.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2135.15
                   attributes:
                     - key: direction
@@ -4838,48 +1530,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2599.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2735.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2972.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2730.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2723.2
                   attributes:
                     - key: direction
@@ -4888,48 +1540,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 559.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 650.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 824.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 619.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 649.2
                   attributes:
                     - key: direction
@@ -4938,17 +1550,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4958,47 +1560,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -5008,78 +1570,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2040.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2085.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2148
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2110.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2074
                   attributes:
                     - key: direction
@@ -5088,8 +1580,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/sec}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -5097,46 +1589,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "928"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "1120"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1646"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1291"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1058"
                   attributes:
                     - key: direction
@@ -5145,48 +1597,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "570"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "768"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1269"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "927"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "681"
                   attributes:
                     - key: direction
@@ -5195,17 +1607,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5215,47 +1617,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5265,58 +1627,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "357"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "351"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "376"
                   attributes:
                     - key: direction
@@ -5325,68 +1637,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "363"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3475"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2959"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4924"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4364"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3058"
                   attributes:
                     - key: direction
@@ -5395,48 +1647,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3064"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2537"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4373"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "3746"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2569"
                   attributes:
                     - key: direction
@@ -5445,17 +1657,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5465,47 +1667,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5515,78 +1677,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "411"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "422"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "551"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "617"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "488"
                   attributes:
                     - key: direction
@@ -5595,189 +1687,49 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4404"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4079"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "6570"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "5655"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "4117"
                   attributes:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3634"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "3305"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5642"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4674"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "769"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "773"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "927"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "980"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -417,71 +417,15 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -503,46 +447,6 @@ resourceMetrics:
           - description: The latency of operations to the host system's disk.
             gauge:
               dataPoints:
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -551,48 +455,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -601,48 +465,20 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
             gauge:
               dataPoints:
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "905"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1000"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1002"
                   attributes:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -650,46 +486,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "28"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "45"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "88"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "92"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "31"
                   attributes:
                     - key: direction
@@ -698,48 +494,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "25"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "76"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "63"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -748,48 +504,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "8"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "19"
                   attributes:
                     - key: direction
@@ -798,48 +514,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "10"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "6"
                   attributes:
                     - key: direction
@@ -848,17 +524,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -868,78 +534,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2"
                   attributes:
                     - key: direction
@@ -948,48 +544,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1"
                   attributes:
                     - key: direction
@@ -998,17 +554,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1018,58 +564,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -1078,37 +574,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1118,78 +584,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -1198,8 +594,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -1229,57 +625,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1289,38 +635,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -1334,57 +650,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1394,47 +660,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1444,47 +670,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1494,47 +680,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1544,47 +690,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1594,47 +700,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1644,47 +710,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1694,47 +720,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1744,47 +730,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1794,83 +740,13 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/sec}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
             gauge:
               dataPoints:
-                - asDouble: 2782.35
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 2868.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3207.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2940.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2869.5
                   attributes:
                     - key: direction
@@ -1879,48 +755,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 665.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 723.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 983.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 773.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 722.9
                   attributes:
                     - key: direction
@@ -1929,48 +765,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 6
                   attributes:
                     - key: direction
@@ -1979,48 +775,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.25
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 5.45
                   attributes:
                     - key: direction
@@ -2029,48 +785,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2105.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2134.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2213.85
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2156.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2135.15
                   attributes:
                     - key: direction
@@ -2079,48 +795,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2599.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2735.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2972.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2730.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2723.2
                   attributes:
                     - key: direction
@@ -2129,48 +805,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 559.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 650.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 824.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 619.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 649.2
                   attributes:
                     - key: direction
@@ -2179,17 +815,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -2199,47 +825,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -2249,78 +835,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2040.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2085.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2148
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2110.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2074
                   attributes:
                     - key: direction
@@ -2329,8 +845,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/sec}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -2338,46 +854,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "928"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "1120"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1646"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1291"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1058"
                   attributes:
                     - key: direction
@@ -2386,48 +862,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "570"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "768"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1269"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "927"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "681"
                   attributes:
                     - key: direction
@@ -2436,17 +872,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2456,47 +882,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2506,58 +892,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "357"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "351"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "376"
                   attributes:
                     - key: direction
@@ -2566,68 +902,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "363"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3475"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2959"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4924"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4364"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3058"
                   attributes:
                     - key: direction
@@ -2636,48 +912,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3064"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2537"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4373"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "3746"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2569"
                   attributes:
                     - key: direction
@@ -2686,17 +922,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2706,47 +932,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -2756,78 +942,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "411"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "422"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "551"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "617"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "488"
                   attributes:
                     - key: direction
@@ -2836,189 +952,49 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4404"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4079"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "6570"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "5655"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "4117"
                   attributes:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3634"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "3305"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5642"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4674"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "769"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "773"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "927"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "980"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:
@@ -3176,71 +1152,15 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "4000"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: total
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: cpu_reservation_type
-                      value:
-                        stringValue: used
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -3262,46 +1182,6 @@ resourceMetrics:
           - description: The latency of operations to the host system's disk.
             gauge:
               dataPoints:
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -3310,48 +1190,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -3360,48 +1200,20 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
             gauge:
               dataPoints:
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "899"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "905"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1000"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1002"
                   attributes:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -3409,46 +1221,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "28"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "45"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "88"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "92"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "31"
                   attributes:
                     - key: direction
@@ -3457,48 +1229,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "25"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "76"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "63"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -3507,48 +1239,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "6"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "8"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "19"
                   attributes:
                     - key: direction
@@ -3557,48 +1249,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "10"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "6"
                   attributes:
                     - key: direction
@@ -3607,17 +1259,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -3627,78 +1269,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2"
                   attributes:
                     - key: direction
@@ -3707,48 +1279,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1"
                   attributes:
                     - key: direction
@@ -3757,17 +1289,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -3777,58 +1299,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "0"
                   attributes:
                     - key: direction
@@ -3837,37 +1309,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "2"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -3877,78 +1319,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: object
-                      value:
-                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "789"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "645"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "781"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: object
-                      value:
-                        stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "782"
                   attributes:
                     - key: direction
@@ -3957,8 +1329,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -3988,57 +1360,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4048,38 +1370,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/sec}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -4093,57 +1385,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4153,47 +1395,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4203,47 +1405,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4253,47 +1415,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4303,47 +1425,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4353,47 +1435,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4403,47 +1445,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4453,47 +1455,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4503,47 +1465,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4553,83 +1475,13 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/sec}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
             gauge:
               dataPoints:
-                - asDouble: 2782.35
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asDouble: 2868.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 3207.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2940.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2869.5
                   attributes:
                     - key: direction
@@ -4638,48 +1490,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 665.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 723.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 983.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 773.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 722.9
                   attributes:
                     - key: direction
@@ -4688,48 +1500,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.8
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.7
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.65
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 6
                   attributes:
                     - key: direction
@@ -4738,48 +1510,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 5.25
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 5.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 5.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 5.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 5.45
                   attributes:
                     - key: direction
@@ -4788,48 +1520,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2105.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2134.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2213.85
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2156.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2135.15
                   attributes:
                     - key: direction
@@ -4838,48 +1530,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2599.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2735.6
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2972.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2730.2
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2723.2
                   attributes:
                     - key: direction
@@ -4888,48 +1540,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 559.1
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 650.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 824.45
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 619.9
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 649.2
                   attributes:
                     - key: direction
@@ -4938,17 +1550,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -4958,47 +1560,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -5008,78 +1570,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asDouble: 0
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asDouble: 2040.5
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asDouble: 2085.15
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 2148
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asDouble: 2110.3
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asDouble: 2074
                   attributes:
                     - key: direction
@@ -5088,8 +1580,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/sec}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -5097,46 +1589,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "928"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "1120"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1646"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "1291"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "1058"
                   attributes:
                     - key: direction
@@ -5145,48 +1597,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "570"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "768"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1269"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "927"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "681"
                   attributes:
                     - key: direction
@@ -5195,17 +1607,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5215,47 +1617,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5265,58 +1627,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "357"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "351"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
                 - asInt: "376"
                   attributes:
                     - key: direction
@@ -5325,68 +1637,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "363"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "376"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: received
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3475"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2959"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4924"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4364"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3058"
                   attributes:
                     - key: direction
@@ -5395,48 +1647,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3064"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "2537"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4373"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "3746"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "2569"
                   attributes:
                     - key: direction
@@ -5445,17 +1657,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5465,47 +1667,7 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -5515,78 +1677,8 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "411"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "422"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "551"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "617"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: transmitted
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "488"
                   attributes:
                     - key: direction
@@ -5595,189 +1687,49 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "4404"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "1000000"
-                - asInt: "4079"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "6570"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "5655"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "4117"
                   attributes:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "3634"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "3305"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "5642"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "4674"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic1
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
-                - asInt: "0"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic2
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
-                - asInt: "769"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
+                  startTimeUnixNano: "2000000"
                   timeUnixNano: "1000000"
-                - asInt: "773"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "2000000"
-                - asInt: "927"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "3000000"
-                - asInt: "980"
-                  attributes:
-                    - key: object
-                      value:
-                        stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "4000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "6000000"
-                  timeUnixNano: "5000000"
+                  startTimeUnixNano: "2000000"
+                  timeUnixNano: "1000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
This is something that I thought was a little odd for awhile, but didn't necessarily hurt anything until I ran into issues with the googlecloud exporter. It seems to have issues with the Host performance metrics sending historical data with timestamps 20s apart and reported it as a Duplicate error.

This also brings the Host performance metrics in line with what is being done with the VM performance metrics (only sending a single current datapoint vs 5 historical ones). Now we'll also generally avoid situations where timetamps at the tail end of these 5 datapoints would end up being picked up by the following collection as well.

**Link to tracking Issue:** NA

**Testing:**
Unit Tests Ran
Integration Tests Ran
Tested Against Live Environment

**Documentation:** <Describe the documentation added.>
None needed