### PR TITLE
[chore] Share encoding overrides

### DIFF
--- a/internal/coreinternal/textutils/encoding.go
+++ b/internal/coreinternal/textutils/encoding.go
@@ -74,7 +74,7 @@ var encodingOverrides = map[string]encoding.Encoding{
 }
 
 func lookupEncoding(enc string) (encoding.Encoding, error) {
-	if e, ok := encodingOverrides[strings.ToLower(enc)]; ok {
+	if e, ok := EncodingOverridesMap.Get(strings.ToLower(enc)); ok {
 		return e, nil
 	}
 	e, err := ianaindex.IANA.Encoding(enc)
@@ -93,4 +93,13 @@ func IsNop(enc string) bool {
 		return false
 	}
 	return e == encoding.Nop
+}
+
+var EncodingOverridesMap = encodingOverridesMap{}
+
+type encodingOverridesMap struct{}
+
+func (e *encodingOverridesMap) Get(key string) (encoding.Encoding, bool) {
+	v, ok := encodingOverrides[key]
+	return v, ok
 }

--- a/pkg/ottl/ottlfuncs/func_decode.go
+++ b/pkg/ottl/ottlfuncs/func_decode.go
@@ -12,8 +12,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/ianaindex"
-	"golang.org/x/text/encoding/unicode"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/textutils"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
@@ -87,7 +87,7 @@ func Decode[K any](target ottl.Getter[K], encoding string) (ottl.ExprFunc[K], er
 }
 
 func getEncoding(encoding string) (encoding.Encoding, error) {
-	if e, ok := encodingOverrides[strings.ToLower(encoding)]; ok {
+	if e, ok := textutils.EncodingOverridesMap.Get(strings.ToLower(encoding)); ok {
 		return e, nil
 	}
 	e, err := ianaindex.IANA.Encoding(encoding)
@@ -100,15 +100,4 @@ func getEncoding(encoding string) (encoding.Encoding, error) {
 		return nil, fmt.Errorf("no decoder available for encoding: %s", encoding)
 	}
 	return e, nil
-}
-
-var encodingOverrides = map[string]encoding.Encoding{
-	"":         unicode.UTF8,
-	"nop":      encoding.Nop,
-	"ascii":    unicode.UTF8,
-	"us-ascii": unicode.UTF8,
-	"utf8":     unicode.UTF8,
-	"utf-8":    unicode.UTF8,
-	"utf16":    unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
-	"utf-16":   unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
 }

--- a/pkg/stanza/decode/decode.go
+++ b/pkg/stanza/decode/decode.go
@@ -10,8 +10,9 @@ import (
 
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/ianaindex"
-	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/textutils"
 )
 
 type Decoder struct {
@@ -46,20 +47,9 @@ func (d *Decoder) Decode(msgBuf []byte) ([]byte, error) {
 	}
 }
 
-var encodingOverrides = map[string]encoding.Encoding{
-	"":         unicode.UTF8,
-	"nop":      encoding.Nop,
-	"ascii":    unicode.UTF8,
-	"us-ascii": unicode.UTF8,
-	"utf8":     unicode.UTF8,
-	"utf-8":    unicode.UTF8,
-	"utf16":    unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
-	"utf-16":   unicode.UTF16(unicode.LittleEndian, unicode.IgnoreBOM),
-}
-
 // LookupEncoding attempts to match the string name provided with a character set encoding.
 func LookupEncoding(enc string) (encoding.Encoding, error) {
-	if e, ok := encodingOverrides[strings.ToLower(enc)]; ok {
+	if e, ok := textutils.EncodingOverridesMap.Get(strings.ToLower(enc)); ok {
 		return e, nil
 	}
 	e, err := ianaindex.IANA.Encoding(enc)


### PR DESCRIPTION
**Description:**
Follow up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/33942. I'd like to share the exact override key strings so that they don't get out of sync. Maybe this is too much effort, but wanted to discuss

It looks like there is some more reuse between textutils and stanza, but that could be done in a separate PR.
