### PR TITLE
[processor/interval] Refacor with time-base partitioning strategy

### DIFF
--- a/processor/intervalprocessor/config.go
+++ b/processor/intervalprocessor/config.go
@@ -11,7 +11,8 @@ import (
 )
 
 var (
-	ErrInvalidIntervalValue = errors.New("invalid interval value")
+	ErrInvalidIntervalValue               = errors.New("invalid interval value")
+	ErrIntervalLowesetGranularityIsSecond = errors.New("interval should should not contain milli or nano seconds")
 )
 
 var _ component.Config = (*Config)(nil)
@@ -37,8 +38,12 @@ type PassThrough struct {
 // Validate checks whether the input configuration has all of the required fields for the processor.
 // An error is returned if there are any invalid inputs.
 func (config *Config) Validate() error {
-	if config.Interval <= 0 {
+	if config.Interval <= time.Second {
 		return ErrInvalidIntervalValue
+	}
+
+	if config.Interval%time.Second != 0 {
+		return ErrIntervalLowesetGranularityIsSecond
 	}
 
 	return nil

--- a/processor/intervalprocessor/processor_test.go
+++ b/processor/intervalprocessor/processor_test.go
@@ -5,6 +5,7 @@ package intervalprocessor // import "github.com/open-telemetry/opentelemetry-col
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor/processortest"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
 )
@@ -40,69 +42,110 @@ func TestAggregation(t *testing.T) {
 	defer cancel()
 
 	var config *Config
-	for _, tc := range testCases {
-		config = &Config{Interval: time.Second, PassThrough: PassThrough{Gauge: tc.passThrough, Summary: tc.passThrough}}
+	for _, intervals := range []time.Duration{1, 2, 10, 60} {
+		for _, tc := range testCases {
+			config = &Config{Interval: time.Second * intervals, PassThrough: PassThrough{Summary: tc.passThrough, Gauge: tc.passThrough}}
 
-		t.Run(tc.name, func(t *testing.T) {
-			// next stores the results of the filter metric processor
-			next := &consumertest.MetricsSink{}
+			t.Run(fmt.Sprintf("%s/%d_partitions", tc.name, intervals), func(t *testing.T) {
+				// next stores the results of the filter metric processor
+				next := &consumertest.MetricsSink{}
 
-			factory := NewFactory()
-			mgp, err := factory.CreateMetricsProcessor(
-				context.Background(),
-				processortest.NewNopSettings(),
-				config,
-				next,
-			)
-			require.NoError(t, err)
+				factory := NewFactory()
+				mgp, err := factory.CreateMetricsProcessor(
+					context.Background(),
+					processortest.NewNopSettings(),
+					config,
+					next,
+				)
+				require.NoError(t, err)
 
-			dir := filepath.Join("testdata", tc.name)
+				dir := filepath.Join("testdata", tc.name)
 
-			md, err := golden.ReadMetrics(filepath.Join(dir, "input.yaml"))
-			require.NoError(t, err)
+				md, err := golden.ReadMetrics(filepath.Join(dir, "input.yaml"))
+				require.NoError(t, err)
 
-			// Test that ConsumeMetrics works
-			err = mgp.ConsumeMetrics(ctx, md)
-			require.NoError(t, err)
+				// Test that ConsumeMetrics works
+				err = mgp.ConsumeMetrics(ctx, md)
+				require.NoError(t, err)
 
-			require.IsType(t, &Processor{}, mgp)
-			processor := mgp.(*Processor)
+				require.IsType(t, &Processor{}, mgp)
+				processor := mgp.(*Processor)
 
-			// Pretend we hit the interval timer and call export
-			processor.exportMetrics()
+				// Pretend we hit the interval timer and call export
+				for i, p := range processor.partitions {
+					processor.exportMetrics(i)
+					// All the lookup tables should now be empty
+					require.Empty(t, p.rmLookup)
+					require.Empty(t, p.smLookup)
+					require.Empty(t, p.mLookup)
+					require.Empty(t, p.numberLookup)
+					require.Empty(t, p.histogramLookup)
+					require.Empty(t, p.expHistogramLookup)
+					require.Empty(t, p.summaryLookup)
 
-			// All the lookup tables should now be empty
-			require.Empty(t, processor.rmLookup)
-			require.Empty(t, processor.smLookup)
-			require.Empty(t, processor.mLookup)
-			require.Empty(t, processor.numberLookup)
-			require.Empty(t, processor.histogramLookup)
-			require.Empty(t, processor.expHistogramLookup)
-			require.Empty(t, processor.summaryLookup)
+					// Exporting again should return nothing
+					processor.exportMetrics(i)
+				}
 
-			// Exporting again should return nothing
-			processor.exportMetrics()
+				// Next should contain:
+				// 1. Anything left over from ConsumeMetrics()
+				// Then for each partition:
+				// 2. Anything exported from exportMetrics()
+				// 3. An empty entry for the second call to exportMetrics()
+				allMetrics := next.AllMetrics()
+				require.Len(t, allMetrics, 1+(processor.numPartitions*2))
 
-			// Next should have gotten three data sets:
-			// 1. Anything left over from ConsumeMetrics()
-			// 2. Anything exported from exportMetrics()
-			// 3. An empty entry for the second call to exportMetrics()
-			allMetrics := next.AllMetrics()
-			require.Len(t, allMetrics, 3)
+				nextData := allMetrics[0]
+				expectedNextData, err := golden.ReadMetrics(filepath.Join(dir, "next.yaml"))
+				require.NoError(t, err)
+				require.NoError(t, pmetrictest.CompareMetrics(expectedNextData, nextData))
 
-			nextData := allMetrics[0]
-			exportData := allMetrics[1]
-			secondExportData := allMetrics[2]
+				expectedExportData, err := golden.ReadMetrics(filepath.Join(dir, "output.yaml"))
+				require.NoError(t, err)
+				partitionedExportedData := partitionedTestData(expectedExportData, processor.numPartitions)
+				for i := 1; i < 1+(processor.numPartitions*2); i++ {
+					if i%2 == 1 {
+						require.NoError(t, pmetrictest.CompareMetrics(partitionedExportedData[i/2], allMetrics[i]), "the first export data should match the partitioned data")
+						continue
+					}
 
-			expectedNextData, err := golden.ReadMetrics(filepath.Join(dir, "next.yaml"))
-			require.NoError(t, err)
-			require.NoError(t, pmetrictest.CompareMetrics(expectedNextData, nextData))
-
-			expectedExportData, err := golden.ReadMetrics(filepath.Join(dir, "output.yaml"))
-			require.NoError(t, err)
-			require.NoError(t, pmetrictest.CompareMetrics(expectedExportData, exportData))
-
-			require.NoError(t, pmetrictest.CompareMetrics(pmetric.NewMetrics(), secondExportData), "the second export data should be empty")
-		})
+					require.NoError(t, pmetrictest.CompareMetrics(pmetric.NewMetrics(), allMetrics[i]), "the second export data should be empty")
+				}
+			})
+		}
 	}
+}
+
+// partitionedTestData returns the original test data, partitioned into the given number of partitions.
+// The partitioning is done by hashing the stream ID and taking the modulo of the number of partitions.
+func partitionedTestData(md pmetric.Metrics, partitions int) []pmetric.Metrics {
+	out := make([]pmetric.Metrics, partitions)
+
+	for i := 0; i < partitions; i++ {
+		out[i] = pmetric.NewMetrics()
+	}
+
+	for i := 0; i < md.ResourceMetrics().Len(); i++ {
+		rm := md.ResourceMetrics().At(i)
+		resID := identity.OfResource(rm.Resource())
+
+		for j := 0; j < rm.ScopeMetrics().Len(); j++ {
+			sm := rm.ScopeMetrics().At(j)
+			scopeID := identity.OfScope(resID, sm.Scope())
+
+			for y := 0; y < sm.Metrics().Len(); y++ {
+				m := sm.Metrics().At(y)
+				metricID := identity.OfMetric(scopeID, m)
+
+				// int -> uint64 theoretically can lead to overflow.
+				// The only way we get an overflow here is if the interval is greater than 18446744073709551615 seconds.
+				// That's 584942417355 years. I think we're safe.
+				partition := metricID.Hash().Sum64() % uint64(partitions) //nolint
+				rmClone := out[partition].ResourceMetrics().AppendEmpty()
+				rm.CopyTo(rmClone)
+			}
+		}
+	}
+
+	return out
 }


### PR DESCRIPTION
**Description:** 
re-implemention of interval processor using a time-base partitioning strategy. The goal is to smoothen the throughput, avoiding CPU/Memory spikes of the next processor/exporter when receiving the aggregated data.

We're now splitting different metrics into different partitions, where the partitioning decision is made by hashing the metric identity. The number of partitions is decided based on the processor interval, e.g. interval 60s = 60 partitions. 

Every second we export the metrics from one partition, and we do it one by one until the whole interval passes and we go back to the initial partition.

**Link to tracking Issue:** #34906

---

I'm opening the PR early with a rough implementation and passing unit tests, but there's a lot to clean up before marking this as ready.

TODO:
- [ ] Macrobenchmarks
- [x] Remove `Partitioned` from config - It was just a workaround to have a clean git diff
- [x] Remove `Processor` interface and delete `SimpleProcessor`
- [ ] More representative testdata, making sure we touch multiple partitions in unit tests