### PR TITLE
Operators with silent errors will log errors as debug and won't return an error

### DIFF
--- a/.chloggen/operator-silent-error.yaml
+++ b/.chloggen/operator-silent-error.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: An operator configured with silent errors shouldn't log errors while processing log entries.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35008]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -102,9 +102,14 @@ func (t *TransformerOperator) HandleEntryError(ctx context.Context, entry *entry
 	if t.OnError == SendOnError || t.OnError == SendOnErrorQuiet {
 		writeErr := t.Write(ctx, entry)
 		if writeErr != nil {
-			return fmt.Errorf("failed to send entry after error: %w", writeErr)
+			err = fmt.Errorf("failed to send entry after error: %w", writeErr)
 		}
 	}
+
+	if t.OnError == SendOnErrorQuiet || t.OnError == DropOnErrorQuiet {
+		return nil
+	}
+
 	return err
 }
 

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -143,7 +143,7 @@ func TestTransformerDropOnErrorQuiet(t *testing.T) {
 	}
 
 	err := transformer.ProcessWith(ctx, testEntry, transform)
-	require.Error(t, err)
+	require.NoError(t, err)
 	output.AssertNotCalled(t, "Process", mock.Anything, mock.Anything)
 
 	// Test output logs
@@ -233,7 +233,7 @@ func TestTransformerSendOnErrorQuiet(t *testing.T) {
 	}
 
 	err := transformer.ProcessWith(ctx, testEntry, transform)
-	require.Error(t, err)
+	require.NoError(t, err)
 	output.AssertCalled(t, "Process", mock.Anything, mock.Anything)
 
 	// Test output logs


### PR DESCRIPTION
An operator configured with silent errors shouldn't log errors while processing log entries.

**Description:** 
Operators that are expected to sometimes fail, can result in error logs that are quite verbose.
This aims to address this issue by getting rid of error logs that the user wishes to silence (debug logs instead).
By making sure no error is returned, there won't be any need to worry about other components logging error logs.

**Link to tracking Issue:** [Issue #35008](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35008)

**Testing:** 
Manually tested as this is a matter of logs.