### PR TITLE
[chore] Fix Supervisor test on Windows

### DIFF
--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
@@ -12,8 +12,8 @@ capabilities:
   accepts_restart_command: true
 
 storage:
-  directory: "{{.storage_dir}}"
+  directory: '{{.storage_dir}}'
 
 agent:
   executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}
-  health_check_port: "{{ .healthcheck_port }}"
+  health_check_port: {{ .healthcheck_port }}


### PR DESCRIPTION
Fixes an issue where YAML values need to be carefully quoted or Windows paths are interpreted as escaped values.

Also unquote the port number since I think it will be unquoted in most user configs.

**Link to tracking Issue:** https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35033