### PR TITLE
feat: Add ability to rename metrics based on attributes

### DIFF
--- a/.chloggen/awsfirehose-metric-renaming.yaml
+++ b/.chloggen/awsfirehose-metric-renaming.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsfirehosereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Allow renaming the metircs based on incoming metric attributes"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34927]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change allows users to rename the metrics based on the incoming metric
+  attributes such as cloud provider or service name.  This is helpful because
+  otherwise the awsfirehosereceiver uses the plain metric names from CloudWatch,
+  and these can conflict with other metrics from other sources, likely with conflicting
+  attribute sets.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awsfirehosereceiver/README.md
+++ b/receiver/awsfirehosereceiver/README.md
@@ -28,37 +28,57 @@ receivers:
       cert_file: server.crt
       key_file: server.key
 ```
+
 The configuration includes the Opentelemetry collector's server [confighttp](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp#server-configuration),
 which allows for a variety of settings. Only the most relevant ones will be discussed here, but all are available.
 The AWS Kinesis Data Firehose Delivery Streams currently only support HTTPS endpoints using port 443. This can be potentially circumvented
 using a Load Balancer.
 
-### endpoint:
+### endpoint
+
 The address:port to bind the listener to.
 
 default: `localhost:4433`
 
 You can temporarily disable the `component.UseLocalHostAsDefaultHost` feature gate to change this to `0.0.0.0:4433`. This feature gate will be removed in a future release.
 
-### tls:
+### tls
+
 See [documentation](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md#server-configuration) for more details.
 
 A `cert_file` and `key_file` are required.
 
-### record_type:
+### record_type
+
 The type of record being received from the delivery stream. Each unmarshaler handles a specific type, so the field allows the receiver to use the correct one.
 
 default: `cwmetrics`
 
 See the [Record Types](#record-types) section for all available options.
 
-### access_key (Optional):
+### access_key (Optional)
+
 The access key to be checked on each request received. This can be set when creating or updating the delivery stream.
 See [documentation](https://docs.aws.amazon.com/firehose/latest/dev/create-destination.html#create-destination-http) for details.
+
+### name_prefixes
+
+This allows changing the metric name based on attribute values.  For example, given a metric
+named `bytes_received`, it will be renamed to `aws.some-service.bytes_received`:
+
+```yaml
+receivers:
+  awsfirehose:
+    name_prefixes:
+      - attribute_name: cloud.provider
+        default: aws
+      - attribute_name: service.name
+        default: unnamed
+```
 
 ## Record Types
 
 ### cwmetrics
+
 The record type for the CloudWatch metric stream. Expects the format for the records to be JSON.
 See [documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Metric-Streams.html) for details.
-

--- a/receiver/awsfirehosereceiver/config_test.go
+++ b/receiver/awsfirehosereceiver/config_test.go
@@ -33,6 +33,16 @@ func TestLoadConfig(t *testing.T) {
 	require.Equal(t, &Config{
 		RecordType: "cwmetrics",
 		AccessKey:  "some_access_key",
+		NamePrefixes: []NamePrefixConfig{
+			{
+				AttributeName: "alice",
+				Default:       "alice",
+			},
+			{
+				AttributeName: "bob",
+				Default:       "bob",
+			},
+		},
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: "0.0.0.0:4433",
 			TLSSetting: &configtls.ServerConfig{

--- a/receiver/awsfirehosereceiver/testdata/config.yaml
+++ b/receiver/awsfirehosereceiver/testdata/config.yaml
@@ -5,3 +5,8 @@ awsfirehose:
   tls:
     cert_file: server.crt
     key_file: server.key
+  name_prefixes:
+    - attribute_name: alice
+      default: "alice"
+    - attribute_name: bob
+      default: "bob"


### PR DESCRIPTION
**Description:** 

This change allows metric names to be remapped based on attribute values.

The use case here is that the metric names come in and mix with all the other metric feeds one may have, making it harder to filter and limit searches.  For example, `bytes_received` may occur in many different AWS services, as well as many other metric sources.  In our ingestion of firehose metrics, we want to rename this to be `aws.elb.bytes_received` to be specific about what object I am looking at.

I acknowledge that this is not strictly necessary as I could add other filters to further separate this in queries, but that is messy, and should another metric be introduced I would have to find all those filters and update them.

**Link to tracking Issue:**

None created.

**Testing:**

Tests were added for all the new code.

This has been running in our production environment for several weeks now, ingesting customer data as well as our own internal metrics.

**Documentation:**

Description and example added to README.
