### PR TITLE
[chore]: enable error-nil and nil-compare rules from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,14 +137,14 @@ linters-settings:
       - compares
       - empty
       - error-is-as
-      - error-nil
       - expected-actual
       - float-compare
+      - formatter
       - go-require
       - negative-positive
-      - nil-compare
       - require-error
       - suite-dont-use-pkg
+      - suite-subtest-run
       - useless-assert
     enable-all: true
 

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,14 @@ golint:
 gogovulncheck:
 	$(MAKE) $(FOR_GROUP_TARGET) TARGET="govulncheck"
 
+.PHONY: gotestifylint
+gotestifylint:
+	$(MAKE) $(FOR_GROUP_TARGET) TARGET="testifylint"
+
+.PHONY: gotestifylint-fix
+gotestifylint-fix:
+	$(MAKE) $(FOR_GROUP_TARGET) TARGET="testifylint-fix"
+
 .PHONY: goporto
 goporto: $(PORTO)
 	$(PORTO) -w --include-internal --skip-dirs "^cmd$$" ./

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -72,8 +72,10 @@ BUILDER             := $(TOOLS_BIN_DIR)/builder
 GOVULNCHECK         := $(TOOLS_BIN_DIR)/govulncheck
 GCI                 := $(TOOLS_BIN_DIR)/gci
 GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
+TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
+TESTIFYLINT_OPT?= --enable-all --disable=compares,empty,error-is-as,expected-actual,float-compare,formatter,go-require,negative-positive,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
@@ -219,6 +221,15 @@ misspell-correction: $(TOOLS_BIN_DIR)/misspell
 .PHONY: moddownload
 moddownload:
 	$(GOCMD) mod download
+
+.PHONY: testifylint
+testifylint: $(TESTIFYLINT)
+	@echo "running $(TESTIFYLINT)"
+	$(TESTIFYLINT) $(TESTIFYLINT_OPT) ./...
+
+.PHONY: testifylint-fix
+testifylint-fix:
+	@$(MAKE) testifylint TESTIFYLINT_OPT="${TESTIFYLINT_OPT} --fix"
 
 .PHONY: gci
 gci: $(TOOLS_BIN_DIR)/gci

--- a/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
@@ -31,7 +31,7 @@ func TestNewTracesExporter(t *testing.T) {
 	// This will put trace data to send buffer and return success.
 	err = got.ConsumeTraces(context.Background(), traces)
 	assert.NoError(t, err)
-	assert.Nil(t, got.Shutdown(context.Background()))
+	assert.NoError(t, got.Shutdown(context.Background()))
 }
 
 func TestNewFailsWithEmptyTracesExporterName(t *testing.T) {

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -314,10 +314,10 @@ func TestPushMetricsDataWithErr(t *testing.T) {
 		metricNames:  []string{"metric_1", "metric_2"},
 		metricValues: [][]float64{{100}, {4}},
 	})
-	assert.NotNil(t, exp.pushMetricsData(ctx, md))
-	assert.NotNil(t, exp.pushMetricsData(ctx, md))
-	assert.Nil(t, exp.pushMetricsData(ctx, md))
-	assert.Nil(t, exp.shutdown(ctx))
+	assert.Error(t, exp.pushMetricsData(ctx, md))
+	assert.Error(t, exp.pushMetricsData(ctx, md))
+	assert.NoError(t, exp.pushMetricsData(ctx, md))
+	assert.NoError(t, exp.shutdown(ctx))
 }
 
 func TestNewExporterWithoutConfig(t *testing.T) {

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -462,7 +462,7 @@ func BenchmarkAddToGroupedMetric(b *testing.B) {
 		for i := 0; i < numMetrics; i++ {
 			metadata := generateTestMetricMetadata("namespace", int64(1596151098037), "log-group", "log-stream", "cloudwatch-otel", metrics.At(i).Type())
 			err := addToGroupedMetric(metrics.At(i), groupedMetrics, metadata, true, nil, testCfg, emfCalcs)
-			assert.Nil(b, err)
+			assert.NoError(b, err)
 		}
 	}
 }

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -1984,7 +1984,7 @@ func BenchmarkTranslateOtToGroupedMetricWithInstrLibrary(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		groupedMetric := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetric, config)
-		assert.Nil(b, err)
+		assert.NoError(b, err)
 	}
 }
 
@@ -2007,7 +2007,7 @@ func BenchmarkTranslateOtToGroupedMetricWithoutConfigReplacePattern(b *testing.B
 	for n := 0; n < b.N; n++ {
 		groupedMetrics := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
-		assert.Nil(b, err)
+		assert.NoError(b, err)
 	}
 }
 
@@ -2030,7 +2030,7 @@ func BenchmarkTranslateOtToGroupedMetricWithConfigReplaceWithResource(b *testing
 	for n := 0; n < b.N; n++ {
 		groupedMetrics := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
-		assert.Nil(b, err)
+		assert.NoError(b, err)
 	}
 }
 
@@ -2053,7 +2053,7 @@ func BenchmarkTranslateOtToGroupedMetricWithConfigReplaceWithLabel(b *testing.B)
 	for n := 0; n < b.N; n++ {
 		groupedMetrics := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
-		assert.Nil(b, err)
+		assert.NoError(b, err)
 	}
 }
 
@@ -2071,7 +2071,7 @@ func BenchmarkTranslateOtToGroupedMetricWithoutInstrLibrary(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		groupedMetrics := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
-		assert.Nil(b, err)
+		assert.NoError(b, err)
 	}
 }
 
@@ -2140,7 +2140,7 @@ func BenchmarkTranslateGroupedMetricToCWMetricWithFiltering(b *testing.B) {
 	}
 	logger := zap.NewNop()
 	err := m.init(logger)
-	assert.Nil(b, err)
+	assert.NoError(b, err)
 	config := &Config{
 		MetricDeclarations:    []*MetricDeclaration{m},
 		DimensionRollupOption: zeroAndSingleDimensionRollup,

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -409,7 +409,7 @@ func TestFixSegmentName(t *testing.T) {
 
 func TestFixAnnotationKey(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	validKey := "Key_1"
 	fixedKey := fixAnnotationKey(validKey)
@@ -424,7 +424,7 @@ func TestFixAnnotationKey(t *testing.T) {
 
 func TestFixAnnotationKeyWithAllowDot(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	validKey := "Key_1"
 	fixedKey := fixAnnotationKey(validKey)
@@ -585,7 +585,7 @@ func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
 
 func TestResourceAttributesCanBeIndexed(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -618,7 +618,7 @@ func TestResourceAttributesCanBeIndexed(t *testing.T) {
 
 func TestResourceAttributesCanBeIndexedWithAllowDot(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -672,7 +672,7 @@ func TestResourceAttributesNotIndexedIfSubsegment(t *testing.T) {
 
 func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -692,7 +692,7 @@ func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
 
 func TestSpanWithSpecialAttributesAsListedWithAllowDot(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -712,7 +712,7 @@ func TestSpanWithSpecialAttributesAsListedWithAllowDot(t *testing.T) {
 
 func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -731,7 +731,7 @@ func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
 
 func TestSpanWithSpecialAttributesAsListedAndIndexAllWithAllowDot(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", true)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
@@ -1142,7 +1142,7 @@ func TestAwsSdkSpanWithAwsRemoteServiceName(t *testing.T) {
 	jsonStr, err := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, jsonStr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, strings.Contains(jsonStr, "DynamoDb"))
 	assert.False(t, strings.Contains(jsonStr, "DynamoDb.PutItem"))
 	assert.False(t, strings.Contains(jsonStr, user))
@@ -1336,7 +1336,7 @@ func addSpanLink(span ptrace.Span) {
 
 func TestLocalRootConsumer(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "destination operation"
 	resource := getBasicResource()
@@ -1352,7 +1352,7 @@ func TestLocalRootConsumer(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	validateLocalRootDependencySubsegment(t, segments[0], span, *segments[1].ID)
 	assert.Nil(t, segments[0].Links)
@@ -1383,7 +1383,7 @@ func TestNonLocalRootConsumerProcess(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	tempTraceID := span.TraceID()
 	expectedTraceID := "1-" + fmt.Sprintf("%x", tempTraceID[0:4]) + "-" + fmt.Sprintf("%x", tempTraceID[4:16])
@@ -1429,7 +1429,7 @@ func TestLocalRootConsumerAWSNamespace(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Ensure that AWS namespace is not overwritten to remote
 	assert.Equal(t, "aws", *segments[0].Namespace)
@@ -1437,7 +1437,7 @@ func TestLocalRootConsumerAWSNamespace(t *testing.T) {
 
 func TestLocalRootClient(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "SQS Get"
 	resource := getBasicResource()
@@ -1455,7 +1455,7 @@ func TestLocalRootClient(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	validateLocalRootDependencySubsegment(t, segments[0], span, *segments[1].ID)
 	assert.Len(t, segments[0].Links, 1)
@@ -1492,7 +1492,7 @@ func TestLocalRootClientAwsServiceMetrics(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	subsegment := segments[0]
 
@@ -1516,7 +1516,7 @@ func TestLocalRootProducer(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 2)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	validateLocalRootDependencySubsegment(t, segments[0], span, *segments[1].ID)
 	assert.Len(t, segments[0].Links, 1)
@@ -1577,7 +1577,7 @@ func validateLocalRootWithoutDependency(t *testing.T, segment *awsxray.Segment, 
 
 func TestLocalRootServer(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "MyService"
 	resource := getBasicResource()
@@ -1593,14 +1593,14 @@ func TestLocalRootServer(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	validateLocalRootWithoutDependency(t, segments[0], span)
 }
 
 func TestLocalRootInternal(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set("exporter.xray.allowDot", false)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	spanName := "MyInternalService"
 	resource := getBasicResource()
@@ -1616,7 +1616,7 @@ func TestLocalRootInternal(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	validateLocalRootWithoutDependency(t, segments[0], span)
 }
@@ -1637,7 +1637,7 @@ func TestNotLocalRootInternal(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
@@ -1661,7 +1661,7 @@ func TestNotLocalRootConsumer(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
@@ -1685,7 +1685,7 @@ func TestNotLocalRootClient(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
@@ -1709,7 +1709,7 @@ func TestNotLocalRootProducer(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Validate segment
 	assert.Equal(t, "subsegment", *segments[0].Type)
@@ -1735,7 +1735,7 @@ func TestNotLocalRootServer(t *testing.T) {
 
 	assert.NotNil(t, segments)
 	assert.Len(t, segments, 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	// Validate segment
 	assert.Nil(t, segments[0].Type)

--- a/exporter/awsxrayexporter/internal/translator/span_links_test.go
+++ b/exporter/awsxrayexporter/internal/translator/span_links_test.go
@@ -78,11 +78,11 @@ func TestOldSpanLinkError(t *testing.T) {
 
 	_, error1 := MakeSegment(span, resource, nil, false, nil, false)
 
-	assert.NotNil(t, error1)
+	assert.Error(t, error1)
 
 	_, error2 := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
-	assert.NotNil(t, error2)
+	assert.Error(t, error2)
 }
 
 func TestTwoSpanLinks(t *testing.T) {

--- a/exporter/awsxrayexporter/internal/translator/writer_pool_test.go
+++ b/exporter/awsxrayexporter/internal/translator/writer_pool_test.go
@@ -59,7 +59,7 @@ func BenchmarkWithPool(b *testing.B) {
 		w := wp.borrow()
 		segment, _ := MakeSegment(span, pcommon.NewResource(), nil, false, nil, false)
 		err := w.Encode(*segment)
-		assert.Nil(b, err)
+		assert.NoError(b, err)
 		logger.Info(w.String())
 	}
 }

--- a/exporter/azuredataexplorerexporter/factory_test.go
+++ b/exporter/azuredataexplorerexporter/factory_test.go
@@ -50,7 +50,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 	dp.SetDoubleValue(42.42)
 	err = exporter.ConsumeMetrics(context.Background(), testMetrics)
 	assert.Error(t, err)
-	assert.Nil(t, exporter.Shutdown(context.Background()))
+	assert.NoError(t, exporter.Shutdown(context.Background()))
 }
 
 // Given a new factory and no-op exporter , the NewMetric exporter should work.
@@ -105,7 +105,7 @@ func TestCreateLogsExporter(t *testing.T) {
 	// This will fail with auth failure
 	err = exporter.ConsumeLogs(context.Background(), testLogs)
 	assert.Error(t, err)
-	assert.Nil(t, exporter.Shutdown(context.Background()))
+	assert.NoError(t, exporter.Shutdown(context.Background()))
 }
 
 // Given a new factory and no-op exporter , the NewLogs exporter should work.
@@ -150,7 +150,7 @@ func TestCreateTracesExporter(t *testing.T) {
 	ss.Spans().AppendEmpty()
 	err = exporter.ConsumeTraces(context.Background(), testTraces)
 	assert.Error(t, err)
-	assert.Nil(t, exporter.Shutdown(context.Background()))
+	assert.NoError(t, exporter.Shutdown(context.Background()))
 }
 
 // Given a new factory and no-op exporter , the NewLogs exporter should work.

--- a/exporter/datasetexporter/config_test.go
+++ b/exporter/datasetexporter/config_test.go
@@ -94,7 +94,7 @@ func TestConfigValidate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.config.Validate()
 			if err == nil {
-				assert.Nil(t, tt.expected, tt.name)
+				assert.NoError(t, tt.expected, tt.name)
 			} else {
 				assert.Equal(t, tt.expected.Error(), err.Error(), tt.name)
 			}

--- a/exporter/datasetexporter/factory_test.go
+++ b/exporter/datasetexporter/factory_test.go
@@ -34,7 +34,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 		TimeoutSettings:    exporterhelper.NewDefaultTimeoutSettings(),
 	}, cfg, "failed to create default config")
 
-	assert.Nil(t, componenttest.CheckConfigStruct(cfg))
+	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
 }
 
 func TestLoadConfig(t *testing.T) {
@@ -147,8 +147,8 @@ func TestLoadConfig(t *testing.T) {
 
 			sub, err := cm.Sub(tt.id.String())
 			require.NoError(t, err)
-			require.Nil(t, sub.Unmarshal(cfg))
-			if assert.Nil(t, component.ValidateConfig(cfg)) {
+			require.NoError(t, sub.Unmarshal(cfg))
+			if assert.NoError(t, component.ValidateConfig(cfg)) {
 				assert.Equal(t, tt.expected, cfg)
 			}
 		})

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -34,7 +34,7 @@ func TestDefaultTracesMarshalers(t *testing.T) {
 			m, err := createTracesMarshaler(Config{
 				Encoding: e,
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, m)
 		})
 	}
@@ -50,7 +50,7 @@ func TestDefaultMetricsMarshalers(t *testing.T) {
 			m, err := createMetricMarshaler(Config{
 				Encoding: e,
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, m)
 		})
 	}
@@ -67,7 +67,7 @@ func TestDefaultLogsMarshalers(t *testing.T) {
 			m, err := createLogMarshaler(Config{
 				Encoding: e,
 			})
-			require.Nil(t, err)
+			require.NoError(t, err)
 			assert.NotNil(t, m)
 		})
 	}
@@ -122,7 +122,7 @@ func TestOTLPMetricsJsonMarshaling(t *testing.T) {
 					Encoding:                             "otlp_json",
 					PartitionMetricsByResourceAttributes: tt.partitionByResources,
 				})
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			msgs, err := marshaler.Marshal(metric, "KafkaTopicX")
 			require.NoError(t, err, "Must have marshaled the data without error")
@@ -183,7 +183,7 @@ func TestOTLPLogsJsonMarshaling(t *testing.T) {
 					Encoding:                          "otlp_json",
 					PartitionLogsByResourceAttributes: tt.partitionByResources,
 				})
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			msgs, err := marshaler.Marshal(log, "KafkaTopicX")
 			require.NoError(t, err, "Must have marshaled the data without error")
@@ -461,7 +461,7 @@ func TestOTLPTracesJsonMarshaling(t *testing.T) {
 			Encoding:            test.encoding,
 			PartitionTracesByID: test.partitionTracesByID,
 		})
-		require.Nil(t, err, fmt.Sprintf("Must have %s marshaler", test.encoding))
+		require.NoError(t, err, fmt.Sprintf("Must have %s marshaler", test.encoding))
 
 		msg, err := marshaler.Marshal(traces, t.Name())
 		require.NoError(t, err, "Must have marshaled the data without error")

--- a/exporter/loadbalancingexporter/loadbalancer_test.go
+++ b/exporter/loadbalancingexporter/loadbalancer_test.go
@@ -102,7 +102,7 @@ func TestLoadBalancerStart(t *testing.T) {
 		require.NoError(t, p.Shutdown(context.Background()))
 	}()
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 func TestWithDNSResolver(t *testing.T) {
@@ -208,7 +208,7 @@ func TestLoadBalancerShutdown(t *testing.T) {
 	res := p.Shutdown(context.Background())
 
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 func TestOnBackendChanges(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -112,7 +112,7 @@ func TestLogExporterShutdown(t *testing.T) {
 	res := p.Shutdown(context.Background())
 
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 func TestConsumeLogs(t *testing.T) {
@@ -149,7 +149,7 @@ func TestConsumeLogs(t *testing.T) {
 	res := p.ConsumeLogs(context.Background(), simpleLogs())
 
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 func TestConsumeLogsUnexpectedExporterType(t *testing.T) {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -162,7 +162,7 @@ func TestMetricsExporterShutdown(t *testing.T) {
 	res := p.Shutdown(context.Background())
 
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 // loadMetricsMap will parse the given yaml file into a map[string]pmetric.Metrics

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -116,7 +116,7 @@ func TestTracesExporterShutdown(t *testing.T) {
 	res := p.Shutdown(context.Background())
 
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 func TestConsumeTraces(t *testing.T) {
@@ -153,7 +153,7 @@ func TestConsumeTraces(t *testing.T) {
 	res := p.ConsumeTraces(context.Background(), simpleTraces())
 
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 // This test validates that exporter is can concurrently change the endpoints while consuming traces.
@@ -245,7 +245,7 @@ func TestConsumeTracesServiceBased(t *testing.T) {
 	res := p.ConsumeTraces(context.Background(), simpleTracesWithServiceName())
 
 	// verify
-	assert.Nil(t, res)
+	assert.NoError(t, res)
 }
 
 func TestServiceBasedRoutingForSameTraceId(t *testing.T) {
@@ -271,7 +271,7 @@ func TestServiceBasedRoutingForSameTraceId(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			res, err := routingIdentifiersFromTraces(tt.batch, tt.routingKey)
-			assert.Equal(t, err, nil)
+			assert.NoError(t, err)
 			assert.Equal(t, res, tt.res)
 		})
 	}

--- a/exporter/otelarrowexporter/factory_test.go
+++ b/exporter/otelarrowexporter/factory_test.go
@@ -54,7 +54,7 @@ func TestCreateMetricsExporter(t *testing.T) {
 
 	set := exportertest.NewNopSettings()
 	oexp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 }
 
@@ -191,7 +191,7 @@ func TestCreateTracesExporter(t *testing.T) {
 			cfg := tt.config
 			consumer, err := factory.CreateTracesExporter(context.Background(), set, &cfg)
 			if tt.mustFailOnCreate {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 				return
 			}
 			assert.NoError(t, err)
@@ -220,7 +220,7 @@ func TestCreateLogsExporter(t *testing.T) {
 
 	set := exportertest.NewNopSettings()
 	oexp, err := factory.CreateLogsExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 }
 
@@ -233,6 +233,6 @@ func TestCreateArrowTracesExporter(t *testing.T) {
 	}
 	set := exportertest.NewNopSettings()
 	oexp, err := factory.CreateTracesExporter(context.Background(), set, cfg)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, oexp)
 }

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -459,7 +459,7 @@ func Test_PushMetrics(t *testing.T) {
 		require.NoError(t, err)
 		wr := &prompb.WriteRequest{}
 		ok := proto.Unmarshal(dest, wr)
-		require.Nil(t, ok)
+		require.NoError(t, ok)
 		assert.Len(t, wr.Timeseries, expected)
 		if isStaleMarker {
 			assert.True(t, value.IsStaleNaN(wr.Timeseries[0].Samples[0].Value))

--- a/exporter/signalfxexporter/internal/apm/correlations/client_test.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client_test.go
@@ -208,7 +208,7 @@ func TestCorrelationClient(t *testing.T) {
 		forcedRespCode.Store(200)
 		respPayload := map[string][]string{"sf_services": {"testService1"}}
 		respJSON, err := json.Marshal(&respPayload)
-		require.Nil(t, err, "json marshaling failed in test")
+		require.NoError(t, err, "json marshaling failed in test")
 		forcedRespPayload.Store(respJSON)
 
 		var wg sync.WaitGroup

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -72,7 +72,7 @@ func TestBearerAuthenticator(t *testing.T) {
 	bauth := newBearerTokenAuth(cfg, nil)
 	assert.NotNil(t, bauth)
 
-	assert.Nil(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
 	credential, err := bauth.PerRPCCredentials()
 
 	assert.NoError(t, err)
@@ -98,7 +98,7 @@ func TestBearerAuthenticator(t *testing.T) {
 	resp, err := roundTripper.RoundTrip(&http.Request{Header: orgHeaders})
 	assert.NoError(t, err)
 	assert.Equal(t, expectedHeaders, resp.Header)
-	assert.Nil(t, bauth.Shutdown(context.Background()))
+	assert.NoError(t, bauth.Shutdown(context.Background()))
 }
 
 func TestBearerStartWatchStop(t *testing.T) {
@@ -108,7 +108,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	bauth := newBearerTokenAuth(cfg, zaptest.NewLogger(t))
 	assert.NotNil(t, bauth)
 
-	assert.Nil(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Error(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
 
 	credential, err := bauth.PerRPCCredentials()
@@ -128,7 +128,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.True(t, credential.RequireTransportSecurity())
 
 	// change file content once
-	assert.Nil(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0600))
 	time.Sleep(5 * time.Second)
 	credential, _ = bauth.PerRPCCredentials()
 	md, err = credential.GetRequestMetadata(context.Background())
@@ -137,7 +137,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.NoError(t, err)
 
 	// change file content back
-	assert.Nil(t, os.WriteFile(bauth.filename, token, 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, token, 0600))
 	time.Sleep(5 * time.Second)
 	credential, _ = bauth.PerRPCCredentials()
 	md, err = credential.GetRequestMetadata(context.Background())
@@ -146,7 +146,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.Equal(t, md, expectedMd)
 	assert.NoError(t, err)
 
-	assert.Nil(t, bauth.Shutdown(context.Background()))
+	assert.NoError(t, bauth.Shutdown(context.Background()))
 	assert.Nil(t, bauth.shutdownCH)
 }
 
@@ -159,7 +159,7 @@ func TestBearerTokenFileContentUpdate(t *testing.T) {
 	bauth := newBearerTokenAuth(cfg, zaptest.NewLogger(t))
 	assert.NotNil(t, bauth)
 
-	assert.Nil(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
+	assert.NoError(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
 	assert.Error(t, bauth.Start(context.Background(), componenttest.NewNopHost()))
 	defer func() { assert.NoError(t, bauth.Shutdown(context.Background())) }()
 
@@ -178,7 +178,7 @@ func TestBearerTokenFileContentUpdate(t *testing.T) {
 	assert.Equal(t, authHeaderValue, fmt.Sprintf("%s %s", scheme, string(token)))
 
 	// change file content once
-	assert.Nil(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0600))
 	time.Sleep(5 * time.Second)
 
 	tokenNew, err := os.ReadFile(bauth.filename)
@@ -192,7 +192,7 @@ func TestBearerTokenFileContentUpdate(t *testing.T) {
 	assert.Equal(t, authHeaderValue, fmt.Sprintf("%s %s", scheme, string(tokenNew)))
 
 	// change file content back
-	assert.Nil(t, os.WriteFile(bauth.filename, token, 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, token, 0600))
 	time.Sleep(5 * time.Second)
 
 	// check if request is updated with the old token
@@ -213,7 +213,7 @@ func TestBearerServerAuthenticateWithScheme(t *testing.T) {
 	assert.NotNil(t, bauth)
 
 	ctx := context.Background()
-	assert.Nil(t, bauth.Start(ctx, componenttest.NewNopHost()))
+	assert.NoError(t, bauth.Start(ctx, componenttest.NewNopHost()))
 
 	_, err := bauth.Authenticate(ctx, map[string][]string{"authorization": {"Bearer " + token}})
 	assert.NoError(t, err)
@@ -224,7 +224,7 @@ func TestBearerServerAuthenticateWithScheme(t *testing.T) {
 	_, err = bauth.Authenticate(ctx, map[string][]string{"authorization": {"" + token}})
 	assert.Error(t, err)
 
-	assert.Nil(t, bauth.Shutdown(context.Background()))
+	assert.NoError(t, bauth.Shutdown(context.Background()))
 }
 
 func TestBearerServerAuthenticate(t *testing.T) {
@@ -237,7 +237,7 @@ func TestBearerServerAuthenticate(t *testing.T) {
 	assert.NotNil(t, bauth)
 
 	ctx := context.Background()
-	assert.Nil(t, bauth.Start(ctx, componenttest.NewNopHost()))
+	assert.NoError(t, bauth.Start(ctx, componenttest.NewNopHost()))
 
 	_, err := bauth.Authenticate(ctx, map[string][]string{"authorization": {"Bearer " + token}})
 	assert.Error(t, err)
@@ -251,5 +251,5 @@ func TestBearerServerAuthenticate(t *testing.T) {
 	_, err = bauth.Authenticate(ctx, map[string][]string{"authorization": {token}})
 	assert.NoError(t, err)
 
-	assert.Nil(t, bauth.Shutdown(context.Background()))
+	assert.NoError(t, bauth.Shutdown(context.Background()))
 }

--- a/extension/observer/dockerobserver/config_test.go
+++ b/extension/observer/dockerobserver/config_test.go
@@ -75,7 +75,7 @@ func TestValidateConfig(t *testing.T) {
 	assert.Equal(t, "cache_sync_interval must be specified", component.ValidateConfig(cfg).Error())
 
 	cfg = &Config{Config: docker.Config{Endpoint: "someEndpoint", DockerAPIVersion: version, Timeout: 5 * time.Minute}, CacheSyncInterval: 5 * time.Minute}
-	assert.Nil(t, component.ValidateConfig(cfg))
+	assert.NoError(t, component.ValidateConfig(cfg))
 }
 
 func loadConf(t testing.TB, path string, id component.ID) *confmap.Conf {

--- a/extension/observer/ecsobserver/internal/ecsmock/service_test.go
+++ b/extension/observer/ecsobserver/internal/ecsmock/service_test.go
@@ -31,7 +31,7 @@ func TestCluster_ListTasksWithContext(t *testing.T) {
 		assert.True(t, errors.As(err, &aerr))
 		assert.Equal(t, ecs.ErrCodeClusterNotFoundException, aerr.Code())
 		assert.Equal(t, "code "+ecs.ErrCodeClusterNotFoundException+" message "+aerr.Message(), aerr.Error())
-		assert.Nil(t, aerr.OrigErr())
+		assert.NoError(t, aerr.OrigErr())
 	})
 
 	t.Run("get all", func(t *testing.T) {

--- a/extension/observer/ecsobserver/internal/errctx/value_test.go
+++ b/extension/observer/ecsobserver/internal/errctx/value_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestWithValue(t *testing.T) {
-	assert.Nil(t, WithValue(nil, "a", "b"))
+	assert.NoError(t, WithValue(nil, "a", "b"))
 	assert.Panics(t, func() {
 		_ = WithValue(fmt.Errorf("base"), "", nil)
 	})
@@ -35,7 +35,7 @@ func TestWithValue(t *testing.T) {
 }
 
 func TestWithValues(t *testing.T) {
-	assert.Nil(t, WithValues(nil, map[string]any{"a": "b"}))
+	assert.NoError(t, WithValues(nil, map[string]any{"a": "b"}))
 	assert.Panics(t, func() {
 		_ = WithValues(fmt.Errorf("base"), map[string]any{"": "123"})
 	})

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -198,7 +198,7 @@ func TestStreamManager(t *testing.T) {
 	manager := NewLogStreamManager(*svc)
 
 	// Verify that the stream is created in the first time
-	assert.Nil(t, manager.InitStream(StreamKey{
+	assert.NoError(t, manager.InitStream(StreamKey{
 		LogGroupName:  "foo",
 		LogStreamName: "bar",
 	}))
@@ -207,7 +207,7 @@ func TestStreamManager(t *testing.T) {
 	mockCwAPI.AssertNumberOfCalls(t, "CreateLogStream", 1)
 
 	// Verify that the stream is not created in the second time
-	assert.Nil(t, manager.InitStream(StreamKey{
+	assert.NoError(t, manager.InitStream(StreamKey{
 		LogGroupName:  "foo",
 		LogStreamName: "bar",
 	}))
@@ -215,7 +215,7 @@ func TestStreamManager(t *testing.T) {
 	mockCwAPI.AssertNumberOfCalls(t, "CreateLogStream", 1)
 
 	// Verify that a different stream is created
-	assert.Nil(t, manager.InitStream(StreamKey{
+	assert.NoError(t, manager.InitStream(StreamKey{
 		LogGroupName:  "foo",
 		LogStreamName: "bar2",
 	}))
@@ -248,10 +248,10 @@ func TestMultiStreamPusher(t *testing.T) {
 	event.StreamKey.LogStreamName = "bar"
 	event.GeneratedTime = time.Now()
 
-	assert.Nil(t, pusher.AddLogEntry(event))
-	assert.Nil(t, pusher.AddLogEntry(event))
+	assert.NoError(t, pusher.AddLogEntry(event))
+	assert.NoError(t, pusher.AddLogEntry(event))
 	mockCwAPI.AssertNumberOfCalls(t, "PutLogEvents", 0)
-	assert.Nil(t, pusher.ForceFlush())
+	assert.NoError(t, pusher.ForceFlush())
 
 	mockCwAPI.AssertNumberOfCalls(t, "CreateLogStream", 1)
 	mockCwAPI.AssertNumberOfCalls(t, "PutLogEvents", 1)
@@ -266,8 +266,8 @@ func TestMultiStreamPusher(t *testing.T) {
 	event2.StreamKey.LogStreamName = "bar2"
 	event2.GeneratedTime = time.Now()
 
-	assert.Nil(t, pusher.AddLogEntry(event2))
-	assert.Nil(t, pusher.ForceFlush())
+	assert.NoError(t, pusher.AddLogEntry(event2))
+	assert.NoError(t, pusher.ForceFlush())
 
 	mockCwAPI.AssertNumberOfCalls(t, "CreateLogStream", 2)
 	mockCwAPI.AssertNumberOfCalls(t, "PutLogEvents", 2)

--- a/internal/aws/k8s/k8sclient/obj_store_test.go
+++ b/internal/aws/k8s/k8sclient/obj_store_test.go
@@ -25,7 +25,7 @@ var transformFuncWithError = func(v any) (any, error) {
 
 func TestResync(t *testing.T) {
 	o := NewObjStore(transformFunc, zap.NewNop())
-	assert.Nil(t, o.Resync())
+	assert.NoError(t, o.Resync())
 }
 
 func TestGet(t *testing.T) {

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/internal/tools
 go 1.22.0
 
 require (
+	github.com/Antonboom/testifylint v1.4.3
 	github.com/Khan/genqlient v0.7.0
 	github.com/client9/misspell v0.3.4
 	github.com/daixiang0/gci v0.13.4
@@ -31,7 +32,6 @@ require (
 	github.com/Abirdcfly/dupword v0.0.14 // indirect
 	github.com/Antonboom/errname v0.1.13 // indirect
 	github.com/Antonboom/nilnil v0.1.9 // indirect
-	github.com/Antonboom/testifylint v1.3.1 // indirect
 	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/Crocmagnon/fatcontext v0.2.2 // indirect
 	github.com/Djarvur/go-err113 v0.0.0-20210108212216-aea10b59be24 // indirect

--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -12,8 +12,8 @@ github.com/Antonboom/errname v0.1.13 h1:JHICqsewj/fNckzrfVSe+T33svwQxmjC+1ntDsHO
 github.com/Antonboom/errname v0.1.13/go.mod h1:uWyefRYRN54lBg6HseYCFhs6Qjcy41Y3Jl/dVhA87Ns=
 github.com/Antonboom/nilnil v0.1.9 h1:eKFMejSxPSA9eLSensFmjW2XTgTwJMjZ8hUHtV4s/SQ=
 github.com/Antonboom/nilnil v0.1.9/go.mod h1:iGe2rYwCq5/Me1khrysB4nwI7swQvjclR8/YRPl5ihQ=
-github.com/Antonboom/testifylint v1.3.1 h1:Uam4q1Q+2b6H7gvk9RQFw6jyVDdpzIirFOOrbs14eG4=
-github.com/Antonboom/testifylint v1.3.1/go.mod h1:NV0hTlteCkViPW9mSR4wEMfwp+Hs1T3dY60bkvSfhpM=
+github.com/Antonboom/testifylint v1.4.3 h1:ohMt6AHuHgttaQ1xb6SSnxCeK4/rnK7KKzbvs7DmEck=
+github.com/Antonboom/testifylint v1.4.3/go.mod h1:+8Q9+AOLsz5ZiQiiYujJKs9mNz398+M6UgslP4qgJLA=
 github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
 github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Crocmagnon/fatcontext v0.2.2 h1:OrFlsDdOj9hW/oBEJBNSuH7QWf+E9WPVHw+x52bXVbk=

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -11,6 +11,7 @@ package tools // import "github.com/open-telemetry/opentelemetry-collector-contr
 // This ensures that all systems use the same version of tools in addition to regular dependencies.
 
 import (
+	_ "github.com/Antonboom/testifylint"
 	_ "github.com/Khan/genqlient"
 	_ "github.com/client9/misspell/cmd/misspell"
 	_ "github.com/daixiang0/gci"

--- a/pkg/ottl/ottlfuncs/func_log_test.go
+++ b/pkg/ottl/ottlfuncs/func_log_test.go
@@ -102,7 +102,7 @@ func Test_Log(t *testing.T) {
 			})
 			result, err := exprFunc(nil, nil)
 			assert.ErrorContains(t, err, tt.errorStr)
-			assert.Equal(t, nil, result)
+			assert.Nil(t, result)
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_substring_test.go
+++ b/pkg/ottl/ottlfuncs/func_substring_test.go
@@ -208,7 +208,7 @@ func Test_substring_error(t *testing.T) {
 			exprFunc := substring(tt.target, tt.start, tt.length)
 			result, err := exprFunc(nil, nil)
 			assert.Error(t, err)
-			assert.Equal(t, nil, result)
+			assert.Nil(t, result)
 		})
 	}
 }

--- a/pkg/stanza/entry/copy_test.go
+++ b/pkg/stanza/entry/copy_test.go
@@ -31,7 +31,7 @@ func TestCopyValueByte(t *testing.T) {
 
 func TestCopyValueNil(t *testing.T) {
 	var value any
-	require.Equal(t, nil, copyValue(value))
+	require.Nil(t, copyValue(value))
 }
 
 func TestCopyValueStringArray(t *testing.T) {

--- a/pkg/stanza/entry/entry_test.go
+++ b/pkg/stanza/entry/entry_test.go
@@ -185,7 +185,7 @@ func TestCopyNil(t *testing.T) {
 	require.Equal(t, "", cp.SeverityText)
 	require.Equal(t, map[string]any{}, cp.Attributes)
 	require.Equal(t, map[string]any{}, cp.Resource)
-	require.Equal(t, nil, cp.Body)
+	require.Nil(t, cp.Body)
 	require.Equal(t, []byte{}, cp.TraceID)
 	require.Equal(t, []byte{}, cp.SpanID)
 	require.Equal(t, []byte{}, cp.TraceFlags)

--- a/pkg/stanza/operator/output/drop/output_test.go
+++ b/pkg/stanza/operator/output/drop/output_test.go
@@ -38,5 +38,5 @@ func TestProcess(t *testing.T) {
 
 	entry := entry.New()
 	result := op.Process(context.Background(), entry)
-	require.Nil(t, result)
+	require.NoError(t, result)
 }

--- a/processor/attributesprocessor/attributes_trace_test.go
+++ b/processor/attributesprocessor/attributes_trace_test.go
@@ -500,7 +500,7 @@ func BenchmarkAttributes_FilterSpansByName(b *testing.B) {
 		SpanNames: []string{"^apply.*"},
 	}
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
-	require.Nil(b, err)
+	require.NoError(b, err)
 	require.NotNil(b, tp)
 
 	for _, tt := range testCases {

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -462,7 +462,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			require.NoError(t, mgp.Start(ctx, nil))
 
 			cErr := mgp.ConsumeMetrics(context.Background(), test.inMetrics)
-			assert.Nil(t, cErr)
+			assert.NoError(t, cErr)
 			got := next.AllMetrics()
 
 			require.Len(t, got, 1)

--- a/processor/deltatorateprocessor/processor_test.go
+++ b/processor/deltatorateprocessor/processor_test.go
@@ -134,7 +134,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 			require.NoError(t, mgp.Start(ctx, nil))
 
 			cErr := mgp.ConsumeMetrics(context.Background(), test.inMetrics)
-			assert.Nil(t, cErr)
+			assert.NoError(t, cErr)
 			got := next.AllMetrics()
 
 			require.Len(t, got, 1)

--- a/processor/filterprocessor/factory_test.go
+++ b/processor/filterprocessor/factory_test.go
@@ -103,11 +103,11 @@ func TestCreateProcessors(t *testing.T) {
 					assert.Equal(t, tt.succeed, tErr == nil)
 
 					assert.NotNil(t, mp)
-					assert.Nil(t, mErr)
+					assert.NoError(t, mErr)
 				} else {
 					// Should not break configs with no trace data
 					assert.NotNil(t, tp)
-					assert.Nil(t, tErr)
+					assert.NoError(t, tErr)
 
 					assert.Equal(t, tt.succeed, mp != nil)
 					assert.Equal(t, tt.succeed, mErr == nil)

--- a/processor/filterprocessor/logs_test.go
+++ b/processor/filterprocessor/logs_test.go
@@ -595,7 +595,7 @@ func TestFilterLogProcessor(t *testing.T) {
 			assert.NoError(t, flp.Start(ctx, nil))
 
 			cErr := flp.ConsumeLogs(context.Background(), test.inLogs)
-			assert.Nil(t, cErr)
+			assert.NoError(t, cErr)
 			got := next.AllLogs()
 
 			require.Len(t, got, 1)

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -345,7 +345,7 @@ func TestFilterMetricProcessor(t *testing.T) {
 			assert.NoError(t, fmp.Start(ctx, nil))
 
 			cErr := fmp.ConsumeMetrics(context.Background(), test.inMetrics)
-			assert.Nil(t, cErr)
+			assert.NoError(t, cErr)
 			got := next.AllMetrics()
 
 			if len(test.outMN) == 0 {

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -145,7 +145,7 @@ func TestFilterTraceProcessor(t *testing.T) {
 			require.NoError(t, fmp.Start(ctx, nil))
 
 			cErr := fmp.ConsumeTraces(ctx, test.inTraces)
-			require.Nil(t, cErr)
+			require.NoError(t, cErr)
 			got := next.AllTraces()
 
 			// If all traces got filtered you shouldn't even have ResourceSpans

--- a/processor/k8sattributesprocessor/config_test.go
+++ b/processor/k8sattributesprocessor/config_test.go
@@ -205,9 +205,9 @@ func TestLoadConfig(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
 			if tt.disallowRegex {
-				require.Nil(t, featuregate.GlobalRegistry().Set(disallowFieldExtractConfigRegex.ID(), true))
+				require.NoError(t, featuregate.GlobalRegistry().Set(disallowFieldExtractConfigRegex.ID(), true))
 				t.Cleanup(func() {
-					require.Nil(t, featuregate.GlobalRegistry().Set(disallowFieldExtractConfigRegex.ID(), false))
+					require.NoError(t, featuregate.GlobalRegistry().Set(disallowFieldExtractConfigRegex.ID(), false))
 				})
 			}
 			cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -289,7 +289,7 @@ func TestMetricsGenerationProcessor(t *testing.T) {
 			require.NoError(t, mgp.Start(ctx, nil))
 
 			cErr := mgp.ConsumeMetrics(context.Background(), test.inMetrics)
-			assert.Nil(t, cErr)
+			assert.NoError(t, cErr)
 			got := next.AllMetrics()
 
 			require.Len(t, got, 1)

--- a/processor/remotetapprocessor/processor_test.go
+++ b/processor/remotetapprocessor/processor_test.go
@@ -53,7 +53,7 @@ func TestConsumeMetrics(t *testing.T) {
 			for i := 0; i < c.limit*2; i++ {
 				// send metric to chan c.limit*2 per sec.
 				metric2, err := processor.ConsumeMetrics(context.Background(), metric)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, metric, metric2)
 			}
 
@@ -102,7 +102,7 @@ func TestConsumeLogs(t *testing.T) {
 			// send log to chan c.limit*2 per sec.
 			for i := 0; i < c.limit*2; i++ {
 				log2, err := processor.ConsumeLogs(context.Background(), log)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, log, log2)
 			}
 
@@ -151,7 +151,7 @@ func TestConsumeTraces(t *testing.T) {
 			for i := 0; i < c.limit*2; i++ {
 				// send trace to chan c.limit*2 per sec.
 				trace2, err := processor.ConsumeTraces(context.Background(), trace)
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, trace, trace2)
 			}
 

--- a/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
+++ b/processor/transformprocessor/internal/metrics/func_aggregate_on_attributes_metrics_test.go
@@ -316,7 +316,7 @@ func Test_aggregateOnAttributes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			evaluate, err := AggregateOnAttributes(tt.t, tt.attributes)
-			require.Nil(t, err)
+			require.NoError(t, err)
 
 			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, pmetric.NewMetricSlice(), pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
 			assert.Equal(t, tt.wantErr, err)
@@ -336,7 +336,7 @@ func Test_aggregateOnAttributes(t *testing.T) {
 				sl2 := actualMetrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
 				actualMetric.CopyTo(sl2)
 
-				require.Nil(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder()))
+				require.NoError(t, pmetrictest.CompareMetrics(expectedMetrics, actualMetrics, pmetrictest.IgnoreMetricDataPointsOrder()))
 			}
 		})
 	}

--- a/receiver/aerospikereceiver/scraper_test.go
+++ b/receiver/aerospikereceiver/scraper_test.go
@@ -171,5 +171,5 @@ func TestScrape_CollectClusterMetrics(t *testing.T) {
 
 	err = receiverConnErr.start(context.Background(), componenttest.NewNopHost())
 	require.NoError(t, err)
-	require.Equal(t, receiverConnErr.client, nil, "client should be set to nil because of connection error")
+	require.Nil(t, receiverConnErr.client, "client should be set to nil because of connection error")
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
@@ -15,11 +15,11 @@ import (
 
 func LoadContainerInfo(t *testing.T, file string) []*cinfo.ContainerInfo {
 	info, err := os.ReadFile(file)
-	assert.Nil(t, err, "Fail to read file content")
+	assert.NoError(t, err, "Fail to read file content")
 
 	containers := map[string]*cinfo.ContainerInfo{}
 	err = json.Unmarshal(info, &containers)
-	assert.Nil(t, err, "Fail to parse json string")
+	assert.NoError(t, err, "Fail to parse json string")
 
 	result := make([]*cinfo.ContainerInfo, len(containers))
 	i := 0

--- a/receiver/awsxrayreceiver/factory_test.go
+++ b/receiver/awsxrayreceiver/factory_test.go
@@ -41,7 +41,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 		factory.CreateDefaultConfig().(*Config),
 		consumertest.NewNop(),
 	)
-	assert.Nil(t, err, "trace receiver can be created")
+	assert.NoError(t, err, "trace receiver can be created")
 }
 
 func TestCreateMetricsReceiver(t *testing.T) {
@@ -52,6 +52,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 		factory.CreateDefaultConfig().(*Config),
 		consumertest.NewNop(),
 	)
-	assert.NotNil(t, err, "a trace receiver factory should not create a metric receiver")
+	assert.Error(t, err, "a trace receiver factory should not create a metric receiver")
 	assert.ErrorIs(t, err, component.ErrDataTypeIsNotSupported)
 }

--- a/receiver/cloudfoundryreceiver/converter_test.go
+++ b/receiver/cloudfoundryreceiver/converter_test.go
@@ -217,7 +217,7 @@ func TestConvertLogsEnvelope(t *testing.T) {
 		t.Run(tt.id, func(t *testing.T) {
 			logSlice := plog.NewLogRecordSlice()
 			e := convertEnvelopeToLogs(&tt.envelope, logSlice, now)
-			require.Equal(t, nil, e)
+			require.NoError(t, e)
 			require.Equal(t, 1, logSlice.Len())
 			log := logSlice.At(0)
 			assert.Equal(t, tt.expected["Body"], log.Body().AsString())

--- a/receiver/fluentforwardreceiver/factory_test.go
+++ b/receiver/fluentforwardreceiver/factory_test.go
@@ -31,6 +31,6 @@ func TestCreateReceiver(t *testing.T) {
 	require.Equal(t, metadata.Type, factory.Type())
 
 	tReceiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.Nil(t, err, "receiver creation failed")
+	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/hostmetricsreceiver/hostmetrics_linux_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_linux_test.go
@@ -22,9 +22,9 @@ import (
 
 func TestConsistentRootPaths(t *testing.T) {
 	// use testdata because it's a directory that exists - don't actually use any files in it
-	assert.Nil(t, testValidate("testdata"))
-	assert.Nil(t, testValidate(""))
-	assert.Nil(t, testValidate("/"))
+	assert.NoError(t, testValidate("testdata"))
+	assert.NoError(t, testValidate(""))
+	assert.NoError(t, testValidate("/"))
 }
 
 func TestInconsistentRootPaths(t *testing.T) {

--- a/receiver/hostmetricsreceiver/hostmetrics_others_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_others_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestRootPathNotAllowedOnOS(t *testing.T) {
-	assert.NotNil(t, validateRootPath("testdata"))
+	assert.Error(t, validateRootPath("testdata"))
 }
 
 func TestRootPathUnset(t *testing.T) {
-	assert.Nil(t, validateRootPath(""))
+	assert.NoError(t, validateRootPath(""))
 }

--- a/receiver/jmxreceiver/receiver_test.go
+++ b/receiver/jmxreceiver/receiver_test.go
@@ -31,8 +31,8 @@ func TestReceiver(t *testing.T) {
 	require.Same(t, params.Logger, receiver.logger)
 	require.Same(t, config, receiver.config)
 
-	require.Nil(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
-	require.Nil(t, receiver.Shutdown(context.Background()))
+	require.NoError(t, receiver.Start(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, receiver.Shutdown(context.Background()))
 }
 
 func TestBuildJMXMetricGathererConfig(t *testing.T) {

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -719,7 +719,7 @@ func TestOCReceiverMetrics_HandleNextConsumerResponse(t *testing.T) {
 				require.NotNil(t, ocr)
 
 				ocr.metricsConsumer = sink
-				require.Nil(t, ocr.Start(context.Background(), componenttest.NewNopHost()))
+				require.NoError(t, ocr.Start(context.Background(), componenttest.NewNopHost()))
 				t.Cleanup(func() { require.NoError(t, ocr.Shutdown(context.Background())) })
 
 				cc, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -681,7 +681,7 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 	for _, cfgMut := range cfgMuts {
 		cfgMut(cfg)
 	}
-	require.Nilf(t, err, "Failed to create Prometheus config: %v", err)
+	require.NoErrorf(t, err, "Failed to create Prometheus config: %v", err)
 	defer mp.Close()
 
 	config := &Config{

--- a/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
@@ -47,7 +47,7 @@ func TestReportExtraScrapeMetrics(t *testing.T) {
 func testScraperMetrics(t *testing.T, targets []*testData, reportExtraScrapeMetrics bool) {
 	ctx := context.Background()
 	mp, cfg, err := setupMockPrometheus(targets...)
-	require.Nilf(t, err, "Failed to create Prometheus config: %v", err)
+	require.NoErrorf(t, err, "Failed to create Prometheus config: %v", err)
 	defer mp.Close()
 
 	cms := new(consumertest.MetricsSink)

--- a/receiver/signalfxreceiver/factory_test.go
+++ b/receiver/signalfxreceiver/factory_test.go
@@ -28,14 +28,14 @@ func TestCreateReceiverMetricsFirst(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.Nil(t, err, "receiver creation failed")
+	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	_, err = factory.CreateTracesReceiver(context.Background(), receivertest.NewNopSettings(), cfg, nil)
 	assert.ErrorIs(t, err, component.ErrDataTypeIsNotSupported)
 
 	lReceiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.Nil(t, err, "receiver creation failed")
+	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, lReceiver, "receiver creation failed")
 
 	assert.Same(t, mReceiver, lReceiver)
@@ -47,12 +47,12 @@ func TestCreateReceiverLogsFirst(t *testing.T) {
 	cfg.Endpoint = "localhost:1" // Endpoint is required, not going to be used here.
 
 	lReceiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.Nil(t, err, "receiver creation failed")
+	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, lReceiver, "receiver creation failed")
 
 	params := receivertest.NewNopSettings()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.Nil(t, err, "receiver creation failed")
+	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	assert.Same(t, mReceiver, lReceiver)

--- a/receiver/splunkhecreceiver/factory_test.go
+++ b/receiver/splunkhecreceiver/factory_test.go
@@ -28,12 +28,12 @@ func TestCreateReceiver(t *testing.T) {
 
 	mockLogsConsumer := consumertest.NewNop()
 	lReceiver, err := createLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, mockLogsConsumer)
-	assert.Nil(t, err, "receiver creation failed")
+	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, lReceiver, "receiver creation failed")
 
 	mockMetricsConsumer := consumertest.NewNop()
 	mReceiver, err := createMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, mockMetricsConsumer)
-	assert.Nil(t, err, "receiver creation failed")
+	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 }
 

--- a/receiver/statsdreceiver/receiver_test.go
+++ b/receiver/statsdreceiver/receiver_test.go
@@ -76,7 +76,7 @@ func TestStatsdReceiver_Flush(t *testing.T) {
 	assert.NoError(t, err)
 	r := rcv.(*statsdReceiver)
 	var metrics = pmetric.NewMetrics()
-	assert.Nil(t, r.Flush(ctx, metrics, nextConsumer))
+	assert.NoError(t, r.Flush(ctx, metrics, nextConsumer))
 	assert.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
 	assert.NoError(t, r.Shutdown(ctx))
 }

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -139,7 +139,7 @@ func TestStartTraceReception(t *testing.T) {
 			err = zr.Start(context.Background(), tt.host)
 			assert.Equal(t, tt.wantErr, err != nil)
 			if !tt.wantErr {
-				require.Nil(t, zr.Shutdown(context.Background()))
+				require.NoError(t, zr.Shutdown(context.Background()))
 			}
 		})
 	}


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [error-nil](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-nil) and  [nil-compare](https://github.com/Antonboom/testifylint?tab=readme-ov-file#nil-compare) rules from [testifylint](https://github.com/Antonboom/testifylint)


It also adds testifylint as tool to use with a make command