### PR TITLE
[chore][add-labels.sh] Trim label comment to fix matching

### DIFF
--- a/.github/workflows/scripts/add-labels.sh
+++ b/.github/workflows/scripts/add-labels.sh
@@ -33,8 +33,10 @@ LABELS=$(echo "${COMMENT}" | sed -E 's%^/label%%')
 
 for LABEL_REQ in ${LABELS}; do
     LABEL=$(echo "${LABEL_REQ}" | sed -E s/^[+-]?//)
-    SHOULD_ADD=true
+    # Trim newlines from label that would cause matching to fail
+    LABEL=$(echo "${LABEL}" | tr -d '\n')
 
+    SHOULD_ADD=true
     if [[ "${LABEL_REQ:0:1}" = "-" ]]; then
         SHOULD_ADD=false
     fi


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
[Example failure](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/10494185404/job/29069879053), because of [this comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34792#issuecomment-2302561238). The failure is happening because the match fails when the label has a trailing newline.

Local test without fix:
```
$ export LABEL="os:windows
"
$ if [[ -v COMMON_LABELS["${LABEL}"] ]]; then echo "Hello"; fi
$ 
```

Local test with fix:
```
$ export LABEL="os:windows
"
$ LABEL=$(echo "${LABEL}" | tr -d '\n')
$ if [[ -v COMMON_LABELS["${LABEL}"] ]]; then echo "Hello"; fi
Hello
```