### PR TITLE
[receiver/datadog] fix feature discovery

### DIFF
--- a/.chloggen/datadogreceiver-featurediscovery.yaml
+++ b/.chloggen/datadogreceiver-featurediscovery.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: bugfix
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: datadogreceiver

--- a/.chloggen/datadogreceiver-featurediscovery.yaml
+++ b/.chloggen/datadogreceiver-featurediscovery.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bugfix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add feature discovery
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34718]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -108,6 +108,10 @@ func (ddr *datadogReceiver) Shutdown(ctx context.Context) (err error) {
 }
 
 func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Request) {
+	if req.ContentLength == 0 { //Ping mecanism of Datadog SDK perform http request with empty body when GET /info not implemented.
+		http.Error(w, "Fake featuresdiscovery", http.StatusBadRequest) //The response code should be different of 404 to be considered ok by Datadog SDK.
+		return
+	}
 	obsCtx := ddr.tReceiver.StartTracesOp(req.Context())
 	var err error
 	var spanCount int

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -108,8 +108,8 @@ func (ddr *datadogReceiver) Shutdown(ctx context.Context) (err error) {
 }
 
 func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Request) {
-	if req.ContentLength == 0 { //Ping mecanism of Datadog SDK perform http request with empty body when GET /info not implemented.
-		http.Error(w, "Fake featuresdiscovery", http.StatusBadRequest) //The response code should be different of 404 to be considered ok by Datadog SDK.
+	if req.ContentLength == 0 { // Ping mecanism of Datadog SDK perform http request with empty body when GET /info not implemented.
+		http.Error(w, "Fake featuresdiscovery", http.StatusBadRequest) // The response code should be different of 404 to be considered ok by Datadog SDK.
 		return
 	}
 	obsCtx := ddr.tReceiver.StartTracesOp(req.Context())

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -175,6 +175,7 @@ func TestDatadogMetricsV1_EndToEnd(t *testing.T) {
 	expectedEnvironment, _ := metric.Sum().DataPoints().At(0).Attributes().Get("environment")
 	assert.Equal(t, "test", expectedEnvironment.AsString())
 }
+
 func TestDatadogMetricsV2_EndToEnd(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Endpoint = "localhost:0" // Using a randomly assigned address

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -13,8 +13,6 @@ import (
 	"strings"
 	"testing"
 
-	"net/http/httptest"
-
 	"github.com/DataDog/agent-payload/v5/gogen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -172,23 +170,58 @@ func TestDatadogMetricsV1_EndToEnd(t *testing.T) {
 	assert.Equal(t, "test", expectedEnvironment.AsString())
 }
 func TestDatadogFakeFeatureDiscovery(t *testing.T) {
-
 	cfg := createDefaultConfig().(*Config)
 	cfg.Endpoint = "localhost:0" // Using a randomly assigned address
-
 	dd, err := newDataDogReceiver(
 		cfg,
 		receivertest.NewNopSettings(),
 	)
+	dd.(*datadogReceiver).nextTracesConsumer = consumertest.NewNop()
 	require.NoError(t, err, "Must not error when creating receiver")
-	req := httptest.NewRequest("POST", "http://example.com/foo", nil) // Create a request with content-length :0
 
-	w := httptest.NewRecorder()
-	dd.(*datadogReceiver).handleTraces(w, req)
-	resp := w.Result()
-	body, _ := io.ReadAll(resp.Body)
-	require.Equal(t, string(body), "Fake featuresdiscovery\n", "Expected response to be 'Fake featuresdiscovery', got %s", string(body))
-	require.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	require.NoError(t, dd.Start(ctx, componenttest.NewNopHost()))
+	t.Cleanup(func() {
+		require.NoError(t, dd.Shutdown(ctx), "Must not error shutting down")
+	})
+
+	for _, tc := range []struct {
+		name string
+		op   io.Reader
+
+		expectCode    int
+		expectContent string
+	}{
+		{
+			name:          "Fake featuresdiscovery",
+			op:            nil,
+			expectCode:    http.StatusBadRequest,
+			expectContent: "Fake featuresdiscovery\n",
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req, err := http.NewRequest(
+				http.MethodPost,
+				fmt.Sprintf("http://%s/v0.7/traces", dd.(*datadogReceiver).address),
+				tc.op,
+			)
+			require.NoError(t, err, "Must not error when creating request")
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err, "Must not error performing request")
+
+			actual, err := io.ReadAll(resp.Body)
+			require.NoError(t, errors.Join(err, resp.Body.Close()), "Must not error when reading body")
+
+			assert.Equal(t, tc.expectContent, string(actual))
+			assert.Equal(t, tc.expectCode, resp.StatusCode, "Must match the expected status code")
+		})
+	}
 }
 func TestDatadogMetricsV2_EndToEnd(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -84,6 +84,12 @@ func TestDatadogServer(t *testing.T) {
 			expectCode:    http.StatusBadRequest,
 			expectContent: "Unable to unmarshal reqs\n",
 		},
+		{
+			name:          "Fake featuresdiscovery",
+			op:            nil, // Content-length: 0.
+			expectCode:    http.StatusBadRequest,
+			expectContent: "Fake featuresdiscovery\n",
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -168,60 +174,6 @@ func TestDatadogMetricsV1_EndToEnd(t *testing.T) {
 	assert.Equal(t, 0.7, metric.Sum().DataPoints().At(0).DoubleValue())
 	expectedEnvironment, _ := metric.Sum().DataPoints().At(0).Attributes().Get("environment")
 	assert.Equal(t, "test", expectedEnvironment.AsString())
-}
-func TestDatadogFakeFeatureDiscovery(t *testing.T) {
-	cfg := createDefaultConfig().(*Config)
-	cfg.Endpoint = "localhost:0" // Using a randomly assigned address
-	dd, err := newDataDogReceiver(
-		cfg,
-		receivertest.NewNopSettings(),
-	)
-	dd.(*datadogReceiver).nextTracesConsumer = consumertest.NewNop()
-	require.NoError(t, err, "Must not error when creating receiver")
-
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	require.NoError(t, dd.Start(ctx, componenttest.NewNopHost()))
-	t.Cleanup(func() {
-		require.NoError(t, dd.Shutdown(ctx), "Must not error shutting down")
-	})
-
-	for _, tc := range []struct {
-		name string
-		op   io.Reader
-
-		expectCode    int
-		expectContent string
-	}{
-		{
-			name:          "Fake featuresdiscovery",
-			op:            nil,
-			expectCode:    http.StatusBadRequest,
-			expectContent: "Fake featuresdiscovery\n",
-		},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			req, err := http.NewRequest(
-				http.MethodPost,
-				fmt.Sprintf("http://%s/v0.7/traces", dd.(*datadogReceiver).address),
-				tc.op,
-			)
-			require.NoError(t, err, "Must not error when creating request")
-
-			resp, err := http.DefaultClient.Do(req)
-			require.NoError(t, err, "Must not error performing request")
-
-			actual, err := io.ReadAll(resp.Body)
-			require.NoError(t, errors.Join(err, resp.Body.Close()), "Must not error when reading body")
-
-			assert.Equal(t, tc.expectContent, string(actual))
-			assert.Equal(t, tc.expectCode, resp.StatusCode, "Must match the expected status code")
-		})
-	}
 }
 func TestDatadogMetricsV2_EndToEnd(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

**Link to tracking Issue:** 
Fix https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34718

**Testing:** 
this otel config

```
receivers:
  datadog:
    endpoint: 0.0.0.0:8080
    read_timeout: 60s

processors:
  probabilistic_sampler:
    sampling_percentage: 0

exporters:
  debug:
    verbosity: detailed

service:
  pipelines:
    traces:
      receivers: [datadog]
      processors: [probabilistic_sampler]
      exporters: [debug] 
```
tcpdump on 8080 port and having this http request performed : 
```
PUT /v0.4/traces HTTP/1.1
Content-Type: application/msgpack
Content-Length: 0
Host: 10.0.0.2:8080
Connection: Keep-Alive
Accept-Encoding: gzip
User-Agent: okhttp/3.12.15

HTTP/1.1 400 Bad Request
Content-Type: text/plain; charset=utf-8
X-Content-Type-Options: nosniff
Date: Sun, 18 Aug 2024 22:06:39 GMT
Content-Length: 23

Fake featuresdiscovery
```
**Documentation:** <Describe the documentation added.>