### PR TITLE
[chore]: enable suite-dont-use-pkg rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -138,7 +138,6 @@ linters-settings:
       - formatter
       - go-require
       - require-error
-      - suite-dont-use-pkg
       - suite-subtest-run
       - useless-assert
     enable-all: true

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -77,7 +77,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,require-error,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -52,13 +52,13 @@ func (suite *JMXIntegrationSuite) SetupSuite() {
 	for version, url := range jmxJarReleases {
 		jarPath, err := downloadJMXMetricGathererJAR(url)
 		suite.VersionToJar[version] = jarPath
-		require.NoError(suite.T(), err)
+		suite.Require().NoError(err)
 	}
 }
 
 func (suite *JMXIntegrationSuite) TearDownSuite() {
 	for _, path := range suite.VersionToJar {
-		require.NoError(suite.T(), os.Remove(path))
+		suite.Require().NoError(os.Remove(path))
 	}
 }
 

--- a/receiver/jmxreceiver/internal/subprocess/integration_test.go
+++ b/receiver/jmxreceiver/internal/subprocess/integration_test.go
@@ -53,7 +53,7 @@ func (suite *SubprocessIntegrationSuite) SetupSuite() {
 }
 
 func (suite *SubprocessIntegrationSuite) TearDownSuite() {
-	require.NoError(suite.T(), os.Remove(suite.scriptPath))
+	suite.Require().NoError(os.Remove(suite.scriptPath))
 }
 
 // prepareSubprocess will create a Subprocess based on a temporary script.


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [suite-dont-use-pkg](https://github.com/Antonboom/testifylint?tab=readme-ov-file#suite-dont-use-pkg) rule from [testifylint](https://github.com/Antonboom/testifylint)