### PR TITLE
[chore] go version 1.22.6 -> 1.22.7

### DIFF
--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -58,7 +58,7 @@ jobs:
         run: Install-WindowsFeature -name Web-Server -IncludeManagementTools
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-mod-cache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -161,7 +161,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -184,7 +184,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -253,7 +253,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.23.0", "1.22.6"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["1.23.0", "1.22.7"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-latest]
         group:
           - receiver-0
@@ -369,7 +369,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -407,7 +407,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -433,7 +433,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -503,7 +503,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -604,7 +604,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Mkdir bin and dist
         run: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -87,7 +87,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -66,7 +66,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Prepare release for contrib
         working-directory: opentelemetry-collector-contrib

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -31,7 +31,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/telemetrygen.yml
+++ b/.github/workflows/telemetrygen.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.6"
+          go-version: "1.22.7"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -4,7 +4,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/otelcontrib
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/confmap/provider/s3provider v0.108.0

--- a/cmd/oteltestbedcol/go.mod
+++ b/cmd/oteltestbedcol/go.mod
@@ -4,7 +4,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/oteltestbed
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/carbonexporter v0.108.0

--- a/exporter/dorisexporter/go.mod
+++ b/exporter/dorisexporter/go.mod
@@ -2,7 +2,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorise
 
 go 1.22.0
 
-toolchain go1.22.6
+toolchain go1.22.7
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0

--- a/receiver/googlecloudmonitoringreceiver/go.mod
+++ b/receiver/googlecloudmonitoringreceiver/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudmonitoringreceiver
 
-go 1.22.6
+go 1.22.7
 
 require (
 	github.com/stretchr/testify v1.9.0


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The goal here is to resolve warnings about [GO-2024-3106](https://pkg.go.dev/vuln/GO-2024-3106). Simply replacing all references from `1.22.6` -> `1.22.7`