### PR TITLE
[receiver/webhookevent] fix for issue 35028

### DIFF
--- a/.chloggen/35028-fix-scan-behavior.yaml
+++ b/.chloggen/35028-fix-scan-behavior.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: webhookeventreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed a bug where request bodies containing newline characters caused the results to split into multiple log entries
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35028]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/webhookeventreceiver/receiver.go
+++ b/receiver/webhookeventreceiver/receiver.go
@@ -191,7 +191,7 @@ func (er *eventReceiver) handleReq(w http.ResponseWriter, r *http.Request, _ htt
 		defer er.gzipPool.Put(reader)
 	}
 
-	// finish reading the body into a log
+	// send body into a scanner and then convert the request body into a log
 	sc := bufio.NewScanner(bodyReader)
 	ld, numLogs := reqToLog(sc, r.URL.Query(), er.cfg, er.settings)
 	consumerErr := er.logConsumer.ConsumeLogs(ctx, ld)

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -19,6 +19,18 @@ func reqToLog(sc *bufio.Scanner,
 	query url.Values,
 	_ *Config,
 	settings receiver.Settings) (plog.Logs, int) {
+	// we simply dont split the data passed into scan (i.e. scan the whole thing)
+	// the downside to this approach is that only 1 log per request can be handled.
+	// NOTE: logs will contain these newline characters which could have formatting
+	// consequences downstream.
+	split := func(data []byte, atEOF bool) (advance int, token []byte, err error) {
+		if !atEOF {
+			return 0, nil, nil
+		}
+		return 0, data, bufio.ErrFinalToken
+	}
+	sc.Split(split)
+
 	log := plog.NewLogs()
 	resourceLog := log.ResourceLogs().AppendEmpty()
 	appendMetadata(resourceLog, query)


### PR DESCRIPTION
**Description:** Fixed a bug where request bodies containing newlines caused logs to split into separate entries.

**Link to tracking Issue:**  [35028](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35028)

**Testing:** Added a new unit test to `req_to_log_test.go` for the case where request body data contains newline characters

**Documentation:** Some comments in `req_to_log.go` for clarity were added.