### PR TITLE
feat: add filter_datapoints ottl function to transform processor

### DIFF
--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -220,6 +220,7 @@ In addition to OTTL functions, the processor defines its own functions to help w
 - [copy_metric](#copy_metric)
 - [scale_metric](#scale_metric)
 - [aggregate_on_attributes](#aggregate_on_attributes)
+- [filter_datapoints](#filter_datapoints)
 
 ### convert_sum_to_gauge
 
@@ -406,6 +407,11 @@ The `aggregate_on_attributes` function can also be used in conjunction with
 [delete_matching_keys](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/ottlfuncs#delete_matching_keys).
 
 For example, to remove attribute keys matching a regex and aggregate the metrics on the remaining attributes, you can perform the following statement sequence:
+
+
+### aggregate_on_attributes
+
+....
 
 ```yaml
 statements:

--- a/processor/transformprocessor/internal/metrics/func_filter_datapoints.go
+++ b/processor/transformprocessor/internal/metrics/func_filter_datapoints.go
@@ -1,0 +1,64 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+//import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/transformprocessor/internal/metrics"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+type filterDatapointsArguments struct {
+	Attributes map[string]string
+}
+
+func newFilterDatapointsFactory() ottl.Factory[ottlmetric.TransformContext] {
+	return ottl.NewFactory("filter_datapoints", &filterDatapointsArguments{}, createFilterDatapointsFunction)
+}
+
+func createFilterDatapointsFunction(_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+	args, ok := oArgs.(*filterDatapointsArguments)
+
+	if !ok {
+		return nil, fmt.Errorf("createFilterDatapointsFunction args must be of type *filterDatapointsArguments")
+	}
+
+	return filterDatapoints(args.Attributes)
+}
+
+func filterDatapoints(attributes map[string]string) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+	return func(ctx context.Context, tCtx ottlmetric.TransformContext) (any, error) {
+		// Get the current metric from the context
+		cur := tCtx.GetMetric()
+		// Get the datapoints from the current metric
+		var dps pmetric.NumberDataPointSlice
+		switch cur.Type() {
+		case pmetric.MetricTypeGauge:
+			dps = cur.Gauge().DataPoints()
+		case pmetric.MetricTypeSum:
+			dps = cur.Sum().DataPoints()
+		default:
+			// unsupported metric type
+			return nil, nil
+		}
+		// Remove datapoints that do not match any of the key value pairs in attributes
+		dps.RemoveIf(func(point pmetric.NumberDataPoint) bool {
+			pointAttr := point.Attributes()
+			for key, val := range attributes {
+				pointAttrVal, hasKey := pointAttr.Get(key)
+				if !hasKey || pointAttrVal.Str() != val {
+					return true
+				}
+			}
+			return false
+		})
+
+		return nil, nil
+	}, nil
+}

--- a/processor/transformprocessor/internal/metrics/func_filter_datapoints_test.go
+++ b/processor/transformprocessor/internal/metrics/func_filter_datapoints_test.go
@@ -17,7 +17,7 @@ import (
 func TestFilterDatapoints(t *testing.T) {
 	type testCase struct {
 		name      string
-		args      map[string]string
+		args      map[string][]string
 		valueFunc func() pmetric.Metric
 		wantFunc  func() pmetric.Metric
 		wantErr   bool
@@ -37,7 +37,7 @@ func TestFilterDatapoints(t *testing.T) {
 				metric.Gauge().DataPoints().At(2).Attributes().PutStr("other_key", "value")
 				return metric
 			},
-			args: map[string]string{"key": "value"},
+			args: map[string][]string{"key": []string{"value"}},
 			wantFunc: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test-metric")
@@ -63,7 +63,7 @@ func TestFilterDatapoints(t *testing.T) {
 				metric.Gauge().DataPoints().At(2).Attributes().PutStr("key2", "value2")
 				return metric
 			},
-			args: map[string]string{"key1": "value1", "key2": "value2"},
+			args: map[string][]string{"key1": []string{"value1", "nonesense"}, "key2": []string{"value2", "blah"}},
 			wantFunc: func() pmetric.Metric {
 				metric := pmetric.NewMetric()
 				metric.SetName("test-metric")

--- a/processor/transformprocessor/internal/metrics/func_filter_datapoints_test.go
+++ b/processor/transformprocessor/internal/metrics/func_filter_datapoints_test.go
@@ -1,0 +1,101 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
+)
+
+func TestFilterDatapoints(t *testing.T) {
+	type testCase struct {
+		name      string
+		args      map[string]string
+		valueFunc func() pmetric.Metric
+		wantFunc  func() pmetric.Metric
+		wantErr   bool
+	}
+	tests := []testCase{
+		{
+			name: "Keep datapoints that match attribute",
+			valueFunc: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test-metric")
+				metric.SetEmptyGauge()
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(10.0)
+				metric.Gauge().DataPoints().At(0).Attributes().PutStr("key", "value")
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(15.0)
+				metric.Gauge().DataPoints().At(1).Attributes().PutStr("key", "other_value")
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(20.0)
+				metric.Gauge().DataPoints().At(2).Attributes().PutStr("other_key", "value")
+				return metric
+			},
+			args: map[string]string{"key": "value"},
+			wantFunc: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test-metric")
+				metric.SetEmptyGauge()
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(10.0)
+				metric.Gauge().DataPoints().At(0).Attributes().PutStr("key", "value")
+				return metric
+			},
+			wantErr: false,
+		},
+		{
+			name: "Keep datapoints that match all expected attributes",
+			valueFunc: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test-metric")
+				metric.SetEmptyGauge()
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(10.0)
+				metric.Gauge().DataPoints().At(0).Attributes().PutStr("key1", "value1")
+				metric.Gauge().DataPoints().At(0).Attributes().PutStr("key2", "value2")
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(15.0)
+				metric.Gauge().DataPoints().At(1).Attributes().PutStr("key1", "value1")
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(20.0)
+				metric.Gauge().DataPoints().At(2).Attributes().PutStr("key2", "value2")
+				return metric
+			},
+			args: map[string]string{"key1": "value1", "key2": "value2"},
+			wantFunc: func() pmetric.Metric {
+				metric := pmetric.NewMetric()
+				metric.SetName("test-metric")
+				metric.SetEmptyGauge()
+				metric.Gauge().DataPoints().AppendEmpty().SetDoubleValue(10.0)
+				metric.Gauge().DataPoints().At(0).Attributes().PutStr("key1", "value1")
+				metric.Gauge().DataPoints().At(0).Attributes().PutStr("key2", "value2")
+				return metric
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := ottlmetric.NewTransformContext(
+				tt.valueFunc(),
+				pmetric.NewMetricSlice(),
+				pcommon.NewInstrumentationScope(),
+				pcommon.NewResource(),
+				pmetric.NewScopeMetrics(),
+				pmetric.NewResourceMetrics(),
+			)
+
+			expressionFunc, _ := filterDatapoints(tt.args)
+			_, err := expressionFunc(context.Background(), target)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.EqualValues(t, tt.wantFunc(), target.GetMetric())
+		})
+	}
+}

--- a/processor/transformprocessor/internal/metrics/functions.go
+++ b/processor/transformprocessor/internal/metrics/functions.go
@@ -51,6 +51,7 @@ func MetricFunctions() map[string]ottl.Factory[ottlmetric.TransformContext] {
 		newCopyMetricFactory(),
 		newScaleMetricFactory(),
 		newAggregateOnAttributesFactory(),
+		newFilterDatapointsFactory(),
 	)
 
 	if useConvertBetweenSumAndGaugeMetricContext.IsEnabled() {

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -39,6 +39,7 @@ func Test_MetricFunctions(t *testing.T) {
 	expected["extract_count_metric"] = newExtractCountMetricFactory()
 	expected["copy_metric"] = newCopyMetricFactory()
 	expected["scale_metric"] = newScaleMetricFactory()
+	expected["filter_datapoints"] = newFilterDatapointsFactory()
 
 	defer testutil.SetFeatureGateForTest(t, useConvertBetweenSumAndGaugeMetricContext, true)()
 	actual := MetricFunctions()


### PR DESCRIPTION
**Description:** <Describe what has changed.>

Adds filter_datapoints(attributes: Dict[str, List[str]) ottl function. 

This function removes datapoints that do not match a key-value pair in the attributes argument. This will allow us to reduce the cardinality of metrics.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>