### PR TITLE
Update example in readme for convert_sum_to_gauge and convert_gauge_to_sum

### DIFF
--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -130,12 +130,12 @@ transform:
     - context: metric
       statements:
         - set(description, "Sum") where type == "Sum"
+        - convert_sum_to_gauge() where name == "system.processes.count"
+        - convert_gauge_to_sum("cumulative", false) where name == "prometheus_metric"
     - context: datapoint
       statements:
         - limit(attributes, 100, ["host.name"])
         - truncate_all(attributes, 4096)
-        - convert_sum_to_gauge() where metric.name == "system.processes.count"
-        - convert_gauge_to_sum("cumulative", false) where metric.name == "prometheus_metric"
         
   log_statements:
     - context: resource


### PR DESCRIPTION
**Description:** The feature gate "processor.transform.ConvertBetweenSumAndGaugeMetricContext" was updated from Alpha to Beta. This means that it is now enabled by default. The example in the readme should match with the default behavior which is that the functions convert_sum_to_gauge and convert_gauge_to_sum must be used on the "metric" context

**Link to tracking Issue:** #34567

Maybe the Readme should state clearly in which context the functions can be used?