### PR TITLE
[connector/count] fix typo in metric.datapoint.count

### DIFF
--- a/connector/countconnector/README.md
+++ b/connector/countconnector/README.md
@@ -35,7 +35,7 @@ default behavior of the connector.
 | [Exporter Pipeline Type] | Description                         | Default Metric Names                         |
 | ------------------------ | ----------------------------------- | -------------------------------------------- |
 | traces                   | Counts all spans and span events.   | `trace.span.count`, `trace.span.event.count` |
-| metrics                  | Counts all metrics and data points. | `metric.count`, `metric.data_point.count`    |
+| metrics                  | Counts all metrics and data points. | `metric.count`, `metric.datapoint.count`    |
 | logs                     | Counts all log records.             | `log.record.count`                           |
 
 For example, in the following configuration the connector will count spans and span events from the `traces/in`


### PR DESCRIPTION
**Documentation:** The documentation mentions a metric called "metric.data_point.count" but the metric is actually called "metric.datapoint.count"