### PR TITLE
[chore]: enable compares and empty rules from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,8 +134,6 @@ linters-settings:
 
   testifylint:
     disable:
-      - compares
-      - empty
       - error-is-as
       - expected-actual
       - float-compare

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -75,7 +75,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=compares,empty,error-is-as,expected-actual,float-compare,formatter,go-require,negative-positive,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
+TESTIFYLINT_OPT?= --enable-all --disable=error-is-as,expected-actual,float-compare,formatter,go-require,negative-positive,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/cmd/telemetrygen/internal/logs/worker_test.go
+++ b/cmd/telemetrygen/internal/logs/worker_test.go
@@ -86,9 +86,9 @@ func TestRateOfLogs(t *testing.T) {
 
 	// verify
 	// the minimum acceptable number of logs for the rate of 10/sec for half a second
-	assert.True(t, len(m.logs) >= 5, "there should have been 5 or more logs, had %d", len(m.logs))
+	assert.GreaterOrEqual(t, len(m.logs), 5, "there should have been 5 or more logs, had %d", len(m.logs))
 	// the maximum acceptable number of logs for the rate of 10/sec for half a second
-	assert.True(t, len(m.logs) <= 20, "there should have been less than 20 logs, had %d", len(m.logs))
+	assert.LessOrEqual(t, len(m.logs), 20, "there should have been less than 20 logs, had %d", len(m.logs))
 }
 
 func TestUnthrottled(t *testing.T) {
@@ -109,7 +109,7 @@ func TestUnthrottled(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 	require.NoError(t, Run(cfg, expFunc, logger))
 
-	assert.True(t, len(m.logs) > 100, "there should have been more than 100 logs, had %d", len(m.logs))
+	assert.Greater(t, len(m.logs), 100, "there should have been more than 100 logs, had %d", len(m.logs))
 }
 
 func TestCustomBody(t *testing.T) {

--- a/cmd/telemetrygen/internal/metrics/worker_test.go
+++ b/cmd/telemetrygen/internal/metrics/worker_test.go
@@ -93,9 +93,9 @@ func TestRateOfMetrics(t *testing.T) {
 
 	// assert
 	// the minimum acceptable number of metrics for the rate of 10/sec for half a second
-	assert.True(t, len(m.rms) >= 6, "there should have been more than 6 metrics, had %d", len(m.rms))
+	assert.GreaterOrEqual(t, len(m.rms), 6, "there should have been more than 6 metrics, had %d", len(m.rms))
 	// the maximum acceptable number of metrics for the rate of 10/sec for half a second
-	assert.True(t, len(m.rms) <= 20, "there should have been less than 20 metrics, had %d", len(m.rms))
+	assert.LessOrEqual(t, len(m.rms), 20, "there should have been less than 20 metrics, had %d", len(m.rms))
 }
 
 func TestUnthrottled(t *testing.T) {
@@ -117,7 +117,7 @@ func TestUnthrottled(t *testing.T) {
 	require.NoError(t, Run(cfg, expFunc, logger))
 
 	// assert
-	assert.True(t, len(m.rms) > 100, "there should have been more than 100 metrics, had %d", len(m.rms))
+	assert.Greater(t, len(m.rms), 100, "there should have been more than 100 metrics, had %d", len(m.rms))
 }
 
 func TestSumNoTelemetryAttrs(t *testing.T) {

--- a/cmd/telemetrygen/internal/traces/worker_test.go
+++ b/cmd/telemetrygen/internal/traces/worker_test.go
@@ -93,16 +93,16 @@ func TestRateOfSpans(t *testing.T) {
 	}
 
 	// sanity check
-	require.Len(t, syncer.spans, 0)
+	require.Empty(t, syncer.spans)
 
 	// test
 	require.NoError(t, Run(cfg, zap.NewNop()))
 
 	// verify
 	// the minimum acceptable number of spans for the rate of 10/sec for half a second
-	assert.True(t, len(syncer.spans) >= 6, "there should have been more than 6 spans, had %d", len(syncer.spans))
+	assert.GreaterOrEqual(t, len(syncer.spans), 6, "there should have been more than 6 spans, had %d", len(syncer.spans))
 	// the maximum acceptable number of spans for the rate of 10/sec for half a second
-	assert.True(t, len(syncer.spans) <= 20, "there should have been less than 20 spans, had %d", len(syncer.spans))
+	assert.LessOrEqual(t, len(syncer.spans), 20, "there should have been less than 20 spans, had %d", len(syncer.spans))
 }
 
 func TestSpanDuration(t *testing.T) {
@@ -125,7 +125,7 @@ func TestSpanDuration(t *testing.T) {
 	}
 
 	// sanity check
-	require.Len(t, syncer.spans, 0)
+	require.Empty(t, syncer.spans)
 
 	// test
 	require.NoError(t, Run(cfg, zap.NewNop()))
@@ -154,14 +154,14 @@ func TestUnthrottled(t *testing.T) {
 	}
 
 	// sanity check
-	require.Len(t, syncer.spans, 0)
+	require.Empty(t, syncer.spans)
 
 	// test
 	require.NoError(t, Run(cfg, zap.NewNop()))
 
 	// verify
 	// the minimum acceptable number of spans -- the real number should be > 10k, but CI env might be slower
-	assert.True(t, len(syncer.spans) > 100, "there should have been more than 100 spans, had %d", len(syncer.spans))
+	assert.Greater(t, len(syncer.spans), 100, "there should have been more than 100 spans, had %d", len(syncer.spans))
 }
 
 func TestSpanKind(t *testing.T) {

--- a/connector/exceptionsconnector/connector_metrics_test.go
+++ b/connector/exceptionsconnector/connector_metrics_test.go
@@ -83,7 +83,7 @@ func TestConnectorConsumeTraces(t *testing.T) {
 				assert.NoError(t, err)
 
 				metrics := msink.AllMetrics()
-				assert.Greater(t, len(metrics), 0)
+				assert.NotEmpty(t, metrics)
 				tc.verifier(t, metrics[len(metrics)-1])
 			}
 		})
@@ -103,7 +103,7 @@ func TestConnectorConsumeTraces(t *testing.T) {
 		assert.NoError(t, err)
 
 		metrics := msink.AllMetrics()
-		assert.Greater(t, len(metrics), 0)
+		assert.NotEmpty(t, metrics)
 		verifyBadMetricsOkay(t, metrics[len(metrics)-1])
 	})
 

--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -138,8 +138,8 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
 
 		assert.Len(t, defaultSink.AllLogs(), 1)
-		assert.Len(t, sink0.AllLogs(), 0)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink0.AllLogs())
+		assert.Empty(t, sink1.AllLogs())
 	})
 
 	t.Run("logs matched one expression", func(t *testing.T) {
@@ -153,9 +153,9 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
 
-		assert.Len(t, defaultSink.AllLogs(), 0)
+		assert.Empty(t, defaultSink.AllLogs())
 		assert.Len(t, sink0.AllLogs(), 1)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink1.AllLogs())
 	})
 
 	t.Run("logs matched by two expressions", func(t *testing.T) {
@@ -173,7 +173,7 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
 
-		assert.Len(t, defaultSink.AllLogs(), 0)
+		assert.Empty(t, defaultSink.AllLogs())
 		assert.Len(t, sink0.AllLogs(), 1)
 		assert.Len(t, sink1.AllLogs(), 1)
 
@@ -222,7 +222,7 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllLogs(), 1)
 		assert.Len(t, sink0.AllLogs(), 1)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink1.AllLogs())
 
 		assert.Equal(t, defaultSink.AllLogs()[0].LogRecordCount(), 1)
 		assert.Equal(t, sink0.AllLogs()[0].LogRecordCount(), 1)
@@ -294,8 +294,8 @@ func TestLogsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
 
 		assert.Len(t, defaultSink.AllLogs(), 1)
-		assert.Len(t, sink0.AllLogs(), 0)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink0.AllLogs())
+		assert.Empty(t, sink1.AllLogs())
 	})
 
 	t.Run("logs matched one expression", func(t *testing.T) {
@@ -309,9 +309,9 @@ func TestLogsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
 
-		assert.Len(t, defaultSink.AllLogs(), 0)
+		assert.Empty(t, defaultSink.AllLogs())
 		assert.Len(t, sink0.AllLogs(), 1)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink1.AllLogs())
 	})
 
 	t.Run("logs matched by two expressions, but sinks to one", func(t *testing.T) {
@@ -329,9 +329,9 @@ func TestLogsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeLogs(context.Background(), l))
 
-		assert.Len(t, defaultSink.AllLogs(), 0)
+		assert.Empty(t, defaultSink.AllLogs())
 		assert.Len(t, sink0.AllLogs(), 1)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink1.AllLogs())
 
 		assert.Equal(t, sink0.AllLogs()[0].LogRecordCount(), 2)
 	})
@@ -353,7 +353,7 @@ func TestLogsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllLogs(), 1)
 		assert.Len(t, sink0.AllLogs(), 1)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink1.AllLogs())
 
 		rlog := defaultSink.AllLogs()[0].ResourceLogs().At(0)
 		attr, ok := rlog.Resource().Attributes().Get("X-Tenant")
@@ -374,7 +374,7 @@ func TestLogsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllLogs(), 1)
 		assert.Len(t, sink0.AllLogs(), 1)
-		assert.Len(t, sink1.AllLogs(), 0)
+		assert.Empty(t, sink1.AllLogs())
 
 		assert.Equal(t, defaultSink.AllLogs()[0].LogRecordCount(), 1)
 		assert.Equal(t, sink0.AllLogs()[0].LogRecordCount(), 1)
@@ -433,7 +433,7 @@ func TestLogsResourceAttributeDroppedByOTTL(t *testing.T) {
 	v, ok := attrs.Get("attr")
 	assert.True(t, ok, "non routing attributes shouldn't be dropped")
 	assert.Equal(t, "acme", v.Str())
-	assert.Len(t, sink0.AllLogs(), 0,
+	assert.Empty(t, sink0.AllLogs(),
 		"metrics should not be routed to default pipeline",
 	)
 }

--- a/connector/routingconnector/metrics_test.go
+++ b/connector/routingconnector/metrics_test.go
@@ -141,8 +141,8 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
 
 		assert.Len(t, defaultSink.AllMetrics(), 1)
-		assert.Len(t, sink0.AllMetrics(), 0)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink0.AllMetrics())
+		assert.Empty(t, sink1.AllMetrics())
 	})
 
 	t.Run("metric matched by one of two expressions", func(t *testing.T) {
@@ -158,9 +158,9 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
 
-		assert.Len(t, defaultSink.AllMetrics(), 0)
+		assert.Empty(t, defaultSink.AllMetrics())
 		assert.Len(t, sink0.AllMetrics(), 1)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink1.AllMetrics())
 	})
 
 	t.Run("metric matched by two expressions", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
 
-		assert.Len(t, defaultSink.AllMetrics(), 0)
+		assert.Empty(t, defaultSink.AllMetrics())
 		assert.Len(t, sink0.AllMetrics(), 1)
 		assert.Len(t, sink1.AllMetrics(), 1)
 
@@ -237,7 +237,7 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllMetrics(), 1)
 		assert.Len(t, sink0.AllMetrics(), 1)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink1.AllMetrics())
 
 		assert.Equal(t, defaultSink.AllMetrics()[0].MetricCount(), 1)
 		assert.Equal(t, sink0.AllMetrics()[0].MetricCount(), 1)
@@ -312,8 +312,8 @@ func TestMetricsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
 
 		assert.Len(t, defaultSink.AllMetrics(), 1)
-		assert.Len(t, sink0.AllMetrics(), 0)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink0.AllMetrics())
+		assert.Empty(t, sink1.AllMetrics())
 	})
 
 	t.Run("metric matched by one of two expressions", func(t *testing.T) {
@@ -329,9 +329,9 @@ func TestMetricsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
 
-		assert.Len(t, defaultSink.AllMetrics(), 0)
+		assert.Empty(t, defaultSink.AllMetrics())
 		assert.Len(t, sink0.AllMetrics(), 1)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink1.AllMetrics())
 	})
 
 	t.Run("metric matched by two expressions, but sinks to one", func(t *testing.T) {
@@ -353,9 +353,9 @@ func TestMetricsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeMetrics(context.Background(), m))
 
-		assert.Len(t, defaultSink.AllMetrics(), 0)
+		assert.Empty(t, defaultSink.AllMetrics())
 		assert.Len(t, sink0.AllMetrics(), 1)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink1.AllMetrics())
 
 		assert.Equal(t, sink0.AllMetrics()[0].MetricCount(), 2)
 	})
@@ -381,7 +381,7 @@ func TestMetricsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllMetrics(), 1)
 		assert.Len(t, sink0.AllMetrics(), 1)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink1.AllMetrics())
 
 		rmetric := defaultSink.AllMetrics()[0].ResourceMetrics().At(0)
 		attr, ok := rmetric.Resource().Attributes().Get("value")
@@ -404,7 +404,7 @@ func TestMetricsAreCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllMetrics(), 1)
 		assert.Len(t, sink0.AllMetrics(), 1)
-		assert.Len(t, sink1.AllMetrics(), 0)
+		assert.Empty(t, sink1.AllMetrics())
 
 		assert.Equal(t, defaultSink.AllMetrics()[0].MetricCount(), 1)
 		assert.Equal(t, sink0.AllMetrics()[0].MetricCount(), 1)
@@ -463,7 +463,7 @@ func TestMetricsResourceAttributeDroppedByOTTL(t *testing.T) {
 	v, ok := attrs.Get("attr")
 	assert.True(t, ok, "non routing attributes shouldn't be dropped")
 	assert.Equal(t, "acme", v.Str())
-	require.Len(t, sink0.AllMetrics(), 0,
+	require.Empty(t, sink0.AllMetrics(),
 		"metrics should not be routed to default pipeline",
 	)
 }

--- a/connector/routingconnector/traces_test.go
+++ b/connector/routingconnector/traces_test.go
@@ -139,8 +139,8 @@ func TestTracesCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
 
 		assert.Len(t, defaultSink.AllTraces(), 1)
-		assert.Len(t, sink0.AllTraces(), 0)
-		assert.Len(t, sink1.AllTraces(), 0)
+		assert.Empty(t, sink0.AllTraces())
+		assert.Empty(t, sink1.AllTraces())
 	})
 
 	t.Run("span matched by one of two expressions", func(t *testing.T) {
@@ -154,9 +154,9 @@ func TestTracesCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
 
-		assert.Len(t, defaultSink.AllTraces(), 0)
+		assert.Empty(t, defaultSink.AllTraces())
 		assert.Len(t, sink0.AllTraces(), 1)
-		assert.Len(t, sink1.AllTraces(), 0)
+		assert.Empty(t, sink1.AllTraces())
 	})
 
 	t.Run("span matched by all expressions", func(t *testing.T) {
@@ -175,7 +175,7 @@ func TestTracesCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
 
-		assert.Len(t, defaultSink.AllTraces(), 0)
+		assert.Empty(t, defaultSink.AllTraces())
 		assert.Len(t, sink0.AllTraces(), 1)
 		assert.Len(t, sink1.AllTraces(), 1)
 
@@ -197,7 +197,7 @@ func TestTracesCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllTraces(), 1)
 		assert.Len(t, sink0.AllTraces(), 1)
-		assert.Len(t, sink1.AllTraces(), 0)
+		assert.Empty(t, sink1.AllTraces())
 
 		assert.Equal(t, defaultSink.AllTraces()[0].SpanCount(), 1)
 		assert.Equal(t, sink0.AllTraces()[0].SpanCount(), 1)
@@ -270,8 +270,8 @@ func TestTracesCorrectlyMatchOnceWithOTTL(t *testing.T) {
 		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
 
 		assert.Len(t, defaultSink.AllTraces(), 1)
-		assert.Len(t, sink0.AllTraces(), 0)
-		assert.Len(t, sink1.AllTraces(), 0)
+		assert.Empty(t, sink0.AllTraces())
+		assert.Empty(t, sink1.AllTraces())
 	})
 
 	t.Run("span matched by one of two expressions", func(t *testing.T) {
@@ -285,9 +285,9 @@ func TestTracesCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
 
-		assert.Len(t, defaultSink.AllTraces(), 0)
+		assert.Empty(t, defaultSink.AllTraces())
 		assert.Len(t, sink0.AllTraces(), 1)
-		assert.Len(t, sink1.AllTraces(), 0)
+		assert.Empty(t, sink1.AllTraces())
 	})
 
 	t.Run("span matched by all expressions, but sinks to one", func(t *testing.T) {
@@ -306,9 +306,9 @@ func TestTracesCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		require.NoError(t, conn.ConsumeTraces(context.Background(), tr))
 
-		assert.Len(t, defaultSink.AllTraces(), 0)
+		assert.Empty(t, defaultSink.AllTraces())
 		assert.Len(t, sink0.AllTraces(), 1)
-		assert.Len(t, sink1.AllTraces(), 0)
+		assert.Empty(t, sink1.AllTraces())
 
 		assert.Equal(t, sink0.AllTraces()[0].SpanCount(), 2)
 	})
@@ -326,7 +326,7 @@ func TestTracesCorrectlyMatchOnceWithOTTL(t *testing.T) {
 
 		assert.Len(t, defaultSink.AllTraces(), 1)
 		assert.Len(t, sink0.AllTraces(), 1)
-		assert.Len(t, sink1.AllTraces(), 0)
+		assert.Empty(t, sink1.AllTraces())
 
 		assert.Equal(t, defaultSink.AllTraces()[0].SpanCount(), 1)
 		assert.Equal(t, sink0.AllTraces()[0].SpanCount(), 1)
@@ -387,7 +387,7 @@ func TestTracesResourceAttributeDroppedByOTTL(t *testing.T) {
 	v, ok := attrs.Get("attr")
 	assert.True(t, ok, "non-routing attributes shouldn't have been dropped")
 	assert.Equal(t, "acme", v.Str())
-	require.Len(t, sink0.AllTraces(), 0,
+	require.Empty(t, sink0.AllTraces(),
 		"trace should not be routed to default pipeline",
 	)
 }

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -479,7 +479,7 @@ func TestStaleSeriesCleanup(t *testing.T) {
 		p.keyToMetric[key] = metric
 	}
 	p.cleanCache()
-	assert.Len(t, p.keyToMetric, 0)
+	assert.Empty(t, p.keyToMetric)
 
 	// ConsumeTraces with a trace with different attribute value
 	td = buildSampleTrace(t, "second")
@@ -539,7 +539,7 @@ func TestMapsAreConsistentDuringCleanup(t *testing.T) {
 	// for dimensions from that series. It's important that it happens this way around,
 	// instead of deleting it from `keyToMetric`, otherwise the metrics collector will try
 	// and fail to find dimensions for a series that is about to be removed.
-	assert.Len(t, p.reqTotal, 0)
+	assert.Empty(t, p.reqTotal)
 	assert.Len(t, p.keyToMetric, 1)
 
 	p.metricMutex.RUnlock()
@@ -574,7 +574,7 @@ func TestValidateOwnTelemetry(t *testing.T) {
 		p.keyToMetric[key] = metric
 	}
 	p.cleanCache()
-	assert.Len(t, p.keyToMetric, 0)
+	assert.Empty(t, p.keyToMetric)
 
 	// ConsumeTraces with a trace with different attribute value
 	td = buildSampleTrace(t, "second")

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -113,7 +113,7 @@ func verifyExemplarsExist(t testing.TB, input pmetric.Metrics) bool {
 				dps := metric.Histogram().DataPoints()
 				for dp := 0; dp < dps.Len(); dp++ {
 					d := dps.At(dp)
-					assert.True(t, d.Exemplars().Len() > 0)
+					assert.Greater(t, d.Exemplars().Len(), 0)
 				}
 			}
 		}

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -389,7 +389,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			emfCalcs,
 		)
 		assert.NoError(t, err)
-		assert.Len(t, groupedMetrics, 0)
+		assert.Empty(t, groupedMetrics)
 
 		// Test output warning logs
 		expectedLogs := []observer.LoggedEntry{

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -383,7 +383,7 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 		groupedMetrics := make(map[any]*groupedMetric)
 		err := translator.translateOTelToGroupedMetric(rm, groupedMetrics, config)
 		assert.NoError(t, err)
-		assert.Len(t, groupedMetrics, 0)
+		assert.Empty(t, groupedMetrics)
 	})
 }
 
@@ -1957,7 +1957,7 @@ func TestGroupedMetricToCWMeasurementsWithFilters(t *testing.T) {
 
 			cWMeasurements := groupedMetricToCWMeasurementsWithFilters(groupedMetric, config)
 			if len(tc.expectedDims) == 0 {
-				assert.Len(t, cWMeasurements, 0)
+				assert.Empty(t, cWMeasurements)
 			} else {
 				assert.Len(t, cWMeasurements, 1)
 				dims := cWMeasurements[0].Dimensions

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -512,7 +512,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Len(t, awsData.CWLogs, 0)
+	assert.Empty(t, awsData.CWLogs)
 }
 
 func TestLogGroupsInvalidType(t *testing.T) {
@@ -524,7 +524,7 @@ func TestLogGroupsInvalidType(t *testing.T) {
 
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
-	assert.Len(t, awsData.CWLogs, 0)
+	assert.Empty(t, awsData.CWLogs)
 }
 
 // Simulate Log groups arns being set using OTEL_RESOURCE_ATTRIBUTES

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -240,7 +240,7 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	assert.NotNil(t, segment.Service)
 	assert.NotNil(t, segment.AWS)
 	assert.NotNil(t, segment.Metadata)
-	assert.Len(t, segment.Annotations, 0)
+	assert.Empty(t, segment.Annotations)
 	assert.Equal(t, enterpriseAppID, segment.Metadata["default"]["enterprise.app.id"])
 	assert.Nil(t, segment.Cause)
 	assert.Nil(t, segment.HTTP)
@@ -467,7 +467,7 @@ func TestSpanWithAttributesDefaultNotIndexed(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Len(t, segment.Annotations, 0)
+	assert.Empty(t, segment.Annotations)
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
 	assert.Equal(t, "string", segment.Metadata["default"]["otel.resource.string.key"])
@@ -494,7 +494,7 @@ func TestSpanWithResourceNotStoredIfSubsegment(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Len(t, segment.Annotations, 0)
+	assert.Empty(t, segment.Annotations)
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 	assert.Equal(t, "val2", segment.Metadata["default"]["attr2@2"])
 	assert.Nil(t, segment.Metadata["default"]["otel.resource.string.key"])
@@ -570,7 +570,7 @@ func TestSpanWithAttributesSegmentMetadata(t *testing.T) {
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
 	assert.NotNil(t, segment)
-	assert.Len(t, segment.Annotations, 0)
+	assert.Empty(t, segment.Annotations)
 	assert.Len(t, segment.Metadata, 2)
 	assert.Equal(t, "val1", segment.Metadata["default"]["attr1@1"])
 	assert.Equal(t, "custom_value", segment.Metadata["default"]["custom_key"])

--- a/exporter/awsxrayexporter/internal/translator/span_links_test.go
+++ b/exporter/awsxrayexporter/internal/translator/span_links_test.go
@@ -33,7 +33,7 @@ func TestSpanLinkSimple(t *testing.T) {
 	assert.Len(t, segment.Links, 1)
 	assert.Equal(t, spanLink.SpanID().String(), *segment.Links[0].SpanID)
 	assert.Equal(t, convertedTraceID, *segment.Links[0].TraceID)
-	assert.Len(t, segment.Links[0].Attributes, 0)
+	assert.Empty(t, segment.Links[0].Attributes)
 
 	jsonStr, _ := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 
@@ -52,7 +52,7 @@ func TestSpanLinkEmpty(t *testing.T) {
 
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 
-	assert.Len(t, segment.Links, 0)
+	assert.Empty(t, segment.Links)
 
 	jsonStr, _ := MakeSegmentDocumentString(span, resource, nil, false, nil, false)
 

--- a/exporter/datadogexporter/internal/logs/sender_test.go
+++ b/exporter/datadogexporter/internal/logs/sender_test.go
@@ -195,7 +195,7 @@ func TestSubmitLogs(t *testing.T) {
 			if err := s.SubmitLogs(context.Background(), tt.payload); err != nil {
 				t.Fatal(err)
 			}
-			assert.True(t, calls == tt.numRequests)
+			assert.Equal(t, calls, tt.numRequests)
 		})
 	}
 }

--- a/exporter/datadogexporter/internal/metrics/sketches/sketches_test.go
+++ b/exporter/datadogexporter/internal/metrics/sketches/sketches_test.go
@@ -92,7 +92,7 @@ func TestSketchSeriesListMarshal(t *testing.T) {
 		assert.Equal(t, in.Host, pb.Host)
 		assert.Equal(t, in.Name, pb.Metric)
 		assert.Equal(t, in.Tags, pb.Tags)
-		assert.Len(t, pb.Distributions, 0)
+		assert.Empty(t, pb.Distributions)
 
 		require.Len(t, pb.Dogsketches, len(in.Points))
 		for j, pointPb := range pb.Dogsketches {

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -72,7 +72,7 @@ func TestNewExporter(t *testing.T) {
 	testutil.TestMetrics.CopyTo(testMetrics)
 	err = exp.ConsumeMetrics(context.Background(), testMetrics)
 	require.NoError(t, err)
-	assert.Len(t, server.MetadataChan, 0)
+	assert.Empty(t, server.MetadataChan)
 
 	cfg.HostMetadata.Enabled = true
 	cfg.HostMetadata.HostnameSource = HostnameSourceFirstResource
@@ -393,7 +393,7 @@ func TestNewExporter_Zorkian(t *testing.T) {
 	testutil.TestMetrics.CopyTo(testMetrics)
 	err = exp.ConsumeMetrics(context.Background(), testMetrics)
 	require.NoError(t, err)
-	assert.Len(t, server.MetadataChan, 0)
+	assert.Empty(t, server.MetadataChan)
 
 	cfg.HostMetadata.Enabled = true
 	cfg.HostMetadata.HostnameSource = HostnameSourceFirstResource

--- a/exporter/loadbalancingexporter/resolver_dns_test.go
+++ b/exporter/loadbalancingexporter/resolver_dns_test.go
@@ -303,7 +303,7 @@ func TestShutdownClearsCallbacks(t *testing.T) {
 
 	// verify
 	assert.NoError(t, err)
-	assert.Len(t, res.onChangeCallbacks, 0)
+	assert.Empty(t, res.onChangeCallbacks)
 
 	// check that we can add a new onChange before a new start
 	res.onChange(func(_ []string) {})

--- a/exporter/mezmoexporter/exporter_test.go
+++ b/exporter/mezmoexporter/exporter_test.go
@@ -212,7 +212,7 @@ func TestAddsRequiredAttributes(t *testing.T) {
 
 			lines := body.Lines
 			for _, line := range lines {
-				assert.True(t, line.Timestamp > 0)
+				assert.Greater(t, line.Timestamp, int64(0))
 				assert.Equal(t, line.Level, "info")
 				assert.Equal(t, line.App, "")
 				assert.Equal(t, line.Line, "minimal attribute log")

--- a/exporter/mezmoexporter/utils_test.go
+++ b/exporter/mezmoexporter/utils_test.go
@@ -13,7 +13,7 @@ import (
 func TestTruncateString(t *testing.T) {
 	t.Run("Test empty string", func(t *testing.T) {
 		s := truncateString("", 10)
-		require.Len(t, s, 0)
+		require.Empty(t, s)
 	})
 
 	// Test string is less than the maximum length

--- a/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -317,7 +317,7 @@ func TestArrowExporterStreamConnectError(t *testing.T) {
 
 			require.NoError(t, tc.exporter.Shutdown(bg))
 
-			require.Less(t, 0, len(tc.observedLogs.All()), "should have at least one log: %v", tc.observedLogs.All())
+			require.NotEmpty(t, tc.observedLogs.All(), "should have at least one log: %v", tc.observedLogs.All())
 			require.Equal(t, tc.observedLogs.All()[0].Message, "cannot start arrow stream")
 		})
 	}

--- a/exporter/otelarrowexporter/internal/arrow/stream_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream_test.go
@@ -321,7 +321,7 @@ func TestStreamUnsupported(t *testing.T) {
 
 			tc.waitForShutdown()
 
-			require.Less(t, 0, len(tc.observedLogs.All()), "should have at least one log: %v", tc.observedLogs.All())
+			require.NotEmpty(t, tc.observedLogs.All(), "should have at least one log: %v", tc.observedLogs.All())
 			require.Equal(t, tc.observedLogs.All()[0].Message, "arrow is not supported")
 		})
 	}

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -600,7 +600,7 @@ func TestClassifyOrphanSpans(t *testing.T) {
 			transactionMap: generateEmptyTransactionMap(rootSpan1),
 			spans:          generateOrphanSpansFromSpans(childChildSpan1, childSpan1, childSpan2),
 			assertion: func(t *testing.T, orphanSpans []*sentry.Span) {
-				assert.Len(t, orphanSpans, 0)
+				assert.Empty(t, orphanSpans)
 			},
 		},
 		{
@@ -628,7 +628,7 @@ func TestClassifyOrphanSpans(t *testing.T) {
 			transactionMap: generateEmptyTransactionMap(rootSpan1, rootSpan2),
 			spans:          generateOrphanSpansFromSpans(childChildSpan1, childSpan1, root2childSpan, childSpan2),
 			assertion: func(t *testing.T, orphanSpans []*sentry.Span) {
-				assert.Len(t, orphanSpans, 0)
+				assert.Empty(t, orphanSpans)
 			},
 		},
 	}

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -464,12 +464,12 @@ func TestDefaultDiskTranslations(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, du[0].Dimensions, 4)
 	// cheap test for pct conversion
-	require.True(t, *du[0].Value.DoubleValue > 1)
+	require.Greater(t, *du[0].Value.DoubleValue, 1.0)
 
 	dsu, ok := m["disk.summary_utilization"]
 	require.True(t, ok)
 	require.Len(t, dsu[0].Dimensions, 3)
-	require.True(t, *dsu[0].Value.DoubleValue > 1)
+	require.Greater(t, *dsu[0].Value.DoubleValue, 1.0)
 }
 
 func testGetTranslator(t *testing.T) *translation.MetricTranslator {
@@ -603,7 +603,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	md := getMetrics(metrics)
 	require.Equal(t, 69, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
-	require.Len(t, dps, 0)
+	require.Empty(t, dps)
 }
 
 // Benchmark test for default translation rules on an example hostmetrics dataset.

--- a/exporter/signalfxexporter/internal/apm/correlations/client_test.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client_test.go
@@ -232,11 +232,11 @@ func TestCorrelationClient(t *testing.T) {
 		client.Correlate(testData, CorrelateCB(func(_ *Correlation, _ error) {}))
 
 		cors := waitForCors(serverCh, 1, 3)
-		require.Len(t, cors, 0)
+		require.Empty(t, cors)
 
 		forcedRespCode.Store(200)
 		cors = waitForCors(serverCh, 1, 3)
-		require.Len(t, cors, 0)
+		require.Empty(t, cors)
 	})
 	t.Run("does retry 500 responses", func(t *testing.T) {
 		forcedRespCode.Store(500)
@@ -249,7 +249,7 @@ func TestCorrelationClient(t *testing.T) {
 		client.Correlate(testData, CorrelateCB(func(_ *Correlation, _ error) {}))
 
 		cors := waitForCors(serverCh, 1, 4)
-		require.Len(t, cors, 0)
+		require.Empty(t, cors)
 		require.Equal(t, uint32(5), client.(*Client).maxAttempts)
 		require.Equal(t, int64(5), atomic.LoadInt64(&client.(*Client).TotalRetriedUpdates))
 

--- a/exporter/signalfxexporter/internal/correlation/logshims_test.go
+++ b/exporter/signalfxexporter/internal/correlation/logshims_test.go
@@ -48,7 +48,7 @@ func TestZapShim_Debug(t *testing.T) {
 	e := logs[0]
 	assert.Equal(t, "debug message", e.Message)
 	assert.Equal(t, zap.DebugLevel, e.Level)
-	assert.Len(t, e.Context, 0)
+	assert.Empty(t, e.Context)
 }
 
 func TestZapShim_Warn(t *testing.T) {
@@ -60,7 +60,7 @@ func TestZapShim_Warn(t *testing.T) {
 	e := logs[0]
 	assert.Equal(t, "warn message", e.Message)
 	assert.Equal(t, zap.WarnLevel, e.Level)
-	assert.Len(t, e.Context, 0)
+	assert.Empty(t, e.Context)
 }
 
 func TestZapShim_Info(t *testing.T) {
@@ -72,7 +72,7 @@ func TestZapShim_Info(t *testing.T) {
 	e := logs[0]
 	assert.Equal(t, "info message", e.Message)
 	assert.Equal(t, zap.InfoLevel, e.Level)
-	assert.Len(t, e.Context, 0)
+	assert.Empty(t, e.Context)
 }
 
 func TestZapShim_Panic(t *testing.T) {
@@ -86,7 +86,7 @@ func TestZapShim_Panic(t *testing.T) {
 	e := logs[0]
 	assert.Equal(t, "panic message", e.Message)
 	assert.Equal(t, zap.PanicLevel, e.Level)
-	assert.Len(t, e.Context, 0)
+	assert.Empty(t, e.Context)
 }
 
 func TestZapShim_Fields(t *testing.T) {

--- a/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
@@ -189,7 +189,7 @@ func TestDimensionClient(t *testing.T) {
 			},
 		}))
 		dims := waitForDims(dimCh, 1, 3)
-		require.Len(t, dims, 0)
+		require.Empty(t, dims)
 
 		forcedResp.Store(200)
 		dims = waitForDims(dimCh, 1, 3)
@@ -219,11 +219,11 @@ func TestDimensionClient(t *testing.T) {
 			},
 		}))
 		dims := waitForDims(dimCh, 1, 3)
-		require.Len(t, dims, 0)
+		require.Empty(t, dims)
 
 		forcedResp.Store(200)
 		dims = waitForDims(dimCh, 1, 3)
-		require.Len(t, dims, 0)
+		require.Empty(t, dims)
 	})
 
 	t.Run("does retry 404 responses", func(t *testing.T) {
@@ -239,7 +239,7 @@ func TestDimensionClient(t *testing.T) {
 		}))
 
 		dims := waitForDims(dimCh, 1, 3)
-		require.Len(t, dims, 0)
+		require.Empty(t, dims)
 
 		forcedResp.Store(200)
 		dims = waitForDims(dimCh, 1, 3)
@@ -372,7 +372,7 @@ func TestInvalidUpdatesNotSent(t *testing.T) {
 	}))
 
 	dims := waitForDims(dimCh, 2, 3)
-	require.Len(t, dims, 0)
+	require.Empty(t, dims)
 }
 
 func newString(s string) *string {

--- a/exporter/signalfxexporter/internal/hostmetadata/metadata_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/metadata_test.go
@@ -258,7 +258,7 @@ func TestSyncMetadata(t *testing.T) {
 				require.Len(t, dimClient.getMetadataUpdates(), 1)
 				require.EqualValues(t, tt.wantMetadataUpdate, dimClient.getMetadataUpdates()[0])
 			} else {
-				require.Len(t, dimClient.getMetadataUpdates(), 0)
+				require.Empty(t, dimClient.getMetadataUpdates())
 			}
 
 			require.Equal(t, len(tt.wantLogs), logs.Len())

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -1216,7 +1216,7 @@ func TestInvalidNumberOfDimensions(t *testing.T) {
 			Value: fmt.Sprint("dim_val_", i),
 		})
 	}
-	assert.Len(t, c.MetricsToSignalFxV2(mdInvalid), 0)
+	assert.Empty(t, c.MetricsToSignalFxV2(mdInvalid))
 	require.Equal(t, 1, observedLogs.Len())
 	assert.Equal(t, "dropping datapoint", observedLogs.All()[0].Message)
 	assert.ElementsMatch(t, []zap.Field{

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -508,7 +508,7 @@ func TestReceiveTracesBatches(t *testing.T) {
 			for i, batch := range test.want.batches {
 				require.NotZero(t, got[i])
 				if test.conf.MaxContentLengthTraces != 0 {
-					require.True(t, int(test.conf.MaxContentLengthTraces) > len(got[i].body))
+					require.Greater(t, int(test.conf.MaxContentLengthTraces), len(got[i].body))
 				}
 				if test.conf.DisableCompression {
 					for _, expected := range batch {
@@ -791,7 +791,7 @@ func TestReceiveLogs(t *testing.T) {
 			for i, wantBatch := range test.want.batches {
 				require.NotZero(t, got[i])
 				if test.conf.MaxContentLengthLogs != 0 {
-					require.True(t, int(test.conf.MaxContentLengthLogs) > len(got[i].body))
+					require.Greater(t, int(test.conf.MaxContentLengthLogs), len(got[i].body))
 				}
 				if test.conf.DisableCompression {
 					for _, expected := range wantBatch {
@@ -1163,7 +1163,7 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 				for i, batch := range test.want.batches {
 					require.NotZero(t, got[i])
 					if test.conf.MaxContentLengthMetrics != 0 {
-						require.True(t, int(test.conf.MaxContentLengthMetrics) > len(got[i].body))
+						require.Greater(t, int(test.conf.MaxContentLengthMetrics), len(got[i].body))
 					}
 					if test.want.compressed {
 						validateCompressedContains(t, batch, got[i].body)
@@ -1181,7 +1181,7 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 				}
 
 				if test.want.numBatches == 0 {
-					assert.Len(t, got, 0)
+					assert.Empty(t, got)
 					return
 				}
 

--- a/extension/encoding/jsonlogencodingextension/json_test.go
+++ b/extension/encoding/jsonlogencodingextension/json_test.go
@@ -24,7 +24,7 @@ func TestMarshalUnmarshal(t *testing.T) {
 
 	buf, err := e.MarshalLogs(ld)
 	assert.NoError(t, err)
-	assert.True(t, len(buf) > 0)
+	assert.NotEmpty(t, buf)
 	assert.Equal(t, json, string(buf))
 }
 

--- a/extension/observer/ecsobserver/internal/ecsmock/service_test.go
+++ b/extension/observer/ecsobserver/internal/ecsmock/service_test.go
@@ -78,7 +78,7 @@ func TestCluster_DescribeTasksWithContext(t *testing.T) {
 		res, err := c.DescribeTasksWithContext(ctx, req)
 		require.NoError(t, err)
 		assert.Len(t, res.Tasks, 2)
-		assert.Len(t, res.Failures, 0)
+		assert.Empty(t, res.Failures)
 		assert.Equal(t, "running", aws.StringValue(res.Tasks[0].LastStatus))
 	})
 
@@ -199,7 +199,7 @@ func TestCluster_DescribeContainerInstancesWithContext(t *testing.T) {
 		res, err := c.DescribeContainerInstancesWithContext(ctx, req)
 		require.NoError(t, err)
 		assert.Len(t, res.ContainerInstances, nIDs)
-		assert.Len(t, res.Failures, 0)
+		assert.Empty(t, res.Failures)
 	})
 
 	t.Run("not found", func(t *testing.T) {
@@ -272,7 +272,7 @@ func TestCluster_DescribeServicesWithContext(t *testing.T) {
 		res, err := c.DescribeServicesWithContext(ctx, req)
 		require.NoError(t, err)
 		assert.Len(t, res.Services, 2)
-		assert.Len(t, res.Failures, 0)
+		assert.Empty(t, res.Failures)
 	})
 
 	t.Run("not found", func(t *testing.T) {

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -80,11 +80,11 @@ func TestHostObserver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			hostPorts, notifier := tt.setup()
 			if tt.errorListingConnections {
-				require.Len(t, notifier.endpointsMap, 0)
+				require.Empty(t, notifier.endpointsMap)
 				return
 			}
 
-			require.True(t, len(notifier.endpointsMap) >= len(hostPorts))
+			require.GreaterOrEqual(t, len(notifier.endpointsMap), len(hostPorts))
 
 			for _, hp := range hostPorts {
 				require.NoError(t, hp.err, "Failed to et host and port")

--- a/extension/opampextension/registry_test.go
+++ b/extension/opampextension/registry_test.go
@@ -52,7 +52,7 @@ func TestRegistry_Register(t *testing.T) {
 		sender, err := registry.Register(capabilityString)
 		require.Nil(t, sender)
 		require.ErrorIs(t, err, capabilityErr)
-		require.Len(t, registry.capabilityToMsgChannels, 0, "Setting capability failed, but callback ended up in the map anyways")
+		require.Empty(t, registry.capabilityToMsgChannels, "Setting capability failed, but callback ended up in the map anyways")
 	})
 }
 
@@ -101,7 +101,7 @@ func TestRegistry_ProcessMessage(t *testing.T) {
 		// If we did not skip sending on blocked channels, we'd expect this to never return.
 		registry.ProcessMessage(customMessage)
 
-		require.Len(t, sender.Message(), 0)
+		require.Empty(t, sender.Message())
 	})
 
 	t.Run("Callback is called only for its own capability", func(t *testing.T) {

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -449,7 +449,7 @@ func TestCompactionRemoveTemp(t *testing.T) {
 	// check if emptyTempDir is empty after compaction
 	files, err = os.ReadDir(emptyTempDir)
 	require.NoError(t, err)
-	require.Len(t, files, 0)
+	require.Empty(t, files)
 }
 
 func TestCleanupOnStart(t *testing.T) {

--- a/extension/storage/storagetest/host_test.go
+++ b/extension/storage/storagetest/host_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestStorageHostWithNone(t *testing.T) {
-	require.Len(t, NewStorageHost().GetExtensions(), 0)
+	require.Empty(t, NewStorageHost().GetExtensions())
 }
 
 func TestStorageHostWithOne(t *testing.T) {

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -31,7 +31,7 @@ func TestValidateLogEventWithMutating(t *testing.T) {
 	logEvent.GeneratedTime = time.Now()
 	err := logEvent.Validate(zap.NewNop())
 	assert.NoError(t, err)
-	assert.True(t, *logEvent.InputLogEvent.Timestamp > int64(0))
+	assert.Greater(t, *logEvent.InputLogEvent.Timestamp, int64(0))
 	assert.Len(t, *logEvent.InputLogEvent.Message, 64-perEventHeaderBytes)
 
 	maxEventPayloadBytes = defaultMaxEventPayloadBytes
@@ -99,7 +99,7 @@ func TestLogEventBatch_sortLogEvents(t *testing.T) {
 	logEvents := logEventBatch.putLogEventsInput.LogEvents
 	for i := 1; i < totalEvents; i++ {
 		fmt.Printf("logEvents[%d].Timestamp=%d, logEvents[%d].Timestamp=%d.\n", i-1, *logEvents[i-1].Timestamp, i, *logEvents[i].Timestamp)
-		assert.True(t, *logEvents[i-1].Timestamp < *logEvents[i].Timestamp, "timestamp is not sorted correctly")
+		assert.Less(t, *logEvents[i-1].Timestamp, *logEvents[i].Timestamp, "timestamp is not sorted correctly")
 	}
 }
 
@@ -133,7 +133,7 @@ func TestPusher_newLogEventBatch(t *testing.T) {
 	assert.Equal(t, int64(0), logEventBatch.maxTimestampMs)
 	assert.Equal(t, int64(0), logEventBatch.minTimestampMs)
 	assert.Equal(t, 0, logEventBatch.byteTotal)
-	assert.Len(t, logEventBatch.putLogEventsInput.LogEvents, 0)
+	assert.Empty(t, logEventBatch.putLogEventsInput.LogEvents)
 	assert.Equal(t, p.logStreamName, logEventBatch.putLogEventsInput.LogStreamName)
 	assert.Equal(t, p.logGroupName, logEventBatch.putLogEventsInput.LogGroupName)
 	assert.Equal(t, (*string)(nil), logEventBatch.putLogEventsInput.SequenceToken)

--- a/internal/aws/k8s/k8sclient/clientset_test.go
+++ b/internal/aws/k8s/k8sclient/clientset_test.go
@@ -32,6 +32,6 @@ func TestGetShutdown(t *testing.T) {
 	assert.Nil(t, k8sClient.node)
 	assert.Nil(t, k8sClient.pod)
 	assert.Nil(t, k8sClient.replicaSet)
-	assert.Len(t, optionsToK8sClient, 0)
+	assert.Empty(t, optionsToK8sClient)
 	removeTempKubeConfig()
 }

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -113,7 +113,7 @@ func TestMapWithExpiryAdd(t *testing.T) {
 	defer store.Unlock()
 	val, ok = store.Get(Key{MetricMetadata: "key2"})
 	assert.False(t, ok)
-	assert.True(t, val == nil)
+	assert.Nil(t, val)
 	require.NoError(t, store.Shutdown())
 }
 
@@ -144,7 +144,7 @@ func TestMapWithExpiryCleanup(t *testing.T) {
 	store.Lock()
 	val, ok = store.Get(Key{MetricMetadata: "key1"})
 	assert.False(t, ok)
-	assert.True(t, val == nil)
+	assert.Nil(t, val)
 	assert.Equal(t, 0, store.Size())
 	store.Unlock()
 }

--- a/internal/aws/xray/tracesegment_test.go
+++ b/internal/aws/xray/tracesegment_test.go
@@ -629,7 +629,7 @@ func TestTraceBodyUnMarshalling(t *testing.T) {
 		content, err := os.ReadFile(tc.samplePath)
 		assert.NoError(t, err, fmt.Sprintf("[%s] can not read raw segment", tc.testCase))
 
-		assert.True(t, len(content) > 0, fmt.Sprintf("[%s] content length is 0", tc.testCase))
+		assert.NotEmpty(t, content, fmt.Sprintf("[%s] content length is 0", tc.testCase))
 
 		var actualSeg Segment
 		err = json.Unmarshal(content, &actualSeg)

--- a/internal/common/testutil/testutil_test.go
+++ b/internal/common/testutil/testutil_test.go
@@ -66,5 +66,5 @@ Start Port    End Port
 	require.Len(t, exclusions, 2)
 
 	emptyExclusions := createExclusionsList(t, emptyExclusionsText)
-	require.Len(t, emptyExclusions, 0)
+	require.Empty(t, emptyExclusions)
 }

--- a/internal/coreinternal/goldendataset/resource_generator_test.go
+++ b/internal/coreinternal/goldendataset/resource_generator_test.go
@@ -16,7 +16,7 @@ func TestGenerateResource(t *testing.T) {
 		if rscID == ResourceEmpty {
 			assert.Equal(t, 0, rsc.Attributes().Len())
 		} else {
-			assert.True(t, rsc.Attributes().Len() > 0)
+			assert.Greater(t, rsc.Attributes().Len(), 0)
 		}
 	}
 }

--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -269,7 +269,7 @@ func (ci *ContainerInfo) MappedPortForNamedContainer(t *testing.T, containerName
 }
 
 func (ci *ContainerInfo) container(t *testing.T, name string) testcontainers.Container {
-	require.NotZero(t, len(ci.containers), "no containers in use")
+	require.NotEmpty(t, ci.containers, "no containers in use")
 	c, ok := ci.containers[name]
 	require.True(t, ok, "container with name %q not found", name)
 	return c

--- a/internal/exp/metrics/staleness/priority_queue_test.go
+++ b/internal/exp/metrics/staleness/priority_queue_test.go
@@ -79,7 +79,7 @@ func TestPriorityQueueImpl(t *testing.T) {
 	// And the inner lookup map should also be empty
 	require.IsType(t, &heapPriorityQueue{}, pq)
 	heapQueue := pq.(*heapPriorityQueue)
-	require.Len(t, heapQueue.itemLookup, 0)
+	require.Empty(t, heapQueue.itemLookup)
 }
 
 func generateStreamID(t *testing.T, attributes map[string]any) identity.Stream {

--- a/internal/otelarrow/testutil/testutil_test.go
+++ b/internal/otelarrow/testutil/testutil_test.go
@@ -53,5 +53,5 @@ Start Port    End Port
 	require.Len(t, exclusions, 2)
 
 	emptyExclusions := createExclusionsList(emptyExclusionsText, t)
-	require.Len(t, emptyExclusions, 0)
+	require.Empty(t, emptyExclusions)
 }

--- a/internal/sharedcomponent/sharedcomponent_test.go
+++ b/internal/sharedcomponent/sharedcomponent_test.go
@@ -17,7 +17,7 @@ var id = component.MustNewID("test")
 
 func TestNewSharedComponents(t *testing.T) {
 	comps := NewSharedComponents()
-	assert.Len(t, comps.comps, 0)
+	assert.Empty(t, comps.comps)
 }
 
 type mockComponent struct {
@@ -37,7 +37,7 @@ func TestSharedComponents_GetOrAdd(t *testing.T) {
 
 	// Shutdown nop will remove
 	assert.NoError(t, got.Shutdown(context.Background()))
-	assert.Len(t, comps.comps, 0)
+	assert.Empty(t, comps.comps)
 	assert.NotSame(t, got, comps.GetOrAdd(id, createNop))
 }
 

--- a/pkg/stanza/operator/helper/time_test.go
+++ b/pkg/stanza/operator/helper/time_test.go
@@ -547,7 +547,7 @@ func runLossyTimeParseTest(timeParser *TimeParser, ent *entry.Entry, buildErr bo
 			require.True(t, expected.Equal(ent.Timestamp))
 		} else {
 			diff := time.Duration(math.Abs(float64(expected.Sub(ent.Timestamp))))
-			require.True(t, diff <= maxLoss)
+			require.LessOrEqual(t, diff, maxLoss)
 		}
 	}
 }

--- a/pkg/stanza/operator/operatortest/confmap.go
+++ b/pkg/stanza/operator/operatortest/confmap.go
@@ -37,7 +37,7 @@ func (c ConfigUnmarshalTests) Run(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			testConfMap, err := testConfMaps.Sub(tc.Name)
 			require.NoError(t, err)
-			require.NotZero(t, len(testConfMap.AllKeys()), fmt.Sprintf("config not found: '%s'", tc.Name))
+			require.NotEmpty(t, testConfMap.AllKeys(), fmt.Sprintf("config not found: '%s'", tc.Name))
 
 			cfg := newAnyOpConfig(c.DefaultConfig)
 			err = testConfMap.Unmarshal(cfg)

--- a/pkg/stanza/operator/parser/regex/cache_test.go
+++ b/pkg/stanza/operator/parser/regex/cache_test.go
@@ -34,8 +34,8 @@ func TestNewMemoryCache(t *testing.T) {
 		output := newMemoryCache(tc.maxSize, 0)
 		defer output.stop()
 		require.Equal(t, tc.expect.cache, output.cache)
-		require.Len(t, output.cache, 0, "new memory should always be empty")
-		require.Len(t, output.keys, 0, "new memory should always be empty")
+		require.Empty(t, output.cache, "new memory should always be empty")
+		require.Empty(t, output.keys, "new memory should always be empty")
 		require.Equal(t, tc.expectSize, cap(output.keys), "keys channel should have cap of expected size")
 	}
 }

--- a/pkg/stanza/operator/parser/time/parser_test.go
+++ b/pkg/stanza/operator/parser/time/parser_test.go
@@ -531,7 +531,7 @@ func runLossyTimeParseTest(_ *testing.T, cfg *Config, ent *entry.Entry, buildErr
 		require.Equal(t, ots, ent.ObservedTimestamp, "time parsing should not change observed timestamp")
 
 		diff := time.Duration(math.Abs(float64(expected.Sub(ent.Timestamp))))
-		require.True(t, diff <= maxLoss)
+		require.LessOrEqual(t, diff, maxLoss)
 	}
 }
 

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -952,7 +952,7 @@ func TestSourceBatchDelete(t *testing.T) {
 	require.NoError(t, recombine.Process(ctx, start))
 	require.Len(t, recombine.batchMap, 1)
 	require.NoError(t, recombine.Process(ctx, next))
-	require.Len(t, recombine.batchMap, 0)
+	require.Empty(t, recombine.batchMap)
 	fake.ExpectEntry(t, expect)
 	require.NoError(t, recombine.Stop())
 }

--- a/pkg/stanza/pipeline/config_test.go
+++ b/pkg/stanza/pipeline/config_test.go
@@ -101,7 +101,7 @@ func TestBuildAPipelineDefaultOperator(t *testing.T) {
 			require.Equal(t, "fake", op.GetOutputIDs()[0])
 			exists["noop1"] = true
 		case "fake":
-			require.Len(t, op.GetOutputIDs(), 0)
+			require.Empty(t, op.GetOutputIDs())
 			exists["fake"] = true
 		}
 	}

--- a/pkg/translator/jaeger/traces_to_jaegerproto_test.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto_test.go
@@ -333,7 +333,7 @@ func TestInternalTracesToJaegerProto(t *testing.T) {
 			jbs, err := ProtoFromTraces(test.td)
 			assert.EqualValues(t, test.err, err)
 			if test.jb == nil {
-				assert.Len(t, jbs, 0)
+				assert.Empty(t, jbs)
 			} else {
 				require.Len(t, jbs, 1)
 				assert.EqualValues(t, test.jb, jbs[0])

--- a/pkg/translator/zipkin/zipkinv1/json_test.go
+++ b/pkg/translator/zipkin/zipkinv1/json_test.go
@@ -472,7 +472,7 @@ func TestSpanWithoutTimestampGetsTag(t *testing.T) {
 	assert.NotZero(t, gs.StartTimestamp())
 	assert.NotZero(t, gs.EndTimestamp())
 
-	assert.True(t, gs.StartTimestamp().AsTime().Sub(testStart) >= 0)
+	assert.GreaterOrEqual(t, gs.StartTimestamp().AsTime().Sub(testStart), time.Duration(0))
 
 	wantAttributes := pcommon.NewMap()
 	wantAttributes.PutBool(zipkin.StartTimeAbsent, true)

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -41,7 +41,7 @@ func testMatchError(t *testing.T, mdType pmetric.MetricType, mvType pmetric.Numb
 		err := proc.ConsumeMetrics(context.Background(), testData("", 1, mdType, mvType))
 		assert.Error(t, err)
 		// assert that metrics not be filtered as a result
-		assert.Len(t, next.AllMetrics(), 0)
+		assert.Empty(t, next.AllMetrics())
 	})
 }
 

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -349,7 +349,7 @@ func TestFilterMetricProcessor(t *testing.T) {
 			got := next.AllMetrics()
 
 			if len(test.outMN) == 0 {
-				require.Len(t, got, 0)
+				require.Empty(t, got)
 				return
 			}
 

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -150,7 +150,7 @@ func TestFilterTraceProcessor(t *testing.T) {
 
 			// If all traces got filtered you shouldn't even have ResourceSpans
 			if test.allTracesFiltered {
-				require.Len(t, got, 0)
+				require.Empty(t, got)
 			} else {
 				require.Equal(t, test.spanCountExpected, got[0].SpanCount())
 			}

--- a/processor/groupbytraceprocessor/event_test.go
+++ b/processor/groupbytraceprocessor/event_test.go
@@ -495,7 +495,7 @@ func TestForceShutdown(t *testing.T) {
 	duration := time.Since(start)
 
 	// verify
-	assert.True(t, duration > 20*time.Millisecond)
+	assert.Greater(t, duration, 20*time.Millisecond)
 
 	// wait for shutdown goroutine to end
 	time.Sleep(100 * time.Millisecond)

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -47,12 +47,12 @@ func newPodIdentifier(from string, name string, value string) PodIdentifier {
 }
 
 func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
-	assert.Len(t, c.Pods, 0)
+	assert.Empty(t, c.Pods)
 
 	// pod without IP
 	pod := &api_v1.Pod{}
 	handler(pod)
-	assert.Len(t, c.Pods, 0)
+	assert.Empty(t, c.Pods)
 
 	pod = &api_v1.Pod{}
 	pod.Name = "podA"
@@ -92,11 +92,11 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 }
 
 func namespaceAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
-	assert.Len(t, c.Namespaces, 0)
+	assert.Empty(t, c.Namespaces)
 
 	namespace := &api_v1.Namespace{}
 	handler(namespace)
-	assert.Len(t, c.Namespaces, 0)
+	assert.Empty(t, c.Namespaces)
 
 	namespace = &api_v1.Namespace{}
 	namespace.Name = "namespaceA"
@@ -117,11 +117,11 @@ func namespaceAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj an
 }
 
 func nodeAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
-	assert.Len(t, c.Nodes, 0)
+	assert.Empty(t, c.Nodes)
 
 	node := &api_v1.Node{}
 	handler(node)
-	assert.Len(t, c.Nodes, 0)
+	assert.Empty(t, c.Nodes)
 
 	node = &api_v1.Node{}
 	node.Name = "nodeA"
@@ -227,11 +227,11 @@ func TestNodeAdd(t *testing.T) {
 
 func TestReplicaSetHandler(t *testing.T) {
 	c, _ := newTestClient(t)
-	assert.Len(t, c.ReplicaSets, 0)
+	assert.Empty(t, c.ReplicaSets)
 
 	replicaset := &apps_v1.ReplicaSet{}
 	c.handleReplicaSetAdd(replicaset)
-	assert.Len(t, c.ReplicaSets, 0)
+	assert.Empty(t, c.ReplicaSets)
 
 	// test add replicaset
 	replicaset = &apps_v1.ReplicaSet{}
@@ -282,20 +282,20 @@ func TestReplicaSetHandler(t *testing.T) {
 
 	// test delete replicaset
 	c.handleReplicaSetDelete(updatedReplicaset)
-	assert.Len(t, c.ReplicaSets, 0)
+	assert.Empty(t, c.ReplicaSets)
 	// test delete replicaset when DeletedFinalStateUnknown
 	c.handleReplicaSetAdd(replicaset)
 	require.Len(t, c.ReplicaSets, 1)
 	c.handleReplicaSetDelete(cache.DeletedFinalStateUnknown{
 		Obj: replicaset,
 	})
-	assert.Len(t, c.ReplicaSets, 0)
+	assert.Empty(t, c.ReplicaSets)
 
 }
 
 func TestPodHostNetwork(t *testing.T) {
 	c, _ := newTestClient(t)
-	assert.Len(t, c.Pods, 0)
+	assert.Empty(t, c.Pods)
 
 	// pod will not be added if no rule matches
 	pod := &api_v1.Pod{}
@@ -303,7 +303,7 @@ func TestPodHostNetwork(t *testing.T) {
 	pod.Status.PodIP = "1.1.1.1"
 	pod.Spec.HostNetwork = true
 	c.handlePodAdd(pod)
-	assert.Len(t, c.Pods, 0)
+	assert.Empty(t, c.Pods)
 
 	// pod will be added if rule matches
 	pod.Name = "podB"
@@ -323,7 +323,7 @@ func TestPodHostNetwork(t *testing.T) {
 // correctly
 func TestPodCreate(t *testing.T) {
 	c, _ := newTestClient(t)
-	assert.Len(t, c.Pods, 0)
+	assert.Empty(t, c.Pods)
 
 	// pod is created in Pending phase. At this point it has a UID but no start time or pod IP address
 	pod := &api_v1.Pod{}
@@ -377,7 +377,7 @@ func TestPodAddOutOfSync(t *testing.T) {
 			},
 		},
 	})
-	assert.Len(t, c.Pods, 0)
+	assert.Empty(t, c.Pods)
 
 	pod := &api_v1.Pod{}
 	pod.Name = "podA"
@@ -449,7 +449,7 @@ func TestPodDelete(t *testing.T) {
 	assert.Len(t, c.Pods, 5)
 	got := c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
 	assert.Equal(t, "1.1.1.1", got.Address)
-	assert.Len(t, c.deleteQueue, 0)
+	assert.Empty(t, c.deleteQueue)
 
 	// delete matching IP with wrong name/different pod
 	c.deleteQueue = c.deleteQueue[:0]
@@ -459,7 +459,7 @@ func TestPodDelete(t *testing.T) {
 	got = c.Pods[newPodIdentifier("connection", "k8s.pod.ip", "1.1.1.1")]
 	assert.Len(t, c.Pods, 5)
 	assert.Equal(t, "1.1.1.1", got.Address)
-	assert.Len(t, c.deleteQueue, 0)
+	assert.Empty(t, c.deleteQueue)
 
 	// delete matching IP and name
 	c.deleteQueue = c.deleteQueue[:0]
@@ -530,7 +530,7 @@ func TestNamespaceDelete(t *testing.T) {
 	// delete namespace B when DeletedFinalStateUnknown
 	namespace.Name = "namespaceB"
 	c.handleNamespaceDelete(cache.DeletedFinalStateUnknown{Obj: namespace})
-	assert.Len(t, c.Namespaces, 0)
+	assert.Empty(t, c.Namespaces)
 }
 
 func TestNodeDelete(t *testing.T) {
@@ -565,7 +565,7 @@ func TestNodeDelete(t *testing.T) {
 	// delete node B when DeletedFinalStateUnknown
 	node.Name = "nodeB"
 	c.handleNodeDelete(cache.DeletedFinalStateUnknown{Obj: node})
-	assert.Len(t, c.Nodes, 0)
+	assert.Empty(t, c.Nodes)
 }
 
 func TestDeleteQueue(t *testing.T) {
@@ -591,7 +591,7 @@ func TestDeleteLoop(t *testing.T) {
 	pod.Status.PodIP = "1.1.1.1"
 	c.handlePodAdd(pod)
 	assert.Len(t, c.Pods, 2)
-	assert.Len(t, c.deleteQueue, 0)
+	assert.Empty(t, c.deleteQueue)
 
 	c.handlePodDelete(pod)
 	assert.Len(t, c.Pods, 2)
@@ -610,10 +610,10 @@ func TestDeleteLoop(t *testing.T) {
 
 		time.Sleep(gracePeriod + (time.Millisecond * 50))
 		c.m.Lock()
-		assert.Len(t, c.Pods, 0)
+		assert.Empty(t, c.Pods)
 		c.m.Unlock()
 		c.deleteMut.Lock()
-		assert.Len(t, c.deleteQueue, 0)
+		assert.Empty(t, c.deleteQueue)
 		c.deleteMut.Unlock()
 		close(c.stopCh)
 	}()

--- a/processor/logdedupprocessor/counter_test.go
+++ b/processor/logdedupprocessor/counter_test.go
@@ -106,7 +106,7 @@ func Test_logAggregatorReset(t *testing.T) {
 
 	aggregator.Reset()
 
-	require.Len(t, aggregator.resources, 0)
+	require.Empty(t, aggregator.resources)
 }
 
 func Test_logAggregatorExport(t *testing.T) {

--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -411,7 +411,7 @@ func TestLogsSamplingState(t *testing.T) {
 			require.NoError(t, err)
 
 			if len(tt.log) == 0 {
-				require.Len(t, observed.All(), 0, "should not have logs: %v", observed.All())
+				require.Empty(t, observed.All(), "should not have logs: %v", observed.All())
 				require.Equal(t, "", tt.log)
 			} else {
 				require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())
@@ -507,7 +507,7 @@ func TestLogsMissingRandomness(t *testing.T) {
 					require.Len(t, sampledData, 1)
 					assert.Equal(t, 1, sink.LogRecordCount())
 				} else {
-					require.Len(t, sampledData, 0)
+					require.Empty(t, sampledData)
 					assert.Equal(t, 0, sink.LogRecordCount())
 				}
 
@@ -517,7 +517,7 @@ func TestLogsMissingRandomness(t *testing.T) {
 					require.Contains(t, observed.All()[0].Message, "logs sampler")
 					require.Contains(t, observed.All()[0].Context[0].Interface.(error).Error(), "missing randomness")
 				} else {
-					require.Len(t, observed.All(), 0, "should have no logs: %v", observed.All())
+					require.Empty(t, observed.All(), "should have no logs: %v", observed.All())
 				}
 			})
 		}

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -279,7 +279,7 @@ func Test_tracessamplerprocessor_MissingRandomness(t *testing.T) {
 				require.Len(t, sampledData, 1)
 				assert.Equal(t, 1, sink.SpanCount())
 			} else {
-				require.Len(t, sampledData, 0)
+				require.Empty(t, sampledData)
 				assert.Equal(t, 0, sink.SpanCount())
 			}
 
@@ -289,7 +289,7 @@ func Test_tracessamplerprocessor_MissingRandomness(t *testing.T) {
 				require.Contains(t, observed.All()[0].Message, "traces sampler")
 				require.Contains(t, observed.All()[0].Context[0].Interface.(error).Error(), "missing randomness")
 			} else {
-				require.Len(t, observed.All(), 0, "should have no logs: %v", observed.All())
+				require.Empty(t, observed.All(), "should have no logs: %v", observed.All())
 			}
 		})
 	}
@@ -409,7 +409,7 @@ func Test_tracesamplerprocessor_SpanSamplingPriority(t *testing.T) {
 					require.Len(t, sampledData, 1)
 					assert.Equal(t, 1, sink.SpanCount())
 				} else {
-					require.Len(t, sampledData, 0)
+					require.Empty(t, sampledData)
 					assert.Equal(t, 0, sink.SpanCount())
 				}
 			})
@@ -899,13 +899,13 @@ func Test_tracesamplerprocessor_TraceState(t *testing.T) {
 					}
 					require.Equal(t, expectTS, got.TraceState().AsRaw())
 				} else {
-					require.Len(t, sampledData, 0)
+					require.Empty(t, sampledData)
 					assert.Equal(t, 0, sink.SpanCount())
 					require.Equal(t, "", expectTS)
 				}
 
 				if len(tt.log) == 0 {
-					require.Len(t, observed.All(), 0, "should not have logs: %v", observed.All())
+					require.Empty(t, observed.All(), "should not have logs: %v", observed.All())
 				} else {
 					require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())
 					require.Contains(t, observed.All()[0].Message, "traces sampler")
@@ -1026,7 +1026,7 @@ func Test_tracesamplerprocessor_TraceStateErrors(t *testing.T) {
 
 				sampledData := sink.AllTraces()
 
-				require.Len(t, sampledData, 0)
+				require.Empty(t, sampledData)
 				assert.Equal(t, 0, sink.SpanCount())
 
 				require.Len(t, observed.All(), 1, "should have one log: %v", observed.All())

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -298,7 +298,7 @@ func TestFilterAttributes_NilAttributes(t *testing.T) {
 	_, ok = attr.Get("host.id")
 	assert.True(t, ok)
 
-	assert.Len(t, droppedAttributes, 0)
+	assert.Empty(t, droppedAttributes)
 }
 
 func TestFilterAttributes_NoAttributes(t *testing.T) {
@@ -315,5 +315,5 @@ func TestFilterAttributes_NoAttributes(t *testing.T) {
 	_, ok = attr.Get("host.id")
 	assert.True(t, ok)
 
-	assert.Len(t, droppedAttributes, 0)
+	assert.Empty(t, droppedAttributes)
 }

--- a/processor/routingprocessor/logs_test.go
+++ b/processor/routingprocessor/logs_test.go
@@ -72,7 +72,7 @@ func TestLogs_RoutingWorks_Context(t *testing.T) {
 			})),
 			l,
 		))
-		assert.Len(t, defaultExp.AllLogs(), 0,
+		assert.Empty(t, defaultExp.AllLogs(),
 			"log should not be routed to default exporter",
 		)
 		assert.Len(t, lExp.AllLogs(), 1,
@@ -159,7 +159,7 @@ func TestLogs_RoutingWorks_ResourceAttribute(t *testing.T) {
 		rl.Resource().Attributes().PutStr("X-Tenant", "acme")
 
 		assert.NoError(t, exp.ConsumeLogs(context.Background(), l))
-		assert.Len(t, defaultExp.AllLogs(), 0,
+		assert.Empty(t, defaultExp.AllLogs(),
 			"log should not be routed to default exporter",
 		)
 		assert.Len(t, lExp.AllLogs(), 1,
@@ -322,8 +322,8 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		require.NoError(t, exp.ConsumeLogs(context.Background(), l))
 
 		assert.Len(t, defaultExp.AllLogs(), 1)
-		assert.Len(t, firstExp.AllLogs(), 0)
-		assert.Len(t, secondExp.AllLogs(), 0)
+		assert.Empty(t, firstExp.AllLogs())
+		assert.Empty(t, secondExp.AllLogs())
 	})
 
 	t.Run("logs matched one of two expressions", func(t *testing.T) {
@@ -339,9 +339,9 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, exp.ConsumeLogs(context.Background(), l))
 
-		assert.Len(t, defaultExp.AllLogs(), 0)
+		assert.Empty(t, defaultExp.AllLogs())
 		assert.Len(t, firstExp.AllLogs(), 1)
-		assert.Len(t, secondExp.AllLogs(), 0)
+		assert.Empty(t, secondExp.AllLogs())
 	})
 
 	t.Run("logs matched by all expressions", func(t *testing.T) {
@@ -361,7 +361,7 @@ func TestLogsAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, exp.ConsumeLogs(context.Background(), l))
 
-		assert.Len(t, defaultExp.AllLogs(), 0)
+		assert.Empty(t, defaultExp.AllLogs())
 		assert.Len(t, firstExp.AllLogs(), 1)
 		assert.Len(t, secondExp.AllLogs(), 1)
 
@@ -438,7 +438,7 @@ func TestLogsAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 
 	// verify
 	assert.Len(t, defaultExp.AllLogs(), 1)
-	assert.Len(t, firstExp.AllLogs(), 0)
+	assert.Empty(t, firstExp.AllLogs())
 }
 
 type mockLogsExporter struct {

--- a/processor/routingprocessor/metrics_test.go
+++ b/processor/routingprocessor/metrics_test.go
@@ -132,7 +132,7 @@ func TestMetrics_RoutingWorks_Context(t *testing.T) {
 			})),
 			m,
 		))
-		assert.Len(t, defaultExp.AllMetrics(), 0,
+		assert.Empty(t, defaultExp.AllMetrics(),
 			"metric should not be routed to default exporter",
 		)
 		assert.Len(t, mExp.AllMetrics(), 1,
@@ -221,7 +221,7 @@ func TestMetrics_RoutingWorks_ResourceAttribute(t *testing.T) {
 		rm.Resource().Attributes().PutStr("X-Tenant", "acme")
 
 		assert.NoError(t, exp.ConsumeMetrics(context.Background(), m))
-		assert.Len(t, defaultExp.AllMetrics(), 0,
+		assert.Empty(t, defaultExp.AllMetrics(),
 			"metric should not be routed to default exporter",
 		)
 		assert.Len(t, mExp.AllMetrics(), 1,
@@ -384,8 +384,8 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithOTTL(t *testing.
 		require.NoError(t, exp.ConsumeMetrics(context.Background(), m))
 
 		assert.Len(t, defaultExp.AllMetrics(), 1)
-		assert.Len(t, firstExp.AllMetrics(), 0)
-		assert.Len(t, secondExp.AllMetrics(), 0)
+		assert.Empty(t, firstExp.AllMetrics())
+		assert.Empty(t, secondExp.AllMetrics())
 	})
 
 	t.Run("metric matched by one of two expressions", func(t *testing.T) {
@@ -403,9 +403,9 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithOTTL(t *testing.
 
 		require.NoError(t, exp.ConsumeMetrics(context.Background(), m))
 
-		assert.Len(t, defaultExp.AllMetrics(), 0)
+		assert.Empty(t, defaultExp.AllMetrics())
 		assert.Len(t, firstExp.AllMetrics(), 1)
-		assert.Len(t, secondExp.AllMetrics(), 0)
+		assert.Empty(t, secondExp.AllMetrics())
 	})
 
 	t.Run("metric matched by all expressions", func(t *testing.T) {
@@ -429,7 +429,7 @@ func TestMetricsAreCorrectlySplitPerResourceAttributeRoutingWithOTTL(t *testing.
 
 		require.NoError(t, exp.ConsumeMetrics(context.Background(), m))
 
-		assert.Len(t, defaultExp.AllMetrics(), 0)
+		assert.Empty(t, defaultExp.AllMetrics())
 		assert.Len(t, firstExp.AllMetrics(), 1)
 		assert.Len(t, secondExp.AllMetrics(), 1)
 
@@ -512,5 +512,5 @@ func TestMetricsAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 
 	// verify
 	assert.Len(t, defaultExp.AllMetrics(), 1)
-	assert.Len(t, firstExp.AllMetrics(), 0)
+	assert.Empty(t, firstExp.AllMetrics())
 }

--- a/processor/routingprocessor/traces_test.go
+++ b/processor/routingprocessor/traces_test.go
@@ -176,7 +176,7 @@ func TestTraces_RoutingWorks_Context(t *testing.T) {
 			})),
 			tr,
 		))
-		assert.Len(t, defaultExp.AllTraces(), 0,
+		assert.Empty(t, defaultExp.AllTraces(),
 			"trace should not be routed to default exporter",
 		)
 		assert.Len(t, tExp.AllTraces(), 1,
@@ -264,7 +264,7 @@ func TestTraces_RoutingWorks_ResourceAttribute(t *testing.T) {
 		rs.Resource().Attributes().PutStr("X-Tenant", "acme")
 
 		assert.NoError(t, exp.ConsumeTraces(context.Background(), tr))
-		assert.Len(t, defaultExp.AllTraces(), 0,
+		assert.Empty(t, defaultExp.AllTraces(),
 			"trace should not be routed to default exporter",
 		)
 		assert.Len(t, tExp.AllTraces(), 1,
@@ -377,8 +377,8 @@ func TestTracesAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 		require.NoError(t, exp.ConsumeTraces(context.Background(), tr))
 
 		assert.Len(t, defaultExp.AllTraces(), 1)
-		assert.Len(t, firstExp.AllTraces(), 0)
-		assert.Len(t, secondExp.AllTraces(), 0)
+		assert.Empty(t, firstExp.AllTraces())
+		assert.Empty(t, secondExp.AllTraces())
 	})
 
 	t.Run("span matched by one of two expressions", func(t *testing.T) {
@@ -394,9 +394,9 @@ func TestTracesAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, exp.ConsumeTraces(context.Background(), tr))
 
-		assert.Len(t, defaultExp.AllTraces(), 0)
+		assert.Empty(t, defaultExp.AllTraces())
 		assert.Len(t, firstExp.AllTraces(), 1)
-		assert.Len(t, secondExp.AllTraces(), 0)
+		assert.Empty(t, secondExp.AllTraces())
 	})
 
 	t.Run("spans matched by all expressions", func(t *testing.T) {
@@ -417,7 +417,7 @@ func TestTracesAreCorrectlySplitPerResourceAttributeWithOTTL(t *testing.T) {
 
 		require.NoError(t, exp.ConsumeTraces(context.Background(), tr))
 
-		assert.Len(t, defaultExp.AllTraces(), 0)
+		assert.Empty(t, defaultExp.AllTraces())
 		assert.Len(t, firstExp.AllTraces(), 1)
 		assert.Len(t, secondExp.AllTraces(), 1)
 
@@ -495,7 +495,7 @@ func TestTracesAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 
 	// verify
 	assert.Len(t, defaultExp.AllTraces(), 1)
-	assert.Len(t, firstExp.AllTraces(), 0)
+	assert.Empty(t, firstExp.AllTraces())
 
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/diskio_extractor_test.go
@@ -98,5 +98,5 @@ func TestDiskIOStats(t *testing.T) {
 		cMetrics = extractor.GetValue(result2[0], nil, containerType)
 	}
 
-	assert.Len(t, cMetrics, 0)
+	assert.Empty(t, cMetrics)
 }

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
@@ -47,7 +47,7 @@ func TestFSStats(t *testing.T) {
 		cMetrics = extractor.GetValue(result[0], nil, containerType)
 	}
 
-	assert.Len(t, cMetrics, 0)
+	assert.Empty(t, cMetrics)
 
 	// node type for eks
 

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_task_info_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_task_info_test.go
@@ -75,7 +75,7 @@ func TestECSTaskInfoFail(t *testing.T) {
 	ecsTaskinfo := newECSTaskInfo(ctx, hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, taskReadyC)
 	assert.NotNil(t, ecsTaskinfo)
 	assert.Equal(t, int64(0), ecsTaskinfo.getRunningTaskCount())
-	assert.Len(t, ecsTaskinfo.getRunningTasksInfo(), 0)
+	assert.Empty(t, ecsTaskinfo.getRunningTasksInfo())
 
 	data, err := os.ReadFile("./test/ecsinfo/taskinfo_wrong")
 	body := string(data)
@@ -87,6 +87,6 @@ func TestECSTaskInfoFail(t *testing.T) {
 	ecsTaskinfo = newECSTaskInfo(ctx, hostIPProvider, time.Minute, zap.NewNop(), mockHTTP, taskReadyC)
 	assert.NotNil(t, ecsTaskinfo)
 	assert.Equal(t, int64(0), ecsTaskinfo.getRunningTaskCount())
-	assert.Len(t, ecsTaskinfo.getRunningTasksInfo(), 0)
+	assert.Empty(t, ecsTaskinfo.getRunningTasksInfo())
 
 }

--- a/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/ebsvolume_test.go
@@ -180,5 +180,5 @@ func TestEBSVolume(t *testing.T) {
 	e = newEBSVolume(ctx, sess, "instanceId", "us-west-2", time.Millisecond, zap.NewNop(),
 		clientOption, maxJitterOption, hostMountsOption, LstatOption, evalSymLinksOption)
 	ebsIDs = e.extractEbsIDsUsedByKubernetes()
-	assert.Len(t, ebsIDs, 0)
+	assert.Empty(t, ebsIDs)
 }

--- a/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/stores/podstore_test.go
@@ -557,7 +557,7 @@ func TestPodStore_addPodOwnersAndPodName(t *testing.T) {
 	kubernetesBlob = map[string]any{}
 	podStore.addPodOwnersAndPodName(metric, pod, kubernetesBlob)
 	assert.Equal(t, kpName, metric.GetTag(ci.PodNameKey))
-	assert.Len(t, kubernetesBlob, 0)
+	assert.Empty(t, kubernetesBlob)
 
 	podStore.prefFullPodName = false
 	metric = generateMetric(fields, tags)
@@ -566,7 +566,7 @@ func TestPodStore_addPodOwnersAndPodName(t *testing.T) {
 	kubernetesBlob = map[string]any{}
 	podStore.addPodOwnersAndPodName(metric, pod, kubernetesBlob)
 	assert.Equal(t, kubeProxy, metric.GetTag(ci.PodNameKey))
-	assert.Len(t, kubernetesBlob, 0)
+	assert.Empty(t, kubernetesBlob)
 }
 
 type mockPodClient struct {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator_test.go
@@ -98,7 +98,7 @@ var (
 
 func TestGetMetricsDataAllValid(t *testing.T) {
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataMissingContainerStats(t *testing.T) {
@@ -106,7 +106,7 @@ func TestGetMetricsDataMissingContainerStats(t *testing.T) {
 		{ContainerName: "container-1", DockerID: "001-Missing", DockerName: "docker-container-1", Limits: ecsutil.Limits{CPU: &f, Memory: &v}},
 	}
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataForStoppedContainer(t *testing.T) {
@@ -115,7 +115,7 @@ func TestGetMetricsDataForStoppedContainer(t *testing.T) {
 		{ContainerName: "container-1", DockerID: "001", DockerName: "docker-container-1", CreatedAt: "2020-07-30T22:12:29.842610987Z", StartedAt: "2020-07-30T22:12:31.842610987Z", FinishedAt: "2020-07-31T22:10:29.842610987Z", KnownStatus: "STOPPED", Limits: ecsutil.Limits{CPU: &f, Memory: &v}},
 	}
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestWrongFormatTimeDataForStoppedContainer(t *testing.T) {
@@ -124,7 +124,7 @@ func TestWrongFormatTimeDataForStoppedContainer(t *testing.T) {
 		{ContainerName: "container-1", DockerID: "001", DockerName: "docker-container-1", CreatedAt: "2020-07-30T22:12:29.842610987Z", StartedAt: "2020-07-30T22:12:31.842610987Z", FinishedAt: "2020-07-31 22:10:29", KnownStatus: "STOPPED", Limits: ecsutil.Limits{CPU: &f, Memory: &v}},
 	}
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataMissingContainerLimit(t *testing.T) {
@@ -133,7 +133,7 @@ func TestGetMetricsDataMissingContainerLimit(t *testing.T) {
 	}
 
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataContainerLimitCpuNil(t *testing.T) {
@@ -142,7 +142,7 @@ func TestGetMetricsDataContainerLimitCpuNil(t *testing.T) {
 	}
 
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataContainerLimitMemoryNil(t *testing.T) {
@@ -151,7 +151,7 @@ func TestGetMetricsDataContainerLimitMemoryNil(t *testing.T) {
 	}
 
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataMissingTaskLimit(t *testing.T) {
@@ -166,7 +166,7 @@ func TestGetMetricsDataMissingTaskLimit(t *testing.T) {
 	}
 
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataTaskLimitCpuNil(t *testing.T) {
@@ -182,7 +182,7 @@ func TestGetMetricsDataTaskLimitCpuNil(t *testing.T) {
 	}
 
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataTaskLimitMemoryNil(t *testing.T) {
@@ -198,7 +198,7 @@ func TestGetMetricsDataTaskLimitMemoryNil(t *testing.T) {
 	}
 
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 
 func TestGetMetricsDataCpuReservedZero(t *testing.T) {
@@ -214,7 +214,7 @@ func TestGetMetricsDataCpuReservedZero(t *testing.T) {
 	}
 
 	acc.getMetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(acc.mds))
+	require.NotEmpty(t, acc.mds)
 }
 func TestIsEmptyStats(t *testing.T) {
 	require.False(t, isEmptyStats(&containerStats))

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/metrics_test.go
@@ -93,5 +93,5 @@ func TestMetricData(t *testing.T) {
 
 	logger := zap.NewNop()
 	md := MetricsData(cstats, tm, logger)
-	require.Less(t, 0, len(md))
+	require.NotEmpty(t, md)
 }

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/stats_provider_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/stats_provider_test.go
@@ -69,7 +69,7 @@ func TestGetStats(t *testing.T) {
 			stats, metadata, err := provider.GetStats()
 			if tt.wantError == "" {
 				require.NoError(t, err)
-				require.Less(t, 0, len(stats))
+				require.NotEmpty(t, stats)
 				require.Equal(t, "test200", metadata.Cluster)
 			} else {
 				assert.Equal(t, tt.wantError, err.Error())

--- a/receiver/awss3receiver/s3reader_test.go
+++ b/receiver/awss3receiver/s3reader_test.go
@@ -406,5 +406,5 @@ func Test_readAll_ContextDone(t *testing.T) {
 		return nil
 	})
 	require.Error(t, err)
-	require.Len(t, dataCallbackKeys, 0)
+	require.Empty(t, dataCallbackKeys)
 }

--- a/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
+++ b/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
@@ -66,7 +66,7 @@ func TestSplitHeaderBodyEmptyBody(t *testing.T) {
 		Format:  "json",
 		Version: 1,
 	}, header, "actual header is different from the expected")
-	assert.Len(t, body, 0, "body should be empty")
+	assert.Empty(t, body, "body should be empty")
 }
 
 func TestSplitHeaderBodyInvalidJsonHeader(t *testing.T) {

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -948,7 +948,7 @@ func TestTranslation(t *testing.T) {
 		t.Run(tc.testCase, func(t *testing.T) {
 			content, err := os.ReadFile(tc.samplePath)
 			assert.NoError(t, err, "can not read raw segment")
-			assert.True(t, len(content) > 0, "content length is 0")
+			assert.NotEmpty(t, content, "content length is 0")
 
 			var (
 				actualSeg  awsxray.Segment

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -32,7 +32,7 @@ func TestNewScraper(t *testing.T) {
 	cfg := f.CreateDefaultConfig().(*Config)
 
 	scraper := newScraper(cfg, receivertest.NewNopSettings())
-	require.Len(t, scraper.resources, 0)
+	require.Empty(t, scraper.resources)
 }
 
 func azIDCredentialsFuncMock(string, string, string, *azidentity.ClientSecretCredentialOptions) (*azidentity.ClientSecretCredential, error) {

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -82,7 +82,7 @@ func TestScrape(t *testing.T) {
 
 		var partialScrapeErr scrapererror.PartialScrapeError
 		require.True(t, errors.As(err, &partialScrapeErr), "returned error was not PartialScrapeError")
-		require.True(t, partialScrapeErr.Failed > 0, "Expected scrape failures, but none were recorded!")
+		require.Greater(t, partialScrapeErr.Failed, 0, "Expected scrape failures, but none were recorded!")
 	})
 
 	t.Run("scrape error: failed to connect to client", func(t *testing.T) {

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -140,7 +140,7 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 	require.NoError(t, err)
 
 	// Cache timeout hasn't been reached, so filtered out all items
-	assert.Len(t, filteredItems, 0)
+	assert.Empty(t, filteredItems)
 
 	// Doing this to avoid of relying on timeouts and sleeps(avoid potential flaky tests)
 	syncChannel := make(chan bool)

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder_test.go
@@ -221,7 +221,7 @@ func TestMetricsFromDataPointBuilder_GroupAndFilter_NilDataPoints(t *testing.T) 
 
 	require.NoError(t, err)
 
-	assert.Len(t, groupedDataPoints, 0)
+	assert.Empty(t, groupedDataPoints)
 }
 
 func TestMetricsFromDataPointBuilder_Filter(t *testing.T) {

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
@@ -50,7 +50,7 @@ func TestNewDatabaseReader(t *testing.T) {
 
 	assert.Equal(t, databaseID, reader.database.DatabaseID())
 	assert.Equal(t, logger, reader.logger)
-	assert.Len(t, reader.readers, 0)
+	assert.Empty(t, reader.readers)
 }
 
 func TestNewDatabaseReaderWithError(t *testing.T) {

--- a/receiver/googlecloudspannerreceiver/receiver_test.go
+++ b/receiver/googlecloudspannerreceiver/receiver_test.go
@@ -116,7 +116,7 @@ func TestStart(t *testing.T) {
 
 			if testCase.expectError {
 				require.Error(t, err)
-				assert.Len(t, receiver.projectReaders, 0)
+				assert.Empty(t, receiver.projectReaders)
 			} else {
 				require.NoError(t, err)
 				assert.Len(t, receiver.projectReaders, 1)
@@ -189,7 +189,7 @@ func TestInitializeProjectReaders(t *testing.T) {
 
 			if testCase.expectError {
 				require.Error(t, err)
-				assert.Len(t, receiver.projectReaders, 0)
+				assert.Empty(t, receiver.projectReaders)
 			} else {
 				require.NoError(t, err)
 				assert.Len(t, receiver.projectReaders, 1)

--- a/receiver/k8sclusterreceiver/internal/metadata/metadata_test.go
+++ b/receiver/k8sclusterreceiver/internal/metadata/metadata_test.go
@@ -219,7 +219,7 @@ func TestGetMetadataUpdate(t *testing.T) {
 				require.Len(t, delta, 1)
 				require.Equal(t, *tt.metadataDelta, delta[0].MetadataDelta)
 			} else {
-				require.Zero(t, len(delta))
+				require.Empty(t, delta)
 			}
 		})
 	}

--- a/receiver/k8sobjectsreceiver/receiver_test.go
+++ b/receiver/k8sobjectsreceiver/receiver_test.go
@@ -119,7 +119,7 @@ func TestWatchObject(t *testing.T) {
 	require.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
 
 	time.Sleep(time.Millisecond * 100)
-	assert.Len(t, consumer.Logs(), 0)
+	assert.Empty(t, consumer.Logs())
 	assert.Equal(t, 0, consumer.Count())
 
 	mockClient.createPods(
@@ -191,7 +191,7 @@ func TestExludeDeletedTrue(t *testing.T) {
 	require.NoError(t, r.Start(ctx, componenttest.NewNopHost()))
 
 	time.Sleep(time.Millisecond * 100)
-	assert.Len(t, consumer.Logs(), 0)
+	assert.Empty(t, consumer.Logs())
 	assert.Equal(t, 0, consumer.Count())
 
 	mockClient.deletePods(
@@ -200,7 +200,7 @@ func TestExludeDeletedTrue(t *testing.T) {
 		}, "1"),
 	)
 	time.Sleep(time.Millisecond * 100)
-	assert.Len(t, consumer.Logs(), 0)
+	assert.Empty(t, consumer.Logs())
 	assert.Equal(t, 0, consumer.Count())
 
 	assert.NoError(t, r.Shutdown(ctx))

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata_provider_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata_provider_test.go
@@ -60,7 +60,7 @@ func TestPods(t *testing.T) {
 			podsMetadata, err := metadataProvider.Pods()
 			if tt.wantError == "" {
 				require.NoError(t, err)
-				require.Less(t, 0, len(podsMetadata.Items))
+				require.NotEmpty(t, podsMetadata.Items)
 			} else {
 				assert.Equal(t, tt.wantError, err.Error())
 			}

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metrics_test.go
@@ -45,7 +45,7 @@ func TestMetricAccumulator(t *testing.T) {
 	mbs.NodeMetricsBuilder.Reset()
 	mbs.PodMetricsBuilder.Reset()
 	mbs.OtherMetricsBuilder.Reset()
-	require.Len(t, MetricsData(zap.NewNop(), summary, k8sMetadata, map[MetricGroup]bool{}, mbs), 0)
+	require.Empty(t, MetricsData(zap.NewNop(), summary, k8sMetadata, map[MetricGroup]bool{}, mbs))
 }
 
 func requireMetricsOk(t *testing.T, mds []pmetric.Metrics) {

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -710,7 +710,7 @@ func TestGRPCArrowReceiverAuth(t *testing.T) {
 	assert.NoError(t, cc.Close())
 	require.NoError(t, ocr.Shutdown(context.Background()))
 
-	assert.Len(t, sink.AllTraces(), 0)
+	assert.Empty(t, sink.AllTraces())
 }
 
 func TestConcurrentArrowReceiver(t *testing.T) {

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -176,7 +176,7 @@ func TestEventLoopHandles(t *testing.T) {
 	cli := newContainerScraper(&eventClient, zap.NewNop(), &Config{})
 	assert.NotNil(t, cli)
 
-	assert.Len(t, cli.containers, 0)
+	assert.Empty(t, cli.containers)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go cli.containerEventLoop(ctx)
@@ -195,7 +195,7 @@ func TestEventLoopHandles(t *testing.T) {
 	assert.Eventually(t, func() bool {
 		cli.containersLock.Lock()
 		defer cli.containersLock.Unlock()
-		return assert.Len(t, cli.containers, 0)
+		return assert.Empty(t, cli.containers)
 	}, 1*time.Second, 1*time.Millisecond, "failed to update containers list.")
 }
 
@@ -210,7 +210,7 @@ func TestInspectAndPersistContainer(t *testing.T) {
 	cli := newContainerScraper(&inspectClient, zap.NewNop(), &Config{})
 	assert.NotNil(t, cli)
 
-	assert.Len(t, cli.containers, 0)
+	assert.Empty(t, cli.containers)
 
 	stats, ok := cli.inspectAndPersistContainer(context.Background(), "c1")
 	assert.True(t, ok)

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -196,13 +196,13 @@ service:
 	// 6. Assert that we encounter the stale markers aka special NaNs for the various time series.
 	staleMarkerCount := 0
 	totalSamples := 0
-	require.True(t, len(wReqL) > 0, "Expecting at least one WriteRequest")
+	require.NotEmpty(t, wReqL, "Expecting at least one WriteRequest")
 	for i, wReq := range wReqL {
 		name := fmt.Sprintf("WriteRequest#%d", i)
-		require.True(t, len(wReq.Timeseries) > 0, "Expecting at least 1 timeSeries for:: "+name)
+		require.NotEmpty(t, wReq.Timeseries, "Expecting at least 1 timeSeries for:: "+name)
 		for j, ts := range wReq.Timeseries {
 			fullName := fmt.Sprintf("%s/TimeSeries#%d", name, j)
-			assert.True(t, len(ts.Samples) > 0, "Expected at least 1 Sample in:: "+fullName)
+			assert.NotEmpty(t, ts.Samples, "Expected at least 1 Sample in:: "+fullName)
 
 			// We are strictly counting series directly included in the scrapes, and no
 			// internal timeseries like "up" nor "scrape_seconds" etc.
@@ -225,11 +225,11 @@ service:
 		}
 	}
 
-	require.True(t, totalSamples > 0, "Expected at least 1 sample")
+	require.Greater(t, totalSamples, 0, "Expected at least 1 sample")
 	// On every alternative scrape the prior scrape will be reported as sale.
 	// Expect at least:
 	//    * The first scrape will NOT return stale markers
 	//    * (N-1 / alternatives) = ((10-1) / 2) = ~40% chance of stale markers being emitted.
 	chance := float64(staleMarkerCount) / float64(totalSamples)
-	require.True(t, chance >= 0.4, fmt.Sprintf("Expected at least one stale marker: %.3f", chance))
+	require.GreaterOrEqual(t, chance, 0.4, fmt.Sprintf("Expected at least one stale marker: %.3f", chance))
 }

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -345,7 +345,7 @@ func testTransactionAppendHistogramNoLe(t *testing.T, enableNativeHistograms boo
 	assert.Equal(t, 1, observedLogs.FilterMessage("failed to add datapoint").Len())
 
 	assert.NoError(t, tr.Commit())
-	assert.Len(t, sink.AllMetrics(), 0)
+	assert.Empty(t, sink.AllMetrics())
 }
 
 func TestTransactionAppendSummaryNoQuantile(t *testing.T) {
@@ -384,7 +384,7 @@ func testTransactionAppendSummaryNoQuantile(t *testing.T, enableNativeHistograms
 	assert.Equal(t, 1, observedLogs.FilterMessage("failed to add datapoint").Len())
 
 	assert.NoError(t, tr.Commit())
-	assert.Len(t, sink.AllMetrics(), 0)
+	assert.Empty(t, sink.AllMetrics())
 }
 
 func TestTransactionAppendValidAndInvalid(t *testing.T) {
@@ -1882,7 +1882,7 @@ func (tt buildTestData) run(t *testing.T, enableNativeHistograms bool) {
 		mds := sink.AllMetrics()
 		if wants[i].ResourceMetrics().Len() == 0 {
 			// Receiver does not emit empty metrics, so will not have anything in the sink.
-			require.Len(t, mds, 0)
+			require.Empty(t, mds)
 			st += interval
 			continue
 		}

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -626,7 +626,7 @@ func compareDoubleValue(doubleVal float64) numberPointComparator {
 
 func assertNormalNan() numberPointComparator {
 	return func(t *testing.T, numberDataPoint pmetric.NumberDataPoint) {
-		assert.True(t, math.Float64bits(numberDataPoint.DoubleValue()) == value.NormalNaN,
+		assert.Equal(t, math.Float64bits(numberDataPoint.DoubleValue()), value.NormalNaN,
 			"Metric double value is not normalNaN as expected")
 	}
 }
@@ -663,7 +663,7 @@ func compareSummary(count uint64, sum float64, quantiles [][]float64) summaryPoi
 				assert.Equal(t, quantiles[i][0], summaryDataPoint.QuantileValues().At(i).Quantile(),
 					"Summary quantile do not match")
 				if math.IsNaN(quantiles[i][1]) {
-					assert.True(t, math.Float64bits(summaryDataPoint.QuantileValues().At(i).Value()) == value.NormalNaN,
+					assert.Equal(t, math.Float64bits(summaryDataPoint.QuantileValues().At(i).Value()), value.NormalNaN,
 						"Summary quantile value is not normalNaN as expected")
 				} else {
 					assert.Equal(t, quantiles[i][1], summaryDataPoint.QuantileValues().At(i).Value(),
@@ -702,7 +702,7 @@ func testComponent(t *testing.T, targets []*testData, alterConfig func(*Config),
 		// verify state after shutdown is called
 		assert.Lenf(t, flattenTargets(receiver.scrapeManager.TargetsAll()), len(targets), "expected %v targets to be running", len(targets))
 		require.NoError(t, receiver.Shutdown(context.Background()))
-		assert.Len(t, flattenTargets(receiver.scrapeManager.TargetsAll()), 0, "expected scrape manager to have no targets")
+		assert.Empty(t, flattenTargets(receiver.scrapeManager.TargetsAll()), "expected scrape manager to have no targets")
 	})
 
 	// waitgroup Wait() is strictly from a server POV indicating the sufficient number and type of requests have been seen

--- a/receiver/prometheusreceiver/metrics_receiver_labels_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_labels_test.go
@@ -37,7 +37,7 @@ func TestExternalLabels(t *testing.T) {
 
 func verifyExternalLabels(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
 	verifyNumValidScrapeResults(t, td, rms)
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	wantAttributes := td.attributes
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
@@ -67,7 +67,7 @@ test_gauge0{label1="value1",label2="value2"} 10
 func verifyLabelLimitTarget1(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
 	// each sample in the scraped metrics is within the configured label_limit, scrape should be successful
 	verifyNumValidScrapeResults(t, td, rms)
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	want := td.attributes
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
@@ -159,7 +159,7 @@ test_summary0_count{label1="value1",label2="value2"} 1000
 
 func verifyLabelConfigTarget1(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
 	verifyNumValidScrapeResults(t, td, rms)
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	want := td.attributes
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
@@ -322,7 +322,7 @@ test_summary0_count{id="1",testLabel=""} 1000
 `
 
 func verifyEmptyLabelValuesTarget1(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	want := td.attributes
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
@@ -397,7 +397,7 @@ test_counter0{id="2",testLabel="foobar"} 110
 `
 
 func verifyEmptyLabelValuesTarget2(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	want := td.attributes
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
@@ -474,7 +474,7 @@ test_gauge0{instance="hostname:8080",job="honor_labels_test",testLabel="value1"}
 
 func verifyHonorLabelsFalse(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
 	want := td.attributes
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
 	ts1 := metrics1.At(0).Gauge().DataPoints().At(0).Timestamp()
@@ -508,7 +508,7 @@ test_counter0 100
 `
 
 func verifyEmptyLabelsTarget1(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	want := td.attributes
 	metrics1 := rms[0].ScopeMetrics().At(0).Metrics()
@@ -575,7 +575,7 @@ func TestHonorLabelsFalseConfig(t *testing.T) {
 }
 
 func verifyHonorLabelsTrue(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	// job and instance label values should be honored from honorLabelsTarget
 	expectedResourceAttributes := pcommon.NewMap()
@@ -692,7 +692,7 @@ func TestRelabelJobInstance(t *testing.T) {
 
 func verifyRelabelJobInstance(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
 	verifyNumValidScrapeResults(t, td, rms)
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	wantAttributes := td.attributes
 	wantAttributes.PutStr("service.name", "not-target1")
@@ -750,7 +750,7 @@ func TestTargetInfoResourceAttributes(t *testing.T) {
 
 func verifyTargetInfoResourceAttributes(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
 	verifyNumValidScrapeResults(t, td, rms)
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	wantAttributes := td.attributes
 	wantAttributes.PutStr("foo", "bar")
@@ -800,7 +800,7 @@ func TestScopeInfoScopeAttributes(t *testing.T) {
 
 func verifyMultipleScopes(t *testing.T, td *testData, rms []pmetric.ResourceMetrics) {
 	verifyNumValidScrapeResults(t, td, rms)
-	require.Greater(t, len(rms), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, rms, "At least one resource metric should be present")
 
 	sms := rms[0].ScopeMetrics()
 	require.Equal(t, sms.Len(), 3, "Three scope metrics should be present")

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -46,7 +46,7 @@ var skippedTests = map[string]struct{}{
 }
 
 func verifyPositiveTarget(t *testing.T, _ *testData, mds []pmetric.ResourceMetrics) {
-	require.Greater(t, len(mds), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, mds, "At least one resource metric should be present")
 	metrics := getMetrics(mds[0])
 	assertUp(t, 1, metrics)
 	// if we only have one ResourceMetrics, then we should have a non-default metric in there
@@ -85,7 +85,7 @@ func verifyFailTarget(t *testing.T, td *testData, mds []pmetric.ResourceMetrics)
 		t.Skip("skipping failing negative OpenMetrics parser tests")
 	}
 
-	require.Greater(t, len(mds), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, mds, "At least one resource metric should be present")
 	metrics := getMetrics(mds[0])
 	assertUp(t, 0, metrics)
 }
@@ -118,7 +118,7 @@ func verifyInvalidTarget(t *testing.T, td *testData, mds []pmetric.ResourceMetri
 		t.Skip("skipping failing negative OpenMetrics parser tests")
 	}
 
-	require.Greater(t, len(mds), 0, "At least one resource metric should be present")
+	require.NotEmpty(t, mds, "At least one resource metric should be present")
 	metrics := getMetrics(mds[0])
 
 	// The Prometheus scrape parser accepted the sample, but the receiver dropped it due to incompatibility with the Otel schema.

--- a/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_report_extra_scrape_metrics_test.go
@@ -64,7 +64,7 @@ func testScraperMetrics(t *testing.T, targets []*testData, reportExtraScrapeMetr
 		// verify state after shutdown is called
 		assert.Lenf(t, flattenTargets(receiver.scrapeManager.TargetsAll()), len(targets), "expected %v targets to be running", len(targets))
 		require.NoError(t, receiver.Shutdown(context.Background()))
-		assert.Len(t, flattenTargets(receiver.scrapeManager.TargetsAll()), 0, "expected scrape manager to have no targets")
+		assert.Empty(t, flattenTargets(receiver.scrapeManager.TargetsAll()), "expected scrape manager to have no targets")
 	})
 
 	// waitgroup Wait() is strictly from a server POV indicating the sufficient number and type of requests have been seen

--- a/receiver/prometheusreceiver/targetallocator/manager_test.go
+++ b/receiver/prometheusreceiver/targetallocator/manager_test.go
@@ -703,7 +703,7 @@ func TestTargetAllocatorJobRetrieval(t *testing.T) {
 			providers := discoveryManager.Providers()
 			if tc.want.empty {
 				// if no base config is supplied and the job retrieval fails then no configuration should be found
-				require.Len(t, providers, 0)
+				require.Empty(t, providers)
 				return
 			}
 

--- a/receiver/solacereceiver/messaging_service_test.go
+++ b/receiver/solacereceiver/messaging_service_test.go
@@ -506,7 +506,7 @@ func TestAMQPSubstituteVariables(t *testing.T) {
 // It is not a perfect comparison but will perform well differentiating between anonymous
 // functions and the amqp named functinos
 func testFunctionEquality(t *testing.T, f1, f2 any) {
-	assert.True(t, (f1 == nil) == (f2 == nil))
+	assert.Equal(t, (f1 == nil), (f2 == nil))
 	if f1 == nil {
 		return
 	}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -297,7 +297,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				assert.Len(t, sink.AllLogs(), 1)
 			},
 			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
-				assert.Len(t, sink.AllMetrics(), 0)
+				assert.Empty(t, sink.AllMetrics())
 			},
 		},
 		{
@@ -312,7 +312,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				assertHecSuccessResponse(t, resp, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Len(t, sink.AllLogs(), 0)
+				assert.Empty(t, sink.AllLogs())
 			},
 			assertMetricsSink: func(t *testing.T, sink *consumertest.MetricsSink) {
 				assert.Len(t, sink.AllMetrics(), 1)
@@ -1614,7 +1614,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assert.Equal(t, map[string]any{"code": float64(10), "text": "Data channel is missing"}, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Len(t, sink.AllLogs(), 0)
+				assert.Empty(t, sink.AllLogs())
 			},
 		},
 		{
@@ -1635,7 +1635,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 				assert.Equal(t, map[string]any{"text": "Invalid data channel", "code": float64(11)}, body)
 			},
 			assertSink: func(t *testing.T, sink *consumertest.LogsSink) {
-				assert.Len(t, sink.AllLogs(), 0)
+				assert.Empty(t, sink.AllLogs())
 			},
 		},
 		{

--- a/receiver/sqlserverreceiver/scraper_windows_test.go
+++ b/receiver/sqlserverreceiver/scraper_windows_test.go
@@ -90,7 +90,7 @@ func TestSqlServerScraper(t *testing.T) {
 	s := newSQLServerPCScraper(settings, cfg)
 
 	assert.NoError(t, s.start(context.Background(), nil))
-	assert.Len(t, s.watcherRecorders, 0)
+	assert.Empty(t, s.watcherRecorders)
 	assert.Equal(t, 21, obsLogs.Len())
 	assert.Equal(t, 21, obsLogs.FilterMessageSnippet("failed to create perf counter with path \\SQLServer:").Len())
 	assert.Equal(t, 21, obsLogs.FilterMessageSnippet("The specified object was not found on the computer.").Len())

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -42,7 +42,7 @@ func (v *LogPresentValidator) Validate(tc *TestCase) {
 		successMsg = fmt.Sprintf("Log '%s' not found", logMsg)
 	}
 
-	if assert.True(tc.t, tc.AgentLogsContains(logMsg) == v.Present, errorMsg) {
+	if assert.Equal(tc.t, tc.AgentLogsContains(logMsg), v.Present, errorMsg) {
 		log.Print(successMsg)
 	}
 }
@@ -130,7 +130,7 @@ func (v *CorrectnessTestValidator) Validate(tc *TestCase) {
 	if len(tc.MockBackend.ReceivedTraces) > 0 {
 		v.assertSentRecdTracingDataEqual(append(tc.MockBackend.ReceivedTraces, tc.MockBackend.DroppedTraces...))
 	}
-	assert.Len(tc.t, v.assertionFailures, 0, "There are span data mismatches.")
+	assert.Empty(tc.t, v.assertionFailures, "There are span data mismatches.")
 }
 
 func (v *CorrectnessTestValidator) RecordResults(tc *TestCase) {


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [compares](https://github.com/Antonboom/testifylint?tab=readme-ov-file#compares) and  [empty](https://github.com/Antonboom/testifylint?tab=readme-ov-file#empty) rules from [testifylint](https://github.com/Antonboom/testifylint)