### PR TITLE
[receiver/apache] Invalid endpoint should not cause panic

### DIFF
--- a/.chloggen/apachereceiver_fix_panic_on_invalid_endpoint.yaml
+++ b/.chloggen/apachereceiver_fix_panic_on_invalid_endpoint.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: apachereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic on invalid endpoint configuration
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34992]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/apachereceiver/factory.go
+++ b/receiver/apachereceiver/factory.go
@@ -46,6 +46,10 @@ func createDefaultConfig() component.Config {
 
 func parseResourceAttributes(endpoint string) (string, string, error) {
 	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", "", err
+	}
+
 	serverName := u.Hostname()
 	port := u.Port()
 

--- a/receiver/apachereceiver/factory_test.go
+++ b/receiver/apachereceiver/factory_test.go
@@ -49,6 +49,7 @@ func TestPortValidate(t *testing.T) {
 		desc         string
 		endpoint     string
 		expectedPort string
+		expectError  bool
 	}{
 		{
 			desc:         "http with specified port",
@@ -80,6 +81,12 @@ func TestPortValidate(t *testing.T) {
 			endpoint:     "abc://localhost/server-status?auto",
 			expectedPort: "",
 		},
+		{
+			desc:         "invalid endpoint",
+			endpoint:     ":missing-schema",
+			expectedPort: "",
+			expectError:  true,
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
@@ -87,7 +94,12 @@ func TestPortValidate(t *testing.T) {
 			cfg.Endpoint = tc.endpoint
 			_, port, err := parseResourceAttributes(tc.endpoint)
 
-			require.NoError(t, err)
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+
 			require.Equal(t, tc.expectedPort, port)
 		})
 	}


### PR DESCRIPTION
**Description:**
The receiver crashes if it fails to parse the endpoint.

**Link to tracking Issue:**
N/A

**Testing:**
Add a test covering this case.

**Documentation:**
Changelog updated.