### PR TITLE
[exporter/datadog] Use correct hostname for logs in logs agent pipeline

### DIFF
--- a/.chloggen/stanley.liu_fix-logs-hostname.yaml
+++ b/.chloggen/stanley.liu_fix-logs-hostname.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use correct hostname for logs when using Datadog Agent logs pipeline with a gateway deployment.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35058]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -304,7 +304,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2 // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.2 // indirect
@@ -830,7 +830,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -749,8 +749,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2 h1:SXJCw
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2/go.mod h1:0o4qKCsmoFkYSgOTKL5UMR1/Ig0pX4bA6gJZjuu8/K4=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2 h1:P1u8lJDnCHiWc0vvvvm9JB36fRFJ2eSvD9ajVo0x1r8=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2/go.mod h1:hruCkJ5hCU6LZ5jkdnST3BHanHeQ73ewPAWIW/oZVmw=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2 h1:gfpTFIkwgLNLCdbYRqMH91uwyvOKnIWMAqHJao0bWTE=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2/go.mod h1:VIWMWkwSq4vtJeI/saiNDFoeh3FdbKFca+YvbE7HCrE=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27 h1:yBmr913VGRz/PFcpLVnXGTQQu7tIB+jMQ8Sss7936qk=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27/go.mod h1:niRElZ9+yd0uG84z4Az+da3JX9UpRu5MrbB32KtF4xI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2 h1:TmEsHhs1mcKsiWTK08aYvZrNZqlbs51FwN6yQVMe7No=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2/go.mod h1:D56XSQiApc7kNzkF2FCJG/6D/8SV3jhdWqe0dDSRGoM=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.2 h1:WTK6fTNgSCuVrz3dngS7R82rq9SVI+E8oQehd/2eEU0=
@@ -2559,8 +2559,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2 // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/pkg/collector/check/defaults v0.56.2 // indirect
@@ -271,7 +271,7 @@ require (
 	go.uber.org/dig v1.17.1 // indirect
 	go.uber.org/fx v1.18.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -94,8 +94,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2 h1:SXJCw
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2/go.mod h1:0o4qKCsmoFkYSgOTKL5UMR1/Ig0pX4bA6gJZjuu8/K4=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2 h1:P1u8lJDnCHiWc0vvvvm9JB36fRFJ2eSvD9ajVo0x1r8=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2/go.mod h1:hruCkJ5hCU6LZ5jkdnST3BHanHeQ73ewPAWIW/oZVmw=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2 h1:gfpTFIkwgLNLCdbYRqMH91uwyvOKnIWMAqHJao0bWTE=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2/go.mod h1:VIWMWkwSq4vtJeI/saiNDFoeh3FdbKFca+YvbE7HCrE=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27 h1:yBmr913VGRz/PFcpLVnXGTQQu7tIB+jMQ8Sss7936qk=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27/go.mod h1:niRElZ9+yd0uG84z4Az+da3JX9UpRu5MrbB32KtF4xI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2 h1:TmEsHhs1mcKsiWTK08aYvZrNZqlbs51FwN6yQVMe7No=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2/go.mod h1:D56XSQiApc7kNzkF2FCJG/6D/8SV3jhdWqe0dDSRGoM=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.2 h1:WTK6fTNgSCuVrz3dngS7R82rq9SVI+E8oQehd/2eEU0=
@@ -1067,8 +1067,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.2
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil v0.57.0-devel.0.20240718200853-81bf3b2e412d
 	github.com/DataDog/datadog-agent/comp/trace/compression/impl-gzip v0.56.2
@@ -362,7 +362,7 @@ require (
 	go.uber.org/fx v1.18.2 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -101,8 +101,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2 h1:SXJCw
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2/go.mod h1:0o4qKCsmoFkYSgOTKL5UMR1/Ig0pX4bA6gJZjuu8/K4=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2 h1:P1u8lJDnCHiWc0vvvvm9JB36fRFJ2eSvD9ajVo0x1r8=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2/go.mod h1:hruCkJ5hCU6LZ5jkdnST3BHanHeQ73ewPAWIW/oZVmw=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2 h1:gfpTFIkwgLNLCdbYRqMH91uwyvOKnIWMAqHJao0bWTE=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2/go.mod h1:VIWMWkwSq4vtJeI/saiNDFoeh3FdbKFca+YvbE7HCrE=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27 h1:yBmr913VGRz/PFcpLVnXGTQQu7tIB+jMQ8Sss7936qk=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27/go.mod h1:niRElZ9+yd0uG84z4Az+da3JX9UpRu5MrbB32KtF4xI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2 h1:TmEsHhs1mcKsiWTK08aYvZrNZqlbs51FwN6yQVMe7No=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2/go.mod h1:D56XSQiApc7kNzkF2FCJG/6D/8SV3jhdWqe0dDSRGoM=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.2 h1:WTK6fTNgSCuVrz3dngS7R82rq9SVI+E8oQehd/2eEU0=
@@ -1205,8 +1205,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/logs/agent/config v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2 // indirect
-	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2 // indirect
+	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.2 // indirect
 	github.com/DataDog/datadog-agent/comp/trace/compression/def v0.56.2 // indirect
@@ -338,7 +338,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/crypto v0.26.0 // indirect
-	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
 	golang.org/x/mod v0.20.0 // indirect
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/oauth2 v0.22.0 // indirect

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -99,8 +99,8 @@ github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2 h1:SXJCw
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline v0.56.2/go.mod h1:0o4qKCsmoFkYSgOTKL5UMR1/Ig0pX4bA6gJZjuu8/K4=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2 h1:P1u8lJDnCHiWc0vvvvm9JB36fRFJ2eSvD9ajVo0x1r8=
 github.com/DataDog/datadog-agent/comp/otelcol/logsagentpipeline/logsagentpipelineimpl v0.56.2/go.mod h1:hruCkJ5hCU6LZ5jkdnST3BHanHeQ73ewPAWIW/oZVmw=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2 h1:gfpTFIkwgLNLCdbYRqMH91uwyvOKnIWMAqHJao0bWTE=
-github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.56.2/go.mod h1:VIWMWkwSq4vtJeI/saiNDFoeh3FdbKFca+YvbE7HCrE=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27 h1:yBmr913VGRz/PFcpLVnXGTQQu7tIB+jMQ8Sss7936qk=
+github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/exporter/logsagentexporter v0.58.0-devel.0.20240905201012-b02662b2ba27/go.mod h1:niRElZ9+yd0uG84z4Az+da3JX9UpRu5MrbB32KtF4xI=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2 h1:TmEsHhs1mcKsiWTK08aYvZrNZqlbs51FwN6yQVMe7No=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.56.2/go.mod h1:D56XSQiApc7kNzkF2FCJG/6D/8SV3jhdWqe0dDSRGoM=
 github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.56.2 h1:WTK6fTNgSCuVrz3dngS7R82rq9SVI+E8oQehd/2eEU0=
@@ -1189,8 +1189,8 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 h1:vr/HnozRka3pE4EsMEg1lgkXJkTFJCVUX+S/ZT6wYzM=
-golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842/go.mod h1:XtvwrStGgqGPLc4cjQfWqZHG1YFdYs6swckp8vpsjnc=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/exporter/datadogexporter/logs_exporter_test.go
+++ b/exporter/datadogexporter/logs_exporter_test.go
@@ -295,6 +295,7 @@ func TestLogsAgentExporter(t *testing.T) {
 					ldd := lrr.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
 					ldd.Attributes().PutStr("attr", "hello")
 					ldd.Attributes().PutStr("service.name", "service")
+					ldd.Attributes().PutStr("host.name", "test-host")
 					return lrr
 				}(),
 				retry: false,
@@ -318,6 +319,8 @@ func TestLogsAgentExporter(t *testing.T) {
 						"attr":                 "hello",
 						"service":              "service",
 						"service.name":         "service",
+						"host.name":            "test-host",
+						"hostname":             "test-host",
 					},
 					"ddsource": "otlp_log_ingestion",
 					"ddtags":   "otel_source:datadog_exporter",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Includes bug fix from https://github.com/DataDog/datadog-agent/pull/28870. In gateway deployments using the logs agent feature gate, some logs may be associated with the hostname of the gateway collector instead of the host sending the logs. This fixes this issue by explicitly assigning the mapped log hostname.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Performed manual tests and added unit test.

**Documentation:** <Describe the documentation added.>