### PR TITLE
[exporter/datadog] Add deprecated note in collector.yaml

### DIFF
--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -458,7 +458,7 @@ exporters:
       ## This may result in an escaping loop if a filelog receiver is watching the collector log output.
       ## See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16380
       ## Note: this config option does not apply when the `exporter.datadogexporter.UseLogsAgentExporter` feature flag is enabled (now enabled by default).
-      ## Deprecated: This config option is not supported in the Datadog Agent logs pipeline.
+      ## Deprecated since v0.107.0: This config option is not supported in the Datadog Agent logs pipeline.
       #
       # dump_payloads: false
 

--- a/exporter/datadogexporter/examples/collector.yaml
+++ b/exporter/datadogexporter/examples/collector.yaml
@@ -458,6 +458,7 @@ exporters:
       ## This may result in an escaping loop if a filelog receiver is watching the collector log output.
       ## See: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/16380
       ## Note: this config option does not apply when the `exporter.datadogexporter.UseLogsAgentExporter` feature flag is enabled (now enabled by default).
+      ## Deprecated: This config option is not supported in the Datadog Agent logs pipeline.
       #
       # dump_payloads: false
 


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
`dump_payloads` was previously deprecated, this PR updates our collector yaml example to include the deprecation note.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>