### PR TITLE
[chore]: enable error-is-as rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -134,7 +134,6 @@ linters-settings:
 
   testifylint:
     disable:
-      - error-is-as
       - expected-actual
       - float-compare
       - formatter

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -75,7 +75,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=error-is-as,expected-actual,float-compare,formatter,go-require,negative-positive,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
+TESTIFYLINT_OPT?= --enable-all --disable=expected-actual,float-compare,formatter,go-require,negative-positive,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -39,7 +39,7 @@ func TestCreateMetricExporter(t *testing.T) {
 		name       string
 		conf       *Config
 		marshalers []MetricsMarshaler
-		err        error
+		err        *net.DNSError
 	}{
 		{
 			name: "valid config (no validating broker)",
@@ -104,7 +104,7 @@ func TestCreateLogExporter(t *testing.T) {
 		name       string
 		conf       *Config
 		marshalers []LogsMarshaler
-		err        error
+		err        *net.DNSError
 	}{
 		{
 			name: "valid config (no validating broker)",
@@ -169,7 +169,7 @@ func TestCreateTraceExporter(t *testing.T) {
 		name       string
 		conf       *Config
 		marshalers []TracesMarshaler
-		err        error
+		err        *net.DNSError
 	}{
 		{
 			name: "valid config (no validating brokers)",

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -245,7 +245,7 @@ func Test_newK8sResolver(t *testing.T) {
 			_, tb := getTelemetryAssets(t)
 			got, err := newK8sResolver(fake.NewSimpleClientset(), tt.args.logger, tt.args.service, tt.args.ports, defaultListWatchTimeout, tb)
 			if tt.wantErr != nil {
-				require.Error(t, err, tt.wantErr)
+				require.ErrorIs(t, err, tt.wantErr)
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.wantNil, got == nil)

--- a/exporter/otelarrowexporter/internal/arrow/stream_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream_test.go
@@ -5,7 +5,6 @@ package arrow
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -216,7 +215,7 @@ func TestStreamUnknownBatchError(t *testing.T) {
 			// sender should get ErrStreamRestarting
 			err := tc.mustSendAndWait()
 			require.Error(t, err)
-			require.True(t, errors.Is(err, ErrStreamRestarting))
+			require.ErrorIs(t, err, ErrStreamRestarting)
 		})
 	}
 }
@@ -347,7 +346,7 @@ func TestStreamSendError(t *testing.T) {
 			// sender should get ErrStreamRestarting
 			err := tc.mustSendAndWait()
 			require.Error(t, err)
-			require.True(t, errors.Is(err, ErrStreamRestarting))
+			require.ErrorIs(t, err, ErrStreamRestarting)
 		})
 	}
 }

--- a/exporter/sumologicexporter/exporter_test.go
+++ b/exporter/sumologicexporter/exporter_test.go
@@ -5,7 +5,6 @@ package sumologicexporter
 
 import (
 	"context"
-	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -192,7 +191,7 @@ func TestAllFailed(t *testing.T) {
 	assert.EqualError(t, err, "failed sending data: status: 500 Internal Server Error")
 
 	var partial consumererror.Logs
-	require.True(t, errors.As(err, &partial))
+	require.ErrorAs(t, err, &partial)
 	assert.Equal(t, logsExpected, partial.Data())
 }
 
@@ -231,7 +230,7 @@ func TestPartiallyFailed(t *testing.T) {
 	assert.EqualError(t, err, "failed sending data: status: 500 Internal Server Error")
 
 	var partial consumererror.Logs
-	require.True(t, errors.As(err, &partial))
+	require.ErrorAs(t, err, &partial)
 	assert.Equal(t, logsExpected, partial.Data())
 }
 
@@ -462,7 +461,7 @@ gauge_metric_name{foo="bar",remote_name="156955",url="http://another_url"} 245 1
 			assert.EqualError(t, err, tc.expectedError)
 
 			var partial consumererror.Metrics
-			require.True(t, errors.As(err, &partial))
+			require.ErrorAs(t, err, &partial)
 			// TODO fix
 			// assert.Equal(t, metrics, partial.GetMetrics())
 		})

--- a/extension/basicauthextension/extension_test.go
+++ b/extension/basicauthextension/extension_test.go
@@ -172,7 +172,7 @@ func TestBasicAuth_HtpasswdInlinePrecedence(t *testing.T) {
 	auth = base64.StdEncoding.EncodeToString([]byte("username:fromfile"))
 
 	_, err = ext.Authenticate(context.Background(), map[string][]string{"authorization": {"Basic " + auth}})
-	assert.Error(t, errInvalidCredentials, err)
+	assert.ErrorIs(t, errInvalidCredentials, err)
 }
 
 func TestBasicAuth_SupportedHeaders(t *testing.T) {

--- a/extension/headerssetterextension/config_test.go
+++ b/extension/headerssetterextension/config_test.go
@@ -69,7 +69,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, sub.Unmarshal(cfg))
 
 			if tt.expectedError != nil {
-				assert.Error(t, component.ValidateConfig(cfg), tt.expectedError)
+				assert.ErrorIs(t, component.ValidateConfig(cfg), tt.expectedError)
 				return
 			}
 			assert.NoError(t, component.ValidateConfig(cfg))

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -116,7 +116,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 		settings             *Config
 		expectedClientConfig *clientcredentials.Config
 		shouldError          bool
-		expectedError        *error
+		expectedError        error
 	}{
 		{
 			name: "client_id_file",
@@ -151,7 +151,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 				ClientSecret: "testsecret",
 			},
 			shouldError:   true,
-			expectedError: &errNoClientIDProvided,
+			expectedError: errNoClientIDProvided,
 		},
 		{
 			name: "missing_client_creds_file",
@@ -160,7 +160,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 				ClientSecretFile: testCredsMissingFile,
 			},
 			shouldError:   true,
-			expectedError: &errNoClientSecretProvided,
+			expectedError: errNoClientSecretProvided,
 		},
 	}
 
@@ -170,7 +170,7 @@ func TestOAuthClientSettingsCredsConfig(t *testing.T) {
 			cfg, err := rc.clientCredentials.createConfig()
 			if test.shouldError {
 				assert.Error(t, err)
-				assert.ErrorAs(t, err, test.expectedError)
+				assert.ErrorIs(t, err, test.expectedError)
 				return
 			}
 			assert.NoError(t, err)

--- a/extension/observer/ecsobserver/exporter_test.go
+++ b/extension/observer/ecsobserver/exporter_test.go
@@ -4,7 +4,6 @@
 package ecsobserver
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -27,7 +26,7 @@ func TestTaskExporter(t *testing.T) {
 		})
 		assert.Error(t, err)
 		v := &errPrivateIPNotFound{}
-		assert.True(t, errors.As(err, &v))
+		assert.ErrorAs(t, err, &v)
 	})
 
 	awsVpcTask := &ecs.Task{
@@ -118,7 +117,7 @@ func TestTaskExporter(t *testing.T) {
 		merr := multierr.Errors(err)
 		require.Len(t, merr, 1)
 		v := &errMappedPortNotFound{}
-		assert.True(t, errors.As(merr[0], &v))
+		assert.ErrorAs(t, merr[0], &v)
 		assert.Len(t, targets, 2)
 	})
 

--- a/extension/observer/ecsobserver/internal/ecsmock/service_test.go
+++ b/extension/observer/ecsobserver/internal/ecsmock/service_test.go
@@ -5,7 +5,6 @@ package ecsmock
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestCluster_ListTasksWithContext(t *testing.T) {
 		_, err := c.ListTasksWithContext(ctx, req)
 		require.Error(t, err)
 		var aerr awserr.Error
-		assert.True(t, errors.As(err, &aerr))
+		assert.ErrorAs(t, err, &aerr)
 		assert.Equal(t, ecs.ErrCodeClusterNotFoundException, aerr.Code())
 		assert.Equal(t, "code "+ecs.ErrCodeClusterNotFoundException+" message "+aerr.Message(), aerr.Error())
 		assert.NoError(t, aerr.OrigErr())

--- a/internal/sqlquery/db_client_test.go
+++ b/internal/sqlquery/db_client_test.go
@@ -70,7 +70,7 @@ func TestDBSQLClient_Nulls(t *testing.T) {
 	}
 	rows, err := cl.QueryRows(context.Background())
 	assert.Error(t, err)
-	assert.True(t, errors.Is(err, ErrNullValueWarning))
+	assert.ErrorIs(t, err, ErrNullValueWarning)
 	assert.Len(t, rows, 1)
 	assert.EqualValues(t, map[string]string{
 		"col_0": "42",
@@ -96,7 +96,7 @@ func TestDBSQLClient_Nulls_MultiRow(t *testing.T) {
 		assert.Len(t, uw, 2)
 
 		for _, err := range uw {
-			assert.True(t, errors.Is(err, ErrNullValueWarning))
+			assert.ErrorIs(t, err, ErrNullValueWarning)
 		}
 	}
 	assert.Len(t, rows, 2)

--- a/pkg/sampling/encoding_test.go
+++ b/pkg/sampling/encoding_test.go
@@ -5,7 +5,6 @@ package sampling
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -187,7 +186,7 @@ func TestRValueSyntax(t *testing.T) {
 			rnd, err := RValueToRandomness(test.in)
 
 			if test.expectErr != nil {
-				require.True(t, errors.Is(err, test.expectErr),
+				require.ErrorIs(t, err, test.expectErr,
 					"%q: not expecting %v wanted %v", test.in, err, test.expectErr,
 				)
 				require.Equal(t, must(RValueToRandomness("00000000000000")), rnd)
@@ -241,7 +240,7 @@ func TestTValueSyntax(t *testing.T) {
 			_, err := TValueToThreshold(test.in)
 
 			if test.expectErr != nil {
-				require.True(t, errors.Is(err, test.expectErr),
+				require.ErrorIs(t, err, test.expectErr,
 					"%q: not expecting %v wanted %v", test.in, err, test.expectErr,
 				)
 			} else {

--- a/pkg/sampling/oteltracestate_test.go
+++ b/pkg/sampling/oteltracestate_test.go
@@ -4,7 +4,6 @@
 package sampling
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -233,7 +232,7 @@ func TestParseOpenTelemetryTraceState(t *testing.T) {
 			otts, err := NewOpenTelemetryTraceState(test.in)
 
 			if test.expectErr != nil {
-				require.True(t, errors.Is(err, test.expectErr), "%q: not expecting %v wanted %v", test.in, err, test.expectErr)
+				require.ErrorIs(t, err, test.expectErr, "%q: not expecting %v wanted %v", test.in, err, test.expectErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/pkg/sampling/w3ctracestate_test.go
+++ b/pkg/sampling/w3ctracestate_test.go
@@ -4,7 +4,6 @@
 package sampling
 
 import (
-	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -116,7 +115,7 @@ func TestParseW3CTraceState(t *testing.T) {
 			w3c, err := NewW3CTraceState(test.in)
 
 			if test.expectErr != nil {
-				require.True(t, errors.Is(err, test.expectErr),
+				require.ErrorIs(t, err, test.expectErr,
 					"%q: not expecting %v wanted %v", test.in, err, test.expectErr,
 				)
 			} else {

--- a/processor/groupbytraceprocessor/factory_test.go
+++ b/processor/groupbytraceprocessor/factory_test.go
@@ -60,7 +60,7 @@ func TestCreateTestProcessorWithNotImplementedOptions(t *testing.T) {
 		p, err := f.CreateTracesProcessor(context.Background(), processortest.NewNopSettings(), tt.config, consumertest.NewNop())
 
 		// verify
-		assert.Error(t, tt.expectedErr, err)
+		assert.ErrorIs(t, tt.expectedErr, err)
 		assert.Nil(t, p)
 	}
 }

--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -253,7 +253,7 @@ func TestTraceErrorFromStorageWhileReleasing(t *testing.T) {
 	err = p.markAsReleased(traceID, p.eventMachine.workers[workerIndexForTraceID(traceID, config.NumWorkers)].fire)
 
 	// verify
-	assert.True(t, errors.Is(err, expectedError))
+	assert.ErrorIs(t, err, expectedError)
 }
 
 func TestTraceErrorFromStorageWhileProcessingTrace(t *testing.T) {
@@ -290,7 +290,7 @@ func TestTraceErrorFromStorageWhileProcessingTrace(t *testing.T) {
 	err := p.onTraceReceived(tracesWithID{id: traceID, td: batch[0]}, p.eventMachine.workers[0])
 
 	// verify
-	assert.True(t, errors.Is(err, expectedError))
+	assert.ErrorIs(t, err, expectedError)
 }
 
 func TestAddSpansToExistingTrace(t *testing.T) {
@@ -385,7 +385,7 @@ func TestTraceErrorFromStorageWhileProcessingSecondTrace(t *testing.T) {
 	)
 
 	// verify
-	assert.True(t, errors.Is(err, expectedError))
+	assert.ErrorIs(t, err, expectedError)
 }
 
 func TestErrorFromStorageWhileRemovingTrace(t *testing.T) {
@@ -412,7 +412,7 @@ func TestErrorFromStorageWhileRemovingTrace(t *testing.T) {
 	err := p.onTraceRemoved(traceID)
 
 	// verify
-	assert.True(t, errors.Is(err, expectedError))
+	assert.ErrorIs(t, err, expectedError)
 }
 
 func TestTraceNotFoundWhileRemovingTrace(t *testing.T) {

--- a/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
+++ b/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
@@ -3,7 +3,6 @@
 package tracesegment
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestSplitHeaderBodyWithSeparatorDoesNotExist(t *testing.T) {
 	_, _, err := SplitHeaderBody(buf)
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.True(t, errors.As(err, &errRecv), "should return recoverable error")
+	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.EqualError(t, err,
 		fmt.Sprintf("unable to split incoming data as header and segment, incoming bytes: %v", buf),
 		"expected error messages")
@@ -41,7 +40,7 @@ func TestSplitHeaderBodyNilBuf(t *testing.T) {
 	_, _, err := SplitHeaderBody(nil)
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.True(t, errors.As(err, &errRecv), "should return recoverable error")
+	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.EqualError(t, err, "buffer to split is nil",
 		"expected error messages")
 }
@@ -52,7 +51,7 @@ func TestSplitHeaderBodyNonJsonHeader(t *testing.T) {
 	_, _, err := SplitHeaderBody(buf)
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.True(t, errors.As(err, &errRecv), "should return recoverable error")
+	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.Contains(t, err.Error(), "invalid character 'o'")
 }
 
@@ -76,7 +75,7 @@ func TestSplitHeaderBodyInvalidJsonHeader(t *testing.T) {
 	assert.Error(t, err, "should fail because version is invalid")
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.True(t, errors.As(err, &errRecv), "should return recoverable error")
+	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.Contains(t, err.Error(),
 		fmt.Sprintf("invalid header %+v", Header{
 			Format:  "json",

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -81,7 +81,7 @@ func TestScrape(t *testing.T) {
 		assert.Equal(t, 0, metrics.DataPointCount(), "Expected 0 datapoints to be collected")
 
 		var partialScrapeErr scrapererror.PartialScrapeError
-		require.True(t, errors.As(err, &partialScrapeErr), "returned error was not PartialScrapeError")
+		require.ErrorAs(t, err, &partialScrapeErr, "returned error was not PartialScrapeError")
 		require.Greater(t, partialScrapeErr.Failed, 0, "Expected scrape failures, but none were recorded!")
 	})
 

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -7,7 +7,6 @@ import (
 	"bufio"
 	"context"
 	"database/sql"
-	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -118,7 +117,7 @@ func TestScrape(t *testing.T) {
 			pmetrictest.IgnoreTimestamp()))
 
 		var partialError scrapererror.PartialScrapeError
-		require.True(t, errors.As(scrapeErr, &partialError), "returned error was not PartialScrapeError")
+		require.ErrorAs(t, scrapeErr, &partialError, "returned error was not PartialScrapeError")
 		// 5 comes from 4 failed "must-have" metrics that aren't present,
 		// and the other failure comes from a row that fails to parse as a number
 		require.Equal(t, partialError.Failed, 5, "Expected partial error count to be 5")


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [error-is-as](https://github.com/Antonboom/testifylint?tab=readme-ov-file#error-is-as) rule from [testifylint](https://github.com/Antonboom/testifylint)