### PR TITLE
[chore] Fix flaky test in filelog receiver

### DIFF
--- a/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
+++ b/pkg/stanza/fileconsumer/matcher/internal/finder/finder.go
@@ -6,6 +6,7 @@ package finder // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"errors"
 	"fmt"
+	"slices"
 
 	"github.com/bmatcuk/doublestar/v4"
 	"golang.org/x/exp/maps"
@@ -46,5 +47,7 @@ func FindFiles(includes []string, excludes []string) ([]string, error) {
 		}
 	}
 
-	return maps.Keys(allSet), errs
+	keys := maps.Keys(allSet)
+	slices.Sort(keys)
+	return keys, errs
 }


### PR DESCRIPTION
Quick fix for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35007.

Ideally we should not need to depend on order of files returned from the finder but there are apparently some subtle implications which need to be better understood before we remove the assumption.