### PR TITLE
[chore][healthcheck, healthcheckv2] Use extensioncapabilities instead of extension for interfaces

### DIFF
--- a/extension/healthcheckextension/go.mod
+++ b/extension/healthcheckextension/go.mod
@@ -10,7 +10,8 @@ require (
 	go.opentelemetry.io/collector/config/confighttp v0.108.2-0.20240829190554-7da6b618a7ee
 	go.opentelemetry.io/collector/config/configtls v1.14.2-0.20240829190554-7da6b618a7ee
 	go.opentelemetry.io/collector/confmap v1.14.2-0.20240829190554-7da6b618a7ee
-	go.opentelemetry.io/collector/extension v0.108.2-0.20240829190554-7da6b618a7ee
+	go.opentelemetry.io/collector/extension v0.108.2-0.20240904103727-46d0f7361e34
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.0.0-20240904103727-46d0f7361e34
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 )
@@ -38,7 +39,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.20.2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.56.0 // indirect
+	github.com/prometheus/common v0.57.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/rs/cors v1.11.0 // indirect
@@ -64,7 +65,7 @@ require (
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd // indirect
-	google.golang.org/grpc v1.65.0 // indirect
+	google.golang.org/grpc v1.66.0 // indirect
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/extension/healthcheckextension/go.sum
+++ b/extension/healthcheckextension/go.sum
@@ -59,8 +59,8 @@ github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjs
 github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
-github.com/prometheus/common v0.56.0 h1:UffReloqkBtvtQEYDg2s+uDPGRrJyC6vZWPGXf6OhPY=
-github.com/prometheus/common v0.56.0/go.mod h1:7uRPFSUTbfZWsJ7MHY56sqt7hLQu3bxXHDnNhl8E9qI=
+github.com/prometheus/common v0.57.0 h1:Ro/rKjwdq9mZn1K5QPctzh+MA4Lp0BuYk5ZZEVhoNcY=
+github.com/prometheus/common v0.57.0/go.mod h1:7uRPFSUTbfZWsJ7MHY56sqt7hLQu3bxXHDnNhl8E9qI=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
@@ -97,10 +97,12 @@ go.opentelemetry.io/collector/confmap v1.14.2-0.20240829190554-7da6b618a7ee h1:+
 go.opentelemetry.io/collector/confmap v1.14.2-0.20240829190554-7da6b618a7ee/go.mod h1:GrIZ12P/9DPOuTpe2PIS51a0P/ZM6iKtByVee1Uf3+k=
 go.opentelemetry.io/collector/consumer v0.108.1 h1:75zHUpIDfgZMp3t9fYdpXXE6/wsBs9DwTZdfwS3+NDI=
 go.opentelemetry.io/collector/consumer v0.108.1/go.mod h1:xu2pOTqK+uCFXZWd9RcU8s6sCRwK5GyuP64YuHLMzzA=
-go.opentelemetry.io/collector/extension v0.108.2-0.20240829190554-7da6b618a7ee h1:yuy6iGp41ARpBTR3E0IjwbJNps4me7QBlViAXIT00Xs=
-go.opentelemetry.io/collector/extension v0.108.2-0.20240829190554-7da6b618a7ee/go.mod h1:0Ialf9Lc/ESknUYJnAeQjGdQvlhLtJav0sv+Eo2xMnU=
+go.opentelemetry.io/collector/extension v0.108.2-0.20240904103727-46d0f7361e34 h1:/d0M2IMIHwKrzxZIM+0kauw9Lpb1hl+1hGkovXKJ0HI=
+go.opentelemetry.io/collector/extension v0.108.2-0.20240904103727-46d0f7361e34/go.mod h1:bYUxJz7GgbmE/F/qZei1dlYEFKGeDWqOMzLVyPR/GdY=
 go.opentelemetry.io/collector/extension/auth v0.108.2-0.20240829190554-7da6b618a7ee h1:w6Y6lOz9HRkl0rjdxmlqp209tvtWIaXOUqYH4YqTY1s=
 go.opentelemetry.io/collector/extension/auth v0.108.2-0.20240829190554-7da6b618a7ee/go.mod h1:CmNrylNxbrs/awKHOdRWdu5BMAUxXyY94ry9LrKH/tQ=
+go.opentelemetry.io/collector/extension/extensioncapabilities v0.0.0-20240904103727-46d0f7361e34 h1:FC3I6h8ODFoQslf+OD7hjy+5AUV6IvN8O4ki65f7Tes=
+go.opentelemetry.io/collector/extension/extensioncapabilities v0.0.0-20240904103727-46d0f7361e34/go.mod h1:7IzPu1zWshi3L8bzgWxG47bfVOjRC+lirL05XRUMxAU=
 go.opentelemetry.io/collector/featuregate v1.14.2-0.20240829190554-7da6b618a7ee h1:kOnDlEC1EDsymDjAZe8LZhwbVqnWPtPwSlUXDYwUmws=
 go.opentelemetry.io/collector/featuregate v1.14.2-0.20240829190554-7da6b618a7ee/go.mod h1:47xrISO71vJ83LSMm8+yIDsUbKktUp48Ovt7RR6VbRs=
 go.opentelemetry.io/collector/pdata v1.14.2-0.20240829190554-7da6b618a7ee h1:vqnRTZckt4i+bGcR+d/LAOAe4nAAs/KkN2L2CTXvW0Q=
@@ -158,8 +160,8 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd h1:6TEm2ZxXoQmFWFlt1vNxvVOa1Q0dXFQD1m/rYjXmS0E=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
-google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
-google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
+google.golang.org/grpc v1.66.0 h1:DibZuoBznOxbDQxRINckZcUvnCEvrW9pcWIE2yF9r1c=
+google.golang.org/grpc v1.66.0/go.mod h1:s3/l6xSSCURdVfAnL+TqCNMyTDAGN6+lZeVxnZR128Y=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -11,7 +11,7 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componentstatus"
-	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension/internal/healthcheck"
@@ -26,7 +26,7 @@ type healthCheckExtension struct {
 	settings component.TelemetrySettings
 }
 
-var _ extension.PipelineWatcher = (*healthCheckExtension)(nil)
+var _ extensioncapabilities.PipelineWatcher = (*healthCheckExtension)(nil)
 
 func (hc *healthCheckExtension) Start(ctx context.Context, host component.Host) error {
 

--- a/extension/healthcheckv2extension/extension.go
+++ b/extension/healthcheckv2extension/extension.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component/componentstatus"
 	"go.opentelemetry.io/collector/confmap"
 	"go.opentelemetry.io/collector/extension"
+	"go.opentelemetry.io/collector/extension/extensioncapabilities"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
 
@@ -34,8 +35,8 @@ type healthCheckExtension struct {
 }
 
 var _ component.Component = (*healthCheckExtension)(nil)
-var _ extension.ConfigWatcher = (*healthCheckExtension)(nil)
-var _ extension.PipelineWatcher = (*healthCheckExtension)(nil)
+var _ extensioncapabilities.ConfigWatcher = (*healthCheckExtension)(nil)
+var _ extensioncapabilities.PipelineWatcher = (*healthCheckExtension)(nil)
 
 func newExtension(
 	ctx context.Context,
@@ -142,24 +143,24 @@ func (hc *healthCheckExtension) ComponentStatusChanged(
 	hc.eventCh <- &eventSourcePair{source: source, event: event}
 }
 
-// NotifyConfig implements the extension.ConfigWatcher interface.
+// NotifyConfig implements the extensioncapabilities.ConfigWatcher interface.
 func (hc *healthCheckExtension) NotifyConfig(ctx context.Context, conf *confmap.Conf) error {
 	var err error
 	for _, comp := range hc.subcomponents {
-		if cw, ok := comp.(extension.ConfigWatcher); ok {
+		if cw, ok := comp.(extensioncapabilities.ConfigWatcher); ok {
 			err = multierr.Append(err, cw.NotifyConfig(ctx, conf))
 		}
 	}
 	return err
 }
 
-// Ready implements the extension.PipelineWatcher interface.
+// Ready implements the extensioncapabilities.PipelineWatcher interface.
 func (hc *healthCheckExtension) Ready() error {
 	close(hc.readyCh)
 	return nil
 }
 
-// NotReady implements the extension.PipelineWatcher interface.
+// NotReady implements the extensioncapabilities.PipelineWatcher interface.
 func (hc *healthCheckExtension) NotReady() error {
 	return nil
 }

--- a/extension/healthcheckv2extension/go.mod
+++ b/extension/healthcheckv2extension/go.mod
@@ -12,7 +12,8 @@ require (
 	go.opentelemetry.io/collector/config/confignet v0.108.2-0.20240829190554-7da6b618a7ee
 	go.opentelemetry.io/collector/config/configtls v1.14.2-0.20240829190554-7da6b618a7ee
 	go.opentelemetry.io/collector/confmap v1.14.2-0.20240829190554-7da6b618a7ee
-	go.opentelemetry.io/collector/extension v0.108.2-0.20240829190554-7da6b618a7ee
+	go.opentelemetry.io/collector/extension v0.108.2-0.20240904103727-46d0f7361e34
+	go.opentelemetry.io/collector/extension/extensioncapabilities v0.0.0-20240904103727-46d0f7361e34
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
@@ -43,7 +44,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.20.2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.56.0 // indirect
+	github.com/prometheus/common v0.57.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rs/cors v1.11.0 // indirect
 	go.opentelemetry.io/collector v0.108.2-0.20240829190554-7da6b618a7ee // indirect

--- a/extension/healthcheckv2extension/go.sum
+++ b/extension/healthcheckv2extension/go.sum
@@ -61,8 +61,8 @@ github.com/prometheus/client_golang v1.20.2 h1:5ctymQzZlyOON1666svgwn3s6IKWgfbjs
 github.com/prometheus/client_golang v1.20.2/go.mod h1:PIEt8X02hGcP8JWbeHyeZ53Y/jReSnHgO035n//V5WE=
 github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
-github.com/prometheus/common v0.56.0 h1:UffReloqkBtvtQEYDg2s+uDPGRrJyC6vZWPGXf6OhPY=
-github.com/prometheus/common v0.56.0/go.mod h1:7uRPFSUTbfZWsJ7MHY56sqt7hLQu3bxXHDnNhl8E9qI=
+github.com/prometheus/common v0.57.0 h1:Ro/rKjwdq9mZn1K5QPctzh+MA4Lp0BuYk5ZZEVhoNcY=
+github.com/prometheus/common v0.57.0/go.mod h1:7uRPFSUTbfZWsJ7MHY56sqt7hLQu3bxXHDnNhl8E9qI=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -103,10 +103,12 @@ go.opentelemetry.io/collector/confmap v1.14.2-0.20240829190554-7da6b618a7ee h1:+
 go.opentelemetry.io/collector/confmap v1.14.2-0.20240829190554-7da6b618a7ee/go.mod h1:GrIZ12P/9DPOuTpe2PIS51a0P/ZM6iKtByVee1Uf3+k=
 go.opentelemetry.io/collector/consumer v0.108.1 h1:75zHUpIDfgZMp3t9fYdpXXE6/wsBs9DwTZdfwS3+NDI=
 go.opentelemetry.io/collector/consumer v0.108.1/go.mod h1:xu2pOTqK+uCFXZWd9RcU8s6sCRwK5GyuP64YuHLMzzA=
-go.opentelemetry.io/collector/extension v0.108.2-0.20240829190554-7da6b618a7ee h1:yuy6iGp41ARpBTR3E0IjwbJNps4me7QBlViAXIT00Xs=
-go.opentelemetry.io/collector/extension v0.108.2-0.20240829190554-7da6b618a7ee/go.mod h1:0Ialf9Lc/ESknUYJnAeQjGdQvlhLtJav0sv+Eo2xMnU=
+go.opentelemetry.io/collector/extension v0.108.2-0.20240904103727-46d0f7361e34 h1:/d0M2IMIHwKrzxZIM+0kauw9Lpb1hl+1hGkovXKJ0HI=
+go.opentelemetry.io/collector/extension v0.108.2-0.20240904103727-46d0f7361e34/go.mod h1:bYUxJz7GgbmE/F/qZei1dlYEFKGeDWqOMzLVyPR/GdY=
 go.opentelemetry.io/collector/extension/auth v0.108.2-0.20240829190554-7da6b618a7ee h1:w6Y6lOz9HRkl0rjdxmlqp209tvtWIaXOUqYH4YqTY1s=
 go.opentelemetry.io/collector/extension/auth v0.108.2-0.20240829190554-7da6b618a7ee/go.mod h1:CmNrylNxbrs/awKHOdRWdu5BMAUxXyY94ry9LrKH/tQ=
+go.opentelemetry.io/collector/extension/extensioncapabilities v0.0.0-20240904103727-46d0f7361e34 h1:FC3I6h8ODFoQslf+OD7hjy+5AUV6IvN8O4ki65f7Tes=
+go.opentelemetry.io/collector/extension/extensioncapabilities v0.0.0-20240904103727-46d0f7361e34/go.mod h1:7IzPu1zWshi3L8bzgWxG47bfVOjRC+lirL05XRUMxAU=
 go.opentelemetry.io/collector/featuregate v1.14.2-0.20240829190554-7da6b618a7ee h1:kOnDlEC1EDsymDjAZe8LZhwbVqnWPtPwSlUXDYwUmws=
 go.opentelemetry.io/collector/featuregate v1.14.2-0.20240829190554-7da6b618a7ee/go.mod h1:47xrISO71vJ83LSMm8+yIDsUbKktUp48Ovt7RR6VbRs=
 go.opentelemetry.io/collector/pdata v1.14.2-0.20240829190554-7da6b618a7ee h1:vqnRTZckt4i+bGcR+d/LAOAe4nAAs/KkN2L2CTXvW0Q=

--- a/extension/healthcheckv2extension/internal/http/server.go
+++ b/extension/healthcheckv2extension/internal/http/server.go
@@ -36,7 +36,7 @@ type Server struct {
 }
 
 var _ component.Component = (*Server)(nil)
-var _ extension.ConfigWatcher = (*Server)(nil)
+var _ extensioncapabilities.ConfigWatcher = (*Server)(nil)
 
 func NewServer(
 	config *Config,
@@ -114,7 +114,7 @@ func (s *Server) Shutdown(context.Context) error {
 	return nil
 }
 
-// NotifyConfig implements the extension.ConfigWatcher interface.
+// NotifyConfig implements the extensioncapabilities.ConfigWatcher interface.
 func (s *Server) NotifyConfig(_ context.Context, conf *confmap.Conf) error {
 	confBytes, err := json.Marshal(conf.ToStringMap())
 	if err != nil {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Changes to use `extensioncapabilities` instead of `extension`

**Link to tracking Issue:** Needed for open-telemetry/opentelemetry-collector/pull/11043
