### PR TITLE
[testbed] Passing processor configs in a struct slice to preserve order

### DIFF
--- a/.chloggen/testbed_proc_order_fix.yaml
+++ b/.chloggen/testbed_proc_order_fix.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: testbed
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "`scenarios.createConfigYaml()` and `utils.CreateConfigYaml()` functions now take processor configs as a struct slice argument instead of `map[string]string`."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33003]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - This is to preserve processor order. `ProcessorNameAndConfigBody` is the newly created struct.
+
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/testbed/README.md
+++ b/testbed/README.md
@@ -85,13 +85,14 @@ Generally, when designing a test for new exporter and receiver components, devel
     		},
     		...
     	}
-    
-    	processors := map[string]string{
-    		"batch": `
-      batch:
+    	processors := []ProcessorNameAndConfigBody{
+    		{
+    			Name: "batch",
+    			Body: `
+	  batch:
     `,
+			},
     	}
-    
     	for _, test := range tests {
     		t.Run(test.name, func(t *testing.T) {
     			Scenario10kItemsPerSecond(

--- a/testbed/correctnesstests/connectors/correctness_test.go
+++ b/testbed/correctnesstests/connectors/correctness_test.go
@@ -21,11 +21,14 @@ func TestMain(m *testing.M) {
 }
 
 func TestGoldenData(t *testing.T) {
-	processors := map[string]string{
-		"batch": `
+	processors := []correctnesstests.ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
     send_batch_size: 1024
 `,
+		},
 	}
 	sampleTest := correctnesstests.PipelineDef{
 		TestName:  "test routing",
@@ -49,7 +52,7 @@ func testWithGoldenDataset(
 	receiver testbed.DataReceiver,
 	resourceSpec testbed.ResourceSpec,
 	connector testbed.DataConnector,
-	processors map[string]string,
+	processors []correctnesstests.ProcessorNameAndConfigBody,
 ) {
 	dataProvider := testbed.NewGoldenDataProvider(
 		"../../../internal/coreinternal/goldendataset/testdata/generated_pict_pairs_traces.txt",

--- a/testbed/correctnesstests/traces/correctness_test.go
+++ b/testbed/correctnesstests/traces/correctness_test.go
@@ -25,11 +25,14 @@ func TestMain(m *testing.M) {
 func TestTracingGoldenData(t *testing.T) {
 	tests, err := correctnesstests.LoadPictOutputPipelineDefs("testdata/generated_pict_pairs_traces_pipeline.txt")
 	require.NoError(t, err)
-	processors := map[string]string{
-		"batch": `
+	processors := []correctnesstests.ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
     send_batch_size: 1024
 `,
+		},
 	}
 	for _, test := range tests {
 		test.TestName = fmt.Sprintf("%s-%s", test.Receiver, test.Exporter)
@@ -46,7 +49,7 @@ func testWithTracingGoldenDataset(
 	sender testbed.DataSender,
 	receiver testbed.DataReceiver,
 	resourceSpec testbed.ResourceSpec,
-	processors map[string]string,
+	processors []correctnesstests.ProcessorNameAndConfigBody,
 ) {
 	dataProvider := testbed.NewGoldenDataProvider(
 		"../../../internal/coreinternal/goldendataset/testdata/generated_pict_pairs_traces.txt",

--- a/testbed/correctnesstests/utils.go
+++ b/testbed/correctnesstests/utils.go
@@ -18,6 +18,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
 
+type ProcessorNameAndConfigBody struct {
+	Name string
+	Body string
+}
+
 // CreateConfigYaml creates a yaml config for an otel collector given a testbed sender, testbed receiver, any
 // processors, and a pipeline type. A collector created from the resulting yaml string should be able to talk
 // the specified sender and receiver.
@@ -26,7 +31,7 @@ func CreateConfigYaml(
 	sender testbed.DataSender,
 	receiver testbed.DataReceiver,
 	connector testbed.DataConnector,
-	processors map[string]string,
+	processors []ProcessorNameAndConfigBody,
 ) string {
 
 	// Prepare extra processor config section and comma-separated list of extra processor
@@ -35,12 +40,12 @@ func CreateConfigYaml(
 	processorsList := ""
 	if len(processors) > 0 {
 		first := true
-		for name, cfg := range processors {
-			processorsSections += cfg + "\n"
+		for i := range processors {
+			processorsSections += processors[i].Body + "\n"
 			if !first {
 				processorsList += ","
 			}
-			processorsList += name
+			processorsList += processors[i].Name
 			first = false
 		}
 	}

--- a/testbed/stabilitytests/trace_test.go
+++ b/testbed/stabilitytests/trace_test.go
@@ -24,10 +24,13 @@ import (
 var (
 	contribPerfResultsSummary = &testbed.PerformanceResults{}
 	resourceCheckPeriod, _    = time.ParseDuration("1m")
-	processorsConfig          = map[string]string{
-		"batch": `
+	processorsConfig          = []scenarios.ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
 `,
+		},
 	}
 )
 

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -159,10 +159,13 @@ func TestLog10kDPS(t *testing.T) {
 		},
 	}
 
-	processors := map[string]string{
-		"batch": `
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
 `,
+		},
 	}
 
 	for _, test := range tests {
@@ -282,10 +285,14 @@ func TestLogLargeFiles(t *testing.T) {
 			sleepSeconds: 200,
 		},
 	}
-	processors := map[string]string{
-		"batch": `
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
-`}
+`,
+		},
+	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			ScenarioLong(
@@ -302,10 +309,13 @@ func TestLogLargeFiles(t *testing.T) {
 }
 
 func TestLargeFileOnce(t *testing.T) {
-	processors := map[string]string{
-		"batch": `
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
 `,
+		},
 	}
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
 	require.NoError(t, err)

--- a/testbed/tests/resource_processor_test.go
+++ b/testbed/tests/resource_processor_test.go
@@ -109,8 +109,8 @@ func TestMetricResourceProcessor(t *testing.T) {
 			require.NoError(t, err)
 
 			agentProc := testbed.NewChildProcessCollector(testbed.WithEnvVar("GOMAXPROCS", "2"))
-			processors := map[string]string{
-				"resource": test.resourceProcessorConfig,
+			processors := []ProcessorNameAndConfigBody{
+				{Name: "resource", Body: test.resourceProcessorConfig},
 			}
 			configStr := createConfigYaml(t, sender, receiver, resultDir, processors, nil)
 			configCleanup, err := agentProc.PrepareConfig(configStr)

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -26,6 +26,11 @@ var (
 	performanceResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
 )
 
+type ProcessorNameAndConfigBody struct {
+	Name string
+	Body string
+}
+
 // createConfigYaml creates a collector config file that corresponds to the
 // sender and receiver used in the test and returns the config file name.
 // Map of processor names to their configs. Config is in YAML and must be
@@ -36,7 +41,7 @@ func createConfigYaml(
 	sender testbed.DataSender,
 	receiver testbed.DataReceiver,
 	resultDir string,
-	processors map[string]string,
+	processors []ProcessorNameAndConfigBody,
 	extensions map[string]string,
 ) string {
 
@@ -51,12 +56,12 @@ func createConfigYaml(
 	processorsList := ""
 	if len(processors) > 0 {
 		first := true
-		for name, cfg := range processors {
-			processorsSections += cfg + "\n"
+		for i := range processors {
+			processorsSections += processors[i].Body + "\n"
 			if !first {
 				processorsList += ","
 			}
-			processorsList += name
+			processorsList += processors[i].Name
 			first = false
 		}
 	}
@@ -133,7 +138,7 @@ func Scenario10kItemsPerSecond(
 	receiver testbed.DataReceiver,
 	resourceSpec testbed.ResourceSpec,
 	resultsSummary testbed.TestResultsSummary,
-	processors map[string]string,
+	processors []ProcessorNameAndConfigBody,
 	extensions map[string]string,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
@@ -191,7 +196,7 @@ func Scenario10kItemsPerSecondAlternateBackend(
 	backend testbed.DataReceiver,
 	resourceSpec testbed.ResourceSpec,
 	resultsSummary testbed.TestResultsSummary,
-	processors map[string]string,
+	processors []ProcessorNameAndConfigBody,
 	extensions map[string]string,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
@@ -261,7 +266,7 @@ func genRandByteString(length int) string {
 
 // Scenario1kSPSWithAttrs runs a performance test at 1k sps with specified span attributes
 // and test options.
-func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, processors map[string]string, extensions map[string]string) {
+func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, processors []ProcessorNameAndConfigBody, extensions map[string]string) {
 	for i := range tests {
 		test := tests[i]
 
@@ -317,8 +322,8 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, proce
 // Defines RAM usage range for defined processor type.
 type processorConfig struct {
 	Name string
-	// map of processor types to their config YAML to use.
-	Processor           map[string]string
+	// slice of processor structs with their names and config YAML to use.
+	Processor           []ProcessorNameAndConfigBody
 	ExpectedMaxRAM      uint32
 	ExpectedMinFinalRAM uint32
 }
@@ -374,7 +379,7 @@ func ScenarioSendingQueuesFull(
 	resourceSpec testbed.ResourceSpec,
 	sleepTime int,
 	resultsSummary testbed.TestResultsSummary,
-	processors map[string]string,
+	processors []ProcessorNameAndConfigBody,
 	extensions map[string]string,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
@@ -456,7 +461,7 @@ func ScenarioSendingQueuesNotFull(
 	resourceSpec testbed.ResourceSpec,
 	sleepTime int,
 	resultsSummary testbed.TestResultsSummary,
-	processors map[string]string,
+	processors []ProcessorNameAndConfigBody,
 	extensions map[string]string,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
@@ -508,7 +513,7 @@ func ScenarioLong(
 	loadOptions testbed.LoadOptions,
 	resultsSummary testbed.TestResultsSummary,
 	sleepTime int,
-	processors map[string]string,
+	processors []ProcessorNameAndConfigBody,
 ) {
 	resultDir, err := filepath.Abs(path.Join("results", t.Name()))
 	require.NoError(t, err)

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -130,10 +130,13 @@ func TestTrace10kSPS(t *testing.T) {
 		},
 	}
 
-	processors := map[string]string{
-		"batch": `
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
 `,
+		},
 	}
 
 	for _, test := range tests {
@@ -164,10 +167,13 @@ func TestTrace10kSPSJaegerGRPC(t *testing.T) {
 			ExpectedMaxRAM: 100,
 		},
 		performanceResultsSummary,
-		map[string]string{
-			"batch": `
+		[]ProcessorNameAndConfigBody{
+			{
+				Name: "batch",
+				Body: `
   batch:
 `,
+			},
 		},
 		nil,
 	)
@@ -175,15 +181,18 @@ func TestTrace10kSPSJaegerGRPC(t *testing.T) {
 
 func TestTraceNoBackend10kSPS(t *testing.T) {
 
-	limitProcessors := map[string]string{
-		"memory_limiter": `
+	limitProcessors := []ProcessorNameAndConfigBody{
+		{
+			Name: "memory_limiter",
+			Body: `
   memory_limiter:
    check_interval: 100ms
    limit_mib: 20
 `,
+		},
 	}
 
-	noLimitProcessors := map[string]string{}
+	noLimitProcessors := []ProcessorNameAndConfigBody{}
 
 	var processorsConfig = []processorConfig{
 		{
@@ -330,11 +339,16 @@ func TestTraceAttributesProcessor(t *testing.T) {
 			require.NoError(t, err)
 
 			// Use processor to add attributes to certain spans.
-			processors := map[string]string{
-				"batch": `
+			processors := []ProcessorNameAndConfigBody{
+				{
+					Name: "batch",
+					Body: `
   batch:
 `,
-				"attributes": `
+				},
+				{
+					Name: "attributes",
+					Body: `
   attributes:
     include:
       match_type: regexp
@@ -345,6 +359,7 @@ func TestTraceAttributesProcessor(t *testing.T) {
         key: "new_attr"
         value: "string value"
 `,
+				},
 			}
 
 			agentProc := testbed.NewChildProcessCollector(testbed.WithEnvVar("GOMAXPROCS", "2"))
@@ -416,11 +431,16 @@ func TestTraceAttributesProcessorJaegerGRPC(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use processor to add attributes to certain spans.
-	processors := map[string]string{
-		"batch": `
+	processors := []ProcessorNameAndConfigBody{
+		{
+			Name: "batch",
+			Body: `
   batch:
 `,
-		"attributes": `
+		},
+		{
+			Name: "attributes",
+			Body: `
   attributes:
     include:
       match_type: regexp
@@ -431,6 +451,7 @@ func TestTraceAttributesProcessorJaegerGRPC(t *testing.T) {
         key: "new_attr"
         value: "string value"
 `,
+		},
 	}
 
 	agentProc := testbed.NewChildProcessCollector(testbed.WithEnvVar("GOMAXPROCS", "2"))


### PR DESCRIPTION
**Description:** <Describe what has changed.>
Previously, the processor config was passed as a map, because of which preserving the processor order was not possible.
Changed the data type to a newly added struct slice so that the processors are used in the supplied order.

**NOTE** that this change is breaking - if any of these changed functions are directly used, they will break as existing usages supply map.

**Link to tracking Issue:** <Issue number if applicable>
Resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33003
