### PR TITLE
[exporter/clickhouse] Add client info for identifying exporter in `system.query_log`

### DIFF
--- a/.chloggen/clickhouse-add-client-info.yaml
+++ b/.chloggen/clickhouse-add-client-info.yaml
@@ -10,7 +10,7 @@ component: clickhouseexporter
 note: Add client info to queries
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [34915]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/clickhouse-add-client-info.yaml
+++ b/.chloggen/clickhouse-add-client-info.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: clickhouseexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add client info to queries
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This change adds client product info to the system.query_log for more insight on where queries originate
+
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -290,6 +290,11 @@ Connection options:
 - `compress` (default = lz4): Controls the compression algorithm. Valid options: `none` (disabled), `zstd`, `lz4` (default), `gzip`, `deflate`, `br`, `true` (lz4). Ignored if `compress` is set in the `endpoint` or `connection_params`.
 - `async_insert` (default = true): Enables [async inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts). Ignored if async inserts are configured in the `endpoint` or `connection_params`. Async inserts may still be overridden server-side.
 
+Additional DSN features:
+
+The underlying `clickhouse-go` module offers additional configuration. These can be set in the exporter's `endpoint` or `connection_params` config values.
+- `client_info_product` Must be in `productName/version` format. By default the exporter will append its binary build information. You can use this information to track the origin of `INSERT` statements in the `system.query_log` table.
+
 ClickHouse tables:
 
 - `logs_table_name` (default = otel_logs): The table name for logs.

--- a/exporter/clickhouseexporter/README.md
+++ b/exporter/clickhouseexporter/README.md
@@ -293,7 +293,7 @@ Connection options:
 Additional DSN features:
 
 The underlying `clickhouse-go` module offers additional configuration. These can be set in the exporter's `endpoint` or `connection_params` config values.
-- `client_info_product` Must be in `productName/version` format. By default the exporter will append its binary build information. You can use this information to track the origin of `INSERT` statements in the `system.query_log` table.
+- `client_info_product` Must be in `productName/version` format with comma separated entries. By default the exporter will append its binary build information. You can use this information to track the origin of `INSERT` statements in the `system.query_log` table.
 
 ClickHouse tables:
 

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -20,7 +20,7 @@ import (
 
 // Config defines configuration for Elastic exporter.
 type Config struct {
-	collectorVersionResolver CollectorVersionResolver
+	collectorVersionResolver collectorVersionResolver
 
 	TimeoutSettings           exporterhelper.TimeoutConfig `mapstructure:",squash"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -20,6 +20,8 @@ import (
 
 // Config defines configuration for Elastic exporter.
 type Config struct {
+	collectorVersionResolver CollectorVersionResolver
+
 	TimeoutSettings           exporterhelper.TimeoutConfig `mapstructure:",squash"`
 	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
 	QueueSettings             exporterhelper.QueueConfig `mapstructure:"sending_queue"`
@@ -148,7 +150,7 @@ func (cfg *Config) buildDSN() (string, error) {
 	}
 
 	productInfo := queryParams.Get("client_info_product")
-	binaryProductInfo := fmt.Sprintf("%s/%s", "otelcol", getCollectorVersion())
+	binaryProductInfo := fmt.Sprintf("%s/%s", "otelcol", cfg.collectorVersionResolver.GetVersion())
 	if productInfo == "" {
 		productInfo = binaryProductInfo
 	} else {

--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -177,7 +177,7 @@ func (cfg *Config) buildDB() (*sql.DB, error) {
 		opts.ClientInfo.Products = []struct {
 			Name    string
 			Version string
-		}{{"otel-exporter", getCollectorVersion()}}
+		}{{"otelcol", getCollectorVersion()}}
 	}
 
 	conn := clickhouse.OpenDB(opts)

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -32,7 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	defaultCfg := createDefaultConfig()
-	defaultCfg.(*Config).collectorVersionResolver = NewDefaultTestCollectorVersionResolver()
+	defaultCfg.(*Config).collectorVersionResolver = newDefaultTestCollectorVersionResolver()
 	defaultCfg.(*Config).Endpoint = defaultEndpoint
 
 	storageID := component.MustNewIDWithName("file_storage", "clickhouse")
@@ -48,7 +48,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, "full"),
 			expected: &Config{
-				collectorVersionResolver: NewDefaultTestCollectorVersionResolver(),
+				collectorVersionResolver: newDefaultTestCollectorVersionResolver(),
 				Endpoint:                 defaultEndpoint,
 				Database:                 "otel",
 				Username:                 "foo",
@@ -91,7 +91,7 @@ func TestLoadConfig(t *testing.T) {
 		t.Run(tt.id.String(), func(t *testing.T) {
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
-			cfg.(*Config).collectorVersionResolver = NewDefaultTestCollectorVersionResolver()
+			cfg.(*Config).collectorVersionResolver = newDefaultTestCollectorVersionResolver()
 
 			sub, err := cm.Sub(tt.id.String())
 			require.NoError(t, err)
@@ -508,7 +508,7 @@ func TestConfig_buildDSN(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := createDefaultConfig().(*Config)
-			cfg.collectorVersionResolver = NewDefaultTestCollectorVersionResolver()
+			cfg.collectorVersionResolver = newDefaultTestCollectorVersionResolver()
 			mergeConfigWithFields(cfg, tt.fields)
 			dsn, err := cfg.buildDSN()
 

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -32,6 +32,8 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
+		collectorVersionResolver: NewBinaryCollectorVersionResolver(),
+
 		TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
 		QueueSettings:    exporterhelper.NewDefaultQueueConfig(),
 		BackOffConfig:    configretry.NewDefaultBackOffConfig(),

--- a/exporter/clickhouseexporter/factory.go
+++ b/exporter/clickhouseexporter/factory.go
@@ -32,7 +32,7 @@ func NewFactory() exporter.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		collectorVersionResolver: NewBinaryCollectorVersionResolver(),
+		collectorVersionResolver: newBinaryCollectorVersionResolver(),
 
 		TimeoutSettings:  exporterhelper.NewDefaultTimeoutConfig(),
 		QueueSettings:    exporterhelper.NewDefaultQueueConfig(),

--- a/exporter/clickhouseexporter/integration_test.go
+++ b/exporter/clickhouseexporter/integration_test.go
@@ -1,6 +1,9 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build integration
+// +build integration
+
 package clickhouseexporter
 
 import (
@@ -24,10 +27,10 @@ func TestIntegration(t *testing.T) {
 		image string
 	}{
 		// TODO: Skipping due to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32530
-		{
-			name:  "test clickhouse 24-alpine",
-			image: "clickhouse/clickhouse-server:24-alpine",
-		},
+		// {
+		//	name:  "test clickhouse 24-alpine",
+		//	image: "clickhouse/clickhouse-server:24-alpine",
+		// },
 		// {
 		//	name:  "test clickhouse 23-alpine",
 		//	image: "clickhouse/clickhouse-server:23-alpine",

--- a/exporter/clickhouseexporter/integration_test.go
+++ b/exporter/clickhouseexporter/integration_test.go
@@ -1,9 +1,6 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build integration
-// +build integration
-
 package clickhouseexporter
 
 import (
@@ -27,10 +24,10 @@ func TestIntegration(t *testing.T) {
 		image string
 	}{
 		// TODO: Skipping due to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32530
-		// {
-		//	name:  "test clickhouse 24-alpine",
-		//	image: "clickhouse/clickhouse-server:24-alpine",
-		// },
+		{
+			name:  "test clickhouse 24-alpine",
+			image: "clickhouse/clickhouse-server:24-alpine",
+		},
 		// {
 		//	name:  "test clickhouse 23-alpine",
 		//	image: "clickhouse/clickhouse-server:23-alpine",

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -8,19 +8,19 @@ import (
 	"runtime/debug"
 )
 
-type CollectorVersionResolver interface {
+type collectorVersionResolver interface {
 	// GetVersion returns the collector build information for use in query tracking.
 	// Version should not include any slashes.
 	GetVersion() string
 }
 
-// BinaryCollectorVersionResolver will use the Go binary to detect the collector version.
-type BinaryCollectorVersionResolver struct {
+// binaryCollectorVersionResolver will use the Go binary to detect the collector version.
+type binaryCollectorVersionResolver struct {
 	version string
 }
 
-func NewBinaryCollectorVersionResolver() *BinaryCollectorVersionResolver {
-	resolver := BinaryCollectorVersionResolver{}
+func newBinaryCollectorVersionResolver() *binaryCollectorVersionResolver {
+	resolver := binaryCollectorVersionResolver{}
 
 	osInformation := runtime.GOOS[:3] + "-" + runtime.GOARCH
 	resolver.version = "unknown-" + osInformation
@@ -33,6 +33,6 @@ func NewBinaryCollectorVersionResolver() *BinaryCollectorVersionResolver {
 	return &resolver
 }
 
-func (r *BinaryCollectorVersionResolver) GetVersion() string {
+func (r *binaryCollectorVersionResolver) GetVersion() string {
 	return r.version
 }

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -23,7 +23,7 @@ func NewBinaryCollectorVersionResolver() *BinaryCollectorVersionResolver {
 	resolver.version = "unknown-" + osInformation
 
 	info, ok := debug.ReadBuildInfo()
-	if ok {
+	if ok && info.Main.Version != "" {
 		resolver.version = info.Main.Version + "-" + osInformation
 	}
 

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -15,7 +15,7 @@ var (
 func getCollectorVersion() string {
 	once.Do(func() {
 		osInformation := runtime.GOOS[:3] + "-" + runtime.GOARCH
-		unknownVersion := "otelc-unknown-" + osInformation
+		unknownVersion := "unknown-" + osInformation
 
 		info, ok := debug.ReadBuildInfo()
 		if !ok {
@@ -27,7 +27,7 @@ func getCollectorVersion() string {
 			if mod.Path == "go.opentelemetry.io/collector" {
 				// Extract the semantic version without metadata.
 				semVer := strings.SplitN(mod.Version, "-", 2)[0]
-				cachedVersion = "otelc-" + semVer + "-" + osInformation
+				cachedVersion = semVer + "-" + osInformation
 				return
 			}
 		}

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -1,0 +1,39 @@
+package clickhouseexporter
+
+import (
+	"runtime"
+	"runtime/debug"
+	"strings"
+	"sync"
+)
+
+var (
+	once          sync.Once
+	cachedVersion string
+)
+
+func getCollectorVersion() string {
+	once.Do(func() {
+		osInformation := runtime.GOOS[:3] + "-" + runtime.GOARCH
+		unknownVersion := "otelc-unknown-" + osInformation
+
+		info, ok := debug.ReadBuildInfo()
+		if !ok {
+			cachedVersion = unknownVersion
+			return
+		}
+
+		for _, mod := range info.Deps {
+			if mod.Path == "go.opentelemetry.io/collector" {
+				// Extract the semantic version without metadata.
+				semVer := strings.SplitN(mod.Version, "-", 2)[0]
+				cachedVersion = "otelc-" + semVer + "-" + osInformation
+				return
+			}
+		}
+
+		cachedVersion = unknownVersion
+	})
+
+	return cachedVersion
+}

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -3,37 +3,26 @@ package clickhouseexporter
 import (
 	"runtime"
 	"runtime/debug"
-	"strings"
 	"sync"
 )
 
 var (
-	once          sync.Once
-	cachedVersion string
+	once    sync.Once
+	version string
 )
 
 func getCollectorVersion() string {
 	once.Do(func() {
 		osInformation := runtime.GOOS[:3] + "-" + runtime.GOARCH
-		unknownVersion := "unknown-" + osInformation
+		version = "unknown-" + osInformation
 
 		info, ok := debug.ReadBuildInfo()
 		if !ok {
-			cachedVersion = unknownVersion
 			return
 		}
 
-		for _, mod := range info.Deps {
-			if mod.Path == "go.opentelemetry.io/collector" {
-				// Extract the semantic version without metadata.
-				semVer := strings.SplitN(mod.Version, "-", 2)[0]
-				cachedVersion = semVer + "-" + osInformation
-				return
-			}
-		}
-
-		cachedVersion = unknownVersion
+		version = info.Main.Version + "-" + osInformation
 	})
 
-	return cachedVersion
+	return version
 }

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -7,22 +7,22 @@ import (
 )
 
 var (
-	once    sync.Once
-	version string
+	versionOnce      sync.Once
+	collectorVersion string
 )
 
 func getCollectorVersion() string {
-	once.Do(func() {
+	versionOnce.Do(func() {
 		osInformation := runtime.GOOS[:3] + "-" + runtime.GOARCH
-		version = "unknown-" + osInformation
+		collectorVersion = "unknown-" + osInformation
 
 		info, ok := debug.ReadBuildInfo()
 		if !ok {
 			return
 		}
 
-		version = info.Main.Version + "-" + osInformation
+		collectorVersion = info.Main.Version + "-" + osInformation
 	})
 
-	return version
+	return collectorVersion
 }

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package clickhouseexporter
+package clickhouseexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter"
 
 import (
 	"runtime"

--- a/exporter/clickhouseexporter/version_info.go
+++ b/exporter/clickhouseexporter/version_info.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package clickhouseexporter
 
 import (

--- a/exporter/clickhouseexporter/version_info_test.go
+++ b/exporter/clickhouseexporter/version_info_test.go
@@ -8,10 +8,6 @@ type testCollectorVersionResolver struct {
 	version string
 }
 
-func newTestCollectorVersionResolver(version string) *testCollectorVersionResolver {
-	return &testCollectorVersionResolver{version: version}
-}
-
 func newDefaultTestCollectorVersionResolver() *testCollectorVersionResolver {
 	return &testCollectorVersionResolver{version: "test"}
 }

--- a/exporter/clickhouseexporter/version_info_test.go
+++ b/exporter/clickhouseexporter/version_info_test.go
@@ -1,0 +1,18 @@
+package clickhouseexporter
+
+// TestCollectorVersionResolver will return a constant value for the collector version.
+type TestCollectorVersionResolver struct {
+	version string
+}
+
+func NewTestCollectorVersionResolver(version string) *TestCollectorVersionResolver {
+	return &TestCollectorVersionResolver{version: version}
+}
+
+func NewDefaultTestCollectorVersionResolver() *TestCollectorVersionResolver {
+	return &TestCollectorVersionResolver{version: "test"}
+}
+
+func (r *TestCollectorVersionResolver) GetVersion() string {
+	return r.version
+}

--- a/exporter/clickhouseexporter/version_info_test.go
+++ b/exporter/clickhouseexporter/version_info_test.go
@@ -3,19 +3,19 @@
 
 package clickhouseexporter
 
-// TestCollectorVersionResolver will return a constant value for the collector version.
-type TestCollectorVersionResolver struct {
+// testCollectorVersionResolver will return a constant value for the collector version.
+type testCollectorVersionResolver struct {
 	version string
 }
 
-func NewTestCollectorVersionResolver(version string) *TestCollectorVersionResolver {
-	return &TestCollectorVersionResolver{version: version}
+func newTestCollectorVersionResolver(version string) *testCollectorVersionResolver {
+	return &testCollectorVersionResolver{version: version}
 }
 
-func NewDefaultTestCollectorVersionResolver() *TestCollectorVersionResolver {
-	return &TestCollectorVersionResolver{version: "test"}
+func newDefaultTestCollectorVersionResolver() *testCollectorVersionResolver {
+	return &testCollectorVersionResolver{version: "test"}
 }
 
-func (r *TestCollectorVersionResolver) GetVersion() string {
+func (r *testCollectorVersionResolver) GetVersion() string {
 	return r.version
 }

--- a/exporter/clickhouseexporter/version_info_test.go
+++ b/exporter/clickhouseexporter/version_info_test.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package clickhouseexporter
 
 // TestCollectorVersionResolver will return a constant value for the collector version.


### PR DESCRIPTION
**Description:**

This change will include information about the collector version and OS/Arch for every `INSERT`. Users can then track the origin of these queries in `system.query_log`. For an official build this will look something like `otelcol/v0.114.0-lin-amd64`.

This is implemented by setting `client_info_product` in the DSN. The underlying ClickHouse Go driver will then attach it upon connection. Users can already add their own version info in `endpoint` or `connection_params`, but this change will now safely set or append to that value with the binary's information.

**Documentation:**
- Added notes to README for `client_product_info`

**Testing:**
- Add/updated unit tests