### PR TITLE
[processor/remotetapprocessor] don't require Origin header

### DIFF
--- a/.chloggen/remotetap-origin.yaml
+++ b/.chloggen/remotetap-origin.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: remotetapprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Origin header is no longer required for websocket connections
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34925]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/remotetapprocessor/processor.go
+++ b/processor/remotetapprocessor/processor.go
@@ -52,7 +52,7 @@ func (w *wsprocessor) Start(ctx context.Context, host component.Host) error {
 	if err != nil {
 		return fmt.Errorf("failed to bind to address %s: %w", w.config.Endpoint, err)
 	}
-	w.server, err = w.config.ServerConfig.ToServer(ctx, host, w.telemetrySettings, websocket.Handler(w.handleConn))
+	w.server, err = w.config.ServerConfig.ToServer(ctx, host, w.telemetrySettings, websocket.Server{Handler: w.handleConn})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Description:**

Currently remotetap runs a server using [`websocket.Handler`](https://pkg.go.dev/golang.org/x/net/websocket#Handler.ServeHTTP)
This internally creates a [`websocket.Server`](https://cs.opensource.google/go/x/net/+/refs/tags/v0.28.0:websocket/server.go;l=111)
that [requires a `Origin` header](https://cs.opensource.google/go/x/net/+/refs/tags/v0.28.0:websocket/server.go;l=101-107) in the incoming request.
While this makes sense for browser usage,
for the collector we may want to use other tools e.g. CLI tools which do not set an `Origin` header.

This changes the server to use `websocket.Server` directly, without setting `Handshake`,
[bypassing the origin check](https://cs.opensource.google/go/x/net/+/refs/tags/v0.28.0:websocket/server.go;l=32-41)

**Link to tracking Issue:** N/A issue reported in slack

**Testing:** manual https://cloud-native.slack.com/archives/C01N6P7KR6W/p1724957510485869?thread_ts=1724863668.431979&cid=C01N6P7KR6W

**Documentation:** none / bug fix