### PR TITLE
[chore][connector/servicegraph] Remove deprecated option from README

### DIFF
--- a/connector/servicegraphconnector/README.md
+++ b/connector/servicegraphconnector/README.md
@@ -118,7 +118,6 @@ datasources:
 
 The following settings are required:
 
-- `metrics_exporter`: the name of the exporter that this connector will write metrics to. This exporter **must** be present in a pipeline.
 - `latency_histogram_buckets`: the list of durations defining the latency histogram buckets.
     - Default: `[2ms, 4ms, 6ms, 8ms, 10ms, 50ms, 100ms, 200ms, 400ms, 800ms, 1s, 1400ms, 2s, 5s, 10s, 15s]`
 - `dimensions`: the list of dimensions to add together with the default dimensions defined above.


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The `metrics_exporter` option was deprecated in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/32902. The README should not regard this option as required, and I believe shouldn't reference it as all since it's a no-op.