### PR TITLE
Make dashpole a codeowner of prometheus exporters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,8 +71,8 @@ exporter/mezmoexporter/                                             @open-teleme
 exporter/opencensusexporter/                                        @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 exporter/opensearchexporter/                                        @open-telemetry/collector-contrib-approvers @Aneurysm9 @MitchellGale @MaxKsyunz @YANG-DB
 exporter/otelarrowexporter/                                         @open-telemetry/collector-contrib-approvers @jmacd @moh-osman3 @lquerel
-exporter/prometheusexporter/                                        @open-telemetry/collector-contrib-approvers @Aneurysm9
-exporter/prometheusremotewriteexporter/                             @open-telemetry/collector-contrib-approvers @Aneurysm9 @rapphil
+exporter/prometheusexporter/                                        @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole
+exporter/prometheusremotewriteexporter/                             @open-telemetry/collector-contrib-approvers @Aneurysm9 @rapphil @dashpole
 exporter/pulsarexporter/                                            @open-telemetry/collector-contrib-approvers @dmitryax @dao-jun
 exporter/rabbitmqexporter/                                          @open-telemetry/collector-contrib-approvers @swar8080 @atoulme
 exporter/sapmexporter/                                              @open-telemetry/collector-contrib-approvers @dmitryax @atoulme
@@ -159,7 +159,7 @@ pkg/translator/jaeger/                                              @open-teleme
 pkg/translator/loki/                                                @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @mar4uk
 pkg/translator/opencensus/                                          @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 pkg/translator/prometheus/                                          @open-telemetry/collector-contrib-approvers @dashpole @bertysentry
-pkg/translator/prometheusremotewrite/                               @open-telemetry/collector-contrib-approvers @Aneurysm9
+pkg/translator/prometheusremotewrite/                               @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole
 pkg/translator/signalfx/                                            @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/translator/skywalking/                                          @open-telemetry/collector-contrib-approvers @JaredTan95
 pkg/translator/zipkin/                                              @open-telemetry/collector-contrib-approvers @MovieStoreGuy @andrzej-stencel @crobert-1

--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [core], [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Fprometheus%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Fprometheus) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Fprometheus%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Fprometheus) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@dashpole](https://www.github.com/dashpole) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -8,7 +8,7 @@ status:
   - core
   - contrib
   codeowners:
-    active: [Aneurysm9]
+    active: [Aneurysm9, dashpole]
 
 tests:
   config:

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [core], [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Fprometheusremotewrite%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Fprometheusremotewrite) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Fprometheusremotewrite%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Fprometheusremotewrite) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@rapphil](https://www.github.com/rapphil) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@rapphil](https://www.github.com/rapphil), [@dashpole](https://www.github.com/dashpole) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -6,7 +6,7 @@ status:
     beta: [metrics]
   distributions: [core, contrib]
   codeowners:
-    active: [Aneurysm9, rapphil]
+    active: [Aneurysm9, rapphil, dashpole]
 
 tests:
   expect_consumer_error: true

--- a/pkg/translator/prometheusremotewrite/metadata.yaml
+++ b/pkg/translator/prometheusremotewrite/metadata.yaml
@@ -1,3 +1,3 @@
 status:
   codeowners:
-    active: [Aneurysm9]
+    active: [Aneurysm9, dashpole]


### PR DESCRIPTION
**Description:**

Add myself as a codeowner of PRW and prometheus exporter components, and the PRW translation library.  I have some additional capacity to take these on, and will help with upcoming prometheus features (creation time, PRW 2.0, etc).

This will help me facilitate the LFX internship i'm co-mentoring: https://mentorship.lfx.linuxfoundation.org/project/3fa26f90-87aa-46a4-80f9-00195ae276e8

cc @Aneurysm9 @rapphil @ArthurSens @aknuds1 