### PR TITLE
[chore]: enable len rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,7 +141,6 @@ linters-settings:
       - expected-actual
       - float-compare
       - go-require
-      - len
       - negative-positive
       - nil-compare
       - require-error

--- a/cmd/telemetrygen/internal/traces/worker_test.go
+++ b/cmd/telemetrygen/internal/traces/worker_test.go
@@ -262,7 +262,7 @@ func TestSpansWithNoAttrs(t *testing.T) {
 	assert.Len(t, syncer.spans, 4) // each trace has two spans
 	for _, span := range syncer.spans {
 		attributes := span.Attributes()
-		assert.Equal(t, 2, len(attributes), "it shouldn't have more than 2 fixed attributes")
+		assert.Len(t, attributes, 2, "it shouldn't have more than 2 fixed attributes")
 	}
 }
 
@@ -284,7 +284,7 @@ func TestSpansWithOneAttrs(t *testing.T) {
 	assert.Len(t, syncer.spans, 4) // each trace has two spans
 	for _, span := range syncer.spans {
 		attributes := span.Attributes()
-		assert.Equal(t, 3, len(attributes), "it should have more than 3 attributes")
+		assert.Len(t, attributes, 3, "it should have more than 3 attributes")
 	}
 }
 
@@ -306,7 +306,7 @@ func TestSpansWithMultipleAttrs(t *testing.T) {
 	assert.Len(t, syncer.spans, 4) // each trace has two spans
 	for _, span := range syncer.spans {
 		attributes := span.Attributes()
-		assert.Equal(t, 4, len(attributes), "it should have more than 4 attributes")
+		assert.Len(t, attributes, 4, "it should have more than 4 attributes")
 	}
 }
 

--- a/connector/countconnector/connector_test.go
+++ b/connector/countconnector/connector_test.go
@@ -265,7 +265,7 @@ func TestTracesToMetrics(t *testing.T) {
 			assert.NoError(t, conn.ConsumeTraces(context.Background(), testSpans))
 
 			allMetrics := sink.AllMetrics()
-			assert.Equal(t, 1, len(allMetrics))
+			assert.Len(t, allMetrics, 1)
 
 			// golden.WriteMetrics(t, filepath.Join("testdata", "traces", tc.name+".yaml"), allMetrics[0])
 			expected, err := golden.ReadMetrics(filepath.Join("testdata", "traces", tc.name+".yaml"))
@@ -507,7 +507,7 @@ func TestMetricsToMetrics(t *testing.T) {
 			assert.NoError(t, conn.ConsumeMetrics(context.Background(), testMetrics))
 
 			allMetrics := sink.AllMetrics()
-			assert.Equal(t, 1, len(allMetrics))
+			assert.Len(t, allMetrics, 1)
 
 			// golden.WriteMetrics(t, filepath.Join("testdata", "metrics", tc.name+".yaml"), allMetrics[0])
 			expected, err := golden.ReadMetrics(filepath.Join("testdata", "metrics", tc.name+".yaml"))
@@ -679,7 +679,7 @@ func TestLogsToMetrics(t *testing.T) {
 			assert.NoError(t, conn.ConsumeLogs(context.Background(), testLogs))
 
 			allMetrics := sink.AllMetrics()
-			assert.Equal(t, 1, len(allMetrics))
+			assert.Len(t, allMetrics, 1)
 
 			// golden.WriteMetrics(t, filepath.Join("testdata", "logs", tc.name+".yaml"), allMetrics[0])
 			expected, err := golden.ReadMetrics(filepath.Join("testdata", "logs", tc.name+".yaml"))

--- a/connector/datadogconnector/connector_native_test.go
+++ b/connector/datadogconnector/connector_native_test.go
@@ -104,7 +104,7 @@ func TestContainerTagsNative(t *testing.T) {
 
 	// check if the container tags are added to the metrics
 	metrics := metricsSink.AllMetrics()
-	assert.Equal(t, 1, len(metrics))
+	assert.Len(t, metrics, 1)
 
 	ch := make(chan []byte, 100)
 	tr := newTranslatorWithStatsChannel(t, zap.NewNop(), ch)
@@ -117,7 +117,7 @@ func TestContainerTagsNative(t *testing.T) {
 	require.NoError(t, err)
 
 	tags := sp.Stats[0].Tags
-	assert.Equal(t, 3, len(tags))
+	assert.Len(t, tags, 3)
 	assert.ElementsMatch(t, []string{"region:my-region", "zone:my-zone", "az:my-az"}, tags)
 }
 
@@ -187,7 +187,7 @@ func TestMeasuredAndClientKindNative(t *testing.T) {
 	}
 
 	metrics := metricsSink.AllMetrics()
-	require.Equal(t, 1, len(metrics))
+	require.Len(t, metrics, 1)
 
 	ch := make(chan []byte, 100)
 	tr := newTranslatorWithStatsChannel(t, zap.NewNop(), ch)

--- a/connector/datadogconnector/connector_test.go
+++ b/connector/datadogconnector/connector_test.go
@@ -158,7 +158,7 @@ func TestContainerTags(t *testing.T) {
 	err = connector.ConsumeTraces(context.Background(), trace2)
 	assert.NoError(t, err)
 	// check if the container tags are added to the cache
-	assert.Equal(t, 1, len(connector.containerTagCache.Items()))
+	assert.Len(t, connector.containerTagCache.Items(), 1)
 	count := 0
 	connector.containerTagCache.Items()["my-container-id"].Object.(*sync.Map).Range(func(_, _ any) bool {
 		count++
@@ -175,7 +175,7 @@ func TestContainerTags(t *testing.T) {
 
 	// check if the container tags are added to the metrics
 	metrics := metricsSink.AllMetrics()
-	assert.Equal(t, 1, len(metrics))
+	assert.Len(t, metrics, 1)
 
 	ch := make(chan []byte, 100)
 	tr := newTranslatorWithStatsChannel(t, zap.NewNop(), ch)
@@ -188,7 +188,7 @@ func TestContainerTags(t *testing.T) {
 	require.NoError(t, err)
 
 	tags := sp.Stats[0].Tags
-	assert.Equal(t, 3, len(tags))
+	assert.Len(t, tags, 3)
 	assert.ElementsMatch(t, []string{"region:my-region", "zone:my-zone", "az:my-az"}, tags)
 }
 

--- a/connector/roundrobinconnector/connector_test.go
+++ b/connector/roundrobinconnector/connector_test.go
@@ -50,17 +50,17 @@ func TestLogsRoundRobin(t *testing.T) {
 	assert.NoError(t, logs.ConsumeLogs(ctx, plog.NewLogs()))
 	assert.NoError(t, logs.ConsumeLogs(ctx, plog.NewLogs()))
 
-	assert.Equal(t, 1, len(sink1.AllLogs()))
-	assert.Equal(t, 1, len(sink2.AllLogs()))
-	assert.Equal(t, 1, len(sink3.AllLogs()))
+	assert.Len(t, sink1.AllLogs(), 1)
+	assert.Len(t, sink2.AllLogs(), 1)
+	assert.Len(t, sink3.AllLogs(), 1)
 
 	assert.NoError(t, logs.ConsumeLogs(ctx, plog.NewLogs()))
 	assert.NoError(t, logs.ConsumeLogs(ctx, plog.NewLogs()))
 	assert.NoError(t, logs.ConsumeLogs(ctx, plog.NewLogs()))
 
-	assert.Equal(t, 2, len(sink1.AllLogs()))
-	assert.Equal(t, 2, len(sink2.AllLogs()))
-	assert.Equal(t, 2, len(sink3.AllLogs()))
+	assert.Len(t, sink1.AllLogs(), 2)
+	assert.Len(t, sink2.AllLogs(), 2)
+	assert.Len(t, sink3.AllLogs(), 2)
 
 	assert.NoError(t, logs.Shutdown(ctx))
 }
@@ -87,17 +87,17 @@ func TestMetricsRoundRobin(t *testing.T) {
 	assert.NoError(t, metrics.ConsumeMetrics(ctx, pmetric.NewMetrics()))
 	assert.NoError(t, metrics.ConsumeMetrics(ctx, pmetric.NewMetrics()))
 
-	assert.Equal(t, 1, len(sink1.AllMetrics()))
-	assert.Equal(t, 1, len(sink2.AllMetrics()))
-	assert.Equal(t, 1, len(sink3.AllMetrics()))
+	assert.Len(t, sink1.AllMetrics(), 1)
+	assert.Len(t, sink2.AllMetrics(), 1)
+	assert.Len(t, sink3.AllMetrics(), 1)
 
 	assert.NoError(t, metrics.ConsumeMetrics(ctx, pmetric.NewMetrics()))
 	assert.NoError(t, metrics.ConsumeMetrics(ctx, pmetric.NewMetrics()))
 	assert.NoError(t, metrics.ConsumeMetrics(ctx, pmetric.NewMetrics()))
 
-	assert.Equal(t, 2, len(sink1.AllMetrics()))
-	assert.Equal(t, 2, len(sink2.AllMetrics()))
-	assert.Equal(t, 2, len(sink3.AllMetrics()))
+	assert.Len(t, sink1.AllMetrics(), 2)
+	assert.Len(t, sink2.AllMetrics(), 2)
+	assert.Len(t, sink3.AllMetrics(), 2)
 
 	assert.NoError(t, metrics.Shutdown(ctx))
 }
@@ -124,17 +124,17 @@ func TestTracesRoundRobin(t *testing.T) {
 	assert.NoError(t, traces.ConsumeTraces(ctx, ptrace.NewTraces()))
 	assert.NoError(t, traces.ConsumeTraces(ctx, ptrace.NewTraces()))
 
-	assert.Equal(t, 1, len(sink1.AllTraces()))
-	assert.Equal(t, 1, len(sink2.AllTraces()))
-	assert.Equal(t, 1, len(sink3.AllTraces()))
+	assert.Len(t, sink1.AllTraces(), 1)
+	assert.Len(t, sink2.AllTraces(), 1)
+	assert.Len(t, sink3.AllTraces(), 1)
 
 	assert.NoError(t, traces.ConsumeTraces(ctx, ptrace.NewTraces()))
 	assert.NoError(t, traces.ConsumeTraces(ctx, ptrace.NewTraces()))
 	assert.NoError(t, traces.ConsumeTraces(ctx, ptrace.NewTraces()))
 
-	assert.Equal(t, 2, len(sink1.AllTraces()))
-	assert.Equal(t, 2, len(sink2.AllTraces()))
-	assert.Equal(t, 2, len(sink3.AllTraces()))
+	assert.Len(t, sink1.AllTraces(), 2)
+	assert.Len(t, sink2.AllTraces(), 2)
+	assert.Len(t, sink3.AllTraces(), 2)
 
 	assert.NoError(t, traces.Shutdown(ctx))
 }

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -480,7 +480,7 @@ func TestStaleSeriesCleanup(t *testing.T) {
 		p.keyToMetric[key] = metric
 	}
 	p.cleanCache()
-	assert.Equal(t, 0, len(p.keyToMetric))
+	assert.Len(t, p.keyToMetric, 0)
 
 	// ConsumeTraces with a trace with different attribute value
 	td = buildSampleTrace(t, "second")
@@ -526,8 +526,8 @@ func TestMapsAreConsistentDuringCleanup(t *testing.T) {
 	go p.cleanCache()
 
 	// Since everything is locked, nothing has happened, so both should still have length 1
-	assert.Equal(t, 1, len(p.reqTotal))
-	assert.Equal(t, 1, len(p.keyToMetric))
+	assert.Len(t, p.reqTotal, 1)
+	assert.Len(t, p.keyToMetric, 1)
 
 	// Now we pretend that we have stopped collecting metrics, by unlocking seriesMutex
 	p.seriesMutex.Unlock()
@@ -540,8 +540,8 @@ func TestMapsAreConsistentDuringCleanup(t *testing.T) {
 	// for dimensions from that series. It's important that it happens this way around,
 	// instead of deleting it from `keyToMetric`, otherwise the metrics collector will try
 	// and fail to find dimensions for a series that is about to be removed.
-	assert.Equal(t, 0, len(p.reqTotal))
-	assert.Equal(t, 1, len(p.keyToMetric))
+	assert.Len(t, p.reqTotal, 0)
+	assert.Len(t, p.keyToMetric, 1)
 
 	p.metricMutex.RUnlock()
 	p.seriesMutex.Unlock()
@@ -575,7 +575,7 @@ func TestValidateOwnTelemetry(t *testing.T) {
 		p.keyToMetric[key] = metric
 	}
 	p.cleanCache()
-	assert.Equal(t, 0, len(p.keyToMetric))
+	assert.Len(t, p.keyToMetric, 0)
 
 	// ConsumeTraces with a trace with different attribute value
 	td = buildSampleTrace(t, "second")

--- a/exporter/alertmanagerexporter/alertmanager_exporter_test.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter_test.go
@@ -101,7 +101,7 @@ func TestAlertManagerExporterExtractEvents(t *testing.T) {
 
 			// test - events
 			got := am.extractEvents(traces)
-			assert.Equal(t, tt.events, len(got))
+			assert.Len(t, got, tt.events)
 		})
 	}
 }
@@ -133,7 +133,7 @@ func TestAlertManagerExporterEventNameAttributes(t *testing.T) {
 	got := am.extractEvents(traces)
 
 	// test - result length
-	assert.Equal(t, 1, len(got))
+	assert.Len(t, got, 1)
 
 	// test - count of attributes
 	assert.Equal(t, 3, got[0].spanEvent.Attributes().Len())

--- a/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice_test.go
@@ -75,7 +75,7 @@ func TestLogsDataToLogService(t *testing.T) {
 	totalLogCount := 10
 	validLogCount := totalLogCount - 1
 	gotLogs := logDataToLogService(createLogData(10))
-	assert.Equal(t, len(gotLogs), 9)
+	assert.Len(t, gotLogs, 9)
 
 	gotLogPairs := make([][]logKeyValuePair, 0, len(gotLogs))
 

--- a/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice_test.go
+++ b/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice_test.go
@@ -30,7 +30,7 @@ func (kv logKeyValuePairs) Less(i, j int) bool { return kv[i].Key < kv[j].Key }
 
 func TestTraceDataToLogService(t *testing.T) {
 	gotLogs := traceDataToLogServiceData(constructSpanData())
-	assert.Equal(t, len(gotLogs), 2)
+	assert.Len(t, gotLogs, 2)
 
 	gotLogPairs := make([][]logKeyValuePair, 0, len(gotLogs))
 

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -140,7 +140,7 @@ func TestConfigValidate(t *testing.T) {
 	}
 	assert.NoError(t, component.ValidateConfig(cfg))
 
-	assert.Equal(t, 2, len(cfg.MetricDescriptors))
+	assert.Len(t, cfg.MetricDescriptors, 2)
 	assert.Equal(t, []MetricDescriptor{
 		{Unit: "Count", MetricName: "apiserver_total", Overwrite: true},
 		{Unit: "Megabytes", MetricName: "memory_usage"},

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -370,9 +370,9 @@ func TestNewExporterWithMetricDeclarations(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Invalid metric declaration should be filtered out
-	assert.Equal(t, 3, len(exp.config.MetricDeclarations))
+	assert.Len(t, exp.config.MetricDeclarations, 3)
 	// Invalid dimensions (> 10 dims) should be filtered out
-	assert.Equal(t, 1, len(exp.config.MetricDeclarations[2].Dimensions))
+	assert.Len(t, exp.config.MetricDeclarations[2].Dimensions, 1)
 
 	// Test output warning logs
 	expectedLogs := []observer.LoggedEntry{

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -116,11 +116,11 @@ func TestAddToGroupedMetric(t *testing.T) {
 				assert.NoError(t, err)
 			}
 
-			assert.Equal(t, 1, len(groupedMetrics))
+			assert.Len(t, groupedMetrics, 1)
 			for _, v := range groupedMetrics {
 				assert.Equal(t, len(tc.expectedMetricInfo), len(v.metrics))
 				assert.Equal(t, tc.expectedMetricInfo, v.metrics)
-				assert.Equal(t, 2, len(v.labels))
+				assert.Len(t, v.labels, 2)
 				assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, tc.expectedMetricType), v.metadata)
 				assert.Equal(t, tc.expectedLabels, v.labels)
 			}
@@ -158,7 +158,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		assert.Equal(t, 4, len(groupedMetrics))
+		assert.Len(t, groupedMetrics, 4)
 		for _, group := range groupedMetrics {
 			for metricName, metricInfo := range group.metrics {
 				switch metricName {
@@ -230,7 +230,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			assert.NoError(t, err)
 		}
 
-		assert.Equal(t, 4, len(groupedMetrics))
+		assert.Len(t, groupedMetrics, 4)
 		for _, group := range groupedMetrics {
 			for metricName, metricInfo := range group.metrics {
 				switch metricName {
@@ -348,7 +348,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			)
 			assert.NoError(t, err)
 		}
-		assert.Equal(t, 1, len(groupedMetrics))
+		assert.Len(t, groupedMetrics, 1)
 
 		labels := map[string]string{
 			oTellibDimensionKey: instrumentationLibName,
@@ -389,7 +389,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			emfCalcs,
 		)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(groupedMetrics))
+		assert.Len(t, groupedMetrics, 0)
 
 		// Test output warning logs
 		expectedLogs := []observer.LoggedEntry{

--- a/exporter/awsemfexporter/metric_declaration_test.go
+++ b/exporter/awsemfexporter/metric_declaration_test.go
@@ -226,7 +226,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		}
 		err := m.init(logger)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, len(m.metricRegexList))
+		assert.Len(t, m.metricRegexList, 3)
 	})
 
 	t.Run("with dimensions", func(t *testing.T) {
@@ -239,8 +239,8 @@ func TestMetricDeclarationInit(t *testing.T) {
 		}
 		err := m.init(logger)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, len(m.metricRegexList))
-		assert.Equal(t, 2, len(m.Dimensions))
+		assert.Len(t, m.metricRegexList, 3)
+		assert.Len(t, m.Dimensions, 2)
 	})
 
 	// Test removal of dimension sets with more than 10 elements
@@ -256,8 +256,8 @@ func TestMetricDeclarationInit(t *testing.T) {
 		obsLogger := zap.New(obs)
 		err := m.init(obsLogger)
 		assert.NoError(t, err)
-		assert.Equal(t, 3, len(m.metricRegexList))
-		assert.Equal(t, 1, len(m.Dimensions))
+		assert.Len(t, m.metricRegexList, 3)
+		assert.Len(t, m.Dimensions, 1)
 		// Check logged warning message
 		expectedLogs := []observer.LoggedEntry{{
 			Entry:   zapcore.Entry{Level: zap.WarnLevel, Message: "Dropped dimension set: > 10 dimensions specified."},
@@ -281,7 +281,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		obsLogger := zap.New(obs)
 		err := m.init(obsLogger)
 		assert.NoError(t, err)
-		assert.Equal(t, 1, len(m.Dimensions))
+		assert.Len(t, m.Dimensions, 1)
 		assert.Equal(t, []string{"a", "b", "c"}, m.Dimensions[0])
 		// Check logged warning message
 		expectedLogs := []observer.LoggedEntry{
@@ -324,7 +324,7 @@ func TestMetricDeclarationInit(t *testing.T) {
 		}
 		err := m.init(logger)
 		assert.NoError(t, err)
-		assert.Equal(t, 2, len(m.LabelMatchers))
+		assert.Len(t, m.LabelMatchers, 2)
 		assert.Equal(t, ";", m.LabelMatchers[0].Separator)
 		assert.Equal(t, ".+", m.LabelMatchers[0].Regex)
 		assert.NotNil(t, m.LabelMatchers[0].compiledRegex)

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -352,21 +352,21 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 			err := translator.translateOTelToGroupedMetric(tc.metric, groupedMetrics, config)
 			assert.NoError(t, err)
 			assert.NotNil(t, groupedMetrics)
-			assert.Equal(t, 3, len(groupedMetrics))
+			assert.Len(t, groupedMetrics, 3)
 
 			for _, v := range groupedMetrics {
 				assert.Equal(t, tc.expectedNamespace, v.metadata.namespace)
 				switch {
 				case v.metadata.metricDataType == pmetric.MetricTypeSum:
-					assert.Equal(t, 2, len(v.metrics))
+					assert.Len(t, v.metrics, 2)
 					assert.Equal(t, tc.counterLabels, v.labels)
 					assert.Equal(t, counterSumMetrics, v.metrics)
 				case v.metadata.metricDataType == pmetric.MetricTypeGauge:
-					assert.Equal(t, 2, len(v.metrics))
+					assert.Len(t, v.metrics, 2)
 					assert.Equal(t, tc.counterLabels, v.labels)
 					assert.Equal(t, counterGaugeMetrics, v.metrics)
 				case v.metadata.metricDataType == pmetric.MetricTypeHistogram:
-					assert.Equal(t, 1, len(v.metrics))
+					assert.Len(t, v.metrics, 1)
 					assert.Equal(t, tc.timerLabels, v.labels)
 					assert.Equal(t, timerMetrics, v.metrics)
 				default:
@@ -383,7 +383,7 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 		groupedMetrics := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
 		assert.NoError(t, err)
-		assert.Equal(t, 0, len(groupedMetrics))
+		assert.Len(t, groupedMetrics, 0)
 	})
 }
 
@@ -1493,7 +1493,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 		// Have to perform this hacky equality check because the metric names might not
 		// be in the right order due to map iteration
 		assert.Equal(t, expectedLog.Entry, log.Entry)
-		assert.Equal(t, 2, len(log.Context))
+		assert.Len(t, log.Context, 2)
 		assert.Equal(t, expectedLog.Context[0], log.Context[0])
 		isMatch := false
 		possibleOrders := []zapcore.Field{
@@ -1557,7 +1557,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 		seen := make([]bool, 3)
 		for _, log := range logs.AllUntimed() {
 			assert.Equal(t, expectedEntry, log.Entry)
-			assert.Equal(t, 1, len(log.Context))
+			assert.Len(t, log.Context, 1)
 			hasMatch := false
 			for i, expectedCtx := range expectedContexts {
 				if !seen[i] && log.Context[0].Equals(expectedCtx) {
@@ -1957,9 +1957,9 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 
 			cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
 			if len(tc.expectedDims) == 0 {
-				assert.Equal(t, 0, len(cWMeasurements))
+				assert.Len(t, cWMeasurements, 0)
 			} else {
-				assert.Equal(t, 1, len(cWMeasurements))
+				assert.Len(t, cWMeasurements, 1)
 				dims := cWMeasurements[0].Dimensions
 				assertDimsEqual(t, tc.expectedDims, dims)
 			}
@@ -2335,7 +2335,7 @@ func TestTranslateOtToGroupedMetricForLogGroupAndStream(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.NotNil(t, groupedMetrics)
-			assert.Equal(t, 1, len(groupedMetrics))
+			assert.Len(t, groupedMetrics, 1)
 
 			for _, actual := range groupedMetrics {
 				assert.Equal(t, test.outLogGroupName, actual.metadata.logGroup)
@@ -2366,7 +2366,7 @@ func TestTranslateOtToGroupedMetricForInitialDeltaValue(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.NotNil(t, groupedMetrics)
-			assert.Equal(t, 1, len(groupedMetrics))
+			assert.Len(t, groupedMetrics, 1)
 
 			for _, actual := range groupedMetrics {
 				assert.True(t, actual.metadata.retainInitialValueForDelta)

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -409,7 +409,7 @@ func TestLogGroups(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 }
@@ -437,7 +437,7 @@ func TestLogGroupsFromArns(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 }
@@ -456,7 +456,7 @@ func TestLogGroupsFromStringResourceAttribute(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 1, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 1)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 }
 
@@ -476,7 +476,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	filtered, awsData := makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
@@ -485,7 +485,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
@@ -494,7 +494,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
@@ -503,7 +503,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
@@ -512,7 +512,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 0, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 0)
 }
 
 func TestLogGroupsInvalidType(t *testing.T) {
@@ -524,7 +524,7 @@ func TestLogGroupsInvalidType(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 0, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 0)
 }
 
 // Simulate Log groups arns being set using OTEL_RESOURCE_ATTRIBUTES
@@ -544,7 +544,7 @@ func TestLogGroupsArnsFromStringResourceAttributes(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 1, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 1)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 }
 
@@ -569,7 +569,7 @@ func TestLogGroupsArnsWithAmpersandFromStringResourceAttributes(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 }
@@ -589,7 +589,7 @@ func TestLogGroupsFromConfig(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Equal(t, 2, len(awsData.CWLogs))
+	assert.Len(t, awsData.CWLogs, 2)
 	assert.Contains(t, awsData.CWLogs, cwl1)
 	assert.Contains(t, awsData.CWLogs, cwl2)
 }

--- a/exporter/awsxrayexporter/internal/translator/cause_test.go
+++ b/exporter/awsxrayexporter/internal/translator/cause_test.go
@@ -81,7 +81,7 @@ func TestMakeCauseAwsSdkSpan(t *testing.T) {
 	assert.False(t, isThrottle)
 	assert.NotNil(t, cause)
 
-	assert.Equal(t, 1, len(cause.CauseObject.Exceptions))
+	assert.Len(t, cause.CauseObject.Exceptions, 1)
 	exception := cause.CauseObject.Exceptions[0]
 	assert.Equal(t, AwsIndividualHTTPErrorEventType, *exception.Type)
 	assert.True(t, *exception.Remote)

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -240,7 +240,7 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	assert.NotNil(t, segment.Service)
 	assert.NotNil(t, segment.AWS)
 	assert.NotNil(t, segment.Metadata)
-	assert.Equal(t, 0, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 0)
 	assert.Equal(t, enterpriseAppID, segment.Metadata["default"]["enterprise.app.id"])
 	assert.Nil(t, segment.Cause)
 	assert.Nil(t, segment.HTTP)
@@ -467,7 +467,7 @@ func TestSpanWithAttributesDefaultNotIndexed(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 0, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 0)
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
 	assert.Equal(t, "string", segment.Metadata["default"]["otel.resource.string.key"])
@@ -494,7 +494,7 @@ func TestSpanWithResourceNotStoredIfSubsegment(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 0, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 0)
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
 	assert.Nil(t, segment.Metadata["default"]["otel.resource.string.key"])
@@ -517,7 +517,7 @@ func TestSpanWithAttributesPartlyIndexed(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, []string{"attr1@1", "not_exist"}, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 1, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 1)
 	assert.Equal(t, "val1", segment.Annotations["attr1_1"])
 	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
 }
@@ -535,7 +535,7 @@ func TestSpanWithAnnotationsAttribute(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 1, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 1)
 	assert.Equal(t, "val2", segment.Annotations["attr2_2"])
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 }
@@ -570,8 +570,8 @@ func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 0, len(segment.Annotations))
-	assert.Equal(t, 2, len(segment.Metadata))
+	assert.Len(t, segment.Annotations, 0)
+	assert.Len(t, segment.Metadata, 2)
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 	assert.Equal(t, "custom_value", segment.Metadata["default"]["custom_key"])
 	assert.Equal(t, "retain-value", segment.Metadata["default"][awsxray.AWSXraySegmentMetadataAttributePrefix+"non-xray-sdk"])
@@ -602,7 +602,7 @@ func TestResourceAttributesCanBeIndexed(t *testing.T) {
 	}, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 4, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 4)
 	assert.Equal(t, "string", segment.Annotations["otel_resource_string_key"])
 	assert.Equal(t, int64(10), segment.Annotations["otel_resource_int_key"])
 	assert.Equal(t, 5.0, segment.Annotations["otel_resource_double_key"])
@@ -635,7 +635,7 @@ func TestResourceAttributesCanBeIndexedWithAllowDot(t *testing.T) {
 	}, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 4, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 4)
 	assert.Equal(t, "string", segment.Annotations["otel.resource.string.key"])
 	assert.Equal(t, int64(10), segment.Annotations["otel.resource.int.key"])
 	assert.Equal(t, 5.0, segment.Annotations["otel.resource.double.key"])
@@ -685,7 +685,7 @@ func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 2, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 2)
 	assert.Equal(t, "aws_operation_val", segment.Annotations["aws_operation"])
 	assert.Equal(t, "rpc_method_val", segment.Annotations["rpc_method"])
 }
@@ -705,7 +705,7 @@ func TestSpanWithSpecialAttributesAsListedWithAllowDot(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Equal(t, 2, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 2)
 	assert.Equal(t, "aws_operation_val", segment.Annotations[awsxray.AWSOperationAttribute])
 	assert.Equal(t, "rpc_method_val", segment.Annotations[conventions.AttributeRPCMethod])
 }
@@ -1235,12 +1235,12 @@ func validateLocalRootDependencySubsegment(t *testing.T, segment *awsxray.Segmen
 	assert.Equal(t, expectedTraceID, *segment.TraceID)
 	assert.NotNil(t, segment.HTTP)
 	assert.Equal(t, "POST", *segment.HTTP.Request.Method)
-	assert.Equal(t, 2, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 2)
 	assert.Nil(t, segment.Annotations[awsRemoteService])
 	assert.Nil(t, segment.Annotations[remoteTarget])
 	assert.Equal(t, "myAnnotationValue", segment.Annotations["myAnnotationKey"])
 
-	assert.Equal(t, 8, len(segment.Metadata["default"]))
+	assert.Len(t, segment.Metadata["default"], 8)
 	assert.Equal(t, "receive", segment.Metadata["default"][conventions.AttributeMessagingOperation])
 	assert.Equal(t, "LOCAL_ROOT", segment.Metadata["default"][awsSpanKind])
 	assert.Equal(t, "myRemoteOperation", segment.Metadata["default"][awsRemoteOperation])
@@ -1272,9 +1272,9 @@ func validateLocalRootServiceSegment(t *testing.T, segment *awsxray.Segment, spa
 	assert.Equal(t, "myLocalService", *segment.Name)
 	assert.Equal(t, expectedTraceID, *segment.TraceID)
 	assert.Nil(t, segment.HTTP)
-	assert.Equal(t, 1, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 1)
 	assert.Equal(t, "myAnnotationValue", segment.Annotations["myAnnotationKey"])
-	assert.Equal(t, 1, len(segment.Metadata["default"]))
+	assert.Len(t, segment.Metadata["default"], 1)
 	assert.Equal(t, "service.name=myTest", segment.Metadata["default"]["otel.resource.attributes"])
 	assert.Equal(t, "MySDK", *segment.AWS.XRay.SDK)
 	assert.Equal(t, "1.20.0", *segment.AWS.XRay.SDKVersion)
@@ -1351,14 +1351,14 @@ func TestLocalRootConsumer(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 2, len(segments))
+	assert.Len(t, segments, 2)
 	assert.Nil(t, err)
 
 	validateLocalRootDependencySubsegment(t, segments[0], span, *segments[1].ID)
 	assert.Nil(t, segments[0].Links)
 
 	validateLocalRootServiceSegment(t, segments[1], span)
-	assert.Equal(t, 1, len(segments[1].Links))
+	assert.Len(t, segments[1].Links, 1)
 
 	// Checks these values are the same for both
 	assert.Equal(t, segments[0].StartTime, segments[1].StartTime)
@@ -1382,7 +1382,7 @@ func TestNonLocalRootConsumerProcess(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	tempTraceID := span.TraceID()
@@ -1393,13 +1393,13 @@ func TestNonLocalRootConsumerProcess(t *testing.T) {
 	assert.Equal(t, "destination operation", *segments[0].Name)
 	assert.NotEqual(t, parentSpanID.String(), *segments[0].ID)
 	assert.Equal(t, span.SpanID().String(), *segments[0].ID)
-	assert.Equal(t, 1, len(segments[0].Links))
+	assert.Len(t, segments[0].Links, 1)
 	assert.Equal(t, expectedTraceID, *segments[0].TraceID)
 	assert.NotNil(t, segments[0].HTTP)
 	assert.Equal(t, "POST", *segments[0].HTTP.Request.Method)
-	assert.Equal(t, 1, len(segments[0].Annotations))
+	assert.Len(t, segments[0].Annotations, 1)
 	assert.Equal(t, "myAnnotationValue", segments[0].Annotations["myAnnotationKey"])
-	assert.Equal(t, 7, len(segments[0].Metadata["default"]))
+	assert.Len(t, segments[0].Metadata["default"], 7)
 	assert.Equal(t, "Consumer", segments[0].Metadata["default"][awsSpanKind])
 	assert.Equal(t, "myLocalService", segments[0].Metadata["default"][awsLocalService])
 	assert.Equal(t, "receive", segments[0].Metadata["default"][conventions.AttributeMessagingOperation])
@@ -1428,7 +1428,7 @@ func TestLocalRootConsumerAWSNamespace(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 2, len(segments))
+	assert.Len(t, segments, 2)
 	assert.Nil(t, err)
 
 	// Ensure that AWS namespace is not overwritten to remote
@@ -1454,11 +1454,11 @@ func TestLocalRootClient(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 2, len(segments))
+	assert.Len(t, segments, 2)
 	assert.Nil(t, err)
 
 	validateLocalRootDependencySubsegment(t, segments[0], span, *segments[1].ID)
-	assert.Equal(t, 1, len(segments[0].Links))
+	assert.Len(t, segments[0].Links, 1)
 
 	validateLocalRootServiceSegment(t, segments[1], span)
 	assert.Nil(t, segments[1].Links)
@@ -1491,7 +1491,7 @@ func TestLocalRootClientAwsServiceMetrics(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 2, len(segments))
+	assert.Len(t, segments, 2)
 	assert.Nil(t, err)
 
 	subsegment := segments[0]
@@ -1515,11 +1515,11 @@ func TestLocalRootProducer(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 2, len(segments))
+	assert.Len(t, segments, 2)
 	assert.Nil(t, err)
 
 	validateLocalRootDependencySubsegment(t, segments[0], span, *segments[1].ID)
-	assert.Equal(t, 1, len(segments[0].Links))
+	assert.Len(t, segments[0].Links, 1)
 
 	validateLocalRootServiceSegment(t, segments[1], span)
 	assert.Nil(t, segments[1].Links)
@@ -1537,10 +1537,10 @@ func validateLocalRootWithoutDependency(t *testing.T, segment *awsxray.Segment, 
 	assert.Nil(t, segment.Type)
 	assert.Equal(t, "myLocalService", *segment.Name)
 	assert.Equal(t, span.ParentSpanID().String(), *segment.ParentID)
-	assert.Equal(t, 1, len(segment.Links))
+	assert.Len(t, segment.Links, 1)
 	assert.Equal(t, expectedTraceID, *segment.TraceID)
 	assert.Equal(t, "POST", *segment.HTTP.Request.Method)
-	assert.Equal(t, 2, len(segment.Annotations))
+	assert.Len(t, segment.Annotations, 2)
 	assert.Equal(t, "myRemoteService", segment.Annotations["aws_remote_service"])
 	assert.Equal(t, "myAnnotationValue", segment.Annotations["myAnnotationKey"])
 
@@ -1550,7 +1550,7 @@ func validateLocalRootWithoutDependency(t *testing.T, segment *awsxray.Segment, 
 		numberOfMetadataKeys = 30
 	}
 
-	assert.Equal(t, numberOfMetadataKeys, len(segment.Metadata["default"]))
+	assert.Len(t, segment.Metadata["default"], numberOfMetadataKeys)
 	assert.Equal(t, "receive", segment.Metadata["default"][conventions.AttributeMessagingOperation])
 	assert.Equal(t, "LOCAL_ROOT", segment.Metadata["default"][awsSpanKind])
 	assert.Equal(t, "myRemoteOperation", segment.Metadata["default"][awsRemoteOperation])
@@ -1592,7 +1592,7 @@ func TestLocalRootServer(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	validateLocalRootWithoutDependency(t, segments[0], span)
@@ -1615,7 +1615,7 @@ func TestLocalRootInternal(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	validateLocalRootWithoutDependency(t, segments[0], span)
@@ -1636,7 +1636,7 @@ func TestNotLocalRootInternal(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	// Validate segment
@@ -1660,7 +1660,7 @@ func TestNotLocalRootConsumer(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	// Validate segment
@@ -1684,7 +1684,7 @@ func TestNotLocalRootClient(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	// Validate segment
@@ -1708,7 +1708,7 @@ func TestNotLocalRootProducer(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	// Validate segment
@@ -1734,7 +1734,7 @@ func TestNotLocalRootServer(t *testing.T) {
 	segments, err := MakeSegmentsFromSpan(span, resource, []string{awsRemoteService, "myAnnotationKey"}, false, nil, false)
 
 	assert.NotNil(t, segments)
-	assert.Equal(t, 1, len(segments))
+	assert.Len(t, segments, 1)
 	assert.Nil(t, err)
 
 	// Validate segment

--- a/exporter/awsxrayexporter/internal/translator/span_links_test.go
+++ b/exporter/awsxrayexporter/internal/translator/span_links_test.go
@@ -30,10 +30,10 @@ func TestSpanLinkSimple(t *testing.T) {
 
 	var convertedTraceID, _ = convertToAmazonTraceID(traceID, false)
 
-	assert.Equal(t, 1, len(segment.Links))
+	assert.Len(t, segment.Links, 1)
 	assert.Equal(t, spanLink.SpanID().String(), *segment.Links[0].SpanID)
 	assert.Equal(t, convertedTraceID, *segment.Links[0].TraceID)
-	assert.Equal(t, 0, len(segment.Links[0].Attributes))
+	assert.Len(t, segment.Links[0].Attributes, 0)
 
 	jsonStr, _ := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
@@ -52,7 +52,7 @@ func TestSpanLinkEmpty(t *testing.T) {
 
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
-	assert.Equal(t, 0, len(segment.Links))
+	assert.Len(t, segment.Links, 0)
 
 	jsonStr, _ := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
@@ -111,16 +111,16 @@ func TestTwoSpanLinks(t *testing.T) {
 	var convertedTraceID1, _ = convertToAmazonTraceID(traceID1, false)
 	var convertedTraceID2, _ = convertToAmazonTraceID(traceID2, false)
 
-	assert.Equal(t, 2, len(segment.Links))
+	assert.Len(t, segment.Links, 2)
 	assert.Equal(t, spanLink1.SpanID().String(), *segment.Links[0].SpanID)
 	assert.Equal(t, convertedTraceID1, *segment.Links[0].TraceID)
 
-	assert.Equal(t, 1, len(segment.Links[0].Attributes))
+	assert.Len(t, segment.Links[0].Attributes, 1)
 	assert.Equal(t, "ABC", segment.Links[0].Attributes["myKey1"])
 
 	assert.Equal(t, spanLink2.SpanID().String(), *segment.Links[1].SpanID)
 	assert.Equal(t, convertedTraceID2, *segment.Links[1].TraceID)
-	assert.Equal(t, 1, len(segment.Links[0].Attributes))
+	assert.Len(t, segment.Links[0].Attributes, 1)
 	assert.Equal(t, int64(1234), segment.Links[1].Attributes["myKey2"])
 
 	jsonStr, _ := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
@@ -172,8 +172,8 @@ func TestSpanLinkComplexAttributes(t *testing.T) {
 
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
-	assert.Equal(t, 1, len(segment.Links))
-	assert.Equal(t, 8, len(segment.Links[0].Attributes))
+	assert.Len(t, segment.Links, 1)
+	assert.Len(t, segment.Links[0].Attributes, 8)
 
 	assert.Equal(t, "myValue", segment.Links[0].Attributes["myKey1"])
 	assert.Equal(t, true, segment.Links[0].Attributes["myKey2"])

--- a/exporter/azuredataexplorerexporter/adx_exporter_test.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter_test.go
@@ -168,7 +168,7 @@ func TestIngestedDataRecordCount(t *testing.T) {
 	recordstoingest := genRand.Intn(20)
 	err := adxDataProducer.metricsDataPusher(context.Background(), createMetricsData(recordstoingest))
 	ingestedrecordsactual := ingestor.Records()
-	assert.Equal(t, recordstoingest, len(ingestedrecordsactual), "Number of metrics created should match number of records ingested")
+	assert.Len(t, ingestedrecordsactual, recordstoingest, "Number of metrics created should match number of records ingested")
 	assert.NoError(t, err)
 }
 

--- a/exporter/azuremonitorexporter/metricexporter_test.go
+++ b/exporter/azuremonitorexporter/metricexporter_test.go
@@ -107,7 +107,7 @@ func TestSummaryEnvelopes(t *testing.T) {
 
 func getDataPoint(t testing.TB, metric pmetric.Metric) *contracts.DataPoint {
 	var envelopes []*contracts.Envelope = getMetricPacker().MetricToEnvelopes(metric, getResource(), getScope())
-	require.Equal(t, len(envelopes), 1)
+	require.Len(t, envelopes, 1)
 	envelope := envelopes[0]
 	require.NotNil(t, envelope)
 
@@ -123,7 +123,7 @@ func getDataPoint(t testing.TB, metric pmetric.Metric) *contracts.DataPoint {
 
 	metricData := envelopeData.BaseData.(*contracts.MetricData)
 
-	require.Equal(t, len(metricData.Metrics), 1)
+	require.Len(t, metricData.Metrics, 1)
 
 	dataPoint := metricData.Metrics[0]
 	require.NotNil(t, dataPoint)

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -512,7 +512,7 @@ func TestSpanWithEventsToEnvelopes(t *testing.T) {
 	envelopes, _ := spanToEnvelopes(defaultResource, defaultInstrumentationLibrary, span, true, zap.NewNop())
 
 	assert.NotNil(t, envelopes)
-	assert.Equal(t, 3, len(envelopes))
+	assert.Len(t, envelopes, 3)
 
 	validateEnvelope := func(spanEvent ptrace.SpanEvent, envelope *contracts.Envelope, targetEnvelopeName string) {
 		assert.Equal(t, targetEnvelopeName, envelope.Name)

--- a/exporter/datadogexporter/examples_test.go
+++ b/exporter/datadogexporter/examples_test.go
@@ -82,7 +82,7 @@ func TestExamples(t *testing.T) {
 		require.NoError(t, err)
 		n, err := f.Write(data)
 		require.NoError(t, err)
-		require.Equal(t, n, len(data))
+		require.Len(t, data, n)
 		require.NoError(t, f.Close())
 		defer os.RemoveAll(f.Name())
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594

--- a/exporter/datadogexporter/internal/metrics/series_deprecated_test.go
+++ b/exporter/datadogexporter/internal/metrics/series_deprecated_test.go
@@ -51,7 +51,7 @@ func TestDefaultZorkianMetrics(t *testing.T) {
 
 	assert.Equal(t, "otel.datadog_exporter.metrics.running", *ms[0].Metric)
 	// Assert metrics list length (should be 1)
-	assert.Equal(t, 1, len(ms))
+	assert.Len(t, ms, 1)
 	// Assert timestamp
 	assert.Equal(t, 2.0, *ms[0].Points[0][0])
 	// Assert value (should always be 1.0)

--- a/exporter/datadogexporter/internal/metrics/series_test.go
+++ b/exporter/datadogexporter/internal/metrics/series_test.go
@@ -51,7 +51,7 @@ func TestDefaultMetrics(t *testing.T) {
 
 	assert.Equal(t, "otel.datadog_exporter.metrics.running", ms[0].Metric)
 	// Assert metrics list length (should be 1)
-	assert.Equal(t, 1, len(ms))
+	assert.Len(t, ms, 1)
 	// Assert timestamp
 	assert.Equal(t, int64(2), *ms[0].Points[0].Timestamp)
 	// Assert value (should always be 1.0)
@@ -73,7 +73,7 @@ func TestDefaultMetricsWithRuntimeMetrics(t *testing.T) {
 
 	assert.Equal(t, "otel.datadog_exporter.runtime_metrics.running", ms[0].Metric)
 	// Assert metrics list length (should be 1)
-	assert.Equal(t, 1, len(ms))
+	assert.Len(t, ms, 1)
 	// Assert timestamp
 	assert.Equal(t, int64(2), *ms[0].Points[0].Timestamp)
 	// Assert value (should always be 1.0)

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -72,7 +72,7 @@ func TestNewExporter(t *testing.T) {
 	testutil.TestMetrics.CopyTo(testMetrics)
 	err = exp.ConsumeMetrics(context.Background(), testMetrics)
 	require.NoError(t, err)
-	assert.Equal(t, len(server.MetadataChan), 0)
+	assert.Len(t, server.MetadataChan, 0)
 
 	cfg.HostMetadata.Enabled = true
 	cfg.HostMetadata.HostnameSource = HostnameSourceFirstResource
@@ -393,7 +393,7 @@ func TestNewExporter_Zorkian(t *testing.T) {
 	testutil.TestMetrics.CopyTo(testMetrics)
 	err = exp.ConsumeMetrics(context.Background(), testMetrics)
 	require.NoError(t, err)
-	assert.Equal(t, len(server.MetadataChan), 0)
+	assert.Len(t, server.MetadataChan, 0)
 
 	cfg.HostMetadata.Enabled = true
 	cfg.HostMetadata.HostnameSource = HostnameSourceFirstResource

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -31,7 +31,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Exporters), 2)
+	assert.Len(t, cfg.Exporters, 2)
 
 	r0 := cfg.Exporters[component.NewID(metadata.Type)].(*Config)
 	assert.Equal(t, r0, factory.CreateDefaultConfig().(*Config))

--- a/exporter/influxdbexporter/writer_test.go
+++ b/exporter/influxdbexporter/writer_test.go
@@ -138,9 +138,9 @@ func Test_influxHTTPWriterBatch_maxPayload(t *testing.T) {
 			require.NoError(t, err)
 
 			if testCase.expectMultipleRequests {
-				assert.Equal(t, 2, len(httpRequests))
+				assert.Len(t, httpRequests, 2)
 			} else {
-				assert.Equal(t, 1, len(httpRequests))
+				assert.Len(t, httpRequests, 1)
 			}
 		})
 	}

--- a/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -228,7 +228,7 @@ func TestArrowExporterSuccess(t *testing.T) {
 					case ptrace.Traces:
 						traces, err := testCon.TracesFrom(outputData)
 						require.NoError(t, err)
-						require.Equal(t, 1, len(traces))
+						require.Len(t, traces, 1)
 						otelAssert.Equiv(stdTesting, []json.Marshaler{
 							compareJSONTraces{testData},
 						}, []json.Marshaler{
@@ -237,7 +237,7 @@ func TestArrowExporterSuccess(t *testing.T) {
 					case plog.Logs:
 						logs, err := testCon.LogsFrom(outputData)
 						require.NoError(t, err)
-						require.Equal(t, 1, len(logs))
+						require.Len(t, logs, 1)
 						otelAssert.Equiv(stdTesting, []json.Marshaler{
 							compareJSONLogs{testData},
 						}, []json.Marshaler{
@@ -246,7 +246,7 @@ func TestArrowExporterSuccess(t *testing.T) {
 					case pmetric.Metrics:
 						metrics, err := testCon.MetricsFrom(outputData)
 						require.NoError(t, err)
-						require.Equal(t, 1, len(metrics))
+						require.Len(t, metrics, 1)
 						otelAssert.Equiv(stdTesting, []json.Marshaler{
 							compareJSONMetrics{testData},
 						}, []json.Marshaler{
@@ -547,7 +547,7 @@ func TestArrowExporterStreaming(t *testing.T) {
 				for data := range channel.sendChannel() {
 					traces, err := testCon.TracesFrom(data)
 					require.NoError(t, err)
-					require.Equal(t, 1, len(traces))
+					require.Len(t, traces, 1)
 					actualOutput = append(actualOutput, traces[0])
 					channel.recv <- statusOKFor(data.BatchId)
 				}
@@ -757,7 +757,7 @@ func TestArrowExporterStreamLifetimeAndShutdown(t *testing.T) {
 							for data := range channel.sendChannel() {
 								traces, err := testCon.TracesFrom(data)
 								require.NoError(t, err)
-								require.Equal(t, 1, len(traces))
+								require.Len(t, traces, 1)
 								atomic.AddUint64(&actualCount, 1)
 								channel.recv <- statusOKFor(data.BatchId)
 							}

--- a/exporter/otelarrowexporter/otelarrow_test.go
+++ b/exporter/otelarrowexporter/otelarrow_test.go
@@ -394,7 +394,7 @@ func TestSendTraces(t *testing.T) {
 	// Test the static metadata
 	md = rcv.getMetadata()
 	require.EqualValues(t, expectedHeader, md.Get("header"))
-	require.Equal(t, len(md.Get("User-Agent")), 1)
+	require.Len(t, md.Get("User-Agent"), 1)
 	require.Contains(t, md.Get("User-Agent")[0], "Collector/1.2.3test")
 
 	// Test the caller's dynamic metadata
@@ -567,7 +567,7 @@ func TestSendMetrics(t *testing.T) {
 
 	mdata := rcv.getMetadata()
 	require.EqualValues(t, mdata.Get("header"), expectedHeader)
-	require.Equal(t, len(mdata.Get("User-Agent")), 1)
+	require.Len(t, mdata.Get("User-Agent"), 1)
 	require.Contains(t, mdata.Get("User-Agent")[0], "Collector/1.2.3test")
 
 	st := status.New(codes.InvalidArgument, "Invalid argument")
@@ -858,7 +858,7 @@ func TestSendLogData(t *testing.T) {
 	assert.EqualValues(t, ld, rcv.getLastRequest())
 
 	md := rcv.getMetadata()
-	require.Equal(t, len(md.Get("User-Agent")), 1)
+	require.Len(t, md.Get("User-Agent"), 1)
 	require.Contains(t, md.Get("User-Agent")[0], "Collector/1.2.3test")
 
 	st := status.New(codes.InvalidArgument, "Invalid argument")
@@ -1186,6 +1186,6 @@ func TestUserDialOptions(t *testing.T) {
 	err = exp.ConsumeTraces(context.Background(), td)
 	assert.NoError(t, err)
 
-	require.Equal(t, len(rcv.getMetadata().Get("User-Agent")), 1)
+	require.Len(t, rcv.getMetadata().Get("User-Agent"), 1)
 	require.Contains(t, rcv.getMetadata().Get("User-Agent")[0], testAgent)
 }

--- a/exporter/prometheusexporter/collector_test.go
+++ b/exporter/prometheusexporter/collector_test.go
@@ -126,7 +126,7 @@ func exemplarsEqual(t *testing.T, otelExemplar pmetric.Exemplar, promExemplar *i
 	}
 
 	require.Equal(t, givenValue, promExemplar.GetValue())
-	require.Equal(t, 2, len(promExemplar.GetLabel()))
+	require.Len(t, promExemplar.GetLabel(), 2)
 	ml := make(map[string]string)
 	for _, l := range promExemplar.GetLabel() {
 		ml[l.GetName()] = l.GetValue()
@@ -174,7 +174,7 @@ func TestConvertDoubleHistogramExemplar(t *testing.T) {
 
 	buckets := m.GetHistogram().GetBucket()
 
-	require.Equal(t, 3, len(buckets))
+	require.Len(t, buckets, 3)
 
 	require.Equal(t, 3.0, buckets[0].GetExemplar().GetValue())
 	exemplarsEqual(t, promExporterExemplars, buckets[0].GetExemplar())

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -269,7 +269,7 @@ func Test_export(t *testing.T) {
 		ok := proto.Unmarshal(dest, writeReq)
 		require.NoError(t, ok)
 
-		assert.EqualValues(t, 1, len(writeReq.Timeseries))
+		assert.Len(t, writeReq.Timeseries, 1)
 		require.NotNil(t, writeReq.GetTimeseries())
 		assert.Equal(t, *ts1, writeReq.GetTimeseries()[0])
 		w.WriteHeader(code)
@@ -457,7 +457,7 @@ func Test_PushMetrics(t *testing.T) {
 		wr := &prompb.WriteRequest{}
 		ok := proto.Unmarshal(dest, wr)
 		require.Nil(t, ok)
-		assert.EqualValues(t, expected, len(wr.Timeseries))
+		assert.Len(t, wr.Timeseries, expected)
 		if isStaleMarker {
 			assert.True(t, value.IsStaleNaN(wr.Timeseries[0].Samples[0].Value))
 		}
@@ -1007,10 +1007,10 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 		assert.NoError(t, err)
 		reqs = append(reqs, req)
 	}
-	assert.Equal(t, 1, len(reqs))
+	assert.Len(t, reqs, 1)
 	// We MUST have 2 time series as were passed into tsMap.
 	gotFromWAL := reqs[0]
-	assert.Equal(t, 2, len(gotFromWAL.Timeseries))
+	assert.Len(t, gotFromWAL.Timeseries, 2)
 	want := &prompb.WriteRequest{
 		Timeseries: orderBySampleTimestamp([]prompb.TimeSeries{
 			*ts1, *ts2,

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -66,7 +66,7 @@ func Test_batchTimeSeries(t *testing.T) {
 			}
 
 			assert.NoError(t, err)
-			assert.Equal(t, tt.numExpectedRequests, len(requests))
+			assert.Len(t, requests, tt.numExpectedRequests)
 			if tt.numExpectedRequests <= 1 {
 				assert.Equal(t, math.MaxInt, state.nextTimeSeriesBufferSize)
 				assert.Equal(t, math.MaxInt, state.nextMetricMetadataBufferSize)
@@ -100,7 +100,7 @@ func Test_batchTimeSeriesUpdatesStateForLargeBatches(t *testing.T) {
 	requests, err := batchTimeSeries(tsMap1, 1000000, nil, &state)
 
 	assert.NoError(t, err)
-	assert.Equal(t, 18, len(requests))
+	assert.Len(t, requests, 18)
 	assert.Equal(t, len(requests[len(requests)-2].Timeseries)*2, state.nextTimeSeriesBufferSize)
 	assert.Equal(t, math.MaxInt, state.nextMetricMetadataBufferSize)
 	assert.Equal(t, 36, state.nextRequestBufferSize)
@@ -134,7 +134,7 @@ func Benchmark_batchTimeSeries(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		requests, err := batchTimeSeries(tsMap1, 1000000, nil, &state)
 		assert.NoError(b, err)
-		assert.Equal(b, 18, len(requests))
+		assert.Len(b, requests, 18)
 	}
 }
 

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -143,13 +143,13 @@ func TestDefaultTranslationRules(t *testing.T) {
 	dps, ok = metrics["system.disk.operations.total"]
 	require.True(t, ok, "system.disk.operations.total metrics not found")
 	require.Len(t, dps, 4)
-	require.Equal(t, 2, len(dps[0].Dimensions))
+	require.Len(t, dps[0].Dimensions, 2)
 
 	// system.disk.io.total new metric calculation
 	dps, ok = metrics["system.disk.io.total"]
 	require.True(t, ok, "system.disk.io.total metrics not found")
 	require.Len(t, dps, 2)
-	require.Equal(t, 2, len(dps[0].Dimensions))
+	require.Len(t, dps[0].Dimensions, 2)
 	for _, dp := range dps {
 		var directionFound bool
 		for _, dim := range dp.Dimensions {
@@ -173,20 +173,20 @@ func TestDefaultTranslationRules(t *testing.T) {
 	require.True(t, ok, "disk_ops.total metrics not found")
 	require.Len(t, dps, 1)
 	require.Equal(t, int64(8e3), *dps[0].Value.IntValue)
-	require.Equal(t, 1, len(dps[0].Dimensions))
+	require.Len(t, dps[0].Dimensions, 1)
 	requireDimension(t, dps[0].Dimensions, "host", "host0")
 
 	// system.network.io.total new metric calculation
 	dps, ok = metrics["system.network.io.total"]
 	require.True(t, ok, "system.network.io.total metrics not found")
 	require.Len(t, dps, 2)
-	require.Equal(t, 4, len(dps[0].Dimensions))
+	require.Len(t, dps[0].Dimensions, 4)
 
 	// system.network.packets.total new metric calculation
 	dps, ok = metrics["system.network.packets.total"]
 	require.True(t, ok, "system.network.packets.total metrics not found")
 	require.Len(t, dps, 1)
-	require.Equal(t, 4, len(dps[0].Dimensions))
+	require.Len(t, dps[0].Dimensions, 4)
 	require.Equal(t, int64(350), *dps[0].Value.IntValue)
 	requireDimension(t, dps[0].Dimensions, "direction", "receive")
 
@@ -194,7 +194,7 @@ func TestDefaultTranslationRules(t *testing.T) {
 	dps, ok = metrics["network.total"]
 	require.True(t, ok, "network.total metrics not found")
 	require.Len(t, dps, 1)
-	require.Equal(t, 3, len(dps[0].Dimensions))
+	require.Len(t, dps[0].Dimensions, 3)
 	require.Equal(t, int64(10e9), *dps[0].Value.IntValue)
 }
 
@@ -462,13 +462,13 @@ func TestDefaultDiskTranslations(t *testing.T) {
 
 	du, ok := m["disk.utilization"]
 	require.True(t, ok)
-	require.Equal(t, 4, len(du[0].Dimensions))
+	require.Len(t, du[0].Dimensions, 4)
 	// cheap test for pct conversion
 	require.True(t, *du[0].Value.DoubleValue > 1)
 
 	dsu, ok := m["disk.summary_utilization"]
 	require.True(t, ok)
-	require.Equal(t, 3, len(dsu[0].Dimensions))
+	require.Len(t, dsu[0].Dimensions, 3)
 	require.True(t, *dsu[0].Value.DoubleValue > 1)
 }
 
@@ -506,16 +506,16 @@ func TestDefaultCPUTranslations(t *testing.T) {
 	}
 
 	cpuUtil := m["cpu.utilization"]
-	require.Equal(t, 1, len(cpuUtil))
+	require.Len(t, cpuUtil, 1)
 	for _, pt := range cpuUtil {
 		require.Equal(t, 66, int(*pt.Value.DoubleValue))
 	}
 
 	cpuUtilPerCore := m["cpu.utilization_per_core"]
-	require.Equal(t, 8, len(cpuUtilPerCore))
+	require.Len(t, cpuUtilPerCore, 8)
 
 	cpuNumProcessors := m["cpu.num_processors"]
-	require.Equal(t, 1, len(cpuNumProcessors))
+	require.Len(t, cpuNumProcessors, 1)
 
 	cpuStateMetrics := []string{"cpu.idle", "cpu.interrupt", "cpu.system", "cpu.user"}
 	for _, metric := range cpuStateMetrics {
@@ -583,7 +583,7 @@ func TestDefaultExcludesTranslated(t *testing.T) {
 
 	// the default cpu.utilization metric is added after applying the default translations
 	// (because cpu.utilization_per_core is supplied) and should not be excluded
-	require.Equal(t, 1, len(dps))
+	require.Len(t, dps, 1)
 	require.Equal(t, "cpu.utilization", dps[0].Metric)
 
 }
@@ -603,7 +603,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	md := getMetrics(metrics)
 	require.Equal(t, 69, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
-	require.Equal(t, 0, len(dps))
+	require.Len(t, dps, 0)
 }
 
 // Benchmark test for default translation rules on an example hostmetrics dataset.

--- a/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
+++ b/exporter/signalfxexporter/internal/apm/tracetracker/tracker_test.go
@@ -150,7 +150,7 @@ func TestCorrelationEmptyEnvironment(t *testing.T) {
 	a.ProcessTraces(context.Background(), fakeTraces)
 
 	cors := correlationClient.getCorrelations()
-	assert.Equal(t, 4, len(cors), "expected 4 correlations to be made")
+	assert.Len(t, cors, 4, "expected 4 correlations to be made")
 	for _, c := range cors {
 		assert.Contains(t, []string{"container_id", "kubernetes_pod_uid", "host", "AWSUniqueId"}, c.DimName)
 		assert.Contains(t, []string{"test", "randomAWSUniqueId", "testk8sPodUID", "testContainerID"}, c.DimValue)
@@ -206,5 +206,5 @@ func TestCorrelationUpdates(t *testing.T) {
 	numHostIDDimCorrelations := len(hostIDDims)*(numEnvironments+numServices) + 4 /* 4 deletes for service & environment fetched at startup */
 	numContainerLevelCorrelations := 2 * len(containerLevelIDDims)
 	totalExpectedCorrelations := numHostIDDimCorrelations + numContainerLevelCorrelations
-	assert.Equal(t, totalExpectedCorrelations, len(correlationClient.getCorrelations()), "# of correlation requests do not match")
+	assert.Len(t, correlationClient.getCorrelations(), totalExpectedCorrelations, "# of correlation requests do not match")
 }

--- a/exporter/signalfxexporter/internal/hostmetadata/metadata_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/metadata_test.go
@@ -255,10 +255,10 @@ func TestSyncMetadata(t *testing.T) {
 			syncer.Sync(tt.metricsData)
 
 			if tt.wantMetadataUpdate != nil {
-				require.Equal(t, 1, len(dimClient.getMetadataUpdates()))
+				require.Len(t, dimClient.getMetadataUpdates(), 1)
 				require.EqualValues(t, tt.wantMetadataUpdate, dimClient.getMetadataUpdates()[0])
 			} else {
-				require.Equal(t, 0, len(dimClient.getMetadataUpdates()))
+				require.Len(t, dimClient.getMetadataUpdates(), 0)
 			}
 
 			require.Equal(t, len(tt.wantLogs), logs.Len())

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -1094,7 +1094,7 @@ func Test_MetricDataToSignalFxV2WithHistogramBuckets(t *testing.T) {
 			// of those is not deterministic.
 			sortDimensions(tt.wantSfxDataPoints)
 			sortDimensions(gotSfxDataPoints)
-			assert.Equal(t, tt.wantCount, len(gotSfxDataPoints))
+			assert.Len(t, gotSfxDataPoints, tt.wantCount)
 			assert.Equal(t, tt.wantSfxDataPoints, gotSfxDataPoints)
 		})
 	}
@@ -1193,7 +1193,7 @@ func TestInvalidNumberOfDimensions(t *testing.T) {
 	}
 	c, err := NewMetricsConverter(logger, nil, nil, nil, "_-.", false, true)
 	require.NoError(t, err)
-	assert.EqualValues(t, 1, len(c.MetricsToSignalFxV2(md)))
+	assert.Len(t, c.MetricsToSignalFxV2(md), 1)
 	// No log message should be printed
 	require.Equal(t, 0, observedLogs.Len())
 
@@ -1216,7 +1216,7 @@ func TestInvalidNumberOfDimensions(t *testing.T) {
 			Value: fmt.Sprint("dim_val_", i),
 		})
 	}
-	assert.EqualValues(t, 0, len(c.MetricsToSignalFxV2(mdInvalid)))
+	assert.Len(t, c.MetricsToSignalFxV2(mdInvalid), 0)
 	require.Equal(t, 1, observedLogs.Len())
 	assert.Equal(t, "dropping datapoint", observedLogs.All()[0].Message)
 	assert.ElementsMatch(t, []zap.Field{

--- a/exporter/signalfxexporter/internal/translation/translator_test.go
+++ b/exporter/signalfxexporter/internal/translation/translator_test.go
@@ -2027,7 +2027,7 @@ func TestNewCalculateNewMetricErrors(t *testing.T) {
 			}}, 1, make(chan struct{}))
 			require.NoError(t, err)
 			tr := mt.TranslateDataPoints(logger, dps)
-			require.Equal(t, 2, len(tr))
+			require.Len(t, tr, 2)
 			if test.wantErr == "" {
 				require.Equal(t, 0, observedLogs.Len())
 			} else {
@@ -2086,7 +2086,7 @@ func TestCalcNewMetricInputPairs_SameDims(t *testing.T) {
 		},
 	}
 	pairs := calcNewMetricInputPairs(pts, rule)
-	require.Equal(t, 1, len(pairs))
+	require.Len(t, pairs, 1)
 	pair := pairs[0]
 	require.Equal(t, "m1", pair[0].Metric)
 	require.Equal(t, "m2", pair[1].Metric)
@@ -2149,7 +2149,7 @@ func TestNewMetricInputPairs_MultiPairs(t *testing.T) {
 		},
 	}
 	pairs := calcNewMetricInputPairs(pts, rule)
-	require.Equal(t, 2, len(pairs))
+	require.Len(t, pairs, 2)
 	pair1 := pairs[0]
 	require.EqualValues(t, 1, *pair1[0].Value.IntValue)
 	require.EqualValues(t, 2, *pair1[1].Value.IntValue)
@@ -2528,7 +2528,7 @@ func TestDeltaTranslatorNoMatchingMapping(t *testing.T) {
 	c := testConverter(t, map[string]string{"foo": "bar"})
 	md := intMD(1, 1)
 	idx := indexPts(c.MetricsToSignalFxV2(md))
-	require.Equal(t, 1, len(idx))
+	require.Len(t, idx, 1)
 }
 
 func TestDeltaTranslatorMismatchedValueTypes(t *testing.T) {
@@ -2541,7 +2541,7 @@ func TestDeltaTranslatorMismatchedValueTypes(t *testing.T) {
 	dblTS("cpu0", "user", 1, 1, 1, md2.SetEmptySum().DataPoints().AppendEmpty())
 	pts := c.MetricsToSignalFxV2(wrapMetric(md2))
 	idx := indexPts(pts)
-	require.Equal(t, 1, len(idx))
+	require.Len(t, idx, 1)
 }
 
 func requireDeltaMetricOk(t *testing.T, md1, md2, md3 pmetric.Metrics) (
@@ -2551,11 +2551,11 @@ func requireDeltaMetricOk(t *testing.T, md1, md2, md3 pmetric.Metrics) (
 
 	dp1 := c.MetricsToSignalFxV2(md1)
 	m1 := indexPts(dp1)
-	require.Equal(t, 1, len(m1))
+	require.Len(t, m1, 1)
 
 	dp2 := c.MetricsToSignalFxV2(md2)
 	m2 := indexPts(dp2)
-	require.Equal(t, 2, len(m2))
+	require.Len(t, m2, 2)
 
 	origPts, ok := m2["system.cpu.time"]
 	require.True(t, ok)
@@ -2570,7 +2570,7 @@ func requireDeltaMetricOk(t *testing.T, md1, md2, md3 pmetric.Metrics) (
 
 	dp3 := c.MetricsToSignalFxV2(md3)
 	m3 := indexPts(dp3)
-	require.Equal(t, 2, len(m3))
+	require.Len(t, m3, 2)
 
 	deltaPts2, ok := m3["system.cpu.delta"]
 	require.True(t, ok)

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -786,7 +786,7 @@ func TestReceiveLogs(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, test.want.numBatches, len(got))
+			require.Len(t, got, test.want.numBatches)
 
 			for i, wantBatch := range test.want.batches {
 				require.NotZero(t, got[i])
@@ -1181,7 +1181,7 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 				}
 
 				if test.want.numBatches == 0 {
-					assert.Equal(t, 0, len(got))
+					assert.Len(t, got, 0)
 					return
 				}
 
@@ -1670,7 +1670,7 @@ func Test_pushLogData_ShouldAddHeadersForProfilingData(t *testing.T) {
 	require.NoError(t, err)
 	err = c.pushLogData(context.Background(), profilingData)
 	require.NoError(t, err)
-	assert.Equal(t, 30, len(*headers))
+	assert.Len(t, *headers, 30)
 
 	profilingCount, nonProfilingCount := 0, 0
 	for i := range *headers {

--- a/exporter/splunkhecexporter/integration_test.go
+++ b/exporter/splunkhecexporter/integration_test.go
@@ -252,7 +252,7 @@ func logsTest(t *testing.T, config *Config, url *url.URL, test testCfg) {
 	waitForEventToBeIndexed()
 
 	events := integrationtestutils.CheckEventsFromSplunk("index="+test.config.index+" *", test.startTime)
-	assert.Equal(t, len(events), 1)
+	assert.Len(t, events, 1)
 	// check events fields
 	data, ok := events[0].(map[string]any)
 	assert.True(t, ok, "Invalid event format")
@@ -275,7 +275,7 @@ func metricsTest(t *testing.T, config *Config, url *url.URL, test testCfg) {
 	waitForEventToBeIndexed()
 
 	events := integrationtestutils.CheckMetricsFromSplunk(test.config.index, test.config.event)
-	assert.Equal(t, len(events), 1, "Events length is less than 1. No metrics found")
+	assert.Len(t, events, 1, "Events length is less than 1. No metrics found")
 }
 
 func tracesTest(t *testing.T, config *Config, url *url.URL, test testCfg) {
@@ -291,7 +291,7 @@ func tracesTest(t *testing.T, config *Config, url *url.URL, test testCfg) {
 	waitForEventToBeIndexed()
 
 	events := integrationtestutils.CheckEventsFromSplunk("index="+test.config.index+" *", test.startTime)
-	assert.Equal(t, len(events), 1)
+	assert.Len(t, events, 1)
 	// check fields
 	data, ok := events[0].(map[string]any)
 	assert.True(t, ok, "Invalid event format")

--- a/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice_test.go
+++ b/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice_test.go
@@ -89,7 +89,7 @@ func TestConvertLogs(t *testing.T) {
 	totalLogCount := 10
 	validLogCount := totalLogCount - 1
 	gotLogs := convertLogs(createLogData(10))
-	assert.Equal(t, len(gotLogs), 9)
+	assert.Len(t, gotLogs, 9)
 
 	gotLogPairs := make([][]logKeyValuePair, 0, len(gotLogs))
 

--- a/extension/ackextension/inmemory_test.go
+++ b/extension/ackextension/inmemory_test.go
@@ -83,7 +83,7 @@ func TestExtensionAck_ProcessEvents_Concurrency(t *testing.T) {
 	maps.Copy(map1, map2)
 	maps.Copy(map1, map3)
 
-	require.Equal(t, len(map1), 300)
+	require.Len(t, map1, 300)
 }
 
 func TestExtensionAck_ProcessEvents_EventsUnAcked(t *testing.T) {
@@ -104,7 +104,7 @@ func TestExtensionAck_ProcessEvents_EventsUnAcked(t *testing.T) {
 	// non-acked events should be return false
 	for i := 0; i < 100; i++ {
 		result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{0, 1, 2})
-		require.Equal(t, len(result), 3)
+		require.Len(t, result, 3)
 		require.False(t, result[0])
 		require.False(t, result[1])
 		require.False(t, result[2])
@@ -140,13 +140,13 @@ func TestExtensionAck_ProcessEvents_EventsAcked(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		if i%2 == 0 {
 			result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-			require.Equal(t, len(result), 3)
+			require.Len(t, result, 3)
 			require.False(t, result[1])
 			require.True(t, result[2])
 			require.False(t, result[3])
 		} else {
 			result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-			require.Equal(t, len(result), 3)
+			require.Len(t, result, 3)
 			require.True(t, result[1])
 			require.False(t, result[2])
 			require.True(t, result[3])
@@ -183,13 +183,13 @@ func TestExtensionAck_QueryAcks_Unidempotent(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		if i%2 == 0 {
 			result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-			require.Equal(t, len(result), 3)
+			require.Len(t, result, 3)
 			require.False(t, result[1])
 			require.True(t, result[2])
 			require.False(t, result[3])
 		} else {
 			result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-			require.Equal(t, len(result), 3)
+			require.Len(t, result, 3)
 			require.True(t, result[1])
 			require.False(t, result[2])
 			require.True(t, result[3])
@@ -199,7 +199,7 @@ func TestExtensionAck_QueryAcks_Unidempotent(t *testing.T) {
 	// querying the same acked events should result in false
 	for i := 0; i < 100; i++ {
 		result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-		require.Equal(t, len(result), 3)
+		require.Len(t, result, 3)
 		require.False(t, result[1])
 		require.False(t, result[2])
 		require.False(t, result[3])
@@ -233,7 +233,7 @@ func TestExtensionAckAsync(t *testing.T) {
 	// non-acked events should be return false
 	for i := 0; i < partitionCount; i++ {
 		result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-		require.Equal(t, len(result), 3)
+		require.Len(t, result, 3)
 		require.False(t, result[1])
 		require.False(t, result[2])
 		require.False(t, result[3])
@@ -259,13 +259,13 @@ func TestExtensionAckAsync(t *testing.T) {
 	for i := 0; i < partitionCount; i++ {
 		if i%2 == 0 {
 			result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-			require.Equal(t, len(result), 3)
+			require.Len(t, result, 3)
 			require.False(t, result[1])
 			require.True(t, result[2])
 			require.False(t, result[3])
 		} else {
 			result := ext.QueryAcks(fmt.Sprintf("part-%d", i), []uint64{1, 2, 3})
-			require.Equal(t, len(result), 3)
+			require.Len(t, result, 3)
 			require.True(t, result[1])
 			require.False(t, result[2])
 			require.True(t, result[3])
@@ -285,7 +285,7 @@ func TestExtensionAckAsync(t *testing.T) {
 
 	for i := 0; i < partitionCount; i++ {
 		result := <-resultChan
-		require.Equal(t, len(result), 3)
+		require.Len(t, result, 3)
 		require.False(t, result[1])
 		require.False(t, result[2])
 		require.False(t, result[3])

--- a/extension/observer/ecsobserver/fetcher_test.go
+++ b/extension/observer/ecsobserver/fetcher_test.go
@@ -65,7 +65,7 @@ func TestFetcher_FetchAndDecorate(t *testing.T) {
 	ctx := context.Background()
 	tasks, err := f.fetchAndDecorate(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, nTasks, len(tasks))
+	assert.Len(t, tasks, nTasks)
 	assert.Equal(t, "s0", aws.StringValue(tasks[0].Service.ServiceArn))
 }
 
@@ -78,7 +78,7 @@ func TestFetcher_GetDiscoverableTasks(t *testing.T) {
 		ctx := context.Background()
 		tasks, err := f.getDiscoverableTasks(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, nTasks, len(tasks))
+		assert.Len(t, tasks, nTasks)
 	})
 
 	t.Run("with non discoverable tasks", func(t *testing.T) {
@@ -106,7 +106,7 @@ func TestFetcher_GetDiscoverableTasks(t *testing.T) {
 		require.NoError(t, err)
 
 		// Expect 2 tasks, with LaunchType Fargate and EC2 with non-nil ContainerInstanceArn
-		assert.Equal(t, 2, len(tasks))
+		assert.Len(t, tasks, 2)
 		assert.Equal(t, ecs.LaunchTypeFargate, aws.StringValue(tasks[0].LaunchType))
 		assert.Equal(t, ecs.LaunchTypeEc2, aws.StringValue(tasks[1].LaunchType))
 	})
@@ -178,7 +178,7 @@ func TestFetcher_AttachContainerInstance(t *testing.T) {
 		ctx := context.Background()
 		rawTasks, err := f.getDiscoverableTasks(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, nTasks, len(rawTasks))
+		assert.Len(t, rawTasks, nTasks)
 
 		tasks, err := f.attachTaskDefinition(ctx, rawTasks)
 		require.NoError(t, err)
@@ -216,7 +216,7 @@ func TestFetcher_AttachContainerInstance(t *testing.T) {
 		ctx := context.Background()
 		rawTasks, err := f.getDiscoverableTasks(ctx)
 		require.NoError(t, err)
-		assert.Equal(t, nTasks, len(rawTasks))
+		assert.Len(t, rawTasks, nTasks)
 
 		tasks, err := f.attachTaskDefinition(ctx, rawTasks)
 		require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestFetcher_GetAllServices(t *testing.T) {
 	ctx := context.Background()
 	services, err := f.getAllServices(ctx)
 	require.NoError(t, err)
-	assert.Equal(t, nServices, len(services))
+	assert.Len(t, services, nServices)
 }
 
 func TestFetcher_AttachService(t *testing.T) {

--- a/extension/observer/ecsobserver/internal/ecsmock/service_test.go
+++ b/extension/observer/ecsobserver/internal/ecsmock/service_test.go
@@ -158,7 +158,7 @@ func TestCluster_DescribeInstancesWithContext(t *testing.T) {
 		req := &ec2.DescribeInstancesInput{InstanceIds: ids}
 		res, err := c.DescribeInstancesWithContext(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, nIDs, len(res.Reservations[0].Instances))
+		assert.Len(t, res.Reservations[0].Instances, nIDs)
 	})
 
 	t.Run("invalid id", func(t *testing.T) {
@@ -198,8 +198,8 @@ func TestCluster_DescribeContainerInstancesWithContext(t *testing.T) {
 		req := &ecs.DescribeContainerInstancesInput{ContainerInstances: ids}
 		res, err := c.DescribeContainerInstancesWithContext(ctx, req)
 		require.NoError(t, err)
-		assert.Equal(t, nIDs, len(res.ContainerInstances))
-		assert.Equal(t, 0, len(res.Failures))
+		assert.Len(t, res.ContainerInstances, nIDs)
+		assert.Len(t, res.Failures, 0)
 	})
 
 	t.Run("not found", func(t *testing.T) {

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -80,7 +80,7 @@ func TestHostObserver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			hostPorts, notifier := tt.setup()
 			if tt.errorListingConnections {
-				require.Equal(t, len(notifier.endpointsMap), 0)
+				require.Len(t, notifier.endpointsMap, 0)
 				return
 			}
 

--- a/extension/opampextension/registry_test.go
+++ b/extension/opampextension/registry_test.go
@@ -101,7 +101,7 @@ func TestRegistry_ProcessMessage(t *testing.T) {
 		// If we did not skip sending on blocked channels, we'd expect this to never return.
 		registry.ProcessMessage(customMessage)
 
-		require.Equal(t, 0, len(sender.Message()))
+		require.Len(t, sender.Message(), 0)
 	})
 
 	t.Run("Callback is called only for its own capability", func(t *testing.T) {

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -326,7 +326,7 @@ func TestCompaction(t *testing.T) {
 
 	files, err := os.ReadDir(tempDir)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(files))
+	require.Len(t, files, 1)
 
 	file := files[0]
 	path := filepath.Join(tempDir, file.Name())
@@ -417,7 +417,7 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	// check if only db exists in tempDir
 	files, err := os.ReadDir(tempDir)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(files))
+	require.Len(t, files, 1)
 	fileName := files[0].Name()
 
 	// perform compaction in the same directory
@@ -432,7 +432,7 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	// check if only db exists in tempDir
 	files, err = os.ReadDir(tempDir)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(files))
+	require.Len(t, files, 1)
 	require.Equal(t, fileName, files[0].Name())
 
 	// perform compaction in different directory
@@ -449,7 +449,7 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	// check if emptyTempDir is empty after compaction
 	files, err = os.ReadDir(emptyTempDir)
 	require.NoError(t, err)
-	require.Equal(t, 0, len(files))
+	require.Len(t, files, 0)
 }
 
 func TestCleanupOnStart(t *testing.T) {
@@ -485,7 +485,7 @@ func TestCleanupOnStart(t *testing.T) {
 
 	files, err := os.ReadDir(tempDir)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(files))
+	require.Len(t, files, 1)
 }
 
 func TestCompactionOnStart(t *testing.T) {

--- a/extension/storage/storagetest/host_test.go
+++ b/extension/storage/storagetest/host_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestStorageHostWithNone(t *testing.T) {
-	require.Equal(t, 0, len(NewStorageHost().GetExtensions()))
+	require.Len(t, NewStorageHost().GetExtensions(), 0)
 }
 
 func TestStorageHostWithOne(t *testing.T) {
@@ -20,7 +20,7 @@ func TestStorageHostWithOne(t *testing.T) {
 	host := NewStorageHost().WithInMemoryStorageExtension("one")
 
 	exts := host.GetExtensions()
-	require.Equal(t, 1, len(exts))
+	require.Len(t, exts, 1)
 
 	extOne, exists := exts[storageID]
 	require.True(t, exists)
@@ -39,7 +39,7 @@ func TestStorageHostWithTwo(t *testing.T) {
 		WithFileBackedStorageExtension("two", t.TempDir())
 
 	exts := host.GetExtensions()
-	require.Equal(t, 2, len(exts))
+	require.Len(t, exts, 2)
 
 	extOne, exists := exts[storageOneID]
 	require.True(t, exists)
@@ -67,7 +67,7 @@ func TestStorageHostWithMixed(t *testing.T) {
 		WithNonStorageExtension("non-storage")
 
 	exts := host.GetExtensions()
-	require.Equal(t, 3, len(exts))
+	require.Len(t, exts, 3)
 
 	extOne, exists := exts[storageOneID]
 	require.True(t, exists)

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -32,7 +32,7 @@ func TestValidateLogEventWithMutating(t *testing.T) {
 	err := logEvent.Validate(zap.NewNop())
 	assert.NoError(t, err)
 	assert.True(t, *logEvent.InputLogEvent.Timestamp > int64(0))
-	assert.Equal(t, 64-perEventHeaderBytes, len(*logEvent.InputLogEvent.Message))
+	assert.Len(t, *logEvent.InputLogEvent.Message, 64-perEventHeaderBytes)
 
 	maxEventPayloadBytes = defaultMaxEventPayloadBytes
 }
@@ -133,7 +133,7 @@ func TestPusher_newLogEventBatch(t *testing.T) {
 	assert.Equal(t, int64(0), logEventBatch.maxTimestampMs)
 	assert.Equal(t, int64(0), logEventBatch.minTimestampMs)
 	assert.Equal(t, 0, logEventBatch.byteTotal)
-	assert.Equal(t, 0, len(logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, logEventBatch.putLogEventsInput.LogEvents, 0)
 	assert.Equal(t, p.logStreamName, logEventBatch.putLogEventsInput.LogStreamName)
 	assert.Equal(t, p.logGroupName, logEventBatch.putLogEventsInput.LogGroupName)
 	assert.Equal(t, (*string)(nil), logEventBatch.putLogEventsInput.SequenceToken)
@@ -149,29 +149,29 @@ func TestPusher_addLogEventBatch(t *testing.T) {
 		p.logEventBatch.putLogEventsInput.LogEvents = append(p.logEventBatch.putLogEventsInput.LogEvents, logEvent.InputLogEvent)
 	}
 
-	assert.Equal(t, c, len(p.logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, c)
 
 	assert.NotNil(t, p.addLogEvent(logEvent))
 	// the actual log event add operation happens after the func newLogEventBatchIfNeeded
-	assert.Equal(t, 1, len(p.logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, 1)
 
 	p.logEventBatch.byteTotal = maxRequestPayloadBytes - logEvent.eventPayloadBytes() + 1
 	assert.NotNil(t, p.addLogEvent(logEvent))
-	assert.Equal(t, 1, len(p.logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, 1)
 
 	p.logEventBatch.minTimestampMs, p.logEventBatch.maxTimestampMs = timestampMs, timestampMs
 	assert.NotNil(t, p.addLogEvent(NewEvent(timestampMs+(time.Hour*24+time.Millisecond*1).Nanoseconds()/1e6, msg)))
-	assert.Equal(t, 1, len(p.logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, 1)
 
 	assert.Nil(t, p.addLogEvent(nil))
-	assert.Equal(t, 1, len(p.logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, 1)
 
 	assert.NotNil(t, p.addLogEvent(logEvent))
-	assert.Equal(t, 1, len(p.logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, 1)
 
 	p.logEventBatch.byteTotal = 1
 	assert.Nil(t, p.addLogEvent(nil))
-	assert.Equal(t, 1, len(p.logEventBatch.putLogEventsInput.LogEvents))
+	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, 1)
 
 }
 
@@ -256,8 +256,8 @@ func TestMultiStreamPusher(t *testing.T) {
 	mockCwAPI.AssertNumberOfCalls(t, "CreateLogStream", 1)
 	mockCwAPI.AssertNumberOfCalls(t, "PutLogEvents", 1)
 
-	assert.Equal(t, 1, len(inputs))
-	assert.Equal(t, 2, len(inputs[0].LogEvents))
+	assert.Len(t, inputs, 1)
+	assert.Len(t, inputs[0].LogEvents, 2)
 	assert.Equal(t, "foo", *inputs[0].LogGroupName)
 	assert.Equal(t, "bar", *inputs[0].LogStreamName)
 
@@ -272,8 +272,8 @@ func TestMultiStreamPusher(t *testing.T) {
 	mockCwAPI.AssertNumberOfCalls(t, "CreateLogStream", 2)
 	mockCwAPI.AssertNumberOfCalls(t, "PutLogEvents", 2)
 
-	assert.Equal(t, 2, len(inputs))
-	assert.Equal(t, 1, len(inputs[1].LogEvents))
+	assert.Len(t, inputs, 2)
+	assert.Len(t, inputs[1].LogEvents, 1)
 	assert.Equal(t, "foo", *inputs[1].LogGroupName)
 	assert.Equal(t, "bar2", *inputs[1].LogStreamName)
 }

--- a/internal/aws/ecsutil/client_test.go
+++ b/internal/aws/ecsutil/client_test.go
@@ -30,7 +30,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, "hello", string(resp))
 	require.True(t, tr.closed)
 	require.Equal(t, baseURL.String()+"/stats", tr.url)
-	require.Equal(t, 1, len(tr.header))
+	require.Len(t, tr.header, 1)
 	require.Equal(t, "application/json", tr.header["Content-Type"][0])
 	require.Equal(t, "GET", tr.method)
 }

--- a/internal/aws/ecsutil/metadata_provider_test.go
+++ b/internal/aws/ecsutil/metadata_provider_test.go
@@ -41,7 +41,7 @@ func Test_ecsMetadata_fetchTask(t *testing.T) {
 	assert.Equal(t, "ec2", fetchResp.LaunchType)
 	assert.Equal(t, "us-west-2a", fetchResp.AvailabilityZone)
 	assert.Equal(t, "1", fetchResp.Revision)
-	assert.Equal(t, 3, len(fetchResp.Containers))
+	assert.Len(t, fetchResp.Containers, 3)
 }
 
 func Test_ecsMetadata_fetchContainer(t *testing.T) {

--- a/internal/aws/k8s/k8sclient/clientset_test.go
+++ b/internal/aws/k8s/k8sclient/clientset_test.go
@@ -19,7 +19,7 @@ func TestGetShutdown(t *testing.T) {
 		InitSyncPollInterval(10*time.Nanosecond),
 		InitSyncPollTimeout(20*time.Nanosecond),
 	)
-	assert.Equal(t, 1, len(optionsToK8sClient))
+	assert.Len(t, optionsToK8sClient, 1)
 	assert.NotNil(t, k8sClient.GetClientSet())
 	assert.NotNil(t, k8sClient.GetEpClient())
 	assert.NotNil(t, k8sClient.GetJobClient())
@@ -32,6 +32,6 @@ func TestGetShutdown(t *testing.T) {
 	assert.Nil(t, k8sClient.node)
 	assert.Nil(t, k8sClient.pod)
 	assert.Nil(t, k8sClient.replicaSet)
-	assert.Equal(t, 0, len(optionsToK8sClient))
+	assert.Len(t, optionsToK8sClient, 0)
 	removeTempKubeConfig()
 }

--- a/internal/aws/k8s/k8sclient/obj_store_test.go
+++ b/internal/aws/k8s/k8sclient/obj_store_test.go
@@ -68,7 +68,7 @@ func TestGetList(t *testing.T) {
 		"20036b33-cb03-489b-b778-e516b4dae519": "a",
 	}
 	val := o.List()
-	assert.Equal(t, 1, len(val))
+	assert.Len(t, val, 1)
 	expected := o.objs["20036b33-cb03-489b-b778-e516b4dae519"]
 	assert.Equal(t, expected, val[0])
 }
@@ -119,7 +119,7 @@ func TestDelete(t *testing.T) {
 	assert.True(t, o.refreshed)
 
 	keys := o.ListKeys()
-	assert.Equal(t, 1, len(keys))
+	assert.Len(t, keys, 1)
 	assert.Equal(t, "75ab40d2-552a-4c05-82c9-0ddcb3008657", keys[0])
 }
 
@@ -174,11 +174,11 @@ func TestUpdate(t *testing.T) {
 	assert.NoError(t, err)
 
 	keys := o.ListKeys()
-	assert.Equal(t, 1, len(keys))
+	assert.Len(t, keys, 1)
 	assert.Equal(t, "bc5f5839-f62e-44b9-a79e-af250d92dcb1", keys[0])
 
 	values := o.List()
-	assert.Equal(t, 1, len(values))
+	assert.Len(t, values, 1)
 	assert.Equal(t, updatedObj, values[0])
 }
 

--- a/internal/aws/xray/telemetry/sender_test.go
+++ b/internal/aws/xray/telemetry/sender_test.go
@@ -113,10 +113,10 @@ func TestQueueOverflow(t *testing.T) {
 	}
 	// number of dropped records
 	assert.Equal(t, 5, logs.Len())
-	assert.Equal(t, 20, len(sender.queue))
+	assert.Len(t, sender.queue, 20)
 	sender.send()
 	// only one batch succeeded
-	assert.Equal(t, 15, len(sender.queue))
+	assert.Len(t, sender.queue, 15)
 	// verify that sent back of queue
 	for _, record := range sender.queue {
 		assert.Greater(t, *record.SegmentsSentCount, int64(5))

--- a/internal/common/testutil/testutil.go
+++ b/internal/common/testutil/testutil.go
@@ -110,14 +110,14 @@ func createExclusionsList(t testing.TB, exclusionsText string) []portpair {
 	var exclusions []portpair
 
 	parts := strings.Split(exclusionsText, "--------")
-	require.Equal(t, len(parts), 3)
+	require.Len(t, parts, 3)
 	portsText := strings.Split(parts[2], "*")
 	require.Greater(t, len(portsText), 1) // original text may have a suffix like " - Administered port exclusions."
 	lines := strings.Split(portsText[0], "\n")
 	for _, line := range lines {
 		if strings.TrimSpace(line) != "" {
 			entries := strings.Fields(strings.TrimSpace(line))
-			require.Equal(t, len(entries), 2)
+			require.Len(t, entries, 2)
 			pair := portpair{entries[0], entries[1]}
 			exclusions = append(exclusions, pair)
 		}

--- a/internal/common/testutil/testutil_test.go
+++ b/internal/common/testutil/testutil_test.go
@@ -63,8 +63,8 @@ Start Port    End Port
 * - Administered port exclusions.
 `
 	exclusions := createExclusionsList(t, exclusionsText)
-	require.Equal(t, len(exclusions), 2)
+	require.Len(t, exclusions, 2)
 
 	emptyExclusions := createExclusionsList(t, emptyExclusionsText)
-	require.Equal(t, len(emptyExclusions), 0)
+	require.Len(t, emptyExclusions, 0)
 }

--- a/internal/coreinternal/consumerretry/logs_test.go
+++ b/internal/coreinternal/consumerretry/logs_test.go
@@ -65,7 +65,7 @@ func TestConsumeLogs(t *testing.T) {
 			err := consumer.ConsumeLogs(context.Background(), testdata.GenerateLogsTwoLogRecordsSameResource())
 			assert.Equal(t, tt.expectedErr, err)
 			if err == nil {
-				assert.Equal(t, 1, len(tt.consumer.AllLogs()))
+				assert.Len(t, tt.consumer.AllLogs(), 1)
 				assert.Equal(t, 2, tt.consumer.AllLogs()[0].LogRecordCount())
 				if tt.consumer.acceptAfter > 0 {
 					assert.Equal(t, tt.consumer.rejectCount.Load(), tt.consumer.acceptAfter)
@@ -106,7 +106,7 @@ func TestConsumeLogs_PartialRetry(t *testing.T) {
 	assert.NoError(t, consumer.ConsumeLogs(context.Background(), logs))
 
 	// Verify the logs batch is broken into two parts, one with the partial error and one without.
-	assert.Equal(t, 2, len(sink.AllLogs()))
+	assert.Len(t, sink.AllLogs(), 2)
 	assert.Equal(t, 1, sink.AllLogs()[0].ResourceLogs().Len())
 	assert.Equal(t, 2, sink.AllLogs()[0].LogRecordCount())
 	assert.Equal(t, 1, sink.AllLogs()[1].ResourceLogs().Len())

--- a/internal/coreinternal/goldendataset/pict_metrics_gen_test.go
+++ b/internal/coreinternal/goldendataset/pict_metrics_gen_test.go
@@ -14,7 +14,7 @@ import (
 func TestGenerateMetricDatas(t *testing.T) {
 	mds, err := GenerateMetrics("testdata/generated_pict_pairs_metrics.txt")
 	require.NoError(t, err)
-	require.Equal(t, 25, len(mds))
+	require.Len(t, mds, 25)
 }
 
 func TestPICTtoCfg(t *testing.T) {

--- a/internal/coreinternal/goldendataset/traces_generator_test.go
+++ b/internal/coreinternal/goldendataset/traces_generator_test.go
@@ -13,5 +13,5 @@ func TestGenerateTraces(t *testing.T) {
 	rscSpans, err := GenerateTraces("testdata/generated_pict_pairs_traces.txt",
 		"testdata/generated_pict_pairs_spans.txt")
 	assert.NoError(t, err)
-	assert.Equal(t, 32, len(rscSpans))
+	assert.Len(t, rscSpans, 32)
 }

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -72,7 +72,7 @@ func TestWatchingTimeouts(t *testing.T) {
 	cnt, ofInterest := cli.inspectedContainerIsOfInterest(context.Background(), "SomeContainerId")
 	assert.False(t, ofInterest)
 	assert.Nil(t, cnt)
-	assert.Equal(t, 1, len(logs.All()))
+	assert.Len(t, logs.All(), 1)
 	for _, l := range logs.All() {
 		assert.Contains(t, l.ContextMap()["error"], expectedError)
 	}
@@ -124,7 +124,7 @@ func TestFetchingTimeouts(t *testing.T) {
 
 	assert.Contains(t, err.Error(), expectedError)
 
-	assert.Equal(t, 1, len(logs.All()))
+	assert.Len(t, logs.All(), 1)
 	for _, l := range logs.All() {
 		assert.Contains(t, l.ContextMap()["error"], expectedError)
 	}

--- a/internal/filter/filterset/regexp/regexpfilterset_test.go
+++ b/internal/filter/filterset/regexp/regexpfilterset_test.go
@@ -109,7 +109,7 @@ func TestRegexpDeDup(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, fs)
 	assert.Nil(t, fs.cache)
-	assert.EqualValues(t, 1, len(fs.regexes))
+	assert.Len(t, fs.regexes, 1)
 }
 
 func TestRegexpMatchesCaches(t *testing.T) {

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -45,7 +45,7 @@ func TestClient(t *testing.T) {
 	require.Equal(t, "hello", string(resp))
 	require.True(t, tr.closed)
 	require.Equal(t, baseURL+"/foo", tr.url)
-	require.Equal(t, 1, len(tr.header))
+	require.Len(t, tr.header, 1)
 	require.Equal(t, "application/json", tr.header["Content-Type"][0])
 	require.Equal(t, "GET", tr.method)
 }
@@ -66,7 +66,7 @@ func TestNewTLSClientProvider(t *testing.T) {
 	require.NoError(t, err)
 	c := client.(*clientImpl)
 	tcc := c.httpClient.Transport.(*http.Transport).TLSClientConfig
-	require.Equal(t, 1, len(tcc.Certificates))
+	require.Len(t, tcc.Certificates, 1)
 	require.NotNil(t, tcc.RootCAs)
 }
 

--- a/internal/otelarrow/testutil/testutil.go
+++ b/internal/otelarrow/testutil/testutil.go
@@ -86,14 +86,14 @@ func createExclusionsList(exclusionsText string, t testing.TB) []portpair {
 	var exclusions []portpair
 
 	parts := strings.Split(exclusionsText, "--------")
-	require.Equal(t, len(parts), 3)
+	require.Len(t, parts, 3)
 	portsText := strings.Split(parts[2], "*")
 	require.Greater(t, len(portsText), 1) // original text may have a suffix like " - Administered port exclusions."
 	lines := strings.Split(portsText[0], "\n")
 	for _, line := range lines {
 		if strings.TrimSpace(line) != "" {
 			entries := strings.Fields(strings.TrimSpace(line))
-			require.Equal(t, len(entries), 2)
+			require.Len(t, entries, 2)
 			pair := portpair{entries[0], entries[1]}
 			exclusions = append(exclusions, pair)
 		}

--- a/internal/otelarrow/testutil/testutil_test.go
+++ b/internal/otelarrow/testutil/testutil_test.go
@@ -50,8 +50,8 @@ Start Port    End Port
 * - Administered port exclusions.
 `
 	exclusions := createExclusionsList(exclusionsText, t)
-	require.Equal(t, len(exclusions), 2)
+	require.Len(t, exclusions, 2)
 
 	emptyExclusions := createExclusionsList(emptyExclusionsText, t)
-	require.Equal(t, len(emptyExclusions), 0)
+	require.Len(t, emptyExclusions, 0)
 }

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -2247,7 +2247,7 @@ func Test_basePath_Keys(t *testing.T) {
 		},
 	}
 	ks := bp.Keys()
-	assert.Equal(t, 1, len(ks))
+	assert.Len(t, ks, 1)
 	assert.Equal(t, k, ks[0])
 }
 
@@ -2375,7 +2375,7 @@ func Test_newPath(t *testing.T) {
 	assert.Equal(t, "string", p.Name())
 	assert.Equal(t, "body.string[key]", p.String())
 	assert.Nil(t, p.Next())
-	assert.Equal(t, 1, len(p.Keys()))
+	assert.Len(t, p.Keys(), 1)
 	v, err := p.Keys()[0].String(context.Background(), struct{}{})
 	assert.NoError(t, err)
 	assert.Equal(t, "key", *v)
@@ -2415,7 +2415,7 @@ func Test_newKey(t *testing.T) {
 	}
 	ks := newKeys[any](keys)
 
-	assert.Equal(t, 2, len(ks))
+	assert.Len(t, ks, 2)
 
 	s, err := ks[0].String(context.Background(), nil)
 	assert.NoError(t, err)

--- a/pkg/stanza/adapter/frompdataconverter_test.go
+++ b/pkg/stanza/adapter/frompdataconverter_test.go
@@ -155,7 +155,7 @@ func BenchmarkFromPdataConverter(b *testing.B) {
 							break forLoop
 						}
 
-						require.Equal(b, 250_000, len(entries))
+						require.Len(b, entries, 250_000)
 						n += len(entries)
 
 					case <-timeoutTimer.C:

--- a/pkg/stanza/fileconsumer/attrs/attrs_test.go
+++ b/pkg/stanza/fileconsumer/attrs/attrs_test.go
@@ -86,7 +86,7 @@ func TestResolver(t *testing.T) {
 				assert.Empty(t, attributes[LogFileOwnerGroupName])
 				assert.Empty(t, attributes[LogFileOwnerGroupName])
 			}
-			assert.Equal(t, expectLen, len(attributes))
+			assert.Len(t, attributes, expectLen)
 		})
 	}
 }

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -1351,7 +1351,7 @@ func TestStalePartialFingerprintDiscarded(t *testing.T) {
 	operator.wg.Wait()
 	if runtime.GOOS != "windows" {
 		// On windows, we never keep files in previousPollFiles, so we don't expect to see them here
-		require.Equal(t, len(operator.tracker.PreviousPollFiles()), 1)
+		require.Len(t, operator.tracker.PreviousPollFiles(), 1)
 	}
 
 	// keep append data to file1 and file2

--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
@@ -134,7 +134,7 @@ func TestNewFromFile(t *testing.T) {
 			fp, err := NewFromFile(temp, tc.fingerprintSize)
 			require.NoError(t, err)
 
-			require.Equal(t, tc.expectedLen, len(fp.firstBytes))
+			require.Len(t, fp.firstBytes, tc.expectedLen)
 		})
 	}
 }

--- a/pkg/stanza/fileconsumer/internal/reader/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/reader/fingerprint_test.go
@@ -296,7 +296,7 @@ func (tc updateFingerprintTest) run(bufferSize int) func(*testing.T) {
 
 		i, err := temp.Write(tc.moreBytes)
 		require.NoError(t, err)
-		require.Equal(t, i, len(tc.moreBytes))
+		require.Len(t, tc.moreBytes, i)
 
 		r.ReadToEnd(context.Background())
 

--- a/pkg/stanza/operator/helper/emitter_test.go
+++ b/pkg/stanza/operator/helper/emitter_test.go
@@ -63,7 +63,7 @@ func TestLogEmitterEmitsOnMaxBatchSize(t *testing.T) {
 
 	select {
 	case recv := <-emitter.logChan:
-		require.Equal(t, maxBatchSize, len(recv), "Length of received entries was not the same as max batch size!")
+		require.Len(t, recv, maxBatchSize, "Length of received entries was not the same as max batch size!")
 	case <-timeoutChan:
 		require.FailNow(t, "Failed to receive log entries before timeout")
 	}
@@ -92,7 +92,7 @@ func TestLogEmitterEmitsOnFlushInterval(t *testing.T) {
 
 	select {
 	case recv := <-emitter.logChan:
-		require.Equal(t, 1, len(recv), "Should have received one entry, got %d instead", len(recv))
+		require.Len(t, recv, 1, "Should have received one entry, got %d instead", len(recv))
 	case <-timeoutChan:
 		require.FailNow(t, "Failed to receive log entry before timeout")
 	}

--- a/pkg/stanza/operator/input/windows/buffer_test.go
+++ b/pkg/stanza/operator/input/windows/buffer_test.go
@@ -46,13 +46,13 @@ func TestBufferReadString(t *testing.T) {
 func TestBufferUpdateSize(t *testing.T) {
 	buffer := NewBuffer()
 	buffer.UpdateSizeBytes(1)
-	require.Equal(t, 1, len(buffer.buffer))
+	require.Len(t, buffer.buffer, 1)
 }
 
 func TestBufferUpdateSizeWide(t *testing.T) {
 	buffer := NewBuffer()
 	buffer.UpdateSizeWide(1)
-	require.Equal(t, 2, len(buffer.buffer))
+	require.Len(t, buffer.buffer, 2)
 }
 
 func TestBufferSize(t *testing.T) {

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -950,9 +950,9 @@ func TestSourceBatchDelete(t *testing.T) {
 	ctx := context.Background()
 
 	require.NoError(t, recombine.Process(ctx, start))
-	require.Equal(t, 1, len(recombine.batchMap))
+	require.Len(t, recombine.batchMap, 1)
 	require.NoError(t, recombine.Process(ctx, next))
-	require.Equal(t, 0, len(recombine.batchMap))
+	require.Len(t, recombine.batchMap, 0)
 	fake.ExpectEntry(t, expect)
 	require.NoError(t, recombine.Stop())
 }

--- a/pkg/stanza/pipeline/config_test.go
+++ b/pkg/stanza/pipeline/config_test.go
@@ -29,7 +29,7 @@ func TestBuildPipelineSuccess(t *testing.T) {
 	set := componenttest.NewNopTelemetrySettings()
 	pipe, err := cfg.Build(set)
 	require.NoError(t, err)
-	require.Equal(t, 1, len(pipe.Operators()))
+	require.Len(t, pipe.Operators(), 1)
 }
 
 func TestBuildPipelineNoLogger(t *testing.T) {
@@ -86,22 +86,22 @@ func TestBuildAPipelineDefaultOperator(t *testing.T) {
 	require.NoError(t, err)
 
 	ops := pipe.Operators()
-	require.Equal(t, 3, len(ops))
+	require.Len(t, ops, 3)
 
 	exists := make(map[string]bool)
 
 	for _, op := range ops {
 		switch op.ID() {
 		case "noop":
-			require.Equal(t, 1, len(op.GetOutputIDs()))
+			require.Len(t, op.GetOutputIDs(), 1)
 			require.Equal(t, "noop1", op.GetOutputIDs()[0])
 			exists["noop"] = true
 		case "noop1":
-			require.Equal(t, 1, len(op.GetOutputIDs()))
+			require.Len(t, op.GetOutputIDs(), 1)
 			require.Equal(t, "fake", op.GetOutputIDs()[0])
 			exists["noop1"] = true
 		case "fake":
-			require.Equal(t, 0, len(op.GetOutputIDs()))
+			require.Len(t, op.GetOutputIDs(), 0)
 			exists["fake"] = true
 		}
 	}
@@ -375,7 +375,7 @@ func TestUpdateOutputIDs(t *testing.T) {
 			if tc.defaultOut != nil {
 				expectedNumOps++
 			}
-			require.Equal(t, expectedNumOps, len(ops))
+			require.Len(t, ops, expectedNumOps)
 
 			for i := 0; i < len(ops); i++ {
 				id := ops[i].ID()

--- a/pkg/translator/jaeger/traces_to_jaegerproto_test.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto_test.go
@@ -335,7 +335,7 @@ func TestInternalTracesToJaegerProto(t *testing.T) {
 			if test.jb == nil {
 				assert.Len(t, jbs, 0)
 			} else {
-				require.Equal(t, 1, len(jbs))
+				require.Len(t, jbs, 1)
 				assert.EqualValues(t, test.jb, jbs[0])
 			}
 		})

--- a/pkg/translator/opencensus/traces_to_oc_test.go
+++ b/pkg/translator/opencensus/traces_to_oc_test.go
@@ -345,7 +345,7 @@ func TestInternalTracesToOCTracesAndBack(t *testing.T) {
 	assert.NoError(t, err)
 	for _, td := range tds {
 		ocNode, ocResource, ocSpans := ResourceSpansToOC(td.ResourceSpans().At(0))
-		assert.Equal(t, td.SpanCount(), len(ocSpans))
+		assert.Len(t, ocSpans, td.SpanCount())
 		tdFromOC := OCToTraces(ocNode, ocResource, ocSpans)
 		assert.NotNil(t, tdFromOC)
 		assert.Equal(t, td.SpanCount(), tdFromOC.SpanCount())

--- a/pkg/translator/signalfx/to_metrics_test.go
+++ b/pkg/translator/signalfx/to_metrics_test.go
@@ -225,7 +225,7 @@ func TestToMetrics(t *testing.T) {
 				targetLen := 2*len(pt.Dimensions) + 1
 				dimensions := make([]*sfxpb.Dimension, targetLen)
 				copy(dimensions[1:], pt.Dimensions)
-				assert.Equal(t, targetLen, len(dimensions))
+				assert.Len(t, dimensions, targetLen)
 				assert.Nil(t, dimensions[0])
 				pt.Dimensions = dimensions
 				return []*sfxpb.DataPoint{pt}

--- a/pkg/translator/skywalking/skywalkingproto_to_traces_test.go
+++ b/pkg/translator/skywalking/skywalkingproto_to_traces_test.go
@@ -69,7 +69,7 @@ func TestSwKvPairsToInternalAttributes(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			swKvPairsToInternalAttributes(test.swSpan.GetSpans()[0].Tags, test.dest.Attributes())
-			assert.Equal(t, test.dest.Attributes().Len(), len(test.swSpan.GetSpans()[0].Tags))
+			assert.Len(t, test.swSpan.GetSpans()[0].Tags, test.dest.Attributes().Len())
 			for _, tag := range test.swSpan.GetSpans()[0].Tags {
 				value, _ := test.dest.Attributes().Get(tag.Key)
 				assert.Equal(t, tag.Value, value.AsString())

--- a/pkg/translator/zipkin/zipkinv2/from_translator_test.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator_test.go
@@ -95,7 +95,7 @@ func TestInternalTracesToZipkinSpansAndBack(t *testing.T) {
 	for _, td := range tds {
 		zipkinSpans, err := FromTranslator{}.FromTraces(td)
 		assert.NoError(t, err)
-		assert.Equal(t, td.SpanCount(), len(zipkinSpans))
+		assert.Len(t, zipkinSpans, td.SpanCount())
 		tdFromZS, zErr := ToTranslator{}.ToTraces(zipkinSpans)
 		assert.NoError(t, zErr, zipkinSpans)
 		assert.NotNil(t, tdFromZS)

--- a/pkg/winperfcounters/watcher_test.go
+++ b/pkg/winperfcounters/watcher_test.go
@@ -158,7 +158,7 @@ func TestPerfCounter_ScrapeData(t *testing.T) {
 			name: "total instance",
 			path: `\LogicalDisk(_Total)\Free Megabytes`,
 			assertExpected: func(t *testing.T, data []CounterValue) {
-				assert.Equal(t, 1, len(data))
+				assert.Len(t, data, 1)
 				assert.Empty(t, data[0].InstanceName)
 			},
 		},

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -465,7 +465,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			assert.Nil(t, cErr)
 			got := next.AllMetrics()
 
-			require.Equal(t, 1, len(got))
+			require.Len(t, got, 1)
 			require.Equal(t, test.outMetrics.ResourceMetrics().Len(), got[0].ResourceMetrics().Len())
 
 			expectedMetrics := test.outMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()

--- a/processor/deltatorateprocessor/processor_test.go
+++ b/processor/deltatorateprocessor/processor_test.go
@@ -137,7 +137,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			assert.Nil(t, cErr)
 			got := next.AllMetrics()
 
-			require.Equal(t, 1, len(got))
+			require.Len(t, got, 1)
 			require.Equal(t, test.outMetrics.ResourceMetrics().Len(), got[0].ResourceMetrics().Len())
 
 			expectedMetrics := test.outMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -347,11 +347,11 @@ func TestFilterMetricProcessor(t *testing.T) {
 			got := next.AllMetrics()
 
 			if len(test.outMN) == 0 {
-				require.Equal(t, 0, len(got))
+				require.Len(t, got, 0)
 				return
 			}
 
-			require.Equal(t, 1, len(got))
+			require.Len(t, got, 1)
 			require.Equal(t, len(test.outMN), got[0].ResourceMetrics().Len())
 			for i, wantOut := range test.outMN {
 				gotMetrics := got[0].ResourceMetrics().At(i).ScopeMetrics().At(0).Metrics()

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -148,7 +148,7 @@ func TestFilterTraceProcessor(t *testing.T) {
 
 			// If all traces got filtered you shouldn't even have ResourceSpans
 			if test.allTracesFiltered {
-				require.Equal(t, 0, len(got))
+				require.Len(t, got, 0)
 			} else {
 				require.Equal(t, test.spanCountExpected, got[0].SpanCount())
 			}

--- a/processor/geoipprocessor/geoip_processor_test.go
+++ b/processor/geoipprocessor/geoip_processor_test.go
@@ -145,7 +145,7 @@ func compareAllSignals(cfg component.Config, goldenDir string) func(t *testing.T
 		require.NoError(t, err)
 
 		actualMetrics := nextMetrics.AllMetrics()
-		require.Equal(t, 1, len(actualMetrics))
+		require.Len(t, actualMetrics, 1)
 		// golden.WriteMetrics(t, filepath.Join(dir, "output-metrics.yaml"), actualMetrics[0])
 		require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics[0]))
 
@@ -164,7 +164,7 @@ func compareAllSignals(cfg component.Config, goldenDir string) func(t *testing.T
 		require.NoError(t, err)
 
 		actualTraces := nextTraces.AllTraces()
-		require.Equal(t, 1, len(actualTraces))
+		require.Len(t, actualTraces, 1)
 		// golden.WriteTraces(t, filepath.Join(dir, "output-traces.yaml"), actualTraces[0])
 		require.NoError(t, ptracetest.CompareTraces(expectedTraces, actualTraces[0]))
 
@@ -183,7 +183,7 @@ func compareAllSignals(cfg component.Config, goldenDir string) func(t *testing.T
 		require.NoError(t, err)
 
 		actualLogs := nextLogs.AllLogs()
-		require.Equal(t, 1, len(actualLogs))
+		require.Len(t, actualLogs, 1)
 		// golden.WriteLogs(t, filepath.Join(dir, "output-logs.yaml"), actualLogs[0])
 		require.NoError(t, plogtest.CompareLogs(expectedLogs, actualLogs[0]))
 	}

--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -126,7 +126,7 @@ func TestInternalCacheLimit(t *testing.T) {
 	wg.Wait()
 
 	// verify
-	assert.Equal(t, 5, len(receivedTraceIDs))
+	assert.Len(t, receivedTraceIDs, 5)
 
 	for i := 5; i > 0; i-- { // last 5 traces
 		traceID := pcommon.TraceID(traceIDs[i])

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -47,18 +47,18 @@ func newPodIdentifier(from string, name string, value string) PodIdentifier {
 }
 
 func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
-	assert.Equal(t, 0, len(c.Pods))
+	assert.Len(t, c.Pods, 0)
 
 	// pod without IP
 	pod := &api_v1.Pod{}
 	handler(pod)
-	assert.Equal(t, 0, len(c.Pods))
+	assert.Len(t, c.Pods, 0)
 
 	pod = &api_v1.Pod{}
 	pod.Name = "podA"
 	pod.Status.PodIP = "1.1.1.1"
 	handler(pod)
-	assert.Equal(t, 2, len(c.Pods))
+	assert.Len(t, c.Pods, 2)
 	got := c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
 	assert.Equal(t, "1.1.1.1", got.Address)
 	assert.Equal(t, "podA", got.Name)
@@ -68,7 +68,7 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 	pod.Name = "podB"
 	pod.Status.PodIP = "1.1.1.1"
 	handler(pod)
-	assert.Equal(t, 2, len(c.Pods))
+	assert.Len(t, c.Pods, 2)
 	got = c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
 	assert.Equal(t, "1.1.1.1", got.Address)
 	assert.Equal(t, "podB", got.Name)
@@ -79,7 +79,7 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 	pod.Status.PodIP = "2.2.2.2"
 	pod.UID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	handler(pod)
-	assert.Equal(t, 5, len(c.Pods))
+	assert.Len(t, c.Pods, 5)
 	got = c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "2.2.2.2")]
 	assert.Equal(t, "2.2.2.2", got.Address)
 	assert.Equal(t, "podC", got.Name)
@@ -92,16 +92,16 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 }
 
 func namespaceAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
-	assert.Equal(t, 0, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 0)
 
 	namespace := &api_v1.Namespace{}
 	handler(namespace)
-	assert.Equal(t, 0, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 0)
 
 	namespace = &api_v1.Namespace{}
 	namespace.Name = "namespaceA"
 	handler(namespace)
-	assert.Equal(t, 1, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 1)
 	got := c.Namespaces["namespaceA"]
 	assert.Equal(t, "namespaceA", got.Name)
 	assert.Equal(t, "", got.NamespaceUID)
@@ -110,23 +110,23 @@ func namespaceAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj an
 	namespace.Name = "namespaceB"
 	namespace.UID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	handler(namespace)
-	assert.Equal(t, 2, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 2)
 	got = c.Namespaces["namespaceB"]
 	assert.Equal(t, "namespaceB", got.Name)
 	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", got.NamespaceUID)
 }
 
 func nodeAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
-	assert.Equal(t, 0, len(c.Nodes))
+	assert.Len(t, c.Nodes, 0)
 
 	node := &api_v1.Node{}
 	handler(node)
-	assert.Equal(t, 0, len(c.Nodes))
+	assert.Len(t, c.Nodes, 0)
 
 	node = &api_v1.Node{}
 	node.Name = "nodeA"
 	handler(node)
-	assert.Equal(t, 1, len(c.Nodes))
+	assert.Len(t, c.Nodes, 1)
 	got, ok := c.GetNode("nodeA")
 	assert.True(t, ok)
 	assert.Equal(t, "nodeA", got.Name)
@@ -136,7 +136,7 @@ func nodeAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 	node.Name = "nodeB"
 	node.UID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	handler(node)
-	assert.Equal(t, 2, len(c.Nodes))
+	assert.Len(t, c.Nodes, 2)
 	got, ok = c.GetNode("nodeB")
 	assert.True(t, ok)
 	assert.Equal(t, "nodeB", got.Name)
@@ -227,11 +227,11 @@ func TestNodeAdd(t *testing.T) {
 
 func TestReplicaSetHandler(t *testing.T) {
 	c, _ := newTestClient(t)
-	assert.Equal(t, len(c.ReplicaSets), 0)
+	assert.Len(t, c.ReplicaSets, 0)
 
 	replicaset := &apps_v1.ReplicaSet{}
 	c.handleReplicaSetAdd(replicaset)
-	assert.Equal(t, len(c.ReplicaSets), 0)
+	assert.Len(t, c.ReplicaSets, 0)
 
 	// test add replicaset
 	replicaset = &apps_v1.ReplicaSet{}
@@ -256,7 +256,7 @@ func TestReplicaSetHandler(t *testing.T) {
 		},
 	}
 	c.handleReplicaSetAdd(replicaset)
-	assert.Equal(t, len(c.ReplicaSets), 1)
+	assert.Len(t, c.ReplicaSets, 1)
 	got := c.ReplicaSets[string(replicaset.UID)]
 	assert.Equal(t, got.Name, "deployment-aaa")
 	assert.Equal(t, got.Namespace, "namespaceA")
@@ -270,7 +270,7 @@ func TestReplicaSetHandler(t *testing.T) {
 	updatedReplicaset := replicaset
 	updatedReplicaset.ResourceVersion = "444444"
 	c.handleReplicaSetUpdate(replicaset, updatedReplicaset)
-	assert.Equal(t, len(c.ReplicaSets), 1)
+	assert.Len(t, c.ReplicaSets, 1)
 	got = c.ReplicaSets[string(replicaset.UID)]
 	assert.Equal(t, got.Name, "deployment-aaa")
 	assert.Equal(t, got.Namespace, "namespaceA")
@@ -282,20 +282,20 @@ func TestReplicaSetHandler(t *testing.T) {
 
 	// test delete replicaset
 	c.handleReplicaSetDelete(updatedReplicaset)
-	assert.Equal(t, len(c.ReplicaSets), 0)
+	assert.Len(t, c.ReplicaSets, 0)
 	// test delete replicaset when DeletedFinalStateUnknown
 	c.handleReplicaSetAdd(replicaset)
-	require.Equal(t, len(c.ReplicaSets), 1)
+	require.Len(t, c.ReplicaSets, 1)
 	c.handleReplicaSetDelete(cache.DeletedFinalStateUnknown{
 		Obj: replicaset,
 	})
-	assert.Equal(t, len(c.ReplicaSets), 0)
+	assert.Len(t, c.ReplicaSets, 0)
 
 }
 
 func TestPodHostNetwork(t *testing.T) {
 	c, _ := newTestClient(t)
-	assert.Equal(t, 0, len(c.Pods))
+	assert.Len(t, c.Pods, 0)
 
 	// pod will not be added if no rule matches
 	pod := &api_v1.Pod{}
@@ -303,7 +303,7 @@ func TestPodHostNetwork(t *testing.T) {
 	pod.Status.PodIP = "1.1.1.1"
 	pod.Spec.HostNetwork = true
 	c.handlePodAdd(pod)
-	assert.Equal(t, 0, len(c.Pods))
+	assert.Len(t, c.Pods, 0)
 
 	// pod will be added if rule matches
 	pod.Name = "podB"
@@ -311,7 +311,7 @@ func TestPodHostNetwork(t *testing.T) {
 	pod.UID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	pod.Spec.HostNetwork = true
 	c.handlePodAdd(pod)
-	assert.Equal(t, 1, len(c.Pods))
+	assert.Len(t, c.Pods, 1)
 	got := c.Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")]
 	assert.Equal(t, "2.2.2.2", got.Address)
 	assert.Equal(t, "podB", got.Name)
@@ -323,14 +323,14 @@ func TestPodHostNetwork(t *testing.T) {
 // correctly
 func TestPodCreate(t *testing.T) {
 	c, _ := newTestClient(t)
-	assert.Equal(t, 0, len(c.Pods))
+	assert.Len(t, c.Pods, 0)
 
 	// pod is created in Pending phase. At this point it has a UID but no start time or pod IP address
 	pod := &api_v1.Pod{}
 	pod.Name = "podD"
 	pod.UID = "11111111-2222-3333-4444-555555555555"
 	c.handlePodAdd(pod)
-	assert.Equal(t, 1, len(c.Pods))
+	assert.Len(t, c.Pods, 1)
 	got := c.Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "11111111-2222-3333-4444-555555555555")]
 	assert.Equal(t, "", got.Address)
 	assert.Equal(t, "podD", got.Name)
@@ -341,7 +341,7 @@ func TestPodCreate(t *testing.T) {
 	startTime := meta_v1.NewTime(time.Now())
 	pod.Status.StartTime = &startTime
 	c.handlePodUpdate(&api_v1.Pod{}, pod)
-	assert.Equal(t, 1, len(c.Pods))
+	assert.Len(t, c.Pods, 1)
 	got = c.Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "11111111-2222-3333-4444-555555555555")]
 	assert.Equal(t, "", got.Address)
 	assert.Equal(t, "podD", got.Name)
@@ -350,7 +350,7 @@ func TestPodCreate(t *testing.T) {
 	// pod is Running and has an IP address
 	pod.Status.PodIP = "3.3.3.3"
 	c.handlePodUpdate(&api_v1.Pod{}, pod)
-	assert.Equal(t, 3, len(c.Pods))
+	assert.Len(t, c.Pods, 3)
 	got = c.Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "11111111-2222-3333-4444-555555555555")]
 	assert.Equal(t, "3.3.3.3", got.Address)
 	assert.Equal(t, "podD", got.Name)
@@ -377,7 +377,7 @@ func TestPodAddOutOfSync(t *testing.T) {
 			},
 		},
 	})
-	assert.Equal(t, 0, len(c.Pods))
+	assert.Len(t, c.Pods, 0)
 
 	pod := &api_v1.Pod{}
 	pod.Name = "podA"
@@ -385,7 +385,7 @@ func TestPodAddOutOfSync(t *testing.T) {
 	startTime := meta_v1.NewTime(time.Now())
 	pod.Status.StartTime = &startTime
 	c.handlePodAdd(pod)
-	assert.Equal(t, 3, len(c.Pods))
+	assert.Len(t, c.Pods, 3)
 	got := c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
 	assert.Equal(t, "1.1.1.1", got.Address)
 	assert.Equal(t, "podA", got.Name)
@@ -399,7 +399,7 @@ func TestPodAddOutOfSync(t *testing.T) {
 	startTime2 := meta_v1.NewTime(time.Now().Add(-time.Second * 10))
 	pod2.Status.StartTime = &startTime2
 	c.handlePodAdd(pod2)
-	assert.Equal(t, 4, len(c.Pods))
+	assert.Len(t, c.Pods, 4)
 	got = c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
 	assert.Equal(t, "1.1.1.1", got.Address)
 	assert.Equal(t, "podA", got.Name)
@@ -435,7 +435,7 @@ func TestNodeUpdate(t *testing.T) {
 func TestPodDelete(t *testing.T) {
 	c, _ := newTestClient(t)
 	podAddAndUpdateTest(t, c, c.handlePodAdd)
-	assert.Equal(t, 5, len(c.Pods))
+	assert.Len(t, c.Pods, 5)
 	assert.Equal(t, "1.1.1.1", c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")].Address)
 
 	// delete empty IP pod
@@ -446,10 +446,10 @@ func TestPodDelete(t *testing.T) {
 	pod := &api_v1.Pod{}
 	pod.Status.PodIP = "9.9.9.9"
 	c.handlePodDelete(pod)
-	assert.Equal(t, 5, len(c.Pods))
+	assert.Len(t, c.Pods, 5)
 	got := c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
 	assert.Equal(t, "1.1.1.1", got.Address)
-	assert.Equal(t, 0, len(c.deleteQueue))
+	assert.Len(t, c.deleteQueue, 0)
 
 	// delete matching IP with wrong name/different pod
 	c.deleteQueue = c.deleteQueue[:0]
@@ -457,9 +457,9 @@ func TestPodDelete(t *testing.T) {
 	pod.Status.PodIP = "1.1.1.1"
 	c.handlePodDelete(pod)
 	got = c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
-	assert.Equal(t, 5, len(c.Pods))
+	assert.Len(t, c.Pods, 5)
 	assert.Equal(t, "1.1.1.1", got.Address)
-	assert.Equal(t, 0, len(c.deleteQueue))
+	assert.Len(t, c.deleteQueue, 0)
 
 	// delete matching IP and name
 	c.deleteQueue = c.deleteQueue[:0]
@@ -468,8 +468,8 @@ func TestPodDelete(t *testing.T) {
 	pod.Status.PodIP = "1.1.1.1"
 	tsBeforeDelete := time.Now()
 	c.handlePodDelete(pod)
-	assert.Equal(t, 5, len(c.Pods))
-	assert.Equal(t, 3, len(c.deleteQueue))
+	assert.Len(t, c.Pods, 5)
+	assert.Len(t, c.deleteQueue, 3)
 	deleteRequest := c.deleteQueue[0]
 	assert.Equal(t, newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1"), deleteRequest.id)
 	assert.Equal(t, "podB", deleteRequest.podName)
@@ -484,8 +484,8 @@ func TestPodDelete(t *testing.T) {
 	pod.UID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 	tsBeforeDelete = time.Now()
 	c.handlePodDelete(cache.DeletedFinalStateUnknown{Obj: pod})
-	assert.Equal(t, 5, len(c.Pods))
-	assert.Equal(t, 5, len(c.deleteQueue))
+	assert.Len(t, c.Pods, 5)
+	assert.Len(t, c.deleteQueue, 5)
 	deleteRequest = c.deleteQueue[0]
 	assert.Equal(t, newPodIdentifier("connection", "k8s.pod.ip", "2.2.2.2"), deleteRequest.id)
 	assert.Equal(t, "podC", deleteRequest.podName)
@@ -501,7 +501,7 @@ func TestPodDelete(t *testing.T) {
 func TestNamespaceDelete(t *testing.T) {
 	c, _ := newTestClient(t)
 	namespaceAddAndUpdateTest(t, c, c.handleNamespaceAdd)
-	assert.Equal(t, 2, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 2)
 	assert.Equal(t, "namespaceA", c.Namespaces["namespaceA"].Name)
 
 	// delete empty namespace
@@ -511,32 +511,32 @@ func TestNamespaceDelete(t *testing.T) {
 	namespace := &api_v1.Namespace{}
 	namespace.Name = "namespaceC"
 	c.handleNamespaceDelete(namespace)
-	assert.Equal(t, 2, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 2)
 	got := c.Namespaces["namespaceA"]
 	assert.Equal(t, "namespaceA", got.Name)
 	// delete non-existent namespace when DeletedFinalStateUnknown
 	c.handleNamespaceDelete(cache.DeletedFinalStateUnknown{Obj: namespace})
-	assert.Equal(t, 2, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 2)
 	got = c.Namespaces["namespaceA"]
 	assert.Equal(t, "namespaceA", got.Name)
 
 	// delete namespace A
 	namespace.Name = "namespaceA"
 	c.handleNamespaceDelete(namespace)
-	assert.Equal(t, 1, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 1)
 	got = c.Namespaces["namespaceB"]
 	assert.Equal(t, "namespaceB", got.Name)
 
 	// delete namespace B when DeletedFinalStateUnknown
 	namespace.Name = "namespaceB"
 	c.handleNamespaceDelete(cache.DeletedFinalStateUnknown{Obj: namespace})
-	assert.Equal(t, 0, len(c.Namespaces))
+	assert.Len(t, c.Namespaces, 0)
 }
 
 func TestNodeDelete(t *testing.T) {
 	c, _ := newTestClient(t)
 	nodeAddAndUpdateTest(t, c, c.handleNodeAdd)
-	assert.Equal(t, 2, len(c.Nodes))
+	assert.Len(t, c.Nodes, 2)
 	assert.Equal(t, "nodeA", c.Nodes["nodeA"].Name)
 
 	// delete empty node
@@ -546,32 +546,32 @@ func TestNodeDelete(t *testing.T) {
 	node := &api_v1.Node{}
 	node.Name = "nodeC"
 	c.handleNodeDelete(node)
-	assert.Equal(t, 2, len(c.Nodes))
+	assert.Len(t, c.Nodes, 2)
 	got := c.Nodes["nodeA"]
 	assert.Equal(t, "nodeA", got.Name)
 	// delete non-existent namespace when DeletedFinalStateUnknown
 	c.handleNodeDelete(cache.DeletedFinalStateUnknown{Obj: node})
-	assert.Equal(t, 2, len(c.Nodes))
+	assert.Len(t, c.Nodes, 2)
 	got = c.Nodes["nodeA"]
 	assert.Equal(t, "nodeA", got.Name)
 
 	// delete node A
 	node.Name = "nodeA"
 	c.handleNodeDelete(node)
-	assert.Equal(t, 1, len(c.Nodes))
+	assert.Len(t, c.Nodes, 1)
 	got = c.Nodes["nodeB"]
 	assert.Equal(t, "nodeB", got.Name)
 
 	// delete node B when DeletedFinalStateUnknown
 	node.Name = "nodeB"
 	c.handleNodeDelete(cache.DeletedFinalStateUnknown{Obj: node})
-	assert.Equal(t, 0, len(c.Nodes))
+	assert.Len(t, c.Nodes, 0)
 }
 
 func TestDeleteQueue(t *testing.T) {
 	c, _ := newTestClient(t)
 	podAddAndUpdateTest(t, c, c.handlePodAdd)
-	assert.Equal(t, 5, len(c.Pods))
+	assert.Len(t, c.Pods, 5)
 	assert.Equal(t, "1.1.1.1", c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")].Address)
 
 	// delete pod
@@ -579,8 +579,8 @@ func TestDeleteQueue(t *testing.T) {
 	pod.Name = "podB"
 	pod.Status.PodIP = "1.1.1.1"
 	c.handlePodDelete(pod)
-	assert.Equal(t, 5, len(c.Pods))
-	assert.Equal(t, 3, len(c.deleteQueue))
+	assert.Len(t, c.Pods, 5)
+	assert.Len(t, c.deleteQueue, 3)
 }
 
 func TestDeleteLoop(t *testing.T) {
@@ -590,30 +590,30 @@ func TestDeleteLoop(t *testing.T) {
 	pod := &api_v1.Pod{}
 	pod.Status.PodIP = "1.1.1.1"
 	c.handlePodAdd(pod)
-	assert.Equal(t, 2, len(c.Pods))
-	assert.Equal(t, 0, len(c.deleteQueue))
+	assert.Len(t, c.Pods, 2)
+	assert.Len(t, c.deleteQueue, 0)
 
 	c.handlePodDelete(pod)
-	assert.Equal(t, 2, len(c.Pods))
-	assert.Equal(t, 3, len(c.deleteQueue))
+	assert.Len(t, c.Pods, 2)
+	assert.Len(t, c.deleteQueue, 3)
 
 	gracePeriod := time.Millisecond * 500
 	go c.deleteLoop(time.Millisecond, gracePeriod)
 	go func() {
 		time.Sleep(time.Millisecond * 50)
 		c.m.Lock()
-		assert.Equal(t, 2, len(c.Pods))
+		assert.Len(t, c.Pods, 2)
 		c.m.Unlock()
 		c.deleteMut.Lock()
-		assert.Equal(t, 3, len(c.deleteQueue))
+		assert.Len(t, c.deleteQueue, 3)
 		c.deleteMut.Unlock()
 
 		time.Sleep(gracePeriod + (time.Millisecond * 50))
 		c.m.Lock()
-		assert.Equal(t, 0, len(c.Pods))
+		assert.Len(t, c.Pods, 0)
 		c.m.Unlock()
 		c.deleteMut.Lock()
-		assert.Equal(t, 0, len(c.deleteQueue))
+		assert.Len(t, c.deleteQueue, 0)
 		c.deleteMut.Unlock()
 		close(c.stopCh)
 	}()

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -292,7 +292,7 @@ func TestMetricsGenerationProcessor(t *testing.T) {
 			assert.Nil(t, cErr)
 			got := next.AllMetrics()
 
-			require.Equal(t, 1, len(got))
+			require.Len(t, got, 1)
 			require.Equal(t, test.outMetrics.ResourceMetrics().Len(), got[0].ResourceMetrics().Len())
 
 			expectedMetrics := test.outMetrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -86,7 +86,7 @@ func TestMetricsGrouping(t *testing.T) {
 				assert.NoError(t, cErr)
 
 				got := next.AllMetrics()
-				require.Equal(t, 1, len(got))
+				require.Len(t, got, 1)
 				require.NoError(t, pmetrictest.CompareMetrics(expected, got[0], pmetrictest.IgnoreMetricValues()))
 
 				assert.NoError(t, mtp.Shutdown(context.Background()))

--- a/processor/metricstransformprocessor/metrics_transform_processor_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_test.go
@@ -50,7 +50,7 @@ func TestMetricsTransformProcessor(t *testing.T) {
 
 			// get and check results
 			got := next.AllMetrics()
-			require.Equal(t, 1, len(got))
+			require.Len(t, got, 1)
 			gotMetricsSlice := pmetric.NewMetricSlice()
 			if got[0].ResourceMetrics().Len() > 0 {
 				gotMetricsSlice = got[0].ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()

--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -411,10 +411,10 @@ func TestLogsSamplingState(t *testing.T) {
 			require.NoError(t, err)
 
 			if len(tt.log) == 0 {
-				require.Equal(t, 0, len(observed.All()), "should not have logs: %v", observed.All())
+				require.Len(t, observed.All(), 0, "should not have logs: %v", observed.All())
 				require.Equal(t, "", tt.log)
 			} else {
-				require.Equal(t, 1, len(observed.All()), "should have one log: %v", observed.All())
+				require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())
 				require.Contains(t, observed.All()[0].Message, "logs sampler")
 				require.Contains(t, observed.All()[0].Context[0].Interface.(error).Error(), tt.log)
 			}
@@ -422,7 +422,7 @@ func TestLogsSamplingState(t *testing.T) {
 			sampledData := sink.AllLogs()
 
 			if tt.sampled {
-				require.Equal(t, 1, len(sampledData))
+				require.Len(t, sampledData, 1)
 				assert.Equal(t, 1, sink.LogRecordCount())
 				got := sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 				gotAttrs := got.Attributes()
@@ -504,20 +504,20 @@ func TestLogsMissingRandomness(t *testing.T) {
 
 				sampledData := sink.AllLogs()
 				if tt.sampled {
-					require.Equal(t, 1, len(sampledData))
+					require.Len(t, sampledData, 1)
 					assert.Equal(t, 1, sink.LogRecordCount())
 				} else {
-					require.Equal(t, 0, len(sampledData))
+					require.Len(t, sampledData, 0)
 					assert.Equal(t, 0, sink.LogRecordCount())
 				}
 
 				if tt.pct != 0 {
 					// pct==0 bypasses the randomness check
-					require.Equal(t, 1, len(observed.All()), "should have one log: %v", observed.All())
+					require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())
 					require.Contains(t, observed.All()[0].Message, "logs sampler")
 					require.Contains(t, observed.All()[0].Context[0].Interface.(error).Error(), "missing randomness")
 				} else {
-					require.Equal(t, 0, len(observed.All()), "should have no logs: %v", observed.All())
+					require.Len(t, observed.All(), 0, "should have no logs: %v", observed.All())
 				}
 			})
 		}

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -276,20 +276,20 @@ func Test_tracessamplerprocessor_MissingRandomness(t *testing.T) {
 
 			sampledData := sink.AllTraces()
 			if tt.sampled {
-				require.Equal(t, 1, len(sampledData))
+				require.Len(t, sampledData, 1)
 				assert.Equal(t, 1, sink.SpanCount())
 			} else {
-				require.Equal(t, 0, len(sampledData))
+				require.Len(t, sampledData, 0)
 				assert.Equal(t, 0, sink.SpanCount())
 			}
 
 			if tt.pct != 0 {
 				// pct==0 bypasses the randomness check
-				require.Equal(t, 1, len(observed.All()), "should have one log: %v", observed.All())
+				require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())
 				require.Contains(t, observed.All()[0].Message, "traces sampler")
 				require.Contains(t, observed.All()[0].Context[0].Interface.(error).Error(), "missing randomness")
 			} else {
-				require.Equal(t, 0, len(observed.All()), "should have no logs: %v", observed.All())
+				require.Len(t, observed.All(), 0, "should have no logs: %v", observed.All())
 			}
 		})
 	}
@@ -406,10 +406,10 @@ func Test_tracesamplerprocessor_SpanSamplingPriority(t *testing.T) {
 
 				sampledData := sink.AllTraces()
 				if tt.sampled {
-					require.Equal(t, 1, len(sampledData))
+					require.Len(t, sampledData, 1)
 					assert.Equal(t, 1, sink.SpanCount())
 				} else {
-					require.Equal(t, 0, len(sampledData))
+					require.Len(t, sampledData, 0)
 					assert.Equal(t, 0, sink.SpanCount())
 				}
 			})
@@ -882,7 +882,7 @@ func Test_tracesamplerprocessor_TraceState(t *testing.T) {
 					expectSampled, expectCount, expectTS = tt.sf(mode)
 				}
 				if expectSampled {
-					require.Equal(t, 1, len(sampledData))
+					require.Len(t, sampledData, 1)
 					assert.Equal(t, 1, sink.SpanCount())
 					got := sink.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0)
 					gotTs, err := sampling.NewW3CTraceState(got.TraceState().AsRaw())
@@ -899,15 +899,15 @@ func Test_tracesamplerprocessor_TraceState(t *testing.T) {
 					}
 					require.Equal(t, expectTS, got.TraceState().AsRaw())
 				} else {
-					require.Equal(t, 0, len(sampledData))
+					require.Len(t, sampledData, 0)
 					assert.Equal(t, 0, sink.SpanCount())
 					require.Equal(t, "", expectTS)
 				}
 
 				if len(tt.log) == 0 {
-					require.Equal(t, 0, len(observed.All()), "should not have logs: %v", observed.All())
+					require.Len(t, observed.All(), 0, "should not have logs: %v", observed.All())
 				} else {
-					require.Equal(t, 1, len(observed.All()), "should have one log: %v", observed.All())
+					require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())
 					require.Contains(t, observed.All()[0].Message, "traces sampler")
 					require.Contains(t, observed.All()[0].Context[0].Interface.(error).Error(), tt.log)
 				}
@@ -1026,10 +1026,10 @@ func Test_tracesamplerprocessor_TraceStateErrors(t *testing.T) {
 
 				sampledData := sink.AllTraces()
 
-				require.Equal(t, 0, len(sampledData))
+				require.Len(t, sampledData, 0)
 				assert.Equal(t, 0, sink.SpanCount())
 
-				require.Equal(t, 1, len(observed.All()), "should have one log: %v", observed.All())
+				require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())
 				if observed.All()[0].Message == "trace sampler" {
 					require.Contains(t, observed.All()[0].Context[0].Interface.(error).Error(), expectMessage)
 				} else {

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -298,7 +298,7 @@ func TestFilterAttributes_NilAttributes(t *testing.T) {
 	_, ok = attr.Get("host.id")
 	assert.True(t, ok)
 
-	assert.Equal(t, len(droppedAttributes), 0)
+	assert.Len(t, droppedAttributes, 0)
 }
 
 func TestFilterAttributes_NoAttributes(t *testing.T) {
@@ -315,5 +315,5 @@ func TestFilterAttributes_NoAttributes(t *testing.T) {
 	_, ok = attr.Get("host.id")
 	assert.True(t, ok)
 
-	assert.Equal(t, len(droppedAttributes), 0)
+	assert.Len(t, droppedAttributes, 0)
 }

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -114,7 +114,7 @@ func TestTraceIntegrity(t *testing.T) {
 	span.SetTraceID(pcommon.TraceID([16]byte{13, 14, 15, 16}))
 	spans[spanID] = spanInfo{span: span, resource: resource, scope: scope}
 
-	require.Equal(t, spanCount, len(spans))
+	require.Len(t, spans, spanCount)
 
 	cfg := Config{
 		DecisionWait: defaultTestDecisionWait,
@@ -157,7 +157,7 @@ func TestTraceIntegrity(t *testing.T) {
 	require.EqualValues(t, 4, mpe1.EvaluationCount)
 
 	consumed := nextConsumer.AllTraces()
-	require.Equal(t, 4, len(consumed))
+	require.Len(t, consumed, 4)
 	for _, trace := range consumed {
 		require.Equal(t, 1, trace.SpanCount())
 		require.Equal(t, 1, trace.ResourceSpans().Len())
@@ -410,7 +410,7 @@ func TestMultipleBatchesAreCombinedIntoOne(t *testing.T) {
 	tsp.policyTicker.OnTick() // the first tick always gets an empty batch
 	tsp.policyTicker.OnTick()
 
-	require.EqualValues(t, 3, len(msp.AllTraces()), "There should be three batches, one for each trace")
+	require.Len(t, msp.AllTraces(), 3, "There should be three batches, one for each trace")
 
 	expectedSpanIDs := make(map[int][]pcommon.SpanID)
 	expectedSpanIDs[0] = []pcommon.SpanID{

--- a/processor/transformprocessor/config_test.go
+++ b/processor/transformprocessor/config_test.go
@@ -165,7 +165,7 @@ func TestLoadConfig(t *testing.T) {
 				assert.Error(t, err)
 
 				if tt.errorLen > 0 {
-					assert.Equal(t, tt.errorLen, len(multierr.Errors(err)))
+					assert.Len(t, multierr.Errors(err), tt.errorLen)
 				}
 
 				return

--- a/receiver/awscloudwatchreceiver/logs_test.go
+++ b/receiver/awscloudwatchreceiver/logs_test.go
@@ -162,7 +162,7 @@ func TestDiscovery(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return sink.LogRecordCount() > 0
 	}, 2*time.Second, 10*time.Millisecond)
-	require.Equal(t, len(logsRcvr.groupRequests), 2)
+	require.Len(t, logsRcvr.groupRequests, 2)
 	require.NoError(t, logsRcvr.Shutdown(context.Background()))
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/container_info_processor_test.go
@@ -64,7 +64,7 @@ func TestProcessContainers(t *testing.T) {
 	containerInfos = append(containerInfos, containerInContainerInfos...)
 	mInfo := testutils.MockCPUMemInfo{}
 	metrics := processContainers(containerInfos, mInfo, "eks", zap.NewNop())
-	assert.Equal(t, 3, len(metrics))
+	assert.Len(t, metrics, 3)
 
 	// restore the original value of metrics extractors
 	metricsExtractors = originalMetricsExtractors

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
@@ -98,5 +98,5 @@ func TestDiskIOStats(t *testing.T) {
 		cMetrics = extractor.GetValue(result2[0], nil, containerType)
 	}
 
-	assert.Equal(t, len(cMetrics), 0)
+	assert.Len(t, cMetrics, 0)
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/extractor_test.go
@@ -25,7 +25,7 @@ func TestCAdvisorMetric_Merge(t *testing.T) {
 		logger: zap.NewNop(),
 	}
 	src.Merge(dest)
-	assert.Equal(t, 3, len(src.fields))
+	assert.Len(t, src.fields, 3)
 	assert.Equal(t, 1, src.fields["value1"].(int))
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
@@ -47,7 +47,7 @@ func TestFSStats(t *testing.T) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
 	}
 
-	assert.Equal(t, len(cMetrics), 0)
+	assert.Len(t, cMetrics, 0)
 
 	// node type for eks
 
@@ -131,7 +131,7 @@ func TestFSStatsWithAllowList(t *testing.T) {
 	}
 
 	// There are 3 valid device names which pass the allowlist in testAllowList json.
-	assert.Equal(t, 3, len(cMetrics))
+	assert.Len(t, cMetrics, 3)
 	assert.Equal(t, "tmpfs", cMetrics[0].tags["device"])
 	assert.Equal(t, "/dev/xvda1", cMetrics[1].tags["device"])
 	assert.Equal(t, "overlay", cMetrics[2].tags["device"])

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/net_extractor_test.go
@@ -152,7 +152,7 @@ func TestNetStats(t *testing.T) {
 		},
 	}
 
-	assert.Equal(t, len(cMetrics), 8)
+	assert.Len(t, cMetrics, 8)
 	for i := range expectedFields {
 		AssertContainsTaggedField(t, cMetrics[i], expectedFields[i], expectedTags[i])
 	}

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_task_info_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_task_info_test.go
@@ -75,7 +75,7 @@ func TestECSTaskInfoFail(t *testing.T) {
 	ecsTaskinfo := newECSTaskInfo(ctx, hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, taskReadyC)
 	assert.NotNil(t, ecsTaskinfo)
 	assert.Equal(t, int64(0), ecsTaskinfo.getRunningTaskCount())
-	assert.Equal(t, 0, len(ecsTaskinfo.getRunningTasksInfo()))
+	assert.Len(t, ecsTaskinfo.getRunningTasksInfo(), 0)
 
 	data, err := os.ReadFile("./test/ecsinfo/taskinfo_wrong")
 	body := string(data)
@@ -87,6 +87,6 @@ func TestECSTaskInfoFail(t *testing.T) {
 	ecsTaskinfo = newECSTaskInfo(ctx, hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, taskReadyC)
 	assert.NotNil(t, ecsTaskinfo)
 	assert.Equal(t, int64(0), ecsTaskinfo.getRunningTaskCount())
-	assert.Equal(t, 0, len(ecsTaskinfo.getRunningTasksInfo()))
+	assert.Len(t, ecsTaskinfo.getRunningTasksInfo(), 0)
 
 }

--- a/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
@@ -170,7 +170,7 @@ func TestEBSVolume(t *testing.T) {
 	assert.Equal(t, "", e.getEBSVolumeID("/dev/invalid"))
 
 	ebsIDs := e.extractEbsIDsUsedByKubernetes()
-	assert.Equal(t, 1, len(ebsIDs))
+	assert.Len(t, ebsIDs, 1)
 	assert.Equal(t, "aws://us-west-2b/vol-0d9f0816149eb2050", ebsIDs["/dev/nvme1n1"])
 
 	// set e.hostMounts to an invalid path
@@ -180,5 +180,5 @@ func TestEBSVolume(t *testing.T) {
 	e = newEBSVolume(ctx, sess, "instanceId", "us-west-2", time.Millisecond, zap.NewNop(),
 		clientOption, maxJitterOption, hostMountsOption, LstatOption, evalSymLinksOption)
 	ebsIDs = e.extractEbsIDsUsedByKubernetes()
-	assert.Equal(t, 0, len(ebsIDs))
+	assert.Len(t, ebsIDs, 0)
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -557,7 +557,7 @@ func TestPodStore_addPodOwnersAndPodName(t *testing.T) {
 	kubernetesBlob = map[string]any{}
 	podStore.addPodOwnersAndPodName(metric, pod, kubernetesBlob)
 	assert.Equal(t, kpName, metric.GetTag(ci.PodNameKey))
-	assert.True(t, len(kubernetesBlob) == 0)
+	assert.Len(t, kubernetesBlob, 0)
 
 	podStore.prefFullPodName = false
 	metric = generateMetric(fields, tags)
@@ -566,7 +566,7 @@ func TestPodStore_addPodOwnersAndPodName(t *testing.T) {
 	kubernetesBlob = map[string]any{}
 	podStore.addPodOwnersAndPodName(metric, pod, kubernetesBlob)
 	assert.Equal(t, kubeProxy, metric.GetTag(ci.PodNameKey))
-	assert.True(t, len(kubernetesBlob) == 0)
+	assert.Len(t, kubernetesBlob, 0)
 }
 
 type mockPodClient struct {

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -29,7 +29,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 2)
+	assert.Len(t, cfg.Receivers, 2)
 
 	receiver := cfg.Receivers[component.NewID(metadata.Type)]
 	assert.NoError(t, componenttest.CheckConfigStruct(receiver))

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -28,7 +28,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 2)
+	assert.Len(t, cfg.Receivers, 2)
 
 	r0 := cfg.Receivers[component.NewID(metadata.Type)]
 	assert.Equal(t, "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName", r0.(*Config).Connection)

--- a/receiver/datadogreceiver/internal/translator/series_test.go
+++ b/receiver/datadogreceiver/internal/translator/series_test.go
@@ -83,9 +83,9 @@ func TestHandleMetricsPayloadV2(t *testing.T) {
 			series, err := mt.HandleSeriesV2Payload(req)
 			require.NoError(t, err)
 			require.NoError(t, err, "Failed to parse metrics payload")
-			require.Equal(t, tt.expectedSeriesCount, len(series))
+			require.Len(t, series, tt.expectedSeriesCount)
 			for i, s := range series {
-				require.Equal(t, tt.expectedPointsCounts[i], len(s.Points))
+				require.Len(t, s.Points, tt.expectedPointsCounts[i])
 			}
 		})
 	}

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -121,11 +121,11 @@ func TestTracePayloadV07Unmarshalling(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, "/v0.7/traces", io.NopCloser(bytes.NewReader(bytez)))
 
 	translatedPayloads, _ := HandleTracesPayload(req)
-	assert.Equal(t, len(translatedPayloads), 1, "Expected one translated payload")
+	assert.Len(t, translatedPayloads, 1, "Expected one translated payload")
 	translated := translatedPayloads[0]
 	span := translated.GetChunks()[0].GetSpans()[0]
 	assert.NotNil(t, span)
-	assert.Equal(t, 5, len(span.GetMeta()), "missing attributes")
+	assert.Len(t, span.GetMeta(), 5, "missing attributes")
 	value, exists := span.GetMeta()["service.name"]
 	assert.True(t, exists, "service.name missing")
 	assert.Equal(t, "my-service", value, "service.name attribute value incorrect")
@@ -157,15 +157,15 @@ func TestTracePayloadApiV02Unmarshalling(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPost, "/api/v0.2/traces", io.NopCloser(bytes.NewReader(bytez)))
 
 	translatedPayloads, _ := HandleTracesPayload(req)
-	assert.Equal(t, len(translatedPayloads), 2, "Expected two translated payload")
+	assert.Len(t, translatedPayloads, 2, "Expected two translated payload")
 	for _, translated := range translatedPayloads {
 		assert.NotNil(t, translated)
-		assert.Equal(t, 1, len(translated.Chunks))
-		assert.Equal(t, 1, len(translated.Chunks[0].Spans))
+		assert.Len(t, translated.Chunks, 1)
+		assert.Len(t, translated.Chunks[0].Spans, 1)
 		span := translated.Chunks[0].Spans[0]
 
 		assert.NotNil(t, span)
-		assert.Equal(t, 5, len(span.Meta), "missing attributes")
+		assert.Len(t, span.Meta, 5, "missing attributes")
 		assert.Equal(t, "my-service", span.Meta["service.name"])
 		assert.Equal(t, "my-name", span.Name)
 		assert.Equal(t, "my-resource", span.Resource)

--- a/receiver/gitproviderreceiver/config_test.go
+++ b/receiver/gitproviderreceiver/config_test.go
@@ -33,7 +33,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 2)
+	assert.Len(t, cfg.Receivers, 2)
 
 	r0 := cfg.Receivers[component.NewID(metadata.Type)]
 	defaultConfigGitHubScraper := factory.CreateDefaultConfig()

--- a/receiver/gitproviderreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/gitproviderreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -453,7 +453,7 @@ func TestGetPullRequests(t *testing.T) {
 
 			prs, err := ghs.getPullRequests(context.Background(), client, "repo name")
 
-			assert.Equal(t, tc.expectedPrCount, len(prs))
+			assert.Len(t, prs, tc.expectedPrCount)
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)
 			} else {

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -140,7 +140,7 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Cache timeout hasn't been reached, so filtered out all items
-	assert.Equal(t, 0, len(filteredItems))
+	assert.Len(t, filteredItems, 0)
 
 	// Doing this to avoid of relying on timeouts and sleeps(avoid potential flaky tests)
 	syncChannel := make(chan bool)
@@ -192,13 +192,13 @@ func TestItemCardinalityFilter_FilterItems(t *testing.T) {
 	filteredItems, err = filterCasted.filterItems(items)
 	require.NoError(t, err)
 
-	assert.Equal(t, totalLimit, len(filteredItems))
+	assert.Len(t, filteredItems, totalLimit)
 
 	filteredItems, err = filter.Filter(items)
 	require.NoError(t, err)
 
 	// Cache timeout hasn't been reached, so no more new items expected
-	assert.Equal(t, totalLimit, len(filteredItems))
+	assert.Len(t, filteredItems, totalLimit)
 
 	// Doing this to avoid of relying on timeouts and sleeps(avoid potential flaky tests)
 	syncChannel := make(chan bool)
@@ -280,7 +280,7 @@ func TestGroupByTimestamp(t *testing.T) {
 	items := initialItems(t)
 	groupedItems := groupByTimestamp(items)
 
-	assert.Equal(t, 3, len(groupedItems))
+	assert.Len(t, groupedItems, 3)
 	assertGroupedByKey(t, items, groupedItems, timestamp1, 0)
 	assertGroupedByKey(t, items, groupedItems, timestamp2, 3)
 	assertGroupedByKey(t, items, groupedItems, timestamp3, 6)

--- a/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/testhelpers_test.go
@@ -35,7 +35,7 @@ const (
 )
 
 func assertGroupedByKey(t *testing.T, items []*Item, groupedItems map[time.Time][]*Item, key time.Time, offsetInItems int) {
-	assert.Equal(t, 3, len(groupedItems[key]))
+	assert.Len(t, groupedItems[key], 3)
 
 	for i := 0; i < 3; i++ {
 		assert.Equal(t, items[i+offsetInItems].SeriesKey, groupedItems[key][i].SeriesKey)

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/filterbuilder_test.go
@@ -30,7 +30,7 @@ func TestFilterBuilder_BuildFilterByMetricZeroTotalLimit(t *testing.T) {
 	result := builder.buildFilterByMetricZeroTotalLimit()
 
 	// Because we have 2 groups and each group has 2 metrics
-	assert.Equal(t, len(metricPrefixes)*2, len(result))
+	assert.Len(t, result, len(metricPrefixes)*2)
 	for _, metadataItem := range metadataItems {
 		for _, metricValueMetadata := range metadataItem.QueryMetricValuesMetadata {
 			f, exists := result[metadataItem.MetricNamePrefix+metricValueMetadata.Name()]
@@ -82,7 +82,7 @@ func TestFilterBuilder_BuildFilterByMetricPositiveTotalLimit(t *testing.T) {
 			require.NoError(t, err)
 
 			// Because we have 2 groups and each group has 2 metrics
-			assert.Equal(t, len(testCase.metricPrefixes)*2, len(result))
+			assert.Len(t, result, len(testCase.metricPrefixes)*2)
 			for _, metadataItem := range metadataItems {
 				for _, metricValueMetadata := range metadataItem.QueryMetricValuesMetadata {
 					f, exists := result[metadataItem.MetricNamePrefix+metricValueMetadata.Name()]
@@ -138,7 +138,7 @@ func TestFilterBuilder_HandleLowCardinalityGroups(t *testing.T) {
 			require.NoError(t, err)
 
 			// Because we have 2 groups and each group has 2 metrics
-			assert.Equal(t, len(testCase.metricPrefixes)*2, len(filterByMetric))
+			assert.Len(t, filterByMetric, len(testCase.metricPrefixes)*2)
 			for _, metadataItem := range metadataItems {
 				for _, metricValueMetadata := range metadataItem.QueryMetricValuesMetadata {
 					f, exists := filterByMetric[metadataItem.MetricNamePrefix+metricValueMetadata.Name()]
@@ -194,7 +194,7 @@ func TestFilterBuilder_HandleHighCardinalityGroups(t *testing.T) {
 			require.NoError(t, err)
 
 			// Because we have 2 groups and each group has 2 metrics
-			assert.Equal(t, len(testCase.metricPrefixes)*2, len(filterByMetric))
+			assert.Len(t, filterByMetric, len(testCase.metricPrefixes)*2)
 			for _, metadataItem := range metadataItems {
 				for _, metricValueMetadata := range metadataItem.QueryMetricValuesMetadata {
 					f, exists := filterByMetric[metadataItem.MetricNamePrefix+metricValueMetadata.Name()]
@@ -229,7 +229,7 @@ func TestFilterBuilder_TestConstructFiltersForGroups(t *testing.T) {
 	require.NoError(t, err)
 
 	// Because we have 2 groups and each group has 2 metrics
-	assert.Equal(t, len(metricPrefixes)*2, len(filterByMetric))
+	assert.Len(t, filterByMetric, len(metricPrefixes)*2)
 	for _, metadataItem := range metadataItems {
 		for _, metricValueMetadata := range metadataItem.QueryMetricValuesMetadata {
 			f, exists := filterByMetric[metadataItem.MetricNamePrefix+metricValueMetadata.Name()]
@@ -257,12 +257,12 @@ func TestGroupByCardinality(t *testing.T) {
 
 	result := groupByCardinality(metadataItems)
 
-	assert.Equal(t, 2, len(result))
+	assert.Len(t, result, 2)
 
 	for _, metadataItem := range metadataItems {
 		groups, exists := result[metadataItem.HighCardinality]
 		assert.True(t, exists)
-		assert.Equal(t, 1, len(groups))
+		assert.Len(t, groups, 1)
 		assert.Equal(t, metadataItem, groups[0])
 	}
 }

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
@@ -221,7 +221,7 @@ func TestMetricsFromDataPointBuilder_GroupAndFilter_NilDataPoints(t *testing.T) 
 
 	require.NoError(t, err)
 
-	assert.Equal(t, 0, len(groupedDataPoints))
+	assert.Len(t, groupedDataPoints, 0)
 }
 
 func TestMetricsFromDataPointBuilder_Filter(t *testing.T) {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsdatapoint_test.go
@@ -126,7 +126,7 @@ func TestMetricsDataPoint_HideLockStatsRowrangestartkeyPII(t *testing.T) {
 
 	metricsDataPoint.HideLockStatsRowrangestartkeyPII()
 
-	assert.Equal(t, len(metricsDataPoint.labelValues), 2)
+	assert.Len(t, metricsDataPoint.labelValues, 2)
 	assert.Equal(t, metricsDataPoint.labelValues[0].Value(), "table1.s("+hashOf23+","+hashOfHello+","+hashOf23+"+)")
 	assert.Equal(t, metricsDataPoint.labelValues[1].Value(), "table2("+hashOf23+","+hashOfHello+")")
 }
@@ -149,7 +149,7 @@ func TestMetricsDataPoint_HideLockStatsRowrangestartkeyPIIWithInvalidLabelValue(
 		metricValue: metricValues[0],
 	}
 	metricsDataPoint.HideLockStatsRowrangestartkeyPII()
-	assert.Equal(t, len(metricsDataPoint.labelValues), 4)
+	assert.Len(t, metricsDataPoint.labelValues, 4)
 }
 
 func TestMetricsDataPoint_TruncateQueryText(t *testing.T) {
@@ -168,7 +168,7 @@ func TestMetricsDataPoint_TruncateQueryText(t *testing.T) {
 
 	metricsDataPoint.TruncateQueryText(6)
 
-	assert.Equal(t, len(metricsDataPoint.labelValues), 1)
+	assert.Len(t, metricsDataPoint.labelValues, 1)
 	assert.Equal(t, metricsDataPoint.labelValues[0].Value(), "SELECT")
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsmetadata_test.go
@@ -259,7 +259,7 @@ func TestMetricsMetadata_RowToMetricsDataPoints(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, 1, len(dataPoints))
+				assert.Len(t, dataPoints, 1)
 			}
 		})
 	}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadata_test.go
@@ -41,7 +41,7 @@ func TestMetadata_ToLabelValuesMetadata(t *testing.T) {
 				require.NotNil(t, valuesMetadata)
 				require.NoError(t, err)
 
-				assert.Equal(t, 1, len(valuesMetadata))
+				assert.Len(t, valuesMetadata, 1)
 			}
 		})
 	}
@@ -80,7 +80,7 @@ func TestMetadata_ToMetricValuesMetadata(t *testing.T) {
 				require.NotNil(t, valuesMetadata)
 				require.NoError(t, err)
 
-				assert.Equal(t, 1, len(valuesMetadata))
+				assert.Len(t, valuesMetadata, 1)
 			}
 		})
 	}
@@ -137,8 +137,8 @@ func TestMetadata_MetricsMetadata(t *testing.T) {
 				assert.Equal(t, md.MetricNamePrefix, metricsMetadata.MetricNamePrefix)
 				assert.Equal(t, md.TimestampColumnName, metricsMetadata.TimestampColumnName)
 				assert.Equal(t, md.HighCardinality, metricsMetadata.HighCardinality)
-				assert.Equal(t, 1, len(metricsMetadata.QueryLabelValuesMetadata))
-				assert.Equal(t, 1, len(metricsMetadata.QueryMetricValuesMetadata))
+				assert.Len(t, metricsMetadata.QueryLabelValuesMetadata, 1)
+				assert.Len(t, metricsMetadata.QueryMetricValuesMetadata, 1)
 			}
 		})
 	}

--- a/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadataparser/metadataparser_test.go
@@ -37,7 +37,7 @@ func TestParseMetadataConfig(t *testing.T) {
 				require.Nil(t, metadataSlice)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, 2, len(metadataSlice))
+				assert.Len(t, metadataSlice, 2)
 
 				mData := metadataSlice[0]
 
@@ -58,12 +58,12 @@ func assertMetricsMetadata(t *testing.T, expectedName string, metricsMetadata *m
 	assert.Equal(t, "query", metricsMetadata.Query)
 	assert.Equal(t, "metric_name_prefix", metricsMetadata.MetricNamePrefix)
 
-	assert.Equal(t, 1, len(metricsMetadata.QueryLabelValuesMetadata))
+	assert.Len(t, metricsMetadata.QueryLabelValuesMetadata, 1)
 	assert.Equal(t, "label_name", metricsMetadata.QueryLabelValuesMetadata[0].Name())
 	assert.Equal(t, "LABEL_NAME", metricsMetadata.QueryLabelValuesMetadata[0].ColumnName())
 	assert.Equal(t, metadata.StringValueType, metricsMetadata.QueryLabelValuesMetadata[0].ValueType())
 
-	assert.Equal(t, 1, len(metricsMetadata.QueryMetricValuesMetadata))
+	assert.Len(t, metricsMetadata.QueryMetricValuesMetadata, 1)
 	assert.Equal(t, "metric_name", metricsMetadata.QueryMetricValuesMetadata[0].Name())
 	assert.Equal(t, "METRIC_NAME", metricsMetadata.QueryMetricValuesMetadata[0].ColumnName())
 	assert.Equal(t, "metric_unit", metricsMetadata.QueryMetricValuesMetadata[0].Unit())

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
@@ -50,7 +50,7 @@ func TestNewDatabaseReader(t *testing.T) {
 
 	assert.Equal(t, databaseID, reader.database.DatabaseID())
 	assert.Equal(t, logger, reader.logger)
-	assert.Equal(t, 0, len(reader.readers))
+	assert.Len(t, reader.readers, 0)
 }
 
 func TestNewDatabaseReaderWithError(t *testing.T) {
@@ -94,7 +94,7 @@ func TestInitializeReaders(t *testing.T) {
 
 	readers := initializeReaders(logger, parsedMetadata, database, readerConfig)
 
-	assert.Equal(t, 2, len(readers))
+	assert.Len(t, readers, 2)
 	assert.IsType(t, &currentStatsReader{}, readers[0])
 	assert.IsType(t, &intervalStatsReader{}, readers[1])
 }

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/statsreaders_mockedspanner_test.go
@@ -192,7 +192,7 @@ func TestStatsReaders_Read(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, testCase.expectedMetricsAmount, len(metrics))
+				assert.Len(t, metrics, testCase.expectedMetricsAmount)
 			}
 		})
 	}

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/timestampsgenerator_test.go
@@ -39,7 +39,7 @@ func TestTimestampsGenerator_PullTimestamps(t *testing.T) {
 			}
 			timestamps := generator.pullTimestamps(testCase.lastPullTimestamp, now)
 
-			assert.Equal(t, testCase.amountOfTimestamps, len(timestamps))
+			assert.Len(t, timestamps, testCase.amountOfTimestamps)
 		})
 	}
 }
@@ -51,7 +51,7 @@ func TestPullTimestampsWithDifference(t *testing.T) {
 
 	timestamps := pullTimestampsWithDifference(lowerBound, upperBound, time.Minute)
 
-	assert.Equal(t, expectedAmountOfTimestamps, len(timestamps))
+	assert.Len(t, timestamps, expectedAmountOfTimestamps)
 
 	expectedTimestamp := lowerBound.Add(time.Minute)
 
@@ -64,7 +64,7 @@ func TestPullTimestampsWithDifference(t *testing.T) {
 	upperBound = lowerBound.Add(5 * time.Minute).Add(15 * time.Second)
 	timestamps = pullTimestampsWithDifference(lowerBound, upperBound, time.Minute)
 
-	assert.Equal(t, 6, len(timestamps))
+	assert.Len(t, timestamps, 6)
 
 	expectedTimestamp = lowerBound.Add(time.Minute)
 

--- a/receiver/googlecloudspannerreceiver/receiver_test.go
+++ b/receiver/googlecloudspannerreceiver/receiver_test.go
@@ -116,10 +116,10 @@ func TestStart(t *testing.T) {
 
 			if testCase.expectError {
 				require.Error(t, err)
-				assert.Equal(t, 0, len(receiver.projectReaders))
+				assert.Len(t, receiver.projectReaders, 0)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, 1, len(receiver.projectReaders))
+				assert.Len(t, receiver.projectReaders, 1)
 			}
 		})
 	}
@@ -189,10 +189,10 @@ func TestInitializeProjectReaders(t *testing.T) {
 
 			if testCase.expectError {
 				require.Error(t, err)
-				assert.Equal(t, 0, len(receiver.projectReaders))
+				assert.Len(t, receiver.projectReaders, 0)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, 1, len(receiver.projectReaders))
+				assert.Len(t, receiver.projectReaders, 1)
 			}
 		})
 	}

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -42,7 +42,7 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	assert.Equal(t, len(cfg.Receivers), 2)
+	assert.Len(t, cfg.Receivers, 2)
 
 	r0 := cfg.Receivers[component.NewID(metadata.Type)]
 	defaultConfigCPUScraper := factory.CreateDefaultConfig()

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -201,7 +201,7 @@ func testJaegerAgent(t *testing.T, agentEndpoint string, receiverConfig *configu
 	}, 10*time.Second, 5*time.Millisecond)
 
 	gotTraces := sink.AllTraces()
-	require.Equal(t, 1, len(gotTraces))
+	require.Len(t, gotTraces, 1)
 	assert.EqualValues(t, td, gotTraces[0])
 }
 

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -104,7 +104,7 @@ func TestReception(t *testing.T) {
 	assert.NoError(t, err, "should not have failed to create the Jaeger OpenCensus exporter")
 
 	gotTraces := sink.AllTraces()
-	assert.Equal(t, 1, len(gotTraces))
+	assert.Len(t, gotTraces, 1)
 
 	assert.EqualValues(t, td, gotTraces[0])
 }
@@ -178,7 +178,7 @@ func TestGRPCReception(t *testing.T) {
 	assert.NotNil(t, resp, "response should not have been nil")
 
 	gotTraces := sink.AllTraces()
-	assert.Equal(t, 1, len(gotTraces))
+	assert.Len(t, gotTraces, 1)
 	want := expectedTraceData(now, nowPlus10min, nowPlus10min2sec)
 
 	assert.Len(t, req.Batch.Spans, want.SpanCount(), "got a conflicting amount of spans")
@@ -238,7 +238,7 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	assert.NotNil(t, resp, "response should not have been nil")
 
 	gotTraces := sink.AllTraces()
-	assert.Equal(t, 1, len(gotTraces))
+	assert.Len(t, gotTraces, 1)
 	want := expectedTraceData(now, nowPlus10min, nowPlus10min2sec)
 
 	assert.Len(t, req.Batch.Spans, want.SpanCount(), "got a conflicting amount of spans")

--- a/receiver/k8sclusterreceiver/internal/cronjob/cronjobs_test.go
+++ b/receiver/k8sclusterreceiver/internal/cronjob/cronjobs_test.go
@@ -43,7 +43,7 @@ func TestCronJobMetadata(t *testing.T) {
 
 	actualMetadata := GetMetadata(cj)
 
-	require.Equal(t, 1, len(actualMetadata))
+	require.Len(t, actualMetadata, 1)
 
 	// Assert metadata from Pod.
 	require.Equal(t,

--- a/receiver/k8sclusterreceiver/internal/metadata/metadata_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/metadata_test.go
@@ -216,7 +216,7 @@ func TestGetMetadataUpdate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			delta := GetMetadataUpdate(tt.args.oldMdata, tt.args.newMdata)
 			if tt.metadataDelta != nil {
-				require.Equal(t, 1, len(delta))
+				require.Len(t, delta, 1)
 				require.Equal(t, *tt.metadataDelta, delta[0].MetadataDelta)
 			} else {
 				require.Zero(t, len(delta))

--- a/receiver/k8sclusterreceiver/internal/statefulset/statefulsets_test.go
+++ b/receiver/k8sclusterreceiver/internal/statefulset/statefulsets_test.go
@@ -56,7 +56,7 @@ func TestStatefulsetMetadata(t *testing.T) {
 
 	actualMetadata := GetMetadata(ss)
 
-	require.Equal(t, 1, len(actualMetadata))
+	require.Len(t, actualMetadata, 1)
 
 	require.Equal(t,
 		metadata.KubernetesMetadata{

--- a/receiver/kubeletstatsreceiver/internal/kubelet/accumulator_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/accumulator_test.go
@@ -210,7 +210,7 @@ func TestMetadataErrorCases(t *testing.T) {
 
 			tt.testScenario(acc)
 
-			assert.Equal(t, tt.numMDs, len(acc.m))
+			assert.Len(t, acc.m, tt.numMDs)
 			require.Equal(t, tt.numLogs, logs.Len())
 			for i := 0; i < tt.numLogs; i++ {
 				assert.Equal(t, tt.logMessages[i], logs.All()[i].Message)

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
@@ -45,7 +45,7 @@ func TestMetricAccumulator(t *testing.T) {
 	mbs.NodeMetricsBuilder.Reset()
 	mbs.PodMetricsBuilder.Reset()
 	mbs.OtherMetricsBuilder.Reset()
-	require.Equal(t, 0, len(MetricsData(zap.NewNop(), summary, k8sMetadata, map[MetricGroup]bool{}, mbs)))
+	require.Len(t, MetricsData(zap.NewNop(), summary, k8sMetadata, map[MetricGroup]bool{}, mbs), 0)
 }
 
 func requireMetricsOk(t *testing.T, mds []pmetric.Metrics) {

--- a/receiver/opencensusreceiver/internal/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/internal/octrace/observability_test.go
@@ -109,7 +109,7 @@ func TestExportSpanLinkingMaintainsParentLink(t *testing.T) {
 
 	// Inspection time!
 	gotSpanData := tt.SpanRecorder.Ended()
-	assert.Equal(t, n+1, len(gotSpanData))
+	assert.Len(t, gotSpanData, n+1)
 
 	receiverSpanData := gotSpanData[0]
 	assert.Len(t, receiverSpanData.Links(), 1)

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -584,7 +584,7 @@ func TestOCReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 					assert.Equal(t, ingestionState.expectedCode, status.Code())
 				}
 
-				require.Equal(t, tt.expectedReceivedBatches, len(sink.AllTraces()))
+				require.Len(t, sink.AllTraces(), tt.expectedReceivedBatches)
 				require.NoError(t, testTel.CheckReceiverTraces("grpc", int64(tt.expectedReceivedBatches), int64(tt.expectedIngestionBlockedRPCs)))
 			})
 		}
@@ -742,7 +742,7 @@ func TestOCReceiverMetrics_HandleNextConsumerResponse(t *testing.T) {
 					assert.Equal(t, ingestionState.expectedCode, status.Code())
 				}
 
-				require.Equal(t, tt.expectedReceivedBatches, len(sink.AllMetrics()))
+				require.Len(t, sink.AllMetrics(), tt.expectedReceivedBatches)
 				require.NoError(t, testTel.CheckReceiverMetrics("grpc", int64(tt.expectedReceivedBatches), int64(tt.expectedIngestionBlockedRPCs)))
 			})
 		}

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -131,7 +131,7 @@ func TestOTelArrowReceiverGRPCTracesIngestTest(t *testing.T) {
 		assert.Equal(t, ingestionState.expectedCode, errStatus.Code())
 	}
 
-	require.Equal(t, expectedReceivedBatches, len(sink.AllTraces()))
+	require.Len(t, sink.AllTraces(), expectedReceivedBatches)
 
 	expectedIngestionBlockedRPCs := 1
 	require.NoError(t, tt.CheckReceiverTraces("grpc", int64(expectedReceivedBatches), int64(expectedIngestionBlockedRPCs)))
@@ -710,7 +710,7 @@ func TestGRPCArrowReceiverAuth(t *testing.T) {
 	assert.NoError(t, cc.Close())
 	require.NoError(t, ocr.Shutdown(context.Background()))
 
-	assert.Equal(t, 0, len(sink.AllTraces()))
+	assert.Len(t, sink.AllTraces(), 0)
 }
 
 func TestConcurrentArrowReceiver(t *testing.T) {
@@ -789,7 +789,7 @@ func TestConcurrentArrowReceiver(t *testing.T) {
 
 	// Two spans per stream/item.
 	require.Equal(t, itemsPerStream*numStreams*2, sink.SpanCount())
-	require.Equal(t, itemsPerStream*numStreams, len(sink.Metadatas()))
+	require.Len(t, sink.Metadatas(), itemsPerStream*numStreams)
 
 	for _, md := range sink.Metadatas() {
 		val, err := strconv.Atoi(md.Get("seq")[0])

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -176,7 +176,7 @@ func TestEventLoopHandles(t *testing.T) {
 	cli := newContainerScraper(&eventClient, zap.NewNop(), &Config{})
 	assert.NotNil(t, cli)
 
-	assert.Equal(t, 0, len(cli.containers))
+	assert.Len(t, cli.containers, 0)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go cli.containerEventLoop(ctx)
@@ -187,7 +187,7 @@ func TestEventLoopHandles(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		cli.containersLock.Lock()
 		defer cli.containersLock.Unlock()
-		return assert.Equal(t, 1, len(cli.containers))
+		return assert.Len(t, cli.containers, 1)
 	}, 1*time.Second, 1*time.Millisecond, "failed to update containers list.")
 
 	eventChan <- event{ID: "c1", Status: "died"}
@@ -195,7 +195,7 @@ func TestEventLoopHandles(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		cli.containersLock.Lock()
 		defer cli.containersLock.Unlock()
-		return assert.Equal(t, 0, len(cli.containers))
+		return assert.Len(t, cli.containers, 0)
 	}, 1*time.Second, 1*time.Millisecond, "failed to update containers list.")
 }
 
@@ -210,10 +210,10 @@ func TestInspectAndPersistContainer(t *testing.T) {
 	cli := newContainerScraper(&inspectClient, zap.NewNop(), &Config{})
 	assert.NotNil(t, cli)
 
-	assert.Equal(t, 0, len(cli.containers))
+	assert.Len(t, cli.containers, 0)
 
 	stats, ok := cli.inspectAndPersistContainer(context.Background(), "c1")
 	assert.True(t, ok)
 	assert.NotNil(t, stats)
-	assert.Equal(t, 1, len(cli.containers))
+	assert.Len(t, cli.containers, 1)
 }

--- a/receiver/podmanreceiver/record_metrics_test.go
+++ b/receiver/podmanreceiver/record_metrics_test.go
@@ -99,7 +99,7 @@ func assertMetricEqual(t *testing.T, m pmetric.Metric, dt pmetric.MetricType, pt
 }
 
 func assertPoints(t *testing.T, dpts pmetric.NumberDataPointSlice, pts []point) {
-	assert.Equal(t, dpts.Len(), len(pts))
+	assert.Len(t, pts, dpts.Len())
 	for i, expected := range pts {
 		got := dpts.At(i)
 		assert.Equal(t, got.IntValue(), int64(expected.intVal))

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -90,7 +90,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, r0.TargetAllocator.Interval)
 	assert.Equal(t, "collector-1", r0.TargetAllocator.CollectorID)
 
-	assert.Equal(t, 1, len(r1.PrometheusConfig.ScrapeConfigs))
+	assert.Len(t, r1.PrometheusConfig.ScrapeConfigs, 1)
 	assert.Equal(t, "demo", r1.PrometheusConfig.ScrapeConfigs[0].JobName)
 	assert.Equal(t, promModel.Duration(5*time.Second), r1.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval)
 
@@ -101,7 +101,7 @@ func TestLoadTargetAllocatorConfig(t *testing.T) {
 	require.NoError(t, component.ValidateConfig(cfg))
 
 	r2 := cfg.(*Config)
-	assert.Equal(t, 1, len(r2.PrometheusConfig.ScrapeConfigs))
+	assert.Len(t, r2.PrometheusConfig.ScrapeConfigs, 1)
 	assert.Equal(t, "demo", r2.PrometheusConfig.ScrapeConfigs[0].JobName)
 	assert.Equal(t, promModel.Duration(5*time.Second), r2.PrometheusConfig.ScrapeConfigs[0].ScrapeInterval)
 }

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -450,27 +450,27 @@ func assertMetricPresent(name string, metricTypeExpectations metricTypeComparato
 				switch m.Type() {
 				case pmetric.MetricTypeGauge:
 					for _, npc := range de.numberPointComparator {
-						require.Equal(t, m.Gauge().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Gauge metric '%s' does not match to testdata", name)
+						require.Len(t, dataPointExpectations, m.Gauge().DataPoints().Len(), "Expected number of data-points in Gauge metric '%s' does not match to testdata", name)
 						npc(t, m.Gauge().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeSum:
 					for _, npc := range de.numberPointComparator {
-						require.Equal(t, m.Sum().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Sum metric '%s' does not match to testdata", name)
+						require.Len(t, dataPointExpectations, m.Sum().DataPoints().Len(), "Expected number of data-points in Sum metric '%s' does not match to testdata", name)
 						npc(t, m.Sum().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeHistogram:
 					for _, hpc := range de.histogramPointComparator {
-						require.Equal(t, m.Histogram().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Histogram metric '%s' does not match to testdata", name)
+						require.Len(t, dataPointExpectations, m.Histogram().DataPoints().Len(), "Expected number of data-points in Histogram metric '%s' does not match to testdata", name)
 						hpc(t, m.Histogram().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeSummary:
 					for _, spc := range de.summaryPointComparator {
-						require.Equal(t, m.Summary().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Summary metric '%s' does not match to testdata", name)
+						require.Len(t, dataPointExpectations, m.Summary().DataPoints().Len(), "Expected number of data-points in Summary metric '%s' does not match to testdata", name)
 						spc(t, m.Summary().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					for _, ehc := range de.exponentialHistogramComparator {
-						require.Equal(t, m.ExponentialHistogram().DataPoints().Len(), len(dataPointExpectations), "Expected number of data-points in Exponential Histogram metric '%s' does not match to testdata", name)
+						require.Len(t, dataPointExpectations, m.ExponentialHistogram().DataPoints().Len(), "Expected number of data-points in Exponential Histogram metric '%s' does not match to testdata", name)
 						ehc(t, m.ExponentialHistogram().DataPoints().At(i))
 					}
 				case pmetric.MetricTypeEmpty:

--- a/receiver/redisreceiver/redis_svc_test.go
+++ b/receiver/redisreceiver/redis_svc_test.go
@@ -17,6 +17,6 @@ func TestParser(t *testing.T) {
 	s := newFakeAPIParser()
 	info, err := s.info()
 	require.NoError(t, err)
-	require.Equal(t, 130, len(info))
+	require.Len(t, info, 130)
 	require.Equal(t, "1.24", info["allocator_frag_ratio"]) // spot check
 }

--- a/receiver/sapmreceiver/trace_receiver_test.go
+++ b/receiver/sapmreceiver/trace_receiver_test.go
@@ -350,7 +350,7 @@ func TestReception(t *testing.T) {
 
 			// retrieve received traces
 			got := sink.AllTraces()
-			assert.Equal(t, 1, len(got))
+			assert.Len(t, got, 1)
 
 			// compare what we got to what we wanted
 			t.Log("Comparing expected data to trace data")
@@ -414,7 +414,7 @@ func TestAccessTokenPassthrough(t *testing.T) {
 			assert.NoError(t, resp.Body.Close())
 
 			got := sink.AllTraces()
-			assert.Equal(t, 1, len(got))
+			assert.Len(t, got, 1)
 
 			received := got[0].ResourceSpans()
 			for i := 0; i < received.Len(); i++ {

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -879,7 +879,7 @@ func Test_sfxReceiver_EventAccessTokenPassthrough(t *testing.T) {
 			assert.Equal(t, responseOK, bodyStr)
 
 			got := sink.AllLogs()
-			require.Equal(t, 1, len(got))
+			require.Len(t, got, 1)
 
 			tokenLabel := ""
 			if accessTokenAttr, ok := got[0].ResourceLogs().At(0).Resource().Attributes().Get("com.splunk.signalfx.access_token"); ok {

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -294,10 +294,10 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				assertHecSuccessResponse(t, resp, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 1, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 1)
 			},
 			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
-				assert.Equal(t, 0, len(sink.AllMetrics()))
+				assert.Len(t, sink.AllMetrics(), 0)
 			},
 		},
 		{
@@ -312,10 +312,10 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				assertHecSuccessResponse(t, resp, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 0, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 0)
 			},
 			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
-				assert.Equal(t, 1, len(sink.AllMetrics()))
+				assert.Len(t, sink.AllMetrics(), 1)
 			},
 		},
 		{
@@ -530,7 +530,7 @@ func Test_splunkhecReceiver_TLS(t *testing.T) {
 	t.Log("Splunk HEC Request Received")
 
 	got := sink.AllLogs()
-	require.Equal(t, 1, len(got))
+	require.Len(t, got, 1)
 	assert.Equal(t, want, got[0])
 }
 
@@ -1593,7 +1593,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assertHecSuccessResponse(t, resp, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 1, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 1)
 			},
 		},
 		{
@@ -1614,7 +1614,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assert.Equal(t, map[string]any{"code": float64(10), "text": "Data channel is missing"}, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 0, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 0)
 			},
 		},
 		{
@@ -1635,7 +1635,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assert.Equal(t, map[string]any{"text": "Invalid data channel", "code": float64(11)}, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 0, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 0)
 			},
 		},
 		{
@@ -1660,7 +1660,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assertHecSuccessResponseWithAckID(t, resp, body, 1)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 1, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 1)
 			},
 		},
 		{
@@ -1685,7 +1685,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assertHecSuccessResponseWithAckID(t, resp, body, 1)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 1, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 1)
 			},
 		},
 		{
@@ -1709,7 +1709,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assertHecSuccessResponseWithAckID(t, resp, body, 1)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Equal(t, 1, len(sink.AllLogs()))
+				assert.Len(t, sink.AllLogs(), 1)
 			},
 		},
 	}
@@ -1880,7 +1880,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 				return req
 			}(),
 			assertResource: func(t *testing.T, got []plog.Logs) {
-				require.Equal(t, 1, len(got))
+				require.Len(t, got, 1)
 				resources := got[0].ResourceLogs()
 				assert.Equal(t, 1, resources.Len())
 				resource := resources.At(0).Resource().Attributes()
@@ -1905,7 +1905,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 				return req
 			}(),
 			assertResource: func(t *testing.T, got []plog.Logs) {
-				require.Equal(t, 1, len(got))
+				require.Len(t, got, 1)
 				resources := got[0].ResourceLogs()
 				assert.Equal(t, 1, resources.Len())
 				resource := resources.At(0).Resource().Attributes()
@@ -1930,7 +1930,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 				return req
 			}(),
 			assertResource: func(t *testing.T, got []plog.Logs) {
-				require.Equal(t, 1, len(got))
+				require.Len(t, got, 1)
 				resources := got[0].ResourceLogs()
 				assert.Equal(t, 1, resources.Len())
 				resource := resources.At(0).Resource().Attributes()

--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -607,7 +607,7 @@ func TestMysqlIntegrationMetrics(t *testing.T) {
 }
 
 func testAllSimpleLogs(t *testing.T, logs []plog.Logs) {
-	assert.Equal(t, 1, len(logs))
+	assert.Len(t, logs, 1)
 	assert.Equal(t, 1, logs[0].ResourceLogs().Len())
 	assert.Equal(t, 1, logs[0].ResourceLogs().At(0).ScopeLogs().Len())
 	expectedEntries := []string{

--- a/receiver/sqlserverreceiver/scraper_windows_test.go
+++ b/receiver/sqlserverreceiver/scraper_windows_test.go
@@ -90,7 +90,7 @@ func TestSqlServerScraper(t *testing.T) {
 	s := newSQLServerPCScraper(settings, cfg)
 
 	assert.NoError(t, s.start(context.Background(), nil))
-	assert.Equal(t, 0, len(s.watcherRecorders))
+	assert.Len(t, s.watcherRecorders, 0)
 	assert.Equal(t, 21, obsLogs.Len())
 	assert.Equal(t, 21, obsLogs.FilterMessageSnippet("failed to create perf counter with path \\SQLServer:").Len())
 	assert.Equal(t, 21, obsLogs.FilterMessageSnippet("The specified object was not found on the computer.").Len())

--- a/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
+++ b/receiver/sshcheckreceiver/internal/configssh/configssh_test.go
@@ -118,7 +118,7 @@ func TestAllSSHClientSettings(t *testing.T) {
 			assert.EqualValues(t, client.ClientConfig.User, test.settings.Username)
 
 			if len(test.settings.KeyFile) > 0 || len(test.settings.Password) > 0 {
-				assert.EqualValues(t, 1, len(client.ClientConfig.Auth))
+				assert.Len(t, client.ClientConfig.Auth, 1)
 			}
 		})
 	}
@@ -192,7 +192,7 @@ func Test_Client_Dial(t *testing.T) {
 				assert.EqualValues(t, client.HostKeyCallback, ssh.InsecureIgnoreHostKey()) //#nosec G106
 			}
 			if len(test.settings.KeyFile) > 0 || len(test.settings.Password) > 0 {
-				assert.EqualValues(t, 1, len(client.ClientConfig.Auth))
+				assert.Len(t, client.ClientConfig.Auth, 1)
 			}
 		})
 	}

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
@@ -1491,8 +1491,8 @@ func TestStatsDParser_Initialize(t *testing.T) {
 	instrument := newInstruments(addr)
 	instrument.gauges[teststatsdDMetricdescription] = pmetric.ScopeMetrics{}
 	p.instrumentsByAddress[addrKey] = instrument
-	assert.Equal(t, 1, len(p.instrumentsByAddress))
-	assert.Equal(t, 1, len(p.instrumentsByAddress[addrKey].gauges))
+	assert.Len(t, p.instrumentsByAddress, 1)
+	assert.Len(t, p.instrumentsByAddress[addrKey].gauges, 1)
 	assert.Equal(t, GaugeObserver, p.timerEvents.method)
 	assert.Equal(t, GaugeObserver, p.histogramEvents.method)
 }

--- a/receiver/statsdreceiver/internal/transport/server_test.go
+++ b/receiver/statsdreceiver/internal/transport/server_test.go
@@ -89,7 +89,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			assert.NoError(t, err)
 
 			wgListenAndServe.Wait()
-			assert.Equal(t, 1, len(transferChan))
+			assert.Len(t, transferChan, 1)
 		})
 	}
 }

--- a/receiver/vcenterreceiver/client_test.go
+++ b/receiver/vcenterreceiver/client_test.go
@@ -230,7 +230,7 @@ func TestDatacenterInventoryListObjects(t *testing.T) {
 		}
 		dcs, err := client.DatacenterInventoryListObjects(ctx)
 		require.NoError(t, err)
-		require.Equal(t, len(dcs), 2)
+		require.Len(t, dcs, 2)
 	}, vpx)
 }
 

--- a/receiver/wavefrontreceiver/receiver_test.go
+++ b/receiver/wavefrontreceiver/receiver_test.go
@@ -123,7 +123,7 @@ func Test_wavefrontreceiver_EndToEnd(t *testing.T) {
 			numMetrics = 1
 		}
 		n, err := fmt.Fprint(conn, tt.msg)
-		assert.Equal(t, len(tt.msg), n)
+		assert.Len(t, tt.msg, n)
 		assert.NoError(t, err)
 
 		require.NoError(t, conn.Close())

--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -272,7 +272,7 @@ func requireExpectedLogRecords(t *testing.T, sink *consumertest.LogsSink, expect
 	// logs sometimes take a while to be written, so a substantial wait buffer is needed
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		actualLogRecords = filterAllLogRecordsBySource(t, sink, expectedEventSrc)
-		assert.Equal(c, expectedEventCount, len(actualLogRecords))
+		assert.Len(c, actualLogRecords, expectedEventCount)
 	}, 10*time.Second, 250*time.Millisecond)
 
 	return actualLogRecords

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -128,7 +128,7 @@ func (v *CorrectnessTestValidator) Validate(tc *TestCase) {
 	if len(tc.MockBackend.ReceivedTraces) > 0 {
 		v.assertSentRecdTracingDataEqual(append(tc.MockBackend.ReceivedTraces, tc.MockBackend.DroppedTraces...))
 	}
-	assert.EqualValues(tc.t, 0, len(v.assertionFailures), "There are span data mismatches.")
+	assert.Len(tc.t, v.assertionFailures, 0, "There are span data mismatches.")
 }
 
 func (v *CorrectnessTestValidator) RecordResults(tc *TestCase) {

--- a/testbed/tests/syslog_integration_test.go
+++ b/testbed/tests/syslog_integration_test.go
@@ -182,10 +182,10 @@ service:
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	require.Equal(t, len(backend.ReceivedLogs), 1)
+	require.Len(t, backend.ReceivedLogs, 1)
 	require.Equal(t, backend.ReceivedLogs[0].ResourceLogs().Len(), 1)
 	require.Equal(t, backend.ReceivedLogs[0].ResourceLogs().At(0).ScopeLogs().Len(), 1)
-	require.Equal(t, backend.ReceivedLogs[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().Len(), len(expectedData))
+	require.Len(t, expectedData, backend.ReceivedLogs[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().Len())
 
 	// Clean received logs
 	attributes := []map[string]any{}


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [len](https://github.com/Antonboom/testifylint?tab=readme-ov-file#len) rule from [testifylint](https://github.com/Antonboom/testifylint)