### PR TITLE
[receiver/googlemonitoring] update scope name

### DIFF
--- a/.chloggen/codeboten_update-scope-googlecloudmonitor.yaml
+++ b/.chloggen/codeboten_update-scope-googlecloudmonitor.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudmonitorreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "The scope name has been updated to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver` from `otelcol/googlecloudmonitoringreceiver`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_update-scope-googlecloudmonitor.yaml
+++ b/.chloggen/codeboten_update-scope-googlecloudmonitor.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: googlecloudmonitorreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "The scope name has been updated to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver` from `otelcol/googlecloudmonitoringreceiver`"
+note: "The scope name has been updated from `otelcol/googlecloudmonitoringreceiver` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [34709]

--- a/.chloggen/codeboten_update-scope-googlecloudmonitor.yaml
+++ b/.chloggen/codeboten_update-scope-googlecloudmonitor.yaml
@@ -10,7 +10,7 @@ component: googlecloudmonitorreceiver
 note: "The scope name has been updated to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver` from `otelcol/googlecloudmonitoringreceiver`"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34709]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/googlecloudmonitoringreceiver/internal/metadata/generated_status.go
+++ b/receiver/googlecloudmonitoringreceiver/internal/metadata/generated_status.go
@@ -8,7 +8,7 @@ import (
 
 var (
 	Type      = component.MustNewType("googlecloudmonitoring")
-	ScopeName = "otelcol/googlecloudmonitoringreceiver"
+	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver"
 )
 
 const (

--- a/receiver/googlecloudmonitoringreceiver/metadata.yaml
+++ b/receiver/googlecloudmonitoringreceiver/metadata.yaml
@@ -1,5 +1,4 @@
 type: googlecloudmonitoring
-scope_name: otelcol/googlecloudmonitoringreceiver
 
 status:
   class: receiver


### PR DESCRIPTION
Update scope name to follow the standard of the other components.

Part of open-telemetry/opentelemetry-collector#9494
