### PR TITLE
[receiver/k8scluster] quiet warning down to info

### DIFF
--- a/.chloggen/quiet_k8scluster_warnings.yaml
+++ b/.chloggen/quiet_k8scluster_warnings.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sclusterreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Lower the log level of a message indicating a cache miss from WARN to DEBUG.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34817]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/k8sclusterreceiver/internal/pod/pods.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods.go
@@ -173,7 +173,7 @@ func collectPodJobProperties(pod *corev1.Pod, jobStore cache.Store, logger *zap.
 			logError(err, jobRef, pod.UID, logger)
 			return nil
 		} else if !exists {
-			logWarning(jobRef, pod.UID, logger)
+			logDebug(jobRef, pod.UID, logger)
 			return nil
 		}
 
@@ -196,7 +196,7 @@ func collectPodReplicaSetProperties(pod *corev1.Pod, replicaSetstore cache.Store
 			logError(err, rsRef, pod.UID, logger)
 			return nil
 		} else if !exists {
-			logWarning(rsRef, pod.UID, logger)
+			logDebug(rsRef, pod.UID, logger)
 			return nil
 		}
 
@@ -209,8 +209,8 @@ func collectPodReplicaSetProperties(pod *corev1.Pod, replicaSetstore cache.Store
 	return nil
 }
 
-func logWarning(ref *v1.OwnerReference, podUID types.UID, logger *zap.Logger) {
-	logger.Warn(
+func logDebug(ref *v1.OwnerReference, podUID types.UID, logger *zap.Logger) {
+	logger.Debug(
 		"Resource does not exist in store, properties from it will not be synced.",
 		zap.String(conventions.AttributeK8SPodUID, string(podUID)),
 		zap.String(conventions.AttributeK8SJobUID, string(ref.UID)),

--- a/receiver/k8sclusterreceiver/internal/pod/pods_test.go
+++ b/receiver/k8sclusterreceiver/internal/pod/pods_test.go
@@ -180,7 +180,7 @@ func TestDataCollectorSyncMetadataForPodWorkloads(t *testing.T) {
 			require.NotNil(t, testCase.metadataStore)
 			require.NotNil(t, testCase.resource)
 
-			observedLogger, logs := observer.New(zapcore.WarnLevel)
+			observedLogger, logs := observer.New(zapcore.DebugLevel)
 			logger := zap.New(observedLogger)
 
 			name := fmt.Sprintf("(%s) - %s", kind, tt.name)


### PR DESCRIPTION
**Description:**
We log a warning on cache miss in the k8sclusterreceiver pod watcher.

This PR moves this log from a warning to an info log.