### PR TITLE
[chore]: enable negative-positive rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,7 +137,6 @@ linters-settings:
       - float-compare
       - formatter
       - go-require
-      - negative-positive
       - require-error
       - suite-dont-use-pkg
       - suite-subtest-run

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -77,7 +77,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,negative-positive,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,require-error,suite-dont-use-pkg,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -114,7 +114,7 @@ func verifyExemplarsExist(t testing.TB, input pmetric.Metrics) bool {
 				dps := metric.Histogram().DataPoints()
 				for dp := 0; dp < dps.Len(); dp++ {
 					d := dps.At(dp)
-					assert.Greater(t, d.Exemplars().Len(), 0)
+					assert.Positive(t, d.Exemplars().Len())
 				}
 			}
 		}
@@ -1645,7 +1645,7 @@ func assertDataPointsHaveExactlyOneExemplarForTrace(t *testing.T, metrics pmetri
 				switch metric.Type() {
 				case pmetric.MetricTypeSum:
 					dps := metric.Sum().DataPoints()
-					assert.Greater(t, dps.Len(), 0)
+					assert.Positive(t, dps.Len())
 					for dpi := 0; dpi < dps.Len(); dpi++ {
 						dp := dps.At(dpi)
 						assert.Equal(t, 1, dp.Exemplars().Len())
@@ -1653,7 +1653,7 @@ func assertDataPointsHaveExactlyOneExemplarForTrace(t *testing.T, metrics pmetri
 					}
 				case pmetric.MetricTypeHistogram:
 					dps := metric.Histogram().DataPoints()
-					assert.Greater(t, dps.Len(), 0)
+					assert.Positive(t, dps.Len())
 					for dpi := 0; dpi < dps.Len(); dpi++ {
 						dp := dps.At(dpi)
 						assert.Equal(t, 1, dp.Exemplars().Len())
@@ -1661,7 +1661,7 @@ func assertDataPointsHaveExactlyOneExemplarForTrace(t *testing.T, metrics pmetri
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					dps := metric.ExponentialHistogram().DataPoints()
-					assert.Greater(t, dps.Len(), 0)
+					assert.Positive(t, dps.Len())
 					for dpi := 0; dpi < dps.Len(); dpi++ {
 						dp := dps.At(dpi)
 						assert.Equal(t, 1, dp.Exemplars().Len())

--- a/exporter/datadogexporter/internal/clientutil/retrier_test.go
+++ b/exporter/datadogexporter/internal/clientutil/retrier_test.go
@@ -39,7 +39,7 @@ func TestDoWithRetries(t *testing.T) {
 	)
 	retryNum, err = retrier.DoWithRetries(ctx, func(context.Context) error { return errors.New("action failed") })
 	require.Error(t, err)
-	assert.Greater(t, retryNum, int64(0))
+	assert.Positive(t, retryNum)
 }
 
 func TestNoRetriesOnPermanentError(t *testing.T) {

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -488,8 +488,8 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 	mu.Lock()
 	require.Equal(t, []string{"127.0.0.2"}, lastResolved)
 	mu.Unlock()
-	require.Greater(t, counter1.Load(), int64(0))
-	require.Greater(t, counter2.Load(), int64(0))
+	require.Positive(t, counter1.Load())
+	require.Positive(t, counter2.Load())
 }
 
 func randomLogs() plog.Logs {

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -869,8 +869,8 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 	mu.Lock()
 	require.Equal(t, []string{"127.0.0.2"}, lastResolved)
 	mu.Unlock()
-	require.Greater(t, counter1.Load(), int64(0))
-	require.Greater(t, counter2.Load(), int64(0))
+	require.Positive(t, counter1.Load())
+	require.Positive(t, counter2.Load())
 }
 
 func randomMetrics(t require.TestingT, rmCount int, smCount int, mCount int, dpCount int) pmetric.Metrics {

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -591,8 +591,8 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 	mu.Lock()
 	require.Equal(t, []string{"127.0.0.2"}, lastResolved)
 	mu.Unlock()
-	require.Greater(t, counter1.Load(), int64(0))
-	require.Greater(t, counter2.Load(), int64(0))
+	require.Positive(t, counter1.Load())
+	require.Positive(t, counter2.Load())
 }
 
 func benchConsumeTraces(b *testing.B, endpointsCount int, tracesCount int) {

--- a/exporter/mezmoexporter/exporter_test.go
+++ b/exporter/mezmoexporter/exporter_test.go
@@ -212,7 +212,7 @@ func TestAddsRequiredAttributes(t *testing.T) {
 
 			lines := body.Lines
 			for _, line := range lines {
-				assert.Greater(t, line.Timestamp, int64(0))
+				assert.Positive(t, line.Timestamp)
 				assert.Equal(t, "info", line.Level)
 				assert.Equal(t, "", line.App)
 				assert.Equal(t, "minimal attribute log", line.Line)

--- a/exporter/splunkhecexporter/heartbeat_test.go
+++ b/exporter/splunkhecexporter/heartbeat_test.go
@@ -138,7 +138,7 @@ func Test_Heartbeat_success(t *testing.T) {
 				require.NoError(t, err)
 				return len(got) != 0
 			}, time.Second, 10*time.Millisecond)
-			assert.Greater(t, got[0], int64(0), "there should be at least one success metric datapoint")
+			assert.Positive(t, got[0], "there should be at least one success metric datapoint")
 			attrs, err := getAttributes(reader, sentMetricsName)
 			require.NoError(t, err)
 			assert.Equal(t, attribute.NewSet(attribute.String(metricLabelKey, metricLabelVal)), attrs[0])
@@ -161,7 +161,7 @@ func Test_Heartbeat_failure(t *testing.T) {
 		require.NoError(t, err)
 		return len(got) != 0
 	}, time.Second, 10*time.Millisecond)
-	assert.Greater(t, got[0], int64(0), "there should be at least one failure metric datapoint")
+	assert.Positive(t, got[0], "there should be at least one failure metric datapoint")
 	attrs, err := getAttributes(reader, defaultHBFailedMetricsName)
 	require.NoError(t, err)
 	assert.Equal(t, attribute.NewSet(attribute.String(metricLabelKey, metricLabelVal)), attrs[0])

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -31,7 +31,7 @@ func TestValidateLogEventWithMutating(t *testing.T) {
 	logEvent.GeneratedTime = time.Now()
 	err := logEvent.Validate(zap.NewNop())
 	assert.NoError(t, err)
-	assert.Greater(t, *logEvent.InputLogEvent.Timestamp, int64(0))
+	assert.Positive(t, *logEvent.InputLogEvent.Timestamp)
 	assert.Len(t, *logEvent.InputLogEvent.Message, 64-perEventHeaderBytes)
 
 	maxEventPayloadBytes = defaultMaxEventPayloadBytes

--- a/internal/coreinternal/goldendataset/resource_generator_test.go
+++ b/internal/coreinternal/goldendataset/resource_generator_test.go
@@ -16,7 +16,7 @@ func TestGenerateResource(t *testing.T) {
 		if rscID == ResourceEmpty {
 			assert.Equal(t, 0, rsc.Attributes().Len())
 		} else {
-			assert.Greater(t, rsc.Attributes().Len(), 0)
+			assert.Positive(t, rsc.Attributes().Len())
 		}
 	}
 }

--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -368,13 +368,13 @@ func failureMemoryLimitEnding(t *testing.T, _ testParams, testCon *testConsumer,
 	rSigs, rMsgs := logSigs(testCon.recvLogs)
 
 	// Test for arrow receiver stream errors on both sides.
-	require.Less(t, 0, eSigs["arrow stream error|||code///message///where"], "should have exporter arrow stream errors: %v", eMsgs)
-	require.Less(t, 0, rSigs["arrow stream error|||code///message///where"], "should have receiver arrow stream errors: %v", rSigs)
+	require.Positive(t, eSigs["arrow stream error|||code///message///where"], "should have exporter arrow stream errors: %v", eMsgs)
+	require.Positive(t, rSigs["arrow stream error|||code///message///where"], "should have receiver arrow stream errors: %v", rSigs)
 
 	// Ensure both side's error logs include memory limit errors
 	// one way or another.
-	require.Less(t, 0, countMemoryLimitErrors(rMsgs), "should have memory limit errors: %v", rMsgs)
-	require.Less(t, 0, countMemoryLimitErrors(eMsgs), "should have memory limit errors: %v", eMsgs)
+	require.Positive(t, countMemoryLimitErrors(rMsgs), "should have memory limit errors: %v", rMsgs)
+	require.Positive(t, countMemoryLimitErrors(eMsgs), "should have memory limit errors: %v", eMsgs)
 
 	return nil, nil
 }

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -152,7 +152,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 			// Create a file, then start
 			temp := filetest.OpenTemp(t, tempDir)
 			bytesWritten, err := temp.Write(tc.input)
-			require.Greater(t, bytesWritten, 0)
+			require.Positive(t, bytesWritten)
 			require.NoError(t, err)
 			require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
 			defer func() {
@@ -236,7 +236,7 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 			// Create a file, then start
 			temp := filetest.OpenTemp(t, tempDir)
 			bytesWritten, err := temp.Write(tc.input)
-			require.Greater(t, bytesWritten, 0)
+			require.Positive(t, bytesWritten)
 			require.NoError(t, err)
 			require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
 			defer func() {

--- a/pkg/stanza/operator/input/file/input_test.go
+++ b/pkg/stanza/operator/input/file/input_test.go
@@ -189,7 +189,7 @@ func TestReadUsingNopEncoding(t *testing.T) {
 			// Create a file, then start
 			temp := openTemp(t, tempDir)
 			bytesWritten, err := temp.Write(tc.input)
-			require.Greater(t, bytesWritten, 0)
+			require.Positive(t, bytesWritten)
 			require.NoError(t, err)
 			require.NoError(t, operator.Start(testutil.NewUnscopedMockPersister()))
 			defer func() {

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -353,7 +353,7 @@ func TestIPDetectionFromContext(t *testing.T) {
 		m.assertBatchesLen(1)
 		m.assertResourceObjectLen(0)
 		m.assertResource(0, func(r pcommon.Resource) {
-			require.Greater(t, r.Attributes().Len(), 0)
+			require.Positive(t, r.Attributes().Len())
 			assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
 		})
 	}
@@ -537,7 +537,7 @@ func TestIPSourceWithoutPodAssociation(t *testing.T) {
 			m.testConsume(ctx, traces, metrics, logs, nil)
 			m.assertBatchesLen(i + 1)
 			m.assertResource(i, func(res pcommon.Resource) {
-				require.Greater(t, res.Attributes().Len(), 0)
+				require.Positive(t, res.Attributes().Len())
 				assertResourceHasStringAttribute(t, res, "k8s.pod.ip", tc.out)
 			})
 		})
@@ -623,7 +623,7 @@ func TestIPSourceWithPodAssociation(t *testing.T) {
 			m.testConsume(ctx, traces, metrics, logs, nil)
 			m.assertBatchesLen(i + 1)
 			m.assertResource(i, func(res pcommon.Resource) {
-				require.Greater(t, res.Attributes().Len(), 0)
+				require.Positive(t, res.Attributes().Len())
 				assertResourceHasStringAttribute(t, res, tc.outLabel, tc.outValue)
 			})
 		})
@@ -666,7 +666,7 @@ func TestPodUID(t *testing.T) {
 	m.assertBatchesLen(1)
 	m.assertResourceObjectLen(0)
 	m.assertResource(0, func(r pcommon.Resource) {
-		require.Greater(t, r.Attributes().Len(), 0)
+		require.Positive(t, r.Attributes().Len())
 		assertResourceHasStringAttribute(t, r, "k8s.pod.uid", "ef10d10b-2da5-4030-812e-5f45c1531227")
 	})
 }
@@ -728,7 +728,7 @@ func TestAddPodLabels(t *testing.T) {
 		m.assertBatchesLen(i + 1)
 		m.assertResourceObjectLen(i)
 		m.assertResource(i, func(res pcommon.Resource) {
-			require.Greater(t, res.Attributes().Len(), 0)
+			require.Positive(t, res.Attributes().Len())
 			assertResourceHasStringAttribute(t, res, "k8s.pod.ip", ip)
 			for k, v := range attrs {
 				assertResourceHasStringAttribute(t, res, k, v)

--- a/processor/tailsamplingprocessor/internal/sampling/time_provider_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/time_provider_test.go
@@ -11,5 +11,5 @@ import (
 
 func TestTimeProvider(t *testing.T) {
 	clock := MonotonicClock{}
-	assert.Greater(t, clock.getCurSecond(), int64(0))
+	assert.Positive(t, clock.getCurSecond())
 }

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -82,7 +82,7 @@ func TestScrape(t *testing.T) {
 
 		var partialScrapeErr scrapererror.PartialScrapeError
 		require.ErrorAs(t, err, &partialScrapeErr, "returned error was not PartialScrapeError")
-		require.Greater(t, partialScrapeErr.Failed, 0, "Expected scrape failures, but none were recorded!")
+		require.Positive(t, partialScrapeErr.Failed, "Expected scrape failures, but none were recorded!")
 	})
 
 	t.Run("scrape error: failed to connect to client", func(t *testing.T) {

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -345,7 +345,7 @@ func TestUnixEndpoint(t *testing.T) {
 
 	n, err := conn.Write(parseHexDump("testdata/message-event"))
 	require.NoError(t, err)
-	require.Greater(t, n, 0)
+	require.Positive(t, n)
 
 	var converted []plog.Logs
 	require.Eventually(t, func() bool {

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_windows_test.go
@@ -99,7 +99,7 @@ func TestScrape_Errors(t *testing.T) {
 				pageSize = test.pageSize
 			} else {
 				pageSize = getPageSize()
-				assert.Greater(t, pageSize, uint64(0))
+				assert.Positive(t, pageSize)
 				assert.Zero(t, pageSize%4096) // page size on Windows should always be a multiple of 4KB
 			}
 

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -110,8 +110,8 @@ func TestScrape(t *testing.T) {
 				var scraperErr scrapererror.PartialScrapeError
 				require.ErrorAs(t, err, &scraperErr)
 				noProcessesErrored := scraperErr.Failed
-				require.Lessf(t, 0, noProcessesErrored, "Failed to scrape metrics - : error, but 0 failed process %v", err)
-				require.Lessf(t, 0, noProcessesScraped, "Failed to scrape metrics - : 0 successful scrapes %v", err)
+				require.Positivef(t, noProcessesErrored, "Failed to scrape metrics - : error, but 0 failed process %v", err)
+				require.Positivef(t, noProcessesScraped, "Failed to scrape metrics - : 0 successful scrapes %v", err)
 			}
 
 			require.Greater(t, md.ResourceMetrics().Len(), 1)

--- a/receiver/influxdbreceiver/receiver_test.go
+++ b/receiver/influxdbreceiver/receiver_test.go
@@ -55,7 +55,7 @@ func TestWriteLineProtocol_v2API(t *testing.T) {
 		require.NoError(t, err)
 
 		metrics := nextConsumer.lastMetricsConsumed
-		if assert.NotNil(t, metrics) && assert.Less(t, 0, metrics.DataPointCount()) {
+		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
 			assert.Equal(t, 1, metrics.MetricCount())
 			metric := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
 			assert.Equal(t, "cpu_temp", metric.Name())
@@ -77,7 +77,7 @@ func TestWriteLineProtocol_v2API(t *testing.T) {
 		require.NoError(t, err)
 
 		metrics := nextConsumer.lastMetricsConsumed
-		if assert.NotNil(t, metrics) && assert.Less(t, 0, metrics.DataPointCount()) {
+		if assert.NotNil(t, metrics) && assert.Positive(t, metrics.DataPointCount()) {
 			assert.Equal(t, 1, metrics.MetricCount())
 			metric := metrics.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
 			assert.Equal(t, "cpu_temp", metric.Name())

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
@@ -165,7 +165,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		logRecords := rl.ScopeLogs().At(0).LogRecords()
 		assert.Equal(t, 1, rl.ScopeLogs().Len())
 		assert.Equal(t, 1, logRecords.Len())
-		assert.Greater(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix(), int64(0))
+		assert.Positive(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix())
 		assert.Equal(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix(), observedAt.Unix())
 	})
 

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -225,7 +225,7 @@ service:
 		}
 	}
 
-	require.Greater(t, totalSamples, 0, "Expected at least 1 sample")
+	require.Positive(t, totalSamples, "Expected at least 1 sample")
 	// On every alternative scrape the prior scrape will be reported as sale.
 	// Expect at least:
 	//    * The first scrape will NOT return stale markers


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [negative-positive](https://github.com/Antonboom/testifylint?tab=readme-ov-file#negative-positive) rule from [testifylint](https://github.com/Antonboom/testifylint)