### PR TITLE
[receiver/awsfirehose]: Fix access key validation

### DIFF
--- a/.chloggen/firehose_authn.yaml
+++ b/.chloggen/firehose_authn.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsfirehosereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix validation of requests with empty access key
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34847]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -233,10 +233,14 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 // validate checks the Firehose access key in the header against
 // the one passed into the Config
 func (fmr *firehoseReceiver) validate(r *http.Request) (int, error) {
-	if accessKey := r.Header.Get(headerFirehoseAccessKey); accessKey != "" && accessKey != string(fmr.config.AccessKey) {
-		return http.StatusUnauthorized, errInvalidAccessKey
+	if string(fmr.config.AccessKey) == "" {
+		// No access key is configured - accept all requests.
+		return http.StatusAccepted, nil
 	}
-	return http.StatusAccepted, nil
+	if accessKey := r.Header.Get(headerFirehoseAccessKey); accessKey == string(fmr.config.AccessKey) {
+		return http.StatusAccepted, nil
+	}
+	return http.StatusUnauthorized, errInvalidAccessKey
 }
 
 // getBody reads the body from the request as a slice of bytes.

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -123,6 +123,14 @@ func TestFirehoseRequest(t *testing.T) {
 			wantStatusCode: http.StatusUnauthorized,
 			wantErr:        errInvalidAccessKey,
 		},
+		"WithNoAccessKey": {
+			headers: map[string]string{
+				headerFirehoseAccessKey: "",
+			},
+			body:           testFirehoseRequest(testFirehoseRequestID, noRecords),
+			wantStatusCode: http.StatusUnauthorized,
+			wantErr:        errInvalidAccessKey,
+		},
 		"WithoutRequestId/Body": {
 			headers: map[string]string{
 				headerFirehoseRequestID: testFirehoseRequestID,


### PR DESCRIPTION
**Description:** The `awsfirehosereceiver` can be configured to receive CloudWatch metrics via an AWS Firehose Stream. [Firehose sets the header](https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html) `X-Amz-Firehose-Access-Key` with an arbitrary configured string. The OpenTelemetry Collector awsfirehosereceiver can optionally be configured to require this key on incoming requests. However, when this is configured it still accepts incoming requests with no key.

**Link to tracking Issue:** [Advisory](https://github.com/open-telemetry/opentelemetry-collector-contrib/security/advisories/GHSA-prf6-xjxh-p698)

**Testing:** Tested via reproduction script provided by reporter.


**Fixes:** https://github.com/open-telemetry/opentelemetry-collector-contrib/security/advisories/GHSA-prf6-xjxh-p698