### PR TITLE
[receiver/sqlserver] Emit correct database name resource attribute

### DIFF
--- a/.chloggen/fix_sqlserver_resource_attrs.yaml
+++ b/.chloggen/fix_sqlserver_resource_attrs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sqlserverreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where metrics were being emitted with the wrong database name resource attribute
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35036]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -80,14 +80,13 @@ func (s *sqlServerScraperHelper) Start(context.Context, component.Host) error {
 func (s *sqlServerScraperHelper) Scrape(ctx context.Context) (pmetric.Metrics, error) {
 	var err error
 
-	rb := s.mb.NewResourceBuilder()
 	switch s.sqlQuery {
 	case getSQLServerDatabaseIOQuery(s.instanceName):
-		err = s.recordDatabaseIOMetrics(ctx, rb)
+		err = s.recordDatabaseIOMetrics(ctx)
 	case getSQLServerPerformanceCounterQuery(s.instanceName):
-		err = s.recordDatabasePerfCounterMetrics(ctx, rb)
+		err = s.recordDatabasePerfCounterMetrics(ctx)
 	case getSQLServerPropertiesQuery(s.instanceName):
-		err = s.recordDatabaseStatusMetrics(ctx, rb)
+		err = s.recordDatabaseStatusMetrics(ctx)
 	default:
 		return pmetric.Metrics{}, fmt.Errorf("Attempted to get metrics from unsupported query: %s", s.sqlQuery)
 	}
@@ -96,7 +95,7 @@ func (s *sqlServerScraperHelper) Scrape(ctx context.Context) (pmetric.Metrics, e
 		return pmetric.Metrics{}, err
 	}
 
-	return s.mb.Emit(metadata.WithResource(rb.Emit())), nil
+	return s.mb.Emit(), nil
 }
 
 func (s *sqlServerScraperHelper) Shutdown(_ context.Context) error {
@@ -106,8 +105,7 @@ func (s *sqlServerScraperHelper) Shutdown(_ context.Context) error {
 	return nil
 }
 
-func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context, rb *metadata.ResourceBuilder) error {
-	// TODO: Move constants out to the package level when other queries are added.
+func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context) error {
 	const computerNameKey = "computer_name"
 	const databaseNameKey = "database_name"
 	const physicalFilenameKey = "physical_filename"
@@ -133,11 +131,10 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context, rb
 	now := pcommon.NewTimestampFromTime(time.Now())
 	var val float64
 	for i, row := range rows {
-		if i == 0 {
-			rb.SetSqlserverComputerName(row[computerNameKey])
-			rb.SetSqlserverDatabaseName(row[databaseNameKey])
-			rb.SetSqlserverInstanceName(row[instanceNameKey])
-		}
+		rb := s.mb.NewResourceBuilder()
+		rb.SetSqlserverComputerName(row[computerNameKey])
+		rb.SetSqlserverDatabaseName(row[databaseNameKey])
+		rb.SetSqlserverInstanceName(row[instanceNameKey])
 
 		val, err = strconv.ParseFloat(row[readLatencyMsKey], 64)
 		if err != nil {
@@ -159,6 +156,8 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context, rb
 		errs = append(errs, s.mb.RecordSqlserverDatabaseOperationsDataPoint(now, row[writeCountKey], row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionWrite))
 		errs = append(errs, s.mb.RecordSqlserverDatabaseIoDataPoint(now, row[readBytesKey], row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionRead))
 		errs = append(errs, s.mb.RecordSqlserverDatabaseIoDataPoint(now, row[writeBytesKey], row[physicalFilenameKey], row[logicalFilenameKey], row[fileTypeKey], metadata.AttributeDirectionWrite))
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
 	if len(rows) == 0 {
@@ -168,7 +167,7 @@ func (s *sqlServerScraperHelper) recordDatabaseIOMetrics(ctx context.Context, rb
 	return errors.Join(errs...)
 }
 
-func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Context, rb *metadata.ResourceBuilder) error {
+func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Context) error {
 	const counterKey = "counter"
 	const valueKey = "value"
 	// Constants are the columns for metrics from query
@@ -195,9 +194,8 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 	var errs []error
 	now := pcommon.NewTimestampFromTime(time.Now())
 	for i, row := range rows {
-		if i == 0 {
-			rb.SetSqlserverInstanceName(row[instanceNameKey])
-		}
+		rb := s.mb.NewResourceBuilder()
+		rb.SetSqlserverInstanceName(row[instanceNameKey])
 
 		switch row[counterKey] {
 		case batchRequestRate:
@@ -255,12 +253,14 @@ func (s *sqlServerScraperHelper) recordDatabasePerfCounterMetrics(ctx context.Co
 				s.mb.RecordSqlserverUserConnectionCountDataPoint(now, val)
 			}
 		}
+
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
 	return errors.Join(errs...)
 }
 
-func (s *sqlServerScraperHelper) recordDatabaseStatusMetrics(ctx context.Context, rb *metadata.ResourceBuilder) error {
+func (s *sqlServerScraperHelper) recordDatabaseStatusMetrics(ctx context.Context) error {
 	// Constants are the column names of the database status
 	const dbOnline = "db_online"
 	const dbRestoring = "db_restoring"
@@ -281,10 +281,9 @@ func (s *sqlServerScraperHelper) recordDatabaseStatusMetrics(ctx context.Context
 
 	var errs []error
 	now := pcommon.NewTimestampFromTime(time.Now())
-	for i, row := range rows {
-		if i == 0 {
-			rb.SetSqlserverInstanceName(row[instanceNameKey])
-		}
+	for _, row := range rows {
+		rb := s.mb.NewResourceBuilder()
+		rb.SetSqlserverInstanceName(row[instanceNameKey])
 
 		errs = append(errs, s.mb.RecordSqlserverDatabaseCountDataPoint(now, row[dbOnline], metadata.AttributeDatabaseStatusOnline))
 		errs = append(errs, s.mb.RecordSqlserverDatabaseCountDataPoint(now, row[dbRestoring], metadata.AttributeDatabaseStatusRestoring))
@@ -293,6 +292,7 @@ func (s *sqlServerScraperHelper) recordDatabaseStatusMetrics(ctx context.Context
 		errs = append(errs, s.mb.RecordSqlserverDatabaseCountDataPoint(now, row[dbSuspect], metadata.AttributeDatabaseStatusSuspect))
 		errs = append(errs, s.mb.RecordSqlserverDatabaseCountDataPoint(now, row[dbOffline], metadata.AttributeDatabaseStatusOffline))
 
+		s.mb.EmitForResource(metadata.WithResource(rb.Emit()))
 	}
 
 	return errors.Join(errs...)

--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -110,7 +110,8 @@ func TestSuccessfulScrape(t *testing.T) {
 		assert.NoError(t, pmetrictest.CompareMetrics(actualMetrics, expectedMetrics,
 			pmetrictest.IgnoreMetricDataPointsOrder(),
 			pmetrictest.IgnoreStartTimestamp(),
-			pmetrictest.IgnoreTimestamp()))
+			pmetrictest.IgnoreTimestamp(),
+			pmetrictest.IgnoreResourceMetricsOrder()))
 	}
 }
 

--- a/receiver/sqlserverreceiver/testdata/expectedDatabaseIO.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedDatabaseIO.yaml
@@ -14,86 +14,6 @@ resourceMetrics:
             sum:
               aggregationTemporality: 2
               dataPoints:
-                - asInt: "660992"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBLog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "916480"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: mastlog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/mastlog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1150464"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: modellog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/modellog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1007616"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: templog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/templog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "6840320"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBData
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBData.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
                 - asInt: "4022272"
                   attributes:
                     - key: direction
@@ -108,230 +28,6 @@ resourceMetrics:
                     - key: physical_filename
                       value:
                         stringValue: /var/opt/mssql/data/master.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "10575872"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: modeldev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/model.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "2113536"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev2
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb2.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev3
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb3.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev7
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb7.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "131072"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev8
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb8.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "1019904"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBLog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "8061952"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: mastlog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/mastlog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "968704"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: modellog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/modellog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "180224"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: templog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/templog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "991232"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBData
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBData.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "4096000"
@@ -350,6 +46,250 @@ resourceMetrics:
                         stringValue: /var/opt/mssql/data/master.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.062
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: master
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/master.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.13
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: master
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/master.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "73"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: master
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/master.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "329"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: master
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/master.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: master
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "916480"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: mastlog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/mastlog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "8061952"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: mastlog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/mastlog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.008
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: mastlog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/mastlog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 3.302
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: mastlog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/mastlog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "17"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: mastlog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/mastlog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "608"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: mastlog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/mastlog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: model
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "10575872"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: modeldev
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/model.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asInt: "860160"
                   attributes:
                     - key: direction
@@ -366,23 +306,30 @@ resourceMetrics:
                         stringValue: /var/opt/mssql/data/model.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "32768"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.021
                   attributes:
                     - key: direction
                       value:
-                        stringValue: write
+                        stringValue: read
                     - key: file_type
                       value:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: tempdev
+                        stringValue: modeldev
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb.mdf
+                        stringValue: /var/opt/mssql/data/model.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "90112"
+                - asDouble: 0.016
                   attributes:
                     - key: direction
                       value:
@@ -392,29 +339,36 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: tempdev2
+                        stringValue: modeldev
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb2.ndf
+                        stringValue: /var/opt/mssql/data/model.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "90112"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "53"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: write
+                        stringValue: read
                     - key: file_type
                       value:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: tempdev3
+                        stringValue: modeldev
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb3.ndf
+                        stringValue: /var/opt/mssql/data/model.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "90112"
+                - asInt: "80"
                   attributes:
                     - key: direction
                       value:
@@ -424,61 +378,179 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: tempdev4
+                        stringValue: modeldev
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                        stringValue: /var/opt/mssql/data/model.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "90112"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: model
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1150464"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: write
+                        stringValue: read
                     - key: file_type
                       value:
-                        stringValue: ROWS
+                        stringValue: LOG
                     - key: logical_filename
                       value:
-                        stringValue: tempdev5
+                        stringValue: modellog
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                        stringValue: /var/opt/mssql/data/modellog.ldf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "90112"
+                - asInt: "968704"
                   attributes:
                     - key: direction
                       value:
                         stringValue: write
                     - key: file_type
                       value:
-                        stringValue: ROWS
+                        stringValue: LOG
                     - key: logical_filename
                       value:
-                        stringValue: tempdev6
+                        stringValue: modellog
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                        stringValue: /var/opt/mssql/data/modellog.ldf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "90112"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.007
                   attributes:
                     - key: direction
                       value:
-                        stringValue: write
+                        stringValue: read
                     - key: file_type
                       value:
-                        stringValue: ROWS
+                        stringValue: LOG
                     - key: logical_filename
                       value:
-                        stringValue: tempdev7
+                        stringValue: modellog
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                        stringValue: /var/opt/mssql/data/modellog.ldf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asInt: "90112"
+                - asDouble: 0.031
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: modellog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/modellog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: modellog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/modellog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "111"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: modellog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/modellog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: msdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "6840320"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBData
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBData.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "991232"
                   attributes:
                     - key: direction
                       value:
@@ -488,10 +560,140 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: tempdev8
+                        stringValue: MSDBData
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/tempdb8.ndf
+                        stringValue: /var/opt/mssql/data/MSDBData.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.051
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBData
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBData.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.026
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBData
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBData.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "108"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBData
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBData.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "102"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBData
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBData.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: msdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "660992"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBLog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1019904"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBLog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
               isMonotonic: true
@@ -517,230 +719,6 @@ resourceMetrics:
                         stringValue: /var/opt/mssql/data/MSDBLog.ldf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asDouble: 0.008
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: mastlog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/mastlog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.007
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: modellog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/modellog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: templog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/templog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.051
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBData
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBData.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.062
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: master
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/master.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.021
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: modeldev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/model.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.009
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.001
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev2
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb2.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev3
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb3.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.001
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.002
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.001
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev7
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb7.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.001
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev8
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb8.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
                 - asDouble: 0.027
                   attributes:
                     - key: direction
@@ -757,7 +735,30 @@ resourceMetrics:
                         stringValue: /var/opt/mssql/data/MSDBLog.ldf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asDouble: 3.302
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: MSDBLog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "117"
                   attributes:
                     - key: direction
                       value:
@@ -767,45 +768,49 @@ resourceMetrics:
                         stringValue: LOG
                     - key: logical_filename
                       value:
-                        stringValue: mastlog
+                        stringValue: MSDBLog
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/mastlog.ldf
+                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asDouble: 0.031
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2113536"
                   attributes:
                     - key: direction
                       value:
-                        stringValue: write
+                        stringValue: read
                     - key: file_type
                       value:
-                        stringValue: LOG
+                        stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: modellog
+                        stringValue: tempdev
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/modellog.ldf
+                        stringValue: /var/opt/mssql/data/tempdb.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asDouble: 0.004
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: templog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/templog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.026
+                - asInt: "32768"
                   attributes:
                     - key: direction
                       value:
@@ -815,42 +820,33 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: MSDBData
+                        stringValue: tempdev
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/MSDBData.mdf
+                        stringValue: /var/opt/mssql/data/tempdb.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asDouble: 0.13
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.009
                   attributes:
                     - key: direction
                       value:
-                        stringValue: write
+                        stringValue: read
                     - key: file_type
                       value:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
-                        stringValue: master
+                        stringValue: tempdev
                     - key: physical_filename
                       value:
-                        stringValue: /var/opt/mssql/data/master.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0.016
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: modeldev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/model.mdf
+                        stringValue: /var/opt/mssql/data/tempdb.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asDouble: 0
@@ -869,6 +865,250 @@ resourceMetrics:
                         stringValue: /var/opt/mssql/data/tempdb.mdf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "35"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb.mdf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1007616"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: templog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/templog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "180224"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: templog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/templog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: templog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/templog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.004
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: templog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/templog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "7"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: templog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/templog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "17"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: LOG
+                    - key: logical_filename
+                      value:
+                        stringValue: templog
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/templog.ldf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev2
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb2.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev2
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb2.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.001
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev2
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb2.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
                 - asDouble: 0.001
                   attributes:
                     - key: direction
@@ -885,11 +1125,109 @@ resourceMetrics:
                         stringValue: /var/opt/mssql/data/tempdb2.ndf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-                - asDouble: 0.002
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev2
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb2.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
                   attributes:
                     - key: direction
                       value:
                         stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev2
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb2.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev3
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb3.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev3
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb3.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
                     - key: file_type
                       value:
                         stringValue: ROWS
@@ -911,6 +1249,120 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
+                        stringValue: tempdev3
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb3.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev3
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb3.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev3
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb3.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.001
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
                         stringValue: tempdev4
                     - key: physical_filename
                       value:
@@ -922,6 +1374,120 @@ resourceMetrics:
                     - key: direction
                       value:
                         stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev4
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb4.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
                     - key: file_type
                       value:
                         stringValue: ROWS
@@ -943,6 +1509,120 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev5
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb5.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
                         stringValue: tempdev6
                     - key: physical_filename
                       value:
@@ -959,10 +1639,254 @@ resourceMetrics:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev6
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb6.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
                         stringValue: tempdev7
                     - key: physical_filename
                       value:
                         stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev7
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.001
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev7
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.002
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev7
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: s
+          - description: The number of operations issued on the file.
+            name: sqlserver.database.operations
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "9"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev7
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "11"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev7
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb7.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: '{operations}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.database.name
+          value:
+            stringValue: tempdb
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of bytes of I/O on this file.
+            name: sqlserver.database.io
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "131072"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev8
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb8.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "90112"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev8
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb8.ndf
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+              isMonotonic: true
+            unit: By
+          - description: Total time that the users waited for I/O issued on this file.
+            name: sqlserver.database.latency
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asDouble: 0.001
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: file_type
+                      value:
+                        stringValue: ROWS
+                    - key: logical_filename
+                      value:
+                        stringValue: tempdev8
+                    - key: physical_filename
+                      value:
+                        stringValue: /var/opt/mssql/data/tempdb8.ndf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asDouble: 0.001
@@ -995,230 +1919,6 @@ resourceMetrics:
                         stringValue: read
                     - key: file_type
                       value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBLog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "17"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: mastlog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/mastlog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: modellog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/modellog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "7"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: templog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/templog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "108"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBData
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBData.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "73"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: master
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/master.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "53"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: modeldev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/model.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "35"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev2
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb2.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev3
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb3.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev7
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb7.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "9"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: read
-                    - key: file_type
-                      value:
                         stringValue: ROWS
                     - key: logical_filename
                       value:
@@ -1226,230 +1926,6 @@ resourceMetrics:
                     - key: physical_filename
                       value:
                         stringValue: /var/opt/mssql/data/tempdb8.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "117"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBLog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBLog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "608"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: mastlog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/mastlog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "111"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: modellog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/modellog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "17"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: LOG
-                    - key: logical_filename
-                      value:
-                        stringValue: templog
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/templog.ldf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "102"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: MSDBData
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/MSDBData.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "329"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: master
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/master.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "80"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: modeldev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/model.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "4"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb.mdf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev2
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb2.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev3
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb3.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev4
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb4.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev5
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb5.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev6
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb6.ndf
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "11"
-                  attributes:
-                    - key: direction
-                      value:
-                        stringValue: write
-                    - key: file_type
-                      value:
-                        stringValue: ROWS
-                    - key: logical_filename
-                      value:
-                        stringValue: tempdev7
-                    - key: physical_filename
-                      value:
-                        stringValue: /var/opt/mssql/data/tempdb7.ndf
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
                 - asInt: "11"

--- a/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
+++ b/receiver/sqlserverreceiver/testdata/expectedPerfCounters.yaml
@@ -6,38 +6,6 @@ resourceMetrics:
             stringValue: 8cac97ac9b8f
     scopeMetrics:
       - metrics:
-          - description: Number of batch requests received by SQL Server.
-            gauge:
-              dataPoints:
-                - asDouble: 3375
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.batch.request.rate
-            unit: '{requests}/s'
-          - description: Number of SQL compilations needed.
-            gauge:
-              dataPoints:
-                - asDouble: 413
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.batch.sql_compilation.rate
-            unit: '{compilations}/s'
-          - description: Number of SQL recompilations needed.
-            gauge:
-              dataPoints:
-                - asDouble: 63
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.batch.sql_recompilation.rate
-            unit: '{compilations}/s'
-          - description: Number of lock requests resulting in a wait.
-            gauge:
-              dataPoints:
-                - asDouble: 17
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.lock.wait.rate
-            unit: '{requests}/s'
           - description: Pages found in the buffer pool without having to read from disk.
             gauge:
               dataPoints:
@@ -46,6 +14,16 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: sqlserver.page.buffer_cache.hit_ratio
             unit: '%'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
           - description: The number of processes that are currently blocked
             gauge:
               dataPoints:
@@ -54,28 +32,16 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: sqlserver.processes.blocked
             unit: '{processes}'
-          - description: The number of read operations that were throttled in the last second
-            gauge:
-              dataPoints:
-                - asInt: "0"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asInt: "0"
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.resource_pool.disk.throttled.read.rate
-            unit: '{reads}/s'
-          - description: The number of write operations that were throttled in the last second
-            gauge:
-              dataPoints:
-                - asDouble: 0
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-                - asDouble: 0
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: sqlserver.resource_pool.disk.throttled.write.rate
-            unit: '{writes}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
           - description: Number of users connected to the SQL Server.
             gauge:
               dataPoints:
@@ -84,6 +50,150 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: sqlserver.user.connection.count
             unit: '{connections}'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: Number of lock requests resulting in a wait.
+            gauge:
+              dataPoints:
+                - asDouble: 17
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.lock.wait.rate
+            unit: '{requests}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of read operations that were throttled in the last second
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.resource_pool.disk.throttled.read.rate
+            unit: '{reads}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of write operations that were throttled in the last second
+            gauge:
+              dataPoints:
+                - asDouble: 0
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.resource_pool.disk.throttled.write.rate
+            unit: '{writes}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of write operations that were throttled in the last second
+            gauge:
+              dataPoints:
+                - asDouble: 0
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.resource_pool.disk.throttled.write.rate
+            unit: '{writes}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: The number of read operations that were throttled in the last second
+            gauge:
+              dataPoints:
+                - asInt: "0"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.resource_pool.disk.throttled.read.rate
+            unit: '{reads}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: Number of batch requests received by SQL Server.
+            gauge:
+              dataPoints:
+                - asDouble: 3375
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.batch.request.rate
+            unit: '{requests}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: Number of SQL compilations needed.
+            gauge:
+              dataPoints:
+                - asDouble: 413
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.batch.sql_compilation.rate
+            unit: '{compilations}/s'
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
+          version: latest
+  - resource:
+      attributes:
+        - key: sqlserver.instance.name
+          value:
+            stringValue: 8cac97ac9b8f
+    scopeMetrics:
+      - metrics:
+          - description: Number of SQL recompilations needed.
+            gauge:
+              dataPoints:
+                - asDouble: 63
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: sqlserver.batch.sql_recompilation.rate
+            unit: '{compilations}/s'
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver
           version: latest


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
As explained in the bug description, the receiver was incorrectly setting the database name resource attribute based on the first row returned from the query. The returned rows may have different database names, which means metrics were being labeled as being from the wrong database.

**Link to tracking Issue:** <Issue number if applicable>
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35036

**Testing:** <Describe what testing was performed and which tests were added.>
Updated tests for new expected resource metrics. View changed `testdata/` files to see changed output.