### PR TITLE
[processor/deltatocumulative] partial linear pipeline

### DIFF
--- a/internal/exp/metrics/identity/stream.go
+++ b/internal/exp/metrics/identity/stream.go
@@ -33,7 +33,3 @@ func OfStream[DataPoint attrPoint](m Metric, dp DataPoint) Stream {
 type attrPoint interface {
 	Attributes() pcommon.Map
 }
-
-func Compare[T interface{ Hash() hash.Hash64 }](a, b T) int {
-	return int(a.Hash().Sum64() - b.Hash().Sum64())
-}

--- a/internal/exp/metrics/identity/stream.go
+++ b/internal/exp/metrics/identity/stream.go
@@ -33,3 +33,7 @@ func OfStream[DataPoint attrPoint](m Metric, dp DataPoint) Stream {
 type attrPoint interface {
 	Attributes() pcommon.Map
 }
+
+func Compare[T interface{ Hash() hash.Hash64 }](a, b T) int {
+	return int(a.Hash().Sum64() - b.Hash().Sum64())
+}

--- a/processor/deltatocumulativeprocessor/chain.go
+++ b/processor/deltatocumulativeprocessor/chain.go
@@ -1,0 +1,48 @@
+package deltatocumulativeprocessor
+
+import (
+	"context"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+)
+
+var _ processor.Metrics = Chain(nil)
+
+// Chain calls processors in series.
+// They must be manually setup so that their ConsumeMetrics() invoke each other
+type Chain []processor.Metrics
+
+func (c Chain) Capabilities() consumer.Capabilities {
+	if len(c) == 0 {
+		return consumer.Capabilities{}
+	}
+	return c[0].Capabilities()
+}
+
+func (c Chain) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	if len(c) == 0 {
+		return nil
+	}
+	return c[0].ConsumeMetrics(ctx, md)
+}
+
+func (c Chain) Shutdown(ctx context.Context) error {
+	for _, proc := range c {
+		if err := proc.Shutdown(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c Chain) Start(ctx context.Context, host component.Host) error {
+	for _, proc := range c {
+		if err := proc.Start(ctx, host); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/processor/deltatocumulativeprocessor/chain.go
+++ b/processor/deltatocumulativeprocessor/chain.go
@@ -1,4 +1,7 @@
-package deltatocumulativeprocessor
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deltatocumulativeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 
 import (
 	"context"

--- a/processor/deltatocumulativeprocessor/config.go
+++ b/processor/deltatocumulativeprocessor/config.go
@@ -4,10 +4,14 @@
 package deltatocumulativeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 
 import (
+	"context"
 	"fmt"
+	"math"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
+
+	telemetry "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/lineartelemetry"
 )
 
 var _ component.ConfigValidator = (*Config)(nil)
@@ -33,6 +37,12 @@ func createDefaultConfig() component.Config {
 
 		// disable. TODO: find good default
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31603
-		MaxStreams: 0,
+		MaxStreams: math.MaxInt,
 	}
+}
+
+func (c Config) Metrics(tel telemetry.Metrics) {
+	ctx := context.Background()
+	tel.DeltatocumulativeStreamsMaxStale.Record(ctx, int64(c.MaxStale.Seconds()))
+	tel.DeltatocumulativeStreamsLimit.Record(ctx, int64(c.MaxStreams))
 }

--- a/processor/deltatocumulativeprocessor/config_test.go
+++ b/processor/deltatocumulativeprocessor/config_test.go
@@ -4,6 +4,7 @@
 package deltatocumulativeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 
 import (
+	"math"
 	"path/filepath"
 	"testing"
 	"time"
@@ -37,7 +38,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "set-valid-max_stale"),
 			expected: &Config{
 				MaxStale:   2 * time.Minute,
-				MaxStreams: 0,
+				MaxStreams: math.MaxInt,
 			},
 		},
 		{

--- a/processor/deltatocumulativeprocessor/documentation.md
+++ b/processor/deltatocumulativeprocessor/documentation.md
@@ -14,6 +14,14 @@ number of datapoints dropped due to given 'reason'
 | ---- | ----------- | ---------- | --------- |
 | {datapoint} | Sum | Int | true |
 
+### otelcol_deltatocumulative.datapoints.linear
+
+total number of datapoints processed. may have 'error' attribute, if processing failed
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| {datapoint} | Sum | Int | true |
+
 ### otelcol_deltatocumulative.datapoints.processed
 
 number of datapoints processed
@@ -55,6 +63,14 @@ duration after which streams inactive streams are dropped
 | s | Gauge | Int |
 
 ### otelcol_deltatocumulative.streams.tracked
+
+number of streams tracked
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| {dps} | Sum | Int | false |
+
+### otelcol_deltatocumulative.streams.tracked.linear
 
 number of streams tracked
 

--- a/processor/deltatocumulativeprocessor/factory.go
+++ b/processor/deltatocumulativeprocessor/factory.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 
+	ltel "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/lineartelemetry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/metadata"
 )
 
@@ -32,6 +33,13 @@ func createMetricsProcessor(_ context.Context, set processor.Settings, cfg compo
 	if err != nil {
 		return nil, err
 	}
+	proc := newProcessor(pcfg, set.Logger, telb, next)
 
-	return newProcessor(pcfg, set.Logger, telb, next), nil
+	ltel, err := ltel.New(set.TelemetrySettings)
+	if err != nil {
+		return nil, err
+	}
+	linear := newLinear(pcfg, ltel, proc)
+
+	return Chain{linear, proc}, nil
 }

--- a/processor/deltatocumulativeprocessor/internal/data/add.go
+++ b/processor/deltatocumulativeprocessor/internal/data/add.go
@@ -108,3 +108,7 @@ func (dp ExpHistogram) Add(in ExpHistogram) ExpHistogram {
 
 	return dp
 }
+
+func (dp Summary) Add(Summary) Summary {
+	panic("todo")
+}

--- a/processor/deltatocumulativeprocessor/internal/data/data.go
+++ b/processor/deltatocumulativeprocessor/internal/data/data.go
@@ -10,6 +10,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/expo"
 )
 
+var (
+	_ Point[Number]       = Number{}
+	_ Point[Histogram]    = Histogram{}
+	_ Point[ExpHistogram] = ExpHistogram{}
+	_ Point[Summary]      = Summary{}
+)
+
 type Point[Self any] interface {
 	StartTimestamp() pcommon.Timestamp
 	Timestamp() pcommon.Timestamp
@@ -23,7 +30,7 @@ type Point[Self any] interface {
 
 type Typed[Self any] interface {
 	Point[Self]
-	Number | Histogram | ExpHistogram
+	Number | Histogram | ExpHistogram | Summary
 }
 
 type Number struct {
@@ -94,3 +101,19 @@ var (
 	_ = mustPoint[Histogram]{}
 	_ = mustPoint[ExpHistogram]{}
 )
+
+type Summary struct {
+	pmetric.SummaryDataPoint
+}
+
+func (dp Summary) Clone() Summary {
+	clone := Summary{SummaryDataPoint: pmetric.NewSummaryDataPoint()}
+	if dp.SummaryDataPoint != (pmetric.SummaryDataPoint{}) {
+		dp.CopyTo(clone)
+	}
+	return clone
+}
+
+func (dp Summary) CopyTo(dst Summary) {
+	dp.SummaryDataPoint.CopyTo(dst.SummaryDataPoint)
+}

--- a/processor/deltatocumulativeprocessor/internal/lineartelemetry/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/lineartelemetry/metrics.go
@@ -1,0 +1,70 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry
+
+import (
+	"context"
+	"errors"
+	"reflect"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/metadata"
+)
+
+func New(set component.TelemetrySettings) (Metrics, error) {
+	m := Metrics{
+		tracked: func() int { return 0 },
+	}
+
+	trackedCb := metadata.WithDeltatocumulativeStreamsTrackedLinearCallback(func() int64 {
+		return int64(m.tracked())
+	})
+
+	telb, err := metadata.NewTelemetryBuilder(set, trackedCb)
+	if err != nil {
+		return Metrics{}, err
+	}
+	m.TelemetryBuilder = *telb
+
+	return m, nil
+}
+
+type Metrics struct {
+	metadata.TelemetryBuilder
+
+	tracked func() int
+}
+
+func (m Metrics) Datapoints() Counter {
+	return Counter{Int64Counter: m.DeltatocumulativeDatapointsLinear}
+}
+
+func (m *Metrics) WithTracked(streams func() int) {
+	m.tracked = streams
+}
+
+func Error(msg string) attribute.KeyValue {
+	return attribute.String("error", msg)
+}
+
+func Cause(err error) attribute.KeyValue {
+	for {
+		uw := errors.Unwrap(err)
+		if uw == nil {
+			break
+		}
+		err = uw
+	}
+
+	return Error(reflect.TypeOf(err).String())
+}
+
+type Counter struct{ metric.Int64Counter }
+
+func (c Counter) Inc(ctx context.Context, attrs ...attribute.KeyValue) {
+	c.Add(ctx, 1, metric.WithAttributes(attrs...))
+}

--- a/processor/deltatocumulativeprocessor/internal/lineartelemetry/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/lineartelemetry/metrics.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package telemetry
+package telemetry // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/lineartelemetry"
 
 import (
 	"context"

--- a/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"context"
 	"errors"
 
 	"go.opentelemetry.io/otel/metric"
@@ -28,15 +29,18 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 // TelemetryBuilder provides an interface for components to report telemetry
 // as defined in metadata and user config.
 type TelemetryBuilder struct {
-	meter                                metric.Meter
-	DeltatocumulativeDatapointsDropped   metric.Int64Counter
-	DeltatocumulativeDatapointsProcessed metric.Int64Counter
-	DeltatocumulativeGapsLength          metric.Int64Counter
-	DeltatocumulativeStreamsEvicted      metric.Int64Counter
-	DeltatocumulativeStreamsLimit        metric.Int64Gauge
-	DeltatocumulativeStreamsMaxStale     metric.Int64Gauge
-	DeltatocumulativeStreamsTracked      metric.Int64UpDownCounter
-	meters                               map[configtelemetry.Level]metric.Meter
+	meter                                        metric.Meter
+	DeltatocumulativeDatapointsDropped           metric.Int64Counter
+	DeltatocumulativeDatapointsLinear            metric.Int64Counter
+	DeltatocumulativeDatapointsProcessed         metric.Int64Counter
+	DeltatocumulativeGapsLength                  metric.Int64Counter
+	DeltatocumulativeStreamsEvicted              metric.Int64Counter
+	DeltatocumulativeStreamsLimit                metric.Int64Gauge
+	DeltatocumulativeStreamsMaxStale             metric.Int64Gauge
+	DeltatocumulativeStreamsTracked              metric.Int64UpDownCounter
+	DeltatocumulativeStreamsTrackedLinear        metric.Int64ObservableUpDownCounter
+	observeDeltatocumulativeStreamsTrackedLinear func(context.Context, metric.Observer) error
+	meters                                       map[configtelemetry.Level]metric.Meter
 }
 
 // TelemetryBuilderOption applies changes to default builder.
@@ -48,6 +52,16 @@ type telemetryBuilderOptionFunc func(mb *TelemetryBuilder)
 
 func (tbof telemetryBuilderOptionFunc) apply(mb *TelemetryBuilder) {
 	tbof(mb)
+}
+
+// WithDeltatocumulativeStreamsTrackedLinearCallback sets callback for observable DeltatocumulativeStreamsTrackedLinear metric.
+func WithDeltatocumulativeStreamsTrackedLinearCallback(cb func() int64, opts ...metric.ObserveOption) telemetryBuilderOption {
+	return func(builder *TelemetryBuilder) {
+		builder.observeDeltatocumulativeStreamsTrackedLinear = func(_ context.Context, o metric.Observer) error {
+			o.ObserveInt64(builder.DeltatocumulativeStreamsTrackedLinear, cb(), opts...)
+			return nil
+		}
+	}
 }
 
 // NewTelemetryBuilder provides a struct with methods to update all internal telemetry
@@ -62,6 +76,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.DeltatocumulativeDatapointsDropped, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_deltatocumulative.datapoints.dropped",
 		metric.WithDescription("number of datapoints dropped due to given 'reason'"),
+		metric.WithUnit("{datapoint}"),
+	)
+	errs = errors.Join(errs, err)
+	builder.DeltatocumulativeDatapointsLinear, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_deltatocumulative.datapoints.linear",
+		metric.WithDescription("total number of datapoints processed. may have 'error' attribute, if processing failed"),
 		metric.WithUnit("{datapoint}"),
 	)
 	errs = errors.Join(errs, err)
@@ -100,6 +120,14 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 		metric.WithDescription("number of streams tracked"),
 		metric.WithUnit("{dps}"),
 	)
+	errs = errors.Join(errs, err)
+	builder.DeltatocumulativeStreamsTrackedLinear, err = builder.meters[configtelemetry.LevelBasic].Int64ObservableUpDownCounter(
+		"otelcol_deltatocumulative.streams.tracked.linear",
+		metric.WithDescription("number of streams tracked"),
+		metric.WithUnit("{dps}"),
+	)
+	errs = errors.Join(errs, err)
+	_, err = builder.meters[configtelemetry.LevelBasic].RegisterCallback(builder.observeDeltatocumulativeStreamsTrackedLinear, builder.DeltatocumulativeStreamsTrackedLinear)
 	errs = errors.Join(errs, err)
 	return &builder, errs
 }

--- a/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/deltatocumulativeprocessor/internal/metadata/generated_telemetry.go
@@ -55,13 +55,13 @@ func (tbof telemetryBuilderOptionFunc) apply(mb *TelemetryBuilder) {
 }
 
 // WithDeltatocumulativeStreamsTrackedLinearCallback sets callback for observable DeltatocumulativeStreamsTrackedLinear metric.
-func WithDeltatocumulativeStreamsTrackedLinearCallback(cb func() int64, opts ...metric.ObserveOption) telemetryBuilderOption {
-	return func(builder *TelemetryBuilder) {
+func WithDeltatocumulativeStreamsTrackedLinearCallback(cb func() int64, opts ...metric.ObserveOption) TelemetryBuilderOption {
+	return telemetryBuilderOptionFunc(func(builder *TelemetryBuilder) {
 		builder.observeDeltatocumulativeStreamsTrackedLinear = func(_ context.Context, o metric.Observer) error {
 			o.ObserveInt64(builder.DeltatocumulativeStreamsTrackedLinear, cb(), opts...)
 			return nil
 		}
-	}
+	})
 }
 
 // NewTelemetryBuilder provides a struct with methods to update all internal telemetry

--- a/processor/deltatocumulativeprocessor/internal/metrics/data.go
+++ b/processor/deltatocumulativeprocessor/internal/metrics/data.go
@@ -15,6 +15,11 @@ type Data[D data.Point[D]] interface {
 	Ident() Ident
 }
 
+type Filterable[D data.Point[D]] interface {
+	Data[D]
+	Filter(func(D) bool)
+}
+
 type Sum Metric
 
 func (s Sum) At(i int) data.Number {
@@ -34,6 +39,10 @@ func (s Sum) Filter(expr func(data.Number) bool) {
 	s.Sum().DataPoints().RemoveIf(func(dp pmetric.NumberDataPoint) bool {
 		return !expr(data.Number{NumberDataPoint: dp})
 	})
+}
+
+func (s Sum) SetAggregationTemporality(at pmetric.AggregationTemporality) {
+	s.Sum().SetAggregationTemporality(at)
 }
 
 type Histogram Metric
@@ -57,6 +66,10 @@ func (s Histogram) Filter(expr func(data.Histogram) bool) {
 	})
 }
 
+func (s Histogram) SetAggregationTemporality(at pmetric.AggregationTemporality) {
+	s.Histogram().SetAggregationTemporality(at)
+}
+
 type ExpHistogram Metric
 
 func (s ExpHistogram) At(i int) data.ExpHistogram {
@@ -75,5 +88,51 @@ func (s ExpHistogram) Ident() Ident {
 func (s ExpHistogram) Filter(expr func(data.ExpHistogram) bool) {
 	s.ExponentialHistogram().DataPoints().RemoveIf(func(dp pmetric.ExponentialHistogramDataPoint) bool {
 		return !expr(data.ExpHistogram{DataPoint: dp})
+	})
+}
+
+func (s ExpHistogram) SetAggregationTemporality(at pmetric.AggregationTemporality) {
+	s.ExponentialHistogram().SetAggregationTemporality(at)
+}
+
+type Gauge Metric
+
+func (s Gauge) At(i int) data.Number {
+	dp := Metric(s).Gauge().DataPoints().At(i)
+	return data.Number{NumberDataPoint: dp}
+}
+
+func (s Gauge) Len() int {
+	return Metric(s).Gauge().DataPoints().Len()
+}
+
+func (s Gauge) Ident() Ident {
+	return (*Metric)(&s).Ident()
+}
+
+func (s Gauge) Filter(expr func(data.Number) bool) {
+	s.Gauge().DataPoints().RemoveIf(func(dp pmetric.NumberDataPoint) bool {
+		return !expr(data.Number{NumberDataPoint: dp})
+	})
+}
+
+type Summary Metric
+
+func (s Summary) At(i int) data.Summary {
+	dp := Metric(s).Summary().DataPoints().At(i)
+	return data.Summary{SummaryDataPoint: dp}
+}
+
+func (s Summary) Len() int {
+	return Metric(s).Summary().DataPoints().Len()
+}
+
+func (s Summary) Ident() Ident {
+	return (*Metric)(&s).Ident()
+}
+
+func (s Summary) Filter(expr func(data.Summary) bool) {
+	s.Summary().DataPoints().RemoveIf(func(dp pmetric.SummaryDataPoint) bool {
+		return !expr(data.Summary{SummaryDataPoint: dp})
 	})
 }

--- a/processor/deltatocumulativeprocessor/internal/metrics/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/metrics/metrics.go
@@ -33,3 +33,33 @@ func (m *Metric) Scope() pcommon.InstrumentationScope {
 func From(res pcommon.Resource, scope pcommon.InstrumentationScope, metric pmetric.Metric) Metric {
 	return Metric{res: res, scope: scope, Metric: metric}
 }
+
+func (m Metric) AggregationTemporality() pmetric.AggregationTemporality {
+	switch m.Type() {
+	case pmetric.MetricTypeSum:
+		return m.Sum().AggregationTemporality()
+	case pmetric.MetricTypeHistogram:
+		return m.Histogram().AggregationTemporality()
+	case pmetric.MetricTypeExponentialHistogram:
+		return m.ExponentialHistogram().AggregationTemporality()
+	}
+
+	return pmetric.AggregationTemporalityUnspecified
+}
+
+func (m Metric) Typed() any {
+	//exhaustive:enforce
+	switch m.Type() {
+	case pmetric.MetricTypeSum:
+		return Sum(m)
+	case pmetric.MetricTypeGauge:
+		return Gauge(m)
+	case pmetric.MetricTypeExponentialHistogram:
+		return ExpHistogram(m)
+	case pmetric.MetricTypeHistogram:
+		return Histogram(m)
+	case pmetric.MetricTypeSummary:
+		return Summary(m)
+	}
+	panic("unreachable")
+}

--- a/processor/deltatocumulativeprocessor/internal/streams/data.go
+++ b/processor/deltatocumulativeprocessor/internal/streams/data.go
@@ -39,6 +39,7 @@ func Apply[P data.Point[P], List filterable[P]](dps List, fn func(Ident, P) (P, 
 		next, err := fn(id, dp)
 		if err != nil {
 			if !errors.Is(err, Drop) {
+				err = Error(id, err)
 				errs = errors.Join(errs, err)
 			}
 			return false

--- a/processor/deltatocumulativeprocessor/linear.go
+++ b/processor/deltatocumulativeprocessor/linear.go
@@ -1,0 +1,213 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deltatocumulativeprocessor
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/processor"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/staleness"
+	exp "github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/streams"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/delta"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/metrics"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/streams"
+
+	telemetry "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/lineartelemetry"
+)
+
+var _ processor.Metrics = (*Linear)(nil)
+
+type Linear struct {
+	next processor.Metrics
+	cfg  Config
+
+	state state
+	mtx   sync.Mutex
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	stale staleness.Tracker
+	tel   telemetry.Metrics
+}
+
+func newLinear(cfg *Config, tel telemetry.Metrics, next processor.Metrics) *Linear {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	proc := Linear{
+		next: next,
+		cfg:  *cfg,
+		state: state{
+			nums: make(exp.HashMap[data.Number]),
+			hist: make(exp.HashMap[data.Histogram]),
+			expo: make(exp.HashMap[data.ExpHistogram]),
+		},
+		ctx:    ctx,
+		cancel: cancel,
+
+		stale: staleness.NewTracker(),
+		tel:   tel,
+	}
+
+	tel.WithTracked(proc.state.Len)
+	cfg.Metrics(tel)
+
+	return &proc
+}
+
+func (p *Linear) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
+	p.mtx.Lock()
+	defer p.mtx.Unlock()
+
+	now := time.Now()
+
+	const (
+		keep = true
+		drop = false
+	)
+
+	// possible errors encountered while aggregating.
+	// errors.Join-ed []streams.Error
+	var errs error
+
+	metrics.Filter(md, func(m metrics.Metric) bool {
+		if m.AggregationTemporality() != pmetric.AggregationTemporalityDelta {
+			return keep
+		}
+
+		// NOTE: to make review and migration easier, below only does sums for now.
+		// all other datatypes are handled by older code, which is called after this.
+		//
+		// TODO: implement other datatypes here
+		if m.Type() != pmetric.MetricTypeSum {
+			return keep
+		}
+
+		sum := metrics.Sum(m)
+		state := p.state.nums
+
+		// apply fn to each dp in stream. if fn's err != nil, dp is removed from stream
+		err := streams.Apply(sum, func(id identity.Stream, dp data.Number) (data.Number, error) {
+			acc, ok := state.Load(id)
+			// if at stream limit and stream not seen before, reject
+			if !ok && p.state.Len() >= p.cfg.MaxStreams {
+				p.tel.Datapoints().Inc(ctx, telemetry.Error("limit"))
+				return dp, streams.Drop
+			}
+
+			// stream is alive, update stale tracker
+			p.stale.Refresh(now, id)
+
+			acc, err := func() (data.Number, error) {
+				if !ok {
+					// new stream: there is no existing aggregation, so start new with current dp
+					return dp, nil
+				}
+				// tracked stream: add incoming delta dp to existing cumulative aggregation
+				return acc, delta.AccumulateInto(acc, dp)
+			}()
+
+			// aggregation failed, record as metric and drop datapoint
+			if err != nil {
+				p.tel.Datapoints().Inc(ctx, telemetry.Cause(err))
+				return acc, streams.Drop
+			}
+
+			// store aggregated result in state and return
+			p.tel.Datapoints().Inc(ctx)
+			_ = state.Store(id, acc)
+			return acc, nil
+		})
+		errs = errors.Join(errs, err)
+
+		// all remaining datapoints are cumulative
+		sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+
+		// if no datapoints remain, drop now-empty metric
+		return sum.Len() > 0
+	})
+	if errs != nil {
+		return errs
+	}
+
+	// no need to continue pipeline if we dropped all metrics
+	if md.MetricCount() == 0 {
+		return nil
+	}
+	return p.next.ConsumeMetrics(ctx, md)
+}
+
+func (p *Linear) Start(_ context.Context, _ component.Host) error {
+	if p.cfg.MaxStale != 0 {
+		// delete stale streams once per minute
+		go func() {
+			tick := time.NewTicker(time.Minute)
+			defer tick.Stop()
+			for {
+				select {
+				case <-p.ctx.Done():
+					return
+				case <-tick.C:
+					p.mtx.Lock()
+					stale := p.stale.Collect(p.cfg.MaxStale)
+					for _, id := range stale {
+						p.state.Delete(id)
+					}
+					p.mtx.Unlock()
+				}
+			}
+		}()
+	}
+
+	return nil
+}
+
+func (p *Linear) Shutdown(_ context.Context) error {
+	p.cancel()
+	return nil
+}
+
+func (p *Linear) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: true}
+}
+
+type Metric[T data.Point[T]] interface {
+	metrics.Filterable[T]
+	SetAggregationTemporality(pmetric.AggregationTemporality)
+}
+
+// state keeps a cumulative value, aggregated over time, per stream
+type state struct {
+	nums streams.Map[data.Number]
+
+	// future use
+	hist streams.Map[data.Histogram]
+	expo streams.Map[data.ExpHistogram]
+}
+
+func (m state) Len() int {
+	return m.nums.Len() + m.hist.Len() + m.expo.Len()
+}
+
+func (m state) Has(id identity.Stream) bool {
+	_, nok := m.nums.Load(id)
+	_, hok := m.hist.Load(id)
+	_, eok := m.expo.Load(id)
+	return nok || hok || eok
+}
+
+func (m state) Delete(id identity.Stream) {
+	m.nums.Delete(id)
+	m.hist.Delete(id)
+	m.expo.Delete(id)
+}

--- a/processor/deltatocumulativeprocessor/linear.go
+++ b/processor/deltatocumulativeprocessor/linear.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package deltatocumulativeprocessor
+package deltatocumulativeprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 
 import (
 	"context"
@@ -19,10 +19,9 @@ import (
 	exp "github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/streams"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/delta"
+	telemetry "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/lineartelemetry"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/metrics"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/streams"
-
-	telemetry "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/lineartelemetry"
 )
 
 var _ processor.Metrics = (*Linear)(nil)

--- a/processor/deltatocumulativeprocessor/metadata.yaml
+++ b/processor/deltatocumulativeprocessor/metadata.yaml
@@ -9,7 +9,6 @@ status:
   codeowners:
     active: [sh0rez, RichieSams, jpkrohling]
 
-
 telemetry:
   metrics:
     # streams
@@ -19,6 +18,14 @@ telemetry:
       sum:
         value_type: int
         monotonic: false
+      enabled: true
+    deltatocumulative.streams.tracked.linear:
+      description: number of streams tracked
+      unit: "{dps}"
+      sum:
+        value_type: int
+        monotonic: false
+        async: true
       enabled: true
     deltatocumulative.streams.limit:
       description: upper limit of tracked streams
@@ -49,6 +56,14 @@ telemetry:
       enabled: true
     deltatocumulative.datapoints.dropped:
       description: number of datapoints dropped due to given 'reason'
+      unit: "{datapoint}"
+      sum:
+        value_type: int
+        monotonic: true
+      enabled: true
+
+    deltatocumulative.datapoints.linear:
+      description: total number of datapoints processed. may have 'error' attribute, if processing failed
       unit: "{datapoint}"
       sum:
         value_type: int


### PR DESCRIPTION
**Description:** 
Partially introduces a highly decoupled, linear processing pipeline.
Implemented as a standalone struct to make review easier, will refactor this later.
Instead of overloading `Map.Store()` to do aggregation, staleness and
limiting, this functionality is now explcitly handled in
`ConsumeMetrics`.

This highly aids readability and makes understanding this processor a
lot easier, as less mental context needs to be kept.

*Notes to reviewer*:
See [`68dc901`](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35048/commits/68dc901338cdde86a24c4d38c9456e09cfcab175) for the main added logic.
Compare `processor.go` (old, nested) to `linear.go` (new, linear)

Replaces #34757 

**Link to tracking Issue:** none

**Testing:** This is a refactor. Existing tests were not modified and still pass

**Documentation:** not needed