### PR TITLE
[pkg/ottl] Enhance ParseXML function with intuitive parse format and add MarshalXML function to convert parsed output back to XML

### DIFF
--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -1217,19 +1217,170 @@ Examples:
 
 ### ParseXML
 
-`ParseXML(target)`
+`ParseXML(target, flatten)`
 
-The `ParseXML` Converter returns a `pcommon.Map` struct that is the result of parsing the target string as an XML document.
+The `ParseXML` Converter returns a `pcommon.Map` that is the result of parsing the target string as an XML document.
 
 `target` is a Getter that returns a string. This string should be in XML format.
-If `target` is not a string, nil, or cannot be parsed as XML, `ParseXML` will return an error.
+If `target` is not a string, nil, or cannot be parsed as XML, `ParseXML` will return an error. `flatten` is a boolean that determines whether any arrays in the XML should be flattened. In this context, flattening means that an array of children with a single common attribute will parse as a map with the attribute value as the key and the XML node's value as the value:
+
+For example, this XML document will parse in the following ways:
+
+```xml
+<Log>
+  <User id="00001">
+   Sam
+  </User>
+  <User id="00002">
+   Bob
+  </User>
+  <User id="00003">
+   Alice
+  </User>
+</Log>
+```
+
+<table>
+<tr>
+<th> </th><th> Flattened </th> <th> Unflattened </th>
+
+
+<tr>
+
+<td>
+
+
+</td>
+<td>
+
+```json
+{
+  "Log": {
+    "User": {
+      "00001": "Sam",
+      "00002": "Bob",
+      "00003": "Alice",
+      "xml_ordering": "00001,00003,00003",
+      "xml_flattened_array": "id",
+    }
+  }
+}
+```
+
+</td>
+<td>
+
+```json
+{
+  "Log": {
+    "User": [
+      {
+        "xml_attributes": {
+          "id": "00001",
+        },
+        "xml_value": "Sam",
+      }, 
+      {
+        "xml_attributes": {
+          "id": "00002",
+        },
+        "xml_value": "Bob",
+      }, 
+      {
+        "xml_attributes": {
+          "id": "00003",
+        },
+        "xml_value": "Alice",
+      }
+    ],
+    "xml_ordering": "User.0,User.1,User.2",
+  },
+}
+```
+
+</td>
+</tr>
+</table>
+
+The parser adds the following special fields to the map:
+
+- `xml_ordering`: A comma-separated list of the order in which the XML elements were parsed. In the case of a flattened array, this will be the attribute values, otherwise it will be the tag names. This is used to preserve the order of the XML elements when marshalling the map back to XML. If this value is not present, the order of the elements is not guaranteed.
+- `xml_flattened_array`: If the map represents a flattened array, this will contain name of the attribute that was used to flatten the XML.
+- `xml_attributes`: A map of the attributes of the XML element.
+- `xml_value`: The value of the XML element, if it has attributes or children. For example:
+
+  <table>
+  <tr>
+  <th>Children & Attributes </th><th> XML </th> <th> JSON </th>
+  <tr>
+  <td>
+  Yes
+  </td>
+  <td>
+
+  ```xml
+  <Log>
+    <User id="00001">
+    Sam
+    </User>
+  </Log>
+  ```
+
+  </td>
+  <td>
+
+
+  ```json
+  {
+    "Log": {
+      "User": {
+        "xml_attributes": {
+          "id": "00001",
+        },
+        "xml_value": "Sam",
+      },
+    },
+  }
+  ```
+
+  </td>
+
+  </tr>
+
+  <tr>
+  <td>No</td>
+  <td>
+
+  ```xml
+  <Log>
+    <User>
+      Sam
+    </User>
+  </Log>
+  ```
+
+  </td>
+
+  <td>
+
+  ```json
+  {
+    "Log": {
+      "User":  "Sam",   
+    },
+  }
+  ```
+  </td>
+  </tr>
+  </table>
 
 Unmarshalling XML is done using the following rules:
-1. All character data for an XML element is trimmed, joined, and placed into the `content` field.
-2. The tag for an XML element is trimmed, and placed into the `tag` field.
-3. The attributes for an XML element is placed as a `pcommon.Map` into the `attribute` field.
+1. All character data for an XML element is trimmed, joined, and placed into the `xml_value` field, or as the value of the map if the element has attributes or children.
+2. The tag for an XML element is trimmed, and used as the key in the parent map.
+3. The attributes for an XML element is placed as a `pcommon.Map` into the `xml_attributes` field.
 4. Processing instructions, directives, and comments are ignored and not represented in the resultant map.
-5. All child elements are parsed as above, and placed in a `pcommon.Slice`, which is then placed into the `children` field.
+5. All child elements are parsed as above, and placed in a `pcommon.Map`, with the tag name as the key and the parsed child as the value.
+6. If the `flatten` parameter is set to `true`, then any child elements with a single common attribute will be flattened into a map, with the attribute value as the key and the parsed child as the value. The attribute name will be placed in the `xml_flattened_array` field.
 
 For example, the following XML document:
 ```xml
@@ -1246,44 +1397,33 @@ For example, the following XML document:
 
 will be parsed as:
 ```json
+
 {
-  "tag": "Log",
-  "children": [
-    {
-      "tag": "User",
-      "children": [
-        {
-          "tag": "ID",
-          "content": "00001"
+  "Log":{
+    "User":{
+      "Name":{
+        "xml_attributes":{
+          "type": "first",
         },
-        {
-          "tag": "Name",
-          "content": "Joe",
-          "attributes": {
-            "type": "first"
-          }
-        },
-        {
-          "tag": "Email",
-          "content": "joe.smith@example.com"
-        }
-      ]
+        "xml_value": "Joe",
+      },
+      "Email": "joe.smith@example.com",
+      "ID": "00001",
+      "xml_ordering": "ID,Name,Email",
     },
-    {
-      "tag": "Text",
-      "content": "User fired alert A"
-    }
-  ]
+    "Text": "User fired alert A",
+    "xml_ordering": "User,Text",
+  },
 }
 ```
 
 Examples:
 
-- `ParseXML(body)`
+- `ParseXML(body, false)`
 
-- `ParseXML(attributes["xml"])`
+- `ParseXML(attributes["xml"], false)`
 
-- `ParseXML("<HostInfo hostname=\"example.com\" zone=\"east-1\" cloudprovider=\"aws\" />")`
+- `ParseXML("<HostInfo hostname=\"example.com\" zone=\"east-1\" cloudprovider=\"aws\" />", false)`
 
 
 

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -1012,6 +1012,14 @@ Examples:
 
 - `Int(Log(attributes["duration_ms"])`
 
+### MarshalXML
+
+`MarshalXML(target, Optional[version])`
+
+The `MarshalXML` Converter returns a `string` representation of the target `pcommon.Map` as an XML document. The XML document is generated using the `encoding/xml` package in Go, so is limited to the capabilities of that package, specifically it won't emit self-closing tags.
+
+The target should be the output from the `ParseXML` Converter function, and the versions must match.
+
 ### MD5
 
 `MD5(value)`
@@ -1217,14 +1225,104 @@ Examples:
 
 ### ParseXML
 
-`ParseXML(target, flatten)`
+`ParseXML(target, Optional[version], Optional[flatten])`
 
 The `ParseXML` Converter returns a `pcommon.Map` that is the result of parsing the target string as an XML document.
 
-`target` is a Getter that returns a string. This string should be in XML format.
-If `target` is not a string, nil, or cannot be parsed as XML, `ParseXML` will return an error. `flatten` is a boolean that determines whether any arrays in the XML should be flattened. In this context, flattening means that an array of children with a single common attribute will parse as a map with the attribute value as the key and the XML node's value as the value:
+#### Parameters
+| Name | Type | Description |
+|------|------|-------------|
+| `target` | Getter | A string that should be in XML format.If `target` is not a string, nil, or cannot be parsed as XML, `ParseXML` will return an error. |
+| `version` | int | Either `1` or `2`. If omitted, `version` defaults to `1`. |
+|`flatten` | boolean | Determines whether any arrays in the XML should be flattened. In this context, flattening means that an array of children with a single common attribute will parse as a map with the attribute value as the key and the XML node's value as the value. Only available in version 2.|
 
-For example, this XML document will parse in the following ways:
+#### Version 1 Parsing
+For `version=1` or if version is omitted, parsing XML is done using the following rules:
+1. All character data for an XML element is trimmed, joined, and placed into the `content` field.
+2. The tag for an XML element is trimmed, and placed into the `tag` field.
+3. The attributes for an XML element is placed as a `pcommon.Map` into the `attribute` field.
+4. Processing instructions, directives, and comments are ignored and not represented in the resultant map.
+5. All child elements are parsed as above, and placed in a `pcommon.Slice`, which is then placed into the `children` field.
+
+For example, the following XML document:
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<Log>
+  <User>
+    <ID>00001</ID>
+    <Name type="first">Joe</Name>
+    <Email>joe.smith@example.com</Email>
+  </User>
+  <Text>User fired alert A</Text>
+</Log>
+```
+
+will be parsed as:
+```json
+{
+  "tag": "Log",
+  "children": [
+    {
+      "tag": "User",
+      "children": [
+        {
+          "tag": "ID",
+          "content": "00001"
+        },
+        {
+          "tag": "Name",
+          "content": "Joe",
+          "attributes": {
+            "type": "first"
+          }
+        },
+        {
+          "tag": "Email",
+          "content": "joe.smith@example.com"
+        }
+      ]
+    },
+    {
+      "tag": "Text",
+      "content": "User fired alert A"
+    }
+  ]
+}
+```
+#### Version 2 Parsing
+
+Unmarshalling XML is done using the following rules:
+1. All character data for an XML element is trimmed, joined, and placed into the `xml_value` field, or as the value of the map if the element has attributes or children.
+2. The tag for an XML element is trimmed, and used as the key in the parent map.
+3. The attributes for an XML element is placed as a `pcommon.Map` into the `xml_attributes` field.
+4. Processing instructions, directives, and comments are ignored and not represented in the resultant map.
+5. All child elements are parsed as above, and placed in a `pcommon.Map`, with the tag name as the key and the parsed child as the value.
+6. If the `flatten` parameter is set to `true`, then any child elements with a single common attribute will be flattened into a map, with the attribute value as the key and the parsed child as the value. The attribute name will be placed in the `xml_flattened_array` field.
+
+For `version=2`, the above XML document will parse in the following way:
+```json
+{
+  "Log":  {
+    "User": {
+      "ID": "00001",
+      "Name": {
+        "xml_attributes": {
+          "type": "first",
+        },
+        "xml_value": "Joe",
+      },
+      "Email": "joe.smith@example.com",
+      "xml_ordering": "ID,Name,Email",
+    },
+    "Text": "User fired alert A",
+    "xml_ordering": "User,Text",
+  }
+}
+```
+
+#### Flattening Arrays
+
+If the `flatten` parameter is set to `true`, then any children with a single common attribute will be flattened into a map, with the attribute value as the key and the parsed child as the value. The attribute name will be placed in the `xml_flattened_array` field:
 
 ```xml
 <Log>
@@ -1374,56 +1472,15 @@ The parser adds the following special fields to the map:
   </tr>
   </table>
 
-Unmarshalling XML is done using the following rules:
-1. All character data for an XML element is trimmed, joined, and placed into the `xml_value` field, or as the value of the map if the element has attributes or children.
-2. The tag for an XML element is trimmed, and used as the key in the parent map.
-3. The attributes for an XML element is placed as a `pcommon.Map` into the `xml_attributes` field.
-4. Processing instructions, directives, and comments are ignored and not represented in the resultant map.
-5. All child elements are parsed as above, and placed in a `pcommon.Map`, with the tag name as the key and the parsed child as the value.
-6. If the `flatten` parameter is set to `true`, then any child elements with a single common attribute will be flattened into a map, with the attribute value as the key and the parsed child as the value. The attribute name will be placed in the `xml_flattened_array` field.
-
-For example, the following XML document:
-```xml
-<?xml version="1.0" encoding="UTF-8" ?>
-<Log>
-  <User>
-    <ID>00001</ID>
-    <Name type="first">Joe</Name>
-    <Email>joe.smith@example.com</Email>
-  </User>
-  <Text>User fired alert A</Text>
-</Log>
-```
-
-will be parsed as:
-```json
-
-{
-  "Log":{
-    "User":{
-      "Name":{
-        "xml_attributes":{
-          "type": "first",
-        },
-        "xml_value": "Joe",
-      },
-      "Email": "joe.smith@example.com",
-      "ID": "00001",
-      "xml_ordering": "ID,Name,Email",
-    },
-    "Text": "User fired alert A",
-    "xml_ordering": "User,Text",
-  },
-}
-```
-
 Examples:
 
-- `ParseXML(body, false)`
+- `ParseXML(body)`
 
-- `ParseXML(attributes["xml"], false)`
+- `ParseXML(attributes["xml"], version=2, flatten=true)`
 
-- `ParseXML("<HostInfo hostname=\"example.com\" zone=\"east-1\" cloudprovider=\"aws\" />", false)`
+- `ParseXML("<HostInfo hostname=\"example.com\" zone=\"east-1\" cloudprovider=\"aws\" />")`
+
+- `ParseXML(attributes["xml"], 2)`
 
 
 

--- a/pkg/ottl/ottlfuncs/func_marshal_xml.go
+++ b/pkg/ottl/ottlfuncs/func_marshal_xml.go
@@ -1,0 +1,202 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type MarshalXMLArguments[K any] struct {
+	Target ottl.PMapGetter[K]
+}
+
+func NewMarshalXMLFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("MarshalXML", &MarshalXMLArguments[K]{}, createMarshalXMLFunction[K])
+}
+
+func createMarshalXMLFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*MarshalXMLArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("MarshalXMLFactory args must be of type *MarshalXMLArguments[K]")
+	}
+
+	return marshalXML(args.Target), nil
+}
+
+// marshalXML returns a string that is a result of marshaling the target `pcommon.Map` as XML
+func marshalXML[K any](target ottl.PMapGetter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		targetVal, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+
+		// this map should have a single key, which is the root element
+		if targetVal.Len() != 1 {
+			return nil, errors.New("target map must have a single key")
+		}
+		var root xmlElement
+
+		targetVal.Range(func(k string, v pcommon.Value) bool {
+
+			switch v.Type() {
+			case pcommon.ValueTypeStr:
+				// special case for
+				// <root>
+				//  	value
+				// </root>
+				root = xmlElement{tag: k, text: v.Str()}
+			case pcommon.ValueTypeMap:
+				root = mapToXMLElement(v.Map(), k)
+			default:
+				err = fmt.Errorf("unsupported value type: %v", v.Type())
+			}
+			return false
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		bytes, err := xml.MarshalIndent(&root, "", "\t")
+		if err != nil {
+			return nil, fmt.Errorf("marshal xml: %w", err)
+		}
+		return string(bytes), nil
+	}
+}
+
+func newXMLAttribute(name, value string) xml.Attr {
+	return xml.Attr{Name: xml.Name{Local: name}, Value: value}
+}
+
+// mapToXMLElement takes a pcommon.Map and converts it to an xmlElement
+func mapToXMLElement(m pcommon.Map, tag string) xmlElement {
+	elem := xmlElement{tag: tag}
+	var orderKey string
+	var flattened bool
+	m.Range(func(k string, v pcommon.Value) bool {
+		switch k {
+		case xmlAttributesKey:
+			v.Map().Range(func(k string, v pcommon.Value) bool {
+				elem.attributes = append(elem.attributes, newXMLAttribute(k, v.Str()))
+				return true
+			})
+			return true
+
+		case xmlValueKey:
+			elem.text = v.Str()
+			return true
+		case xmlOrderingKey:
+			orderKey = v.Str()
+			return true
+		}
+
+		switch v.Type() {
+		case pcommon.ValueTypeMap:
+			childMap := v.Map()
+			arrayTag := k
+			// it the child is a flattened array, we need to handle it here
+			var flattenedAttr pcommon.Value
+			flattenedAttr, flattened = childMap.Get(xmlFlattenedArrayKey)
+			if !flattened {
+				// typical case
+				elem.children = append(elem.children, mapToXMLElement(childMap, k))
+			} else {
+				// handle the flattened array
+				childMap.Range(func(k string, v pcommon.Value) bool {
+					switch k {
+					case xmlFlattenedArrayKey:
+						return true
+					case xmlOrderingKey:
+						orderKey = v.Str()
+						return true
+					}
+					child := xmlElement{tag: arrayTag, attributes: []xml.Attr{newXMLAttribute(flattenedAttr.Str(), k)}}
+
+					switch v.Type() {
+					case pcommon.ValueTypeStr:
+						child.text = v.Str()
+					case pcommon.ValueTypeMap:
+						// TODO test this case
+						child.children = append(child.children, mapToXMLElement(v.Map(), k))
+					default:
+						// TODO -- handle this case
+					}
+
+					elem.children = append(elem.children, child)
+
+					return true
+				})
+			}
+		case pcommon.ValueTypeSlice:
+			slice := v.Slice()
+			for i := 0; i < slice.Len(); i++ {
+				val := slice.At(i)
+				if val.Type() == pcommon.ValueTypeStr {
+					// If the nodes in the slice have no attributes or children,
+					// the slice values will be the text for the node
+					elem.children = append(elem.children, xmlElement{tag: k, text: val.Str()})
+				}
+				if val.Type() == pcommon.ValueTypeMap {
+					elem.children = append(elem.children, mapToXMLElement(val.Map(), k))
+				}
+			}
+
+		default:
+			// if the value is not a map or a slice, then it is a leaf node
+			elem.children = append(elem.children, xmlElement{tag: k, text: v.Str()})
+		}
+		return true
+	})
+	// order the children by the xmlOrderKey
+	// if the key is not present, then the order is not guaranteed
+	sortByOrderKey(elem.children, orderKey, flattened)
+
+	return elem
+}
+
+func sortByOrderKey(xml []xmlElement, orderKey string, flattenedArray bool) {
+	if orderKey == "" {
+		return
+	}
+	keys := strings.Split(orderKey, ",")
+	// create a map of the keys to the index
+	keyIndex := make(map[string]int)
+	for i, key := range keys {
+		keyIndex[key] = i
+	}
+	// sort the children by the order key
+
+	sort.Slice(xml, func(i, j int) bool {
+		var iKey, jKey string
+		if flattenedArray {
+			iKey = xml[i].attributes[0].Value
+			jKey = xml[j].attributes[0].Value
+		} else {
+			iKey = xml[i].tag
+			jKey = xml[j].tag
+		}
+		iOrder, iPresent := keyIndex[iKey]
+		jOrder, jPresent := keyIndex[jKey]
+		if iPresent && jPresent {
+			return iOrder < jOrder
+		}
+		if iPresent {
+			return true
+		}
+		if jPresent {
+			return false
+		}
+		return i < j
+	})
+}

--- a/pkg/ottl/ottlfuncs/func_marshal_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_marshal_xml_test.go
@@ -1,0 +1,270 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+// Test_MarshalXML tests that the ParseXML function can parse XML strings into a pcommon.Map,
+// and that the MarshalXML function can serialize the pcommon.Map back into an XML string.
+// Due to limitations with the Go XML package, the XML strings must be formatted in a specific way,
+// most notably that self-closing tags are not supported.
+func Test_MarshalXML(t *testing.T) {
+	tests := []struct {
+		name        string
+		flatten     bool
+		xml         string
+		createError string
+		parseError  string
+	}{
+
+		{
+			name: "Simple example",
+			xml:  "<Log><User><ID>00001</ID><Name>Joe</Name><Email>joe.smith@example.com</Email></User><Text>User did a thing</Text></Log>",
+		},
+		{
+			name: "Formatted example",
+			xml: `
+<Log>
+	<User>
+	<ID>00001</ID>
+	<Name>Joe</Name>
+	<Email>joe.smith@example.com</Email>
+	</User>
+	<Text>User did a thing</Text>
+</Log>`,
+		},
+		{
+			name: "Multiple tags with the same name",
+			xml:  `<Log>This record has a collision<User id="0001"></User><User id="0002"></User></Log>`,
+		},
+		// TODO figure out if this case needs testing and/or the parsing is correct
+		// {
+		// 	name: "Multiple lines of content",
+		// 	xml: `<Log>
+		// 			This record has multiple lines of
+		// 			<User id="0001"></User>
+		// 			text content
+		// 		  </Log>`,
+		// },
+		{
+			name: "Attribute only element",
+			xml:  `<HostInfo hostname="example.com" zone="east-1" cloudprovider="aws"></HostInfo>`,
+		},
+		{
+			name: "Windows Event Log XML",
+			xml: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+					<System>
+						<Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}"></Provider>
+						<EventID>4625</EventID>
+						<Version>0</Version>
+						<Level>0</Level>
+						<Task>12544</Task>
+						<Opcode>0</Opcode>
+						<Keywords>0x8010000000000000</Keywords>
+						<TimeCreated SystemTime="2024-08-15T20:03:15.9454501Z"></TimeCreated>
+						<EventRecordID>57220</EventRecordID>
+						<Correlation ActivityID="{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}"></Correlation>
+						<Execution ProcessID="656" ThreadID="4652"></Execution>
+						<Channel>Security</Channel>
+						<Computer>samuel-windows</Computer>
+						<Security></Security>
+					</System>
+					<EventData>
+						<Data Name="SubjectUserSid">S-1-0-0</Data>
+						<Data Name="SubjectUserName">-</Data>
+						<Data Name="SubjectDomainName">-</Data>
+						<Data Name="SubjectLogonId">0x0</Data>
+						<Data Name="TargetUserSid">S-1-0-0</Data>
+						<Data Name="TargetUserName">Administrator</Data>
+						<Data Name="TargetDomainName">domain</Data>
+						<Data Name="Status">0xc000006d</Data>
+						<Data Name="FailureReason">%%2313</Data>
+						<Data Name="SubStatus">0xc000006a</Data>
+						<Data Name="LogonType">3</Data>
+						<Data Name="LogonProcessName">NtLmSsp</Data>
+						<Data Name="AuthenticationPackageName">NTLM</Data>
+						<Data Name="WorkstationName">-</Data>
+						<Data Name="TransmittedServices">-</Data>
+						<Data Name="LmPackageName">-</Data>
+						<Data Name="KeyLength">0</Data>
+						<Data Name="ProcessId">0x0</Data>
+						<Data Name="ProcessName">-</Data>
+						<Data Name="IpAddress">103.151.140.135</Data>
+						<Data Name="IpPort">0</Data>
+					</EventData>
+				</Event>`,
+		},
+		{
+			name:    "Windows Event Log XML, flattened",
+			flatten: true,
+			xml: `<Event xmlns="http://schemas.microsoft.com/win/2004/08/events/event">
+					<System>
+						<Provider Name="Microsoft-Windows-Security-Auditing" Guid="{54849625-5478-4994-a5ba-3e3b0328c30d}"></Provider>
+						<EventID>4625</EventID>
+						<Version>0</Version>
+						<Level>0</Level>
+						<Task>12544</Task>
+						<Opcode>0</Opcode>
+						<Keywords>0x8010000000000000</Keywords>
+						<TimeCreated SystemTime="2024-08-15T20:03:15.9454501Z"></TimeCreated>
+						<EventRecordID>57220</EventRecordID>
+						<Correlation ActivityID="{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}"></Correlation>
+						<Execution ProcessID="656" ThreadID="4652"></Execution>
+						<Channel>Security</Channel>
+						<Computer>samuel-windows</Computer>
+						<Security></Security>
+					</System>
+					<EventData>
+						<Data Name="SubjectUserSid">S-1-0-0</Data>
+						<Data Name="SubjectUserName">-</Data>
+						<Data Name="SubjectDomainName">-</Data>
+						<Data Name="SubjectLogonId">0x0</Data>
+						<Data Name="TargetUserSid">S-1-0-0</Data>
+						<Data Name="TargetUserName">Administrator</Data>
+						<Data Name="TargetDomainName">domain</Data>
+						<Data Name="Status">0xc000006d</Data>
+						<Data Name="FailureReason">%%2313</Data>
+						<Data Name="SubStatus">0xc000006a</Data>
+						<Data Name="LogonType">3</Data>
+						<Data Name="LogonProcessName">NtLmSsp</Data>
+						<Data Name="AuthenticationPackageName">NTLM</Data>
+						<Data Name="WorkstationName">-</Data>
+						<Data Name="TransmittedServices">-</Data>
+						<Data Name="LmPackageName">-</Data>
+						<Data Name="KeyLength">0</Data>
+						<Data Name="ProcessId">0x0</Data>
+						<Data Name="ProcessName">-</Data>
+						<Data Name="IpAddress">103.151.140.135</Data>
+						<Data Name="IpPort">0</Data>
+					</EventData>
+				</Event>`,
+		},
+		{
+			name: "Tags with dots",
+			xml: `<findToFileResponse xmlns="xmlapi_1.0">
+					<sysact.Activity>
+						<sessionId>UserActivity:0</sessionId>
+						<sessionTime>1701734401632</sessionTime>
+						<sessionIpAddress>154.11.169.22</sessionIpAddress>
+						<serverIpAddress>154.11.169.22</serverIpAddress>
+						<sessionType>SamOss</sessionType>
+						<time>1701734401634</time>
+						<requestId>UserActivity:0</requestId>
+						<username>admin</username>
+						<type>operation</type>
+						<subType>findToFile</subType>
+						<fdn>N/A</fdn>
+						<classId>0</classId>
+						<displayedName>N/A</displayedName>
+						<displayedClassName>N/A</displayedClassName>
+						<siteId>N/A</siteId>
+						<siteName>N/A</siteName>
+						<state>success</state>
+						<deploymentState>0</deploymentState>
+						<objectFullName>425697578</objectFullName>
+						<name>N/A</name>
+						<selfAlarmed>false</selfAlarmed>
+					</sysact.Activity>
+					<sysact.Activity>
+						<sessionId>XML_API_client@n</sessionId>
+						<sessionTime>1701734407353</sessionTime>
+						<sessionIpAddress>154.11.169.54</sessionIpAddress>
+						<serverIpAddress>154.11.169.22</serverIpAddress>
+						<sessionType>SamOss</sessionType>
+						<time>1701734407355</time>
+						<requestId>XML_API_client@n</requestId>
+						<username>meerkat_nsp</username>
+						<type>operation</type>
+						<subType>findToFile</subType>
+						<fdn>N/A</fdn>
+						<classId>0</classId>
+						<displayedName>N/A</displayedName>
+						<displayedClassName>N/A</displayedClassName>
+						<siteId>N/A</siteId>
+						<siteName>N/A</siteName>
+						<state>success</state>
+						<deploymentState>0</deploymentState>
+						<objectFullName>425697579</objectFullName>
+						<name>N/A</name>
+						<selfAlarmed>false</selfAlarmed>
+					</sysact.Activity>
+				</findToFileResponse>`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oArgs := &ParseXMLArguments[any]{
+				FlattenArrays: ottl.StandardBoolGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return tt.flatten, nil
+					},
+				},
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return tt.xml, nil
+					},
+				},
+			}
+			exprFunc, err := createParseXMLFunction[any](ottl.FunctionContext{}, oArgs)
+			if tt.createError != "" {
+				require.ErrorContains(t, err, tt.createError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			result, err := exprFunc(context.Background(), nil)
+			if tt.parseError != "" {
+				require.ErrorContains(t, err, tt.parseError)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			resultMap, ok := result.(pcommon.Map)
+			require.True(t, ok)
+
+			rawMap := resultMap.AsRaw()
+			require.NotNil(t, rawMap)
+
+			// re-marshal the result to compare the output
+			marshalArgs := &MarshalXMLArguments[any]{
+				Target: ottl.StandardPMapGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return resultMap, nil
+					},
+				},
+			}
+			exprFunc, err = createMarshalXMLFunction[any](ottl.FunctionContext{}, marshalArgs)
+			require.NoError(t, err)
+
+			result, err = exprFunc(context.Background(), nil)
+			require.NoError(t, err)
+
+			resultXML, ok := result.(string)
+			require.True(t, ok)
+
+			// remove new lines and tabs from the expected and actual XML
+			tt.xml = strings.ReplaceAll(tt.xml, "\n", "")
+			tt.xml = strings.ReplaceAll(tt.xml, "\t", "")
+
+			resultXML = strings.ReplaceAll(resultXML, "\n", "")
+			resultXML = strings.ReplaceAll(resultXML, "\t", "")
+
+			assert.Equal(t, tt.xml, resultXML)
+
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_marshal_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_marshal_xml_test.go
@@ -206,11 +206,12 @@ func Test_MarshalXML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			oArgs := &ParseXMLArguments[any]{
-				FlattenArrays: ottl.StandardBoolGetter[any]{
+				FlattenArrays: ottl.NewTestingOptional[ottl.BoolGetter[any]](ottl.StandardBoolGetter[any]{
 					Getter: func(_ context.Context, _ any) (any, error) {
 						return tt.flatten, nil
 					},
-				},
+				}),
+
 				Target: ottl.StandardStringGetter[any]{
 					Getter: func(_ context.Context, _ any) (any, error) {
 						return tt.xml, nil

--- a/pkg/ottl/ottlfuncs/func_parse_xml.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml.go
@@ -16,8 +16,20 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 )
 
+// These are metadata keys used in the map returned by the ParseXML function
+// so that the parsed XML can be serialized back to XML.
+// TODO these should be settable by the user
+
+var (
+	xmlAttributesKey     = "xml_attributes"
+	xmlValueKey          = "xml_value"
+	xmlFlattenedArrayKey = "xml_flattened_array"
+	xmlOrderingKey       = "xml_ordering"
+)
+
 type ParseXMLArguments[K any] struct {
-	Target ottl.StringGetter[K]
+	Target        ottl.StringGetter[K]
+	FlattenArrays ottl.BoolGetter[K]
 }
 
 func NewParseXMLFactory[K any]() ottl.Factory[K] {
@@ -31,13 +43,17 @@ func createParseXMLFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments)
 		return nil, fmt.Errorf("ParseXMLFactory args must be of type *ParseXMLArguments[K]")
 	}
 
-	return parseXML(args.Target), nil
+	return parseXML(args.Target, args.FlattenArrays), nil
 }
 
 // parseXML returns a `pcommon.Map` struct that is a result of parsing the target string as XML
-func parseXML[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
+func parseXML[K any](target ottl.StringGetter[K], flattenArrays ottl.BoolGetter[K]) ottl.ExprFunc[K] {
 	return func(ctx context.Context, tCtx K) (any, error) {
 		targetVal, err := target.Get(ctx, tCtx)
+		if err != nil {
+			return nil, err
+		}
+		flattenArraysVal, err := flattenArrays.Get(ctx, tCtx)
 		if err != nil {
 			return nil, err
 		}
@@ -55,7 +71,7 @@ func parseXML[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
 		}
 
 		parsedMap := pcommon.NewMap()
-		parsedXML.intoMap(parsedMap)
+		parsedXML.intoMap(parsedMap, flattenArraysVal)
 
 		return parsedMap, nil
 	}
@@ -66,6 +82,7 @@ type xmlElement struct {
 	attributes []xml.Attr
 	text       string
 	children   []xmlElement
+	order      int
 }
 
 // UnmarshalXML implements xml.Unmarshaler for xmlElement
@@ -105,30 +122,193 @@ func (a *xmlElement) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error 
 }
 
 // intoMap converts and adds the xmlElement into the provided pcommon.Map.
-func (a xmlElement) intoMap(m pcommon.Map) {
-	m.EnsureCapacity(4)
+func (a xmlElement) intoMap(m pcommon.Map, flattenArrays bool) {
 
-	m.PutStr("tag", a.tag)
+	// if there are no attributes or children, then we can just put the text
+	// as the value of the the tag key
 
-	if a.text != "" {
-		m.PutStr("content", a.text)
+	if len(a.attributes) == 0 && len(a.children) == 0 {
+		m.PutStr(a.tag, a.text)
+		return
 	}
 
-	if len(a.attributes) > 0 {
-		attrs := m.PutEmptyMap("attributes")
-		attrs.EnsureCapacity(len(a.attributes))
+	// we have attributes, children, or both, so we need to
+	// create an empty map for the tag key and add the attributes
+	node := m.PutEmptyMap(a.tag)
+	a.childIntoMap(node, flattenArrays)
+}
 
+func (a xmlElement) childIntoMap(m pcommon.Map, flattenArrays bool) {
+	// as a child node, the tag will be the key in the map at the level above, and
+	// we will ignore it. We also will have either attributes or children, otherwise
+	// we would have been a leaf node and we would have been handled by the previous
+	// recursion level
+
+	if len(a.attributes) > 0 {
+		attrs := m.PutEmptyMap(xmlAttributesKey)
+		attrs.EnsureCapacity(len(a.attributes))
 		for _, attr := range a.attributes {
 			attrs.PutStr(attr.Name.Local, attr.Value)
 		}
 	}
 
-	if len(a.children) > 0 {
-		children := m.PutEmptySlice("children")
-		children.EnsureCapacity(len(a.children))
+	if a.text != "" {
+		m.PutStr(xmlValueKey, a.text)
+	}
 
-		for _, child := range a.children {
-			child.intoMap(children.AppendEmpty().SetEmptyMap())
+	// we need to group the children by tag name so that we can put them in a slice
+	// We also need to preserve ordering information
+
+	childrenGrouping := map[string][]*xmlElement{}
+	for i := range a.children {
+		child := &a.children[i]
+		child.order = i
+
+		childrenGrouping[child.tag] = append(childrenGrouping[child.tag], child)
+	}
+
+	// these are the ordering keys for the children that don't end up in a flattened array
+	orderingKeys := make([]string, len(a.children))
+	for tag, children := range childrenGrouping {
+
+		// Only one child with the same tag, no need for slice
+		// The child tag will be the key in the current map.
+		if len(children) == 1 {
+			c := children[0]
+			orderingKeys[c.order] = tag
+
+			// If the child has no attributes or children, then we can just put the text
+			// as the value of the the tag key
+			if len(c.attributes) == 0 && len(c.children) == 0 {
+				m.PutStr(tag, c.text)
+				continue
+			}
+			c.childIntoMap(m.PutEmptyMap(tag), flattenArrays)
+			continue
+		}
+
+		// we're only going to flatten if we have a single grouping
+		if len(childrenGrouping) == 1 && arrayCanBeFlattened(children) && flattenArrays {
+			arrayMap := m.PutEmptyMap(tag)
+			// add a special tag to indicate that this is a flattened array
+			commonAttr := children[0].attributes[0].Name.Local
+			arrayMap.PutStr(xmlFlattenedArrayKey, commonAttr)
+			for _, c := range children {
+				// the child has one common attribute, and either children or a value.
+				key := c.attributes[0].Value
+				orderingKeys[c.order] = key
+				if len(c.children) == 0 {
+					arrayMap.PutStr(key, c.text)
+					continue
+				}
+				childMap := arrayMap.PutEmptyMap(key)
+				c.childIntoMap(childMap, flattenArrays)
+			}
+			// add the ordering key
+			if len(orderingKeys) > 1 {
+				arrayMap.PutStr(xmlOrderingKey, strings.Join(orderingKeys, ","))
+			}
+			return
+		}
+		// More than one child with the same tag, we need to put them in a slice
+		slice := m.PutEmptySlice(tag)
+		for i, child := range children {
+			// If the child has no attributes or children, then we can just put the text
+			// as the value of the tag key
+			if len(child.attributes) == 0 && len(child.children) == 0 {
+				slice.AppendEmpty().SetStr(child.text)
+				continue
+			}
+			childMap := slice.AppendEmpty().SetEmptyMap()
+			child.childIntoMap(childMap, flattenArrays)
+			orderingKeys[child.order] = fmt.Sprintf("%s.%d", tag, i)
 		}
 	}
+	// add the ordering key
+	if len(orderingKeys) > 1 {
+		m.PutStr(xmlOrderingKey, strings.Join(orderingKeys, ","))
+	}
+}
+
+func arrayCanBeFlattened(arr []*xmlElement) bool {
+
+	// If we have a structure like this:
+	//
+	// <EventData>
+	// 		<Data Name='SubjectUserSid'>S-1-0-0</Data>
+	// 		<Data Name='SubjectUserName'>-</Data>
+	// 		<Data
+	// 			Name='SubjectDomainName'>-</Data>
+	// 		<Data Name='SubjectLogonId'>0x0</Data>
+	// 		<Data
+	// 			Name='TargetUserSid'>S-1-0-0</Data>
+	// 		<Data Name='TargetUserName'>Administrator</Data>
+	// 		<Data
+	// 			Name='TargetDomainName'>domain</Data>
+	// 		<Data Name='Status'>0xc000006d</Data>
+	// 		<Data
+	// 			Name='FailureReason'>%%2313</Data>
+	// 		<Data Name='SubStatus'>0xc000006a</Data>
+	// </EventData>
+	//
+	// we can flatten the structure into a map when all the children have:
+	//  - the same tag
+	//	- one attribute, with the same name
+	//	- either children or a value
+	//
+	// 		EventData["Data"]["SubjectUserSid"]				S-1-0-0
+	// 		EventData["Data"]["SubjectDomainName"]			-
+	// 		EventData["Data"]["TargetUserSid"]				S-1-0-0
+	// 		EventData["Data"]["TargetDomainName"]			domain
+	// 		EventData["Data"]["Status"]						0xc000006d
+	// 		EventData["Data"]["FailureReason"]				%%2313
+	// 		EventData["Data"]["SubStatus"]					0xc000006a
+	// 		EventData["Data"][xmlFlattenedArrayKey]		    Name
+
+	for _, elem := range arr {
+		if len(elem.attributes) != 1 {
+			return false
+		}
+		if elem.attributes[0].Name != arr[0].attributes[0].Name {
+			return false
+		}
+		if len(elem.children) != 0 && elem.text != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func (a *xmlElement) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	// Set the start element with the tag name and attributes
+	start.Name.Local = a.tag
+	start.Attr = a.attributes
+
+	// Start the element
+	if err := e.EncodeToken(start); err != nil {
+		return fmt.Errorf("encode start element: %w", err)
+	}
+
+	// If the element has text, encode it
+	if a.text != "" {
+		if err := e.EncodeToken(xml.CharData(a.text)); err != nil {
+			return fmt.Errorf("encode char data: %w", err)
+		}
+	}
+
+	// Recursively encode child elements
+	for _, child := range a.children {
+		child := child
+		if err := e.Encode(&child); err != nil {
+			return fmt.Errorf("encode child element: %w", err)
+		}
+	}
+
+	// End the element
+	if err := e.EncodeToken(start.End()); err != nil {
+		return fmt.Errorf("encode end element: %w", err)
+	}
+
+	// Flush to ensure everything is written
+	return e.Flush()
 }

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -603,11 +603,11 @@ func Test_ParseXML(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			oArgs := &ParseXMLArguments[any]{
-				FlattenArrays: ottl.StandardBoolGetter[any]{
+				FlattenArrays: ottl.NewTestingOptional[ottl.BoolGetter[any]](ottl.StandardBoolGetter[any]{
 					Getter: func(_ context.Context, _ any) (any, error) {
 						return tt.flatten, nil
 					},
-				},
+				}),
 				Target: ottl.StandardStringGetter[any]{
 					Getter: func(_ context.Context, _ any) (any, error) {
 						return tt.xml, nil

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -6,6 +6,8 @@ package ottlfuncs
 import (
 	"context"
 	"fmt"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,139 +20,433 @@ import (
 func Test_ParseXML(t *testing.T) {
 	tests := []struct {
 		name        string
+		flatten     bool
+		xml         string
 		oArgs       ottl.Arguments
 		want        map[string]any
 		createError string
 		parseError  string
 	}{
 		{
-			name: "Text values in nested elements",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return "<Log><User><ID>00001</ID><Name>Joe</Name><Email>joe.smith@example.com</Email></User><Text>User did a thing</Text></Log>", nil
-					},
-				},
-			},
+			name: "Windows Event Log XML",
+			xml: `<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
+					<System>
+						<Provider Name='Microsoft-Windows-Security-Auditing'
+							Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}' />
+						<EventID>4625</EventID>
+						<Version>0</Version>
+						<Level>0</Level>
+						<Task>12544</Task>
+						<Opcode>0</Opcode>
+						<Keywords>0x8010000000000000</Keywords>
+						<TimeCreated SystemTime='2024-08-15T20:03:15.9454501Z' />
+						<EventRecordID>57220</EventRecordID>
+						<Correlation ActivityID='{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}' />
+						<Execution ProcessID='656' ThreadID='4652' />
+						<Channel>Security</Channel>
+						<Computer>samuel-windows</Computer>
+						<Security />
+					</System>
+					<EventData>
+						<Data Name='SubjectUserSid'>S-1-0-0</Data>
+						<Data Name='SubjectUserName'>-</Data>
+						<Data
+							Name='SubjectDomainName'>-</Data>
+						<Data Name='SubjectLogonId'>0x0</Data>
+						<Data
+							Name='TargetUserSid'>S-1-0-0</Data>
+						<Data Name='TargetUserName'>Administrator</Data>
+						<Data
+							Name='TargetDomainName'>domain</Data>
+						<Data Name='Status'>0xc000006d</Data>
+						<Data
+							Name='FailureReason'>%%2313</Data>
+						<Data Name='SubStatus'>0xc000006a</Data>
+						<Data
+							Name='LogonType'>3</Data>
+						<Data Name='LogonProcessName'>NtLmSsp </Data>
+						<Data
+							Name='AuthenticationPackageName'>NTLM</Data>
+						<Data Name='WorkstationName'>-</Data>
+						<Data
+							Name='TransmittedServices'>-</Data>
+						<Data Name='LmPackageName'>-</Data>
+						<Data
+							Name='KeyLength'>0</Data>
+						<Data Name='ProcessId'>0x0</Data>
+						<Data Name='ProcessName'>-</Data>
+						<Data
+							Name='IpAddress'>103.151.140.135</Data>
+						<Data Name='IpPort'>0</Data>
+					</EventData>
+				</Event>`,
+			flatten: false,
 			want: map[string]any{
-				"tag": "Log",
-				"children": []any{
-					map[string]any{
-						"tag": "User",
-						"children": []any{
-							map[string]any{
-								"tag":     "ID",
-								"content": "00001",
+				"Event": map[string]any{
+					"xml_attributes": map[string]any{
+						"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event",
+					},
+					"System": map[string]any{
+						"EventID":       "4625",
+						"xml_ordering":  "Provider,EventID,Version,Level,Task,Opcode,Keywords,TimeCreated,EventRecordID,Correlation,Execution,Channel,Computer,Security",
+						"EventRecordID": "57220",
+						"Level":         "0",
+						"Channel":       "Security",
+						"TimeCreated": map[string]any{
+							"xml_attributes": map[string]any{
+								"SystemTime": "2024-08-15T20:03:15.9454501Z",
 							},
-							map[string]any{
-								"tag":     "Name",
-								"content": "Joe",
+						},
+						"Version":  "0",
+						"Keywords": "0x8010000000000000",
+						"Execution": map[string]any{
+							"xml_attributes": map[string]any{
+								"ProcessID": "656",
+								"ThreadID":  "4652",
 							},
-							map[string]any{
-								"tag":     "Email",
-								"content": "joe.smith@example.com",
+						},
+						"Provider": map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "Microsoft-Windows-Security-Auditing",
+								"Guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+							},
+						},
+						"Computer": "samuel-windows",
+						"Opcode":   "0",
+						"Security": "",
+						"Task":     "12544",
+						"Correlation": map[string]any{
+							"xml_attributes": map[string]any{
+								"ActivityID": "{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}",
 							},
 						},
 					},
-					map[string]any{
-						"tag":     "Text",
-						"content": "User did a thing",
+					"EventData": map[string]any{
+						"Data": []any{map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "SubjectUserSid",
+							},
+							"xml_value": "S-1-0-0",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "SubjectUserName",
+							},
+							"xml_value": "-",
+						}, map[string]any{
+							"xml_value": "-",
+							"xml_attributes": map[string]any{
+								"Name": "SubjectDomainName",
+							},
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "SubjectLogonId",
+							},
+							"xml_value": "0x0",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "TargetUserSid",
+							},
+							"xml_value": "S-1-0-0",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "TargetUserName",
+							},
+							"xml_value": "Administrator",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "TargetDomainName",
+							},
+							"xml_value": "domain",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "Status",
+							},
+							"xml_value": "0xc000006d",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "FailureReason",
+							},
+							"xml_value": "%%2313",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "SubStatus",
+							},
+							"xml_value": "0xc000006a",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "LogonType",
+							},
+							"xml_value": "3",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "LogonProcessName",
+							},
+							"xml_value": "NtLmSsp",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "AuthenticationPackageName",
+							},
+							"xml_value": "NTLM",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "WorkstationName",
+							},
+							"xml_value": "-",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "TransmittedServices",
+							},
+							"xml_value": "-",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "LmPackageName",
+							},
+							"xml_value": "-",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "KeyLength",
+							},
+							"xml_value": "0",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "ProcessId",
+							},
+							"xml_value": "0x0",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "ProcessName",
+							},
+							"xml_value": "-",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "IpAddress",
+							},
+							"xml_value": "103.151.140.135",
+						}, map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "IpPort",
+							},
+							"xml_value": "0",
+						}},
+						"xml_ordering": "Data.0,Data.1,Data.2,Data.3,Data.4,Data.5,Data.6,Data.7,Data.8,Data.9,Data.10,Data.11,Data.12,Data.13,Data.14,Data.15,Data.16,Data.17,Data.18,Data.19,Data.20",
 					},
+					"xml_ordering": "System,EventData",
+				},
+			},
+		},
+		{
+			name:    "Windows Event Log XML, flattened arrays",
+			flatten: true,
+			xml: `<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
+					<System>
+						<Provider Name='Microsoft-Windows-Security-Auditing'
+							Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}' />
+						<EventID>4625</EventID>
+						<Version>0</Version>
+						<Level>0</Level>
+						<Task>12544</Task>
+						<Opcode>0</Opcode>
+						<Keywords>0x8010000000000000</Keywords>
+						<TimeCreated SystemTime='2024-08-15T20:03:15.9454501Z' />
+						<EventRecordID>57220</EventRecordID>
+						<Correlation ActivityID='{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}' />
+						<Execution ProcessID='656' ThreadID='4652' />
+						<Channel>Security</Channel>
+						<Computer>samuel-windows</Computer>
+						<Security />
+					</System>
+					<EventData>
+						<Data Name='SubjectUserSid'>S-1-0-0</Data>
+						<Data Name='SubjectUserName'>-</Data>
+						<Data
+							Name='SubjectDomainName'>-</Data>
+						<Data Name='SubjectLogonId'>0x0</Data>
+						<Data
+							Name='TargetUserSid'>S-1-0-0</Data>
+						<Data Name='TargetUserName'>Administrator</Data>
+						<Data
+							Name='TargetDomainName'>domain</Data>
+						<Data Name='Status'>0xc000006d</Data>
+						<Data
+							Name='FailureReason'>%%2313</Data>
+						<Data Name='SubStatus'>0xc000006a</Data>
+						<Data
+							Name='LogonType'>3</Data>
+						<Data Name='LogonProcessName'>NtLmSsp </Data>
+						<Data
+							Name='AuthenticationPackageName'>NTLM</Data>
+						<Data Name='WorkstationName'>-</Data>
+						<Data
+							Name='TransmittedServices'>-</Data>
+						<Data Name='LmPackageName'>-</Data>
+						<Data
+							Name='KeyLength'>0</Data>
+						<Data Name='ProcessId'>0x0</Data>
+						<Data Name='ProcessName'>-</Data>
+						<Data
+							Name='IpAddress'>103.151.140.135</Data>
+						<Data Name='IpPort'>0</Data>
+					</EventData>
+				</Event>`,
+			want: map[string]any{
+				"Event": map[string]any{
+					"xml_attributes": map[string]any{
+						"xmlns": "http://schemas.microsoft.com/win/2004/08/events/event",
+					},
+					"System": map[string]any{
+						"Task": "12544",
+						"Execution": map[string]any{
+							"xml_attributes": map[string]any{
+								"ProcessID": "656",
+								"ThreadID":  "4652",
+							},
+						},
+						"xml_ordering": "Provider,EventID,Version,Level,Task,Opcode,Keywords,TimeCreated,EventRecordID,Correlation,Execution,Channel,Computer,Security",
+						"Opcode":       "0",
+						"Keywords":     "0x8010000000000000",
+						"Correlation": map[string]any{
+							"xml_attributes": map[string]any{
+								"ActivityID": "{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}",
+							},
+						},
+						"EventID": "4625",
+						"Version": "0",
+						"TimeCreated": map[string]any{
+							"xml_attributes": map[string]any{
+								"SystemTime": "2024-08-15T20:03:15.9454501Z",
+							},
+						},
+						"Level":         "0",
+						"EventRecordID": "57220",
+						"Provider": map[string]any{
+							"xml_attributes": map[string]any{
+								"Name": "Microsoft-Windows-Security-Auditing",
+								"Guid": "{54849625-5478-4994-a5ba-3e3b0328c30d}",
+							},
+						},
+						"Security": "",
+						"Channel":  "Security",
+						"Computer": "samuel-windows",
+					},
+					"EventData": map[string]any{
+						"Data": map[string]any{
+							"FailureReason":             "%%2313",
+							"LogonType":                 "3",
+							"AuthenticationPackageName": "NTLM",
+							"IpAddress":                 "103.151.140.135",
+							"xml_ordering":              "SubjectUserSid,SubjectUserName,SubjectDomainName,SubjectLogonId,TargetUserSid,TargetUserName,TargetDomainName,Status,FailureReason,SubStatus,LogonType,LogonProcessName,AuthenticationPackageName,WorkstationName,TransmittedServices,LmPackageName,KeyLength,ProcessId,ProcessName,IpAddress,IpPort",
+							"SubjectUserSid":            "S-1-0-0",
+							"TargetDomainName":          "domain",
+							"SubStatus":                 "0xc000006a",
+							"WorkstationName":           "-",
+							"KeyLength":                 "0",
+							"ProcessId":                 "0x0",
+							"ProcessName":               "-",
+							"SubjectDomainName":         "-",
+							"SubjectLogonId":            "0x0",
+							"TargetUserName":            "Administrator",
+							"LogonProcessName":          "NtLmSsp",
+							"LmPackageName":             "-",
+							"IpPort":                    "0",
+							"xml_flattened_array":       "Name",
+							"SubjectUserName":           "-",
+							"TargetUserSid":             "S-1-0-0",
+							"Status":                    "0xc000006d",
+							"TransmittedServices":       "-",
+						},
+					},
+					"xml_ordering": "System,EventData",
+				},
+			},
+		},
+		{
+			xml: "<Log><User><ID>00001</ID><Name>Joe</Name><Email>joe.smith@example.com</Email></User><Text>User did a thing</Text></Log>",
+			want: map[string]any{
+				"Log": map[string]any{
+					"User": map[string]any{
+						"ID":           "00001",
+						"Name":         "Joe",
+						"Email":        "joe.smith@example.com",
+						"xml_ordering": "ID,Name,Email",
+					},
+					"Text":         "User did a thing",
+					"xml_ordering": "User,Text",
 				},
 			},
 		},
 		{
 			name: "Formatted example",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `
+			xml: `
 						<Log>
 						  <User>
 						    <ID>00001</ID>
 							<Name>Joe</Name>
 							<Email>joe.smith@example.com</Email>
 						  </User>
-						  <Text>User did a thing</Text>
-						</Log>`, nil
+						  <Text>User fired alert A</Text>
+						</Log>`,
+			want: map[string]any{
+				"Log": map[string]any{
+					"User": map[string]any{
+						"Name":         "Joe",
+						"Email":        "joe.smith@example.com",
+						"ID":           "00001",
+						"xml_ordering": "ID,Name,Email",
 					},
+					"Text":         "User fired alert A",
+					"xml_ordering": "User,Text",
 				},
 			},
+		},
+		{
+			xml: `<Log>This record has a collision<User id="0001"/><User id="0002"/></Log>`,
 			want: map[string]any{
-				"tag": "Log",
-				"children": []any{
-					map[string]any{
-						"tag": "User",
-						"children": []any{
-							map[string]any{
-								"tag":     "ID",
-								"content": "00001",
-							},
-							map[string]any{
-								"tag":     "Name",
-								"content": "Joe",
-							},
-							map[string]any{
-								"tag":     "Email",
-								"content": "joe.smith@example.com",
-							},
+				"Log": map[string]any{
+					"xml_value": "This record has a collision",
+					"User": []any{map[string]any{
+						"xml_attributes": map[string]any{
+							"id": "0001",
 						},
-					},
-					map[string]any{
-						"tag":     "Text",
-						"content": "User did a thing",
-					},
+					}, map[string]any{
+						"xml_attributes": map[string]any{
+							"id": "0002",
+						},
+					}},
+					"xml_ordering": "User.0,User.1",
 				},
 			},
 		},
 		{
 			name: "Multiple tags with the same name",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log>This record has a collision<User id="0001"/><User id="0002"/></Log>`, nil
-					},
-				},
-			},
+			xml:  `<Log>This record has a collision<User id="0001"/><User id="0002"/></Log>`,
 			want: map[string]any{
-				"tag":     "Log",
-				"content": "This record has a collision",
-				"children": []any{
-					map[string]any{
-						"tag": "User",
-						"attributes": map[string]any{
+				"Log": map[string]any{
+					"xml_value": "This record has a collision",
+					"User": []any{map[string]any{
+						"xml_attributes": map[string]any{
 							"id": "0001",
 						},
-					},
-					map[string]any{
-						"tag": "User",
-						"attributes": map[string]any{
+					}, map[string]any{
+						"xml_attributes": map[string]any{
 							"id": "0002",
 						},
-					},
+					}},
+					"xml_ordering": "User.0,User.1",
 				},
 			},
 		},
 		{
 			name: "Multiple lines of content",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log>
-						This record has multiple lines of
-						<User id="0001"/>
-						text content
-						</Log>`, nil
-					},
-				},
-			},
+			xml: `<Log>
+					This record has multiple lines of
+					<User id="0001"/>
+					text content
+				  </Log>`,
 			want: map[string]any{
-				"tag":     "Log",
-				"content": "This record has multiple lines oftext content",
-				"children": []any{
-					map[string]any{
-						"tag": "User",
-						"attributes": map[string]any{
+				"Log": map[string]any{
+					"xml_value": "This record has multiple lines oftext content",
+					"User": map[string]any{
+						"xml_attributes": map[string]any{
 							"id": "0001",
 						},
 					},
@@ -159,132 +455,166 @@ func Test_ParseXML(t *testing.T) {
 		},
 		{
 			name: "Attribute only element",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<HostInfo hostname="example.com" zone="east-1" cloudprovider="aws" />`, nil
-					},
-				},
-			},
+			xml:  `<HostInfo hostname="example.com" zone="east-1" cloudprovider="aws" />`,
 			want: map[string]any{
-				"tag": "HostInfo",
-				"attributes": map[string]any{
-					"hostname":      "example.com",
-					"zone":          "east-1",
-					"cloudprovider": "aws",
+				"HostInfo": map[string]any{
+					"xml_attributes": map[string]any{
+						"hostname":      "example.com",
+						"zone":          "east-1",
+						"cloudprovider": "aws",
+					},
 				},
 			},
 		},
 		{
-			name: "Ignores XML declaration",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<?xml version="1.0" encoding="UTF-8" ?><Log>Log content</Log>`, nil
-					},
-				},
-			},
+			name: "",
+			xml: `
+<findToFileResponse xmlns="xmlapi_1.0">
+    <sysact.Activity>
+        <sessionId>UserActivity:0</sessionId>
+        <sessionTime>1701734401632</sessionTime>
+        <sessionIpAddress>154.11.169.22</sessionIpAddress>
+        <serverIpAddress>154.11.169.22</serverIpAddress>
+        <sessionType>SamOss</sessionType>
+        <time>1701734401634</time>
+        <requestId>UserActivity:0</requestId>
+        <username>admin</username>
+        <type>operation</type>
+        <subType>findToFile</subType>
+        <fdn>N/A</fdn>
+        <classId>0</classId>
+        <displayedName>N/A</displayedName>
+        <displayedClassName>N/A</displayedClassName>
+        <siteId>N/A</siteId>
+        <siteName>N/A</siteName>
+        <state>success</state>
+        <additionalInfo><![CDATA[<params><param name="fullClassName"><value>sysact.Activity</value></param><param name="fileName"><value>user.activity.test.xml.2</value></param><param name="compress"><value>false</value></param><param name="filter"><value>and&gt;greater name="sessionTime" value="1701733501000"&gt;/greater&gt;less name="sessionTime" value="1701734401000"&gt;/less&gt;/and&gt;</value></param><param name="synchronous"><value>true</value></param><param name="requestIdOrNull"><value>UserActivity:0</value></param><param name="timeout"><value>0</value></param><param name="includeSubclasses"><value>true</value></param><param name="timeStamp"><value>false</value></param><param name="principal"><value>admin</value></param></params>]]></additionalInfo>
+        <deploymentState>0</deploymentState>
+        <objectFullName>425697578</objectFullName>
+        <name>N/A</name>
+        <selfAlarmed>false</selfAlarmed>
+        <children-Set />
+    </sysact.Activity>
+    <sysact.Activity>
+        <sessionId>XML_API_client@n</sessionId>
+        <sessionTime>1701734407353</sessionTime>
+        <sessionIpAddress>154.11.169.54</sessionIpAddress>
+        <serverIpAddress>154.11.169.22</serverIpAddress>
+        <sessionType>SamOss</sessionType>
+        <time>1701734407355</time>
+        <requestId>XML_API_client@n</requestId>
+        <username>meerkat_nsp</username>
+        <type>operation</type>
+        <subType>findToFile</subType>
+        <fdn>N/A</fdn>
+        <classId>0</classId>
+        <displayedName>N/A</displayedName>
+        <displayedClassName>N/A</displayedClassName>
+        <siteId>N/A</siteId>
+        <siteName>N/A</siteName>
+        <state>success</state>
+        <additionalInfo><![CDATA[<params><param name="fullClassName"><value>mpr.IMALink</value></param><param name="fileName"><value>meerkat_fornifi/inventory/INV_mpr.IMALink_findToFile.xml</value></param><param name="compress"><value>false</value></param><param name="filter"><value>not&gt;equal name="siteId" value="0.0.0.0"&gt;/equal&gt;/not&gt;</value></param><param name="synchronous"><value>true</value></param><param name="requestIdOrNull"><value>XML_API_client@n</value></param><param name="timeout"><value>0</value></param><param name="includeSubclasses"><value>true</value></param><param name="timeStamp"><value>false</value></param><param name="principal"><value>meerkat_nsp</value></param></params>]]></additionalInfo>
+        <deploymentState>0</deploymentState>
+        <objectFullName>425697579</objectFullName>
+        <name>N/A</name>
+        <selfAlarmed>false</selfAlarmed>
+        <children-Set />
+    </sysact.Activity>
+</findToFileResponse>`,
 			want: map[string]any{
-				"tag":     "Log",
-				"content": "Log content",
-			},
-		},
-		{
-			name: "Ignores comments",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log>This has a comment <!-- This is comment text --></Log>`, nil
+				"findToFileResponse": map[string]any{
+					"xml_attributes": map[string]any{
+						"xmlns": "xmlapi_1.0",
 					},
+					"sysact.Activity": []any{
+						map[string]any{
+							"state":              "success",
+							"serverIpAddress":    "154.11.169.22",
+							"time":               "1701734401634",
+							"username":           "admin",
+							"classId":            "0",
+							"sessionId":          "UserActivity:0",
+							"siteId":             "N/A",
+							"displayedName":      "N/A",
+							"xml_ordering":       "sessionId,sessionTime,sessionIpAddress,serverIpAddress,sessionType,time,requestId,username,type,subType,fdn,classId,displayedName,displayedClassName,siteId,siteName,state,additionalInfo,deploymentState,objectFullName,name,selfAlarmed,children-Set",
+							"objectFullName":     "425697578",
+							"sessionTime":        "1701734401632",
+							"type":               "operation",
+							"sessionType":        "SamOss",
+							"displayedClassName": "N/A",
+							"siteName":           "N/A",
+							"fdn":                "N/A",
+							"deploymentState":    "0",
+							"name":               "N/A",
+							"subType":            "findToFile",
+							"selfAlarmed":        "false",
+							"additionalInfo":     "<params><param name=\"fullClassName\"><value>sysact.Activity</value></param><param name=\"fileName\"><value>user.activity.test.xml.2</value></param><param name=\"compress\"><value>false</value></param><param name=\"filter\"><value>and&gt;greater name=\"sessionTime\" value=\"1701733501000\"&gt;/greater&gt;less name=\"sessionTime\" value=\"1701734401000\"&gt;/less&gt;/and&gt;</value></param><param name=\"synchronous\"><value>true</value></param><param name=\"requestIdOrNull\"><value>UserActivity:0</value></param><param name=\"timeout\"><value>0</value></param><param name=\"includeSubclasses\"><value>true</value></param><param name=\"timeStamp\"><value>false</value></param><param name=\"principal\"><value>admin</value></param></params>",
+							"sessionIpAddress":   "154.11.169.22",
+							"children-Set":       "",
+							"requestId":          "UserActivity:0",
+						},
+						map[string]any{
+							"children-Set":       "",
+							"sessionIpAddress":   "154.11.169.54",
+							"classId":            "0",
+							"selfAlarmed":        "false",
+							"state":              "success",
+							"subType":            "findToFile",
+							"siteId":             "N/A",
+							"deploymentState":    "0",
+							"sessionType":        "SamOss",
+							"xml_ordering":       "sessionId,sessionTime,sessionIpAddress,serverIpAddress,sessionType,time,requestId,username,type,subType,fdn,classId,displayedName,displayedClassName,siteId,siteName,state,additionalInfo,deploymentState,objectFullName,name,selfAlarmed,children-Set",
+							"sessionId":          "XML_API_client@n",
+							"time":               "1701734407355",
+							"displayedName":      "N/A",
+							"additionalInfo":     "<params><param name=\"fullClassName\"><value>mpr.IMALink</value></param><param name=\"fileName\"><value>meerkat_fornifi/inventory/INV_mpr.IMALink_findToFile.xml</value></param><param name=\"compress\"><value>false</value></param><param name=\"filter\"><value>not&gt;equal name=\"siteId\" value=\"0.0.0.0\"&gt;/equal&gt;/not&gt;</value></param><param name=\"synchronous\"><value>true</value></param><param name=\"requestIdOrNull\"><value>XML_API_client@n</value></param><param name=\"timeout\"><value>0</value></param><param name=\"includeSubclasses\"><value>true</value></param><param name=\"timeStamp\"><value>false</value></param><param name=\"principal\"><value>meerkat_nsp</value></param></params>",
+							"sessionTime":        "1701734407353",
+							"requestId":          "XML_API_client@n",
+							"username":           "meerkat_nsp",
+							"objectFullName":     "425697579",
+							"displayedClassName": "N/A",
+							"fdn":                "N/A",
+							"type":               "operation",
+							"name":               "N/A",
+							"serverIpAddress":    "154.11.169.22",
+							"siteName":           "N/A",
+						},
+					},
+					"xml_ordering": "sysact.Activity.0,sysact.Activity.1",
 				},
 			},
-			want: map[string]any{
-				"tag":     "Log",
-				"content": "This has a comment",
-			},
 		},
 		{
-			name: "Ignores processing instructions",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log><?xml-stylesheet type="text/xsl" href="style.xsl"?>Log content</Log>`, nil
-					},
-				},
-			},
-			want: map[string]any{
-				"tag":     "Log",
-				"content": "Log content",
-			},
-		},
-		{
-			name: "Ignores directives",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log><!ELEMENT xi:fallback ANY>Log content</Log>`, nil
-					},
-				},
-			},
-			want: map[string]any{
-				"tag":     "Log",
-				"content": "Log content",
-			},
-		},
-		{
-			name: "Missing closing element",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log id="1">`, nil
-					},
-				},
-			},
-			parseError: "unmarshal xml: decode next token: XML syntax error on line 1: unexpected EOF",
-		},
-		{
-			name: "Missing nested closing element",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log><Text></Log>`, nil
-					},
-				},
-			},
-			parseError: "unmarshal xml: decode next token: XML syntax error on line 1: element <Text> closed by </Log>",
-		},
-		{
-			name: "Multiple XML elements in payload (trailing bytes)",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return `<Log></Log><Log></Log>`, nil
-					},
-				},
-			},
-			parseError: "trailing bytes after parsing xml",
-		},
-		{
-			name: "Error getting target",
-			oArgs: &ParseXMLArguments[any]{
-				Target: ottl.StandardStringGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return "", fmt.Errorf("failed to get string")
-					},
-				},
-			},
-			parseError: "error getting value in ottl.StandardStringGetter[interface {}]: failed to get string",
-		},
-		{
-			name:        "Invalid arguments",
-			oArgs:       nil,
-			createError: "ParseXMLFactory args must be of type *ParseXMLArguments[K]",
+			name: "example",
+			xml: `<Log>
+  <User id="00001">
+   Sam
+  </User>
+  <User id="00002">
+   Bob
+  </User>
+  <User id="00003">
+   Alice
+  </User>
+</Log>`,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			exprFunc, err := createParseXMLFunction[any](ottl.FunctionContext{}, tt.oArgs)
+			oArgs := &ParseXMLArguments[any]{
+				FlattenArrays: ottl.StandardBoolGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return tt.flatten, nil
+					},
+				},
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return tt.xml, nil
+					},
+				},
+			}
+			exprFunc, err := createParseXMLFunction[any](ottl.FunctionContext{}, oArgs)
 			if tt.createError != "" {
 				require.ErrorContains(t, err, tt.createError)
 				return
@@ -303,7 +633,83 @@ func Test_ParseXML(t *testing.T) {
 			resultMap, ok := result.(pcommon.Map)
 			require.True(t, ok)
 
-			require.Equal(t, tt.want, resultMap.AsRaw())
+			rawMap := resultMap.AsRaw()
+			require.NotNil(t, rawMap)
+			// require.Equal(t, tt.want, rawMap)
+			t.Logf("Result: %s", formatMap(rawMap))
+
+			// re-marshal the result to compare the output
+
+			// marshalArgs := &MarshalXMLArguments[any]{
+			// 	Target: ottl.StandardPMapGetter[any]{
+			// 		Getter: func(_ context.Context, _ any) (any, error) {
+			// 			return resultMap, nil
+			// 		},
+			// 	},
+			// }
+			// exprFunc, err = createMarshalXMLFunction[any](ottl.FunctionContext{}, marshalArgs)
+			// require.NoError(t, err)
+
+			// result, err = exprFunc(context.Background(), nil)
+			// require.NoError(t, err)
+
+			// resultXML, ok := result.(string)
+			// require.True(t, ok)
+
+			// // We'd like to compare the XML output, but variations in whitespace, quoting, and most
+			// // importantly, the use of closing tags vs. self-closing tags, make this difficult.
+			// // Instead, we'll parse the marshaled XML and compare the resulting map.
+
+			// oArgs.Target = ottl.StandardStringGetter[any]{
+			// 	Getter: func(_ context.Context, _ any) (any, error) {
+			// 		return resultXML, nil
+			// 	},
+			// }
+			// exprFunc, err = createParseXMLFunction[any](ottl.FunctionContext{}, oArgs)
+			// require.NoError(t, err)
+			// result, err = exprFunc(context.Background(), nil)
+			// require.NoError(t, err)
+			// resultMap, ok = result.(pcommon.Map)
+			// require.True(t, ok)
+
+			// rawMap = resultMap.AsRaw()
+			// require.NotNil(t, rawMap)
+			// require.Equal(t, tt.want, rawMap)
+
 		})
 	}
+}
+
+func formatMap(m map[string]any) string {
+	var b strings.Builder
+	b.WriteString("map[string]any{\n")
+	for key, value := range m {
+		fmt.Fprintf(&b, "\t%q: %s,\n", key, formatValue(value))
+	}
+	b.WriteString("}")
+	return b.String()
+}
+
+func formatValue(value any) string {
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.String:
+		return fmt.Sprintf("%q", value)
+	case reflect.Map:
+		if mapValue, ok := value.(map[string]any); ok {
+			return formatMap(mapValue)
+		}
+	case reflect.Slice:
+		b := strings.Builder{}
+		b.WriteString("[]any{")
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			b.WriteString(formatValue(v.Index(i).Interface()))
+		}
+		b.WriteString("}")
+		return b.String()
+	}
+	return fmt.Sprintf("%v", value)
 }

--- a/pkg/ottl/ottlfuncs/func_parse_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_xml_test.go
@@ -20,6 +20,302 @@ import (
 func Test_ParseXML(t *testing.T) {
 	tests := []struct {
 		name        string
+		oArgs       ottl.Arguments
+		want        map[string]any
+		createError string
+		parseError  string
+	}{
+		{
+			name: "Text values in nested elements",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return "<Log><User><ID>00001</ID><Name>Joe</Name><Email>joe.smith@example.com</Email></User><Text>User did a thing</Text></Log>", nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag": "Log",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"children": []any{
+							map[string]any{
+								"tag":     "ID",
+								"content": "00001",
+							},
+							map[string]any{
+								"tag":     "Name",
+								"content": "Joe",
+							},
+							map[string]any{
+								"tag":     "Email",
+								"content": "joe.smith@example.com",
+							},
+						},
+					},
+					map[string]any{
+						"tag":     "Text",
+						"content": "User did a thing",
+					},
+				},
+			},
+		},
+		{
+			name: "Formatted example",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `
+						<Log>
+						  <User>
+						    <ID>00001</ID>
+							<Name>Joe</Name>
+							<Email>joe.smith@example.com</Email>
+						  </User>
+						  <Text>User did a thing</Text>
+						</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag": "Log",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"children": []any{
+							map[string]any{
+								"tag":     "ID",
+								"content": "00001",
+							},
+							map[string]any{
+								"tag":     "Name",
+								"content": "Joe",
+							},
+							map[string]any{
+								"tag":     "Email",
+								"content": "joe.smith@example.com",
+							},
+						},
+					},
+					map[string]any{
+						"tag":     "Text",
+						"content": "User did a thing",
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple tags with the same name",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log>This record has a collision<User id="0001"/><User id="0002"/></Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "This record has a collision",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"attributes": map[string]any{
+							"id": "0001",
+						},
+					},
+					map[string]any{
+						"tag": "User",
+						"attributes": map[string]any{
+							"id": "0002",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple lines of content",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log>
+						This record has multiple lines of
+						<User id="0001"/>
+						text content
+						</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "This record has multiple lines oftext content",
+				"children": []any{
+					map[string]any{
+						"tag": "User",
+						"attributes": map[string]any{
+							"id": "0001",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Attribute only element",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<HostInfo hostname="example.com" zone="east-1" cloudprovider="aws" />`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag": "HostInfo",
+				"attributes": map[string]any{
+					"hostname":      "example.com",
+					"zone":          "east-1",
+					"cloudprovider": "aws",
+				},
+			},
+		},
+		{
+			name: "Ignores XML declaration",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<?xml version="1.0" encoding="UTF-8" ?><Log>Log content</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "Log content",
+			},
+		},
+		{
+			name: "Ignores comments",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log>This has a comment <!-- This is comment text --></Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "This has a comment",
+			},
+		},
+		{
+			name: "Ignores processing instructions",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log><?xml-stylesheet type="text/xsl" href="style.xsl"?>Log content</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "Log content",
+			},
+		},
+		{
+			name: "Ignores directives",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log><!ELEMENT xi:fallback ANY>Log content</Log>`, nil
+					},
+				},
+			},
+			want: map[string]any{
+				"tag":     "Log",
+				"content": "Log content",
+			},
+		},
+		{
+			name: "Missing closing element",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log id="1">`, nil
+					},
+				},
+			},
+			parseError: "unmarshal xml: decode next token: XML syntax error on line 1: unexpected EOF",
+		},
+		{
+			name: "Missing nested closing element",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log><Text></Log>`, nil
+					},
+				},
+			},
+			parseError: "unmarshal xml: decode next token: XML syntax error on line 1: element <Text> closed by </Log>",
+		},
+		{
+			name: "Multiple XML elements in payload (trailing bytes)",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return `<Log></Log><Log></Log>`, nil
+					},
+				},
+			},
+			parseError: "trailing bytes after parsing xml",
+		},
+		{
+			name: "Error getting target",
+			oArgs: &ParseXMLArguments[any]{
+				Target: ottl.StandardStringGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return "", fmt.Errorf("failed to get string")
+					},
+				},
+			},
+			parseError: "error getting value in ottl.StandardStringGetter[interface {}]: failed to get string",
+		},
+		{
+			name:        "Invalid arguments",
+			oArgs:       nil,
+			createError: "ParseXMLFactory args must be of type *ParseXMLArguments[K]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc, err := createParseXMLFunction[any](ottl.FunctionContext{}, tt.oArgs)
+			if tt.createError != "" {
+				require.ErrorContains(t, err, tt.createError)
+				return
+			}
+
+			require.NoError(t, err)
+
+			result, err := exprFunc(context.Background(), nil)
+			if tt.parseError != "" {
+				require.ErrorContains(t, err, tt.parseError)
+				return
+			}
+
+			assert.NoError(t, err)
+
+			resultMap, ok := result.(pcommon.Map)
+			require.True(t, ok)
+
+			require.Equal(t, tt.want, resultMap.AsRaw())
+			// json, err := jsoniter.MarshalIndent(resultMap.AsRaw(), "", "  ")
+			// require.NoError(t, err)
+			// t.Logf(string(json))
+		})
+	}
+}
+
+func Test_ParseXML_v2(t *testing.T) {
+	tests := []struct {
+		name        string
 		flatten     bool
 		xml         string
 		oArgs       ottl.Arguments
@@ -467,7 +763,7 @@ func Test_ParseXML(t *testing.T) {
 			},
 		},
 		{
-			name: "",
+			name: "Tags with dots",
 			xml: `
 <findToFileResponse xmlns="xmlapi_1.0">
     <sysact.Activity>
@@ -584,35 +880,27 @@ func Test_ParseXML(t *testing.T) {
 				},
 			},
 		},
-		{
-			name: "example",
-			xml: `<Log>
-  <User id="00001">
-   Sam
-  </User>
-  <User id="00002">
-   Bob
-  </User>
-  <User id="00003">
-   Alice
-  </User>
-</Log>`,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			oArgs := &ParseXMLArguments[any]{
-				FlattenArrays: ottl.NewTestingOptional[ottl.BoolGetter[any]](ottl.StandardBoolGetter[any]{
-					Getter: func(_ context.Context, _ any) (any, error) {
-						return tt.flatten, nil
-					},
-				}),
+
 				Target: ottl.StandardStringGetter[any]{
 					Getter: func(_ context.Context, _ any) (any, error) {
 						return tt.xml, nil
 					},
 				},
+				Version: ottl.NewTestingOptional[ottl.IntGetter[any]](ottl.StandardIntGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return int64(2), nil
+					},
+				}),
+				FlattenArrays: ottl.NewTestingOptional[ottl.BoolGetter[any]](ottl.StandardBoolGetter[any]{
+					Getter: func(_ context.Context, _ any) (any, error) {
+						return tt.flatten, nil
+					},
+				}),
 			}
 			exprFunc, err := createParseXMLFunction[any](ottl.FunctionContext{}, oArgs)
 			if tt.createError != "" {

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -70,6 +70,7 @@ func converters[K any]() []ottl.Factory[K] {
 		NewParseJSONFactory[K](),
 		NewParseKeyValueFactory[K](),
 		NewParseXMLFactory[K](),
+		NewMarshalXMLFactory[K](),
 		NewSecondsFactory[K](),
 		NewSHA1Factory[K](),
 		NewSHA256Factory[K](),


### PR DESCRIPTION
## Description:
### Current implementation of ParseXML
The current implementation of the ParseXML produces output that is difficult for users to manipulate, particularly when the XML is complicated. The current design loses the sense of key:value pairs which are helpful for understanding the data, and, more importantly, always parses the XML into arrays, which are difficult to manipulate in OTTL, and don't provide a stable path that can be used to access the data.

This change proposes an additional parsing version for the ParseXML function that would parse XML into a nested map, where the keys are the paths to the data, and the values are the data itself, or in the case of nodes with both values and attributes, using the special keys `xml_attributes` and `xml_value`. It still maintains the order of nodes using the special key `xml_ordering`. Additionally, the proposed implementation can optionally "flatten" arrays, such as the `EventData` node in the following XML, into a single map. The arrays must have a single, common attribute, and no other children (in this case, `EventData` has only `Data` children). This would allow users to access the data more intuitively and would allow for easier manipulation of the data in OTTL. 

This proposed change also includes a new function, `MarshalXML`, to reconstruct the XML from the parsed map. This would allow users to manipulate the data in OTTL, and then convert it back to XML, typically for ingestion into another system.

The proposed implementation would be backward compatible with the current implementation, allowing the user to specify the new implementation as an optional `version` parameter to the ParseXML function.

#### Consider the following XML from a Windows event log, a common telemetry source:

```xml
<Event xmlns='http://schemas.microsoft.com/win/2004/08/events/event'>
    <System>
        <Provider Name='Microsoft-Windows-Security-Auditing'
            Guid='{54849625-5478-4994-a5ba-3e3b0328c30d}' />
        <EventID>4625</EventID>
        <Version>0</Version>
        <Level>0</Level>
        <Task>12544</Task>
        <Opcode>0</Opcode>
        <Keywords>0x8010000000000000</Keywords>
        <TimeCreated SystemTime='2024-09-04T08:38:09.7477579Z' />
        <EventRecordID>1361885</EventRecordID>
        <Correlation ActivityID='{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}' />
        <Execution ProcessID='656' ThreadID='2276' />
        <Channel>Security</Channel>
        <Computer>samuel-vahala</Computer>
        <Security />
    </System>
    <EventData>
        <Data Name='SubjectUserSid'>S-1-0-0</Data>
        <Data Name='SubjectUserName'>-</Data>
        <Data Name='SubjectDomainName'>-</Data>
        <Data Name='SubjectLogonId'>0x0</Data>
        <Data Name='TargetUserSid'>S-1-0-0</Data>
        <Data Name='TargetUserName'>mr_rogers</Data>
        <Data Name='TargetDomainName'>-</Data>
        <Data Name='Status'>0xc000006d</Data>
        <Data Name='FailureReason'>%%2313</Data>
        <Data Name='SubStatus'>0xc0000064</Data>
        <Data Name='LogonType'>3</Data>
        <Data Name='LogonProcessName'>NtLmSsp </Data>
        <Data Name='AuthenticationPackageName'>NTLM</Data>
        <Data Name='WorkstationName'>D-508</Data>
        <Data Name='TransmittedServices'>-</Data>
        <Data Name='LmPackageName'>-</Data>
        <Data Name='KeyLength'>0</Data>
        <Data Name='ProcessId'>0x0</Data>
        <Data Name='ProcessName'>-</Data>
        <Data Name='IpAddress'>194.169.175.45</Data>
        <Data Name='IpPort'>0</Data>
    </EventData>
</Event>
```
#### The current `ParseXML` function renders this output, in a flattened view, using dot-notation:
|Path|Value|
|---|---|
children.0.children.0["attributes"]["Guid"]	|{54849625-5478-4994-a5ba-3e3b0328c30d}
children.0.children.0["attributes"]["Name"]	|Microsoft-Windows-Security-Auditing
children.0.children.0["tag"]	|Provider
children.0.children.1["content"]	|4625
children.0.children.1["tag"]	|EventID
children.0.children.10["attributes"]["ProcessID"]	|656
children.0.children.10["attributes"]["ThreadID"]	|4652
children.0.children.10["tag"]	|Execution
children.0.children.11["content"]	|Security
children.0.children.11["tag"]	|Channel
children.0.children.12["content"]	|samuel-windows
children.0.children.12["tag"]	|Computer
children.0.children.13["tag"]	|Security
children.0.children.2["content"]	|0
children.0.children.2["tag"]	|Version
children.0.children.3["content"]	|0
children.0.children.3["tag"]	|Level
children.0.children.4["content"]	|12544
children.0.children.4["tag"]	|Task
children.0.children.5["content"]	|0
children.0.children.5["tag"]	|Opcode
children.0.children.6["content"]	|0x8010000000000000
children.0.children.6["tag"]	|Keywords
children.0.children.7["attributes"]["SystemTime"]	|2024-08-15T20:03:15.9454501Z
children.0.children.7["tag"]	|TimeCreated
children.0.children.8["content"]	|57220
children.0.children.8["tag"]	|EventRecordID
children.0.children.9["attributes"]["ActivityID"]	|{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}
children.0.children.9["tag"]	|Correlation
children.0.tag	|System
children.1.children.0["attributes"]["Name"]	|SubjectUserSid
children.1.children.0["content"]	|S-1-0-0
children.1.children.0["tag"]	|Data
children.1.children.1["attributes"]["Name"]	|SubjectUserName
children.1.children.1["content"]	|-
children.1.children.1["tag"]	|Data
children.1.children.10["attributes"]["Name"]	|LogonType
children.1.children.10["content"]	|3
children.1.children.10["tag"]	|Data
children.1.children.11["attributes"]["Name"]	|LogonProcessName
children.1.children.11["content"]	|NtLmSsp
children.1.children.11["tag"]	|Data
children.1.children.12["attributes"]["Name"]	|AuthenticationPackageName
children.1.children.12["content"]	|NTLM
children.1.children.12["tag"]	|Data
children.1.children.13["attributes"]["Name"]	|WorkstationName
children.1.children.13["content"]	|-
children.1.children.13["tag"]	|Data
children.1.children.14["attributes"]["Name"]	|TransmittedServices
children.1.children.14["content"]	|-
children.1.children.14["tag"]	|Data
children.1.children.15["attributes"]["Name"]	|LmPackageName
children.1.children.15["content"]	|-
children.1.children.15["tag"]	|Data
children.1.children.16["attributes"]["Name"]	|KeyLength
children.1.children.16["content"]	|0
children.1.children.16["tag"]	|Data
children.1.children.17["attributes"]["Name"]	|ProcessId
children.1.children.17["content"]	|0x0
children.1.children.17["tag"]	|Data
children.1.children.18["attributes"]["Name"]	|ProcessName
children.1.children.18["content"]	|-
children.1.children.18["tag"]	|Data
children.1.children.19["attributes"]["Name"]	|IpAddress
children.1.children.19["content"]	|103.151.140.135
children.1.children.19["tag"]	|Data
children.1.children.2["attributes"]["Name"]	|SubjectDomainName
children.1.children.2["content"]	|-
children.1.children.2["tag"]	|Data
children.1.children.20["attributes"]["Name"]	|IpPort
children.1.children.20["content"]	|0
children.1.children.20["tag"]	|Data
children.1.children.3["attributes"]["Name"]	|SubjectLogonId
children.1.children.3["content"]	|0x0
children.1.children.3["tag"]	|Data
children.1.children.4["attributes"]["Name"]	|TargetUserSid
children.1.children.4["content"]	|S-1-0-0
children.1.children.4["tag"]	|Data
children.1.children.5["attributes"]["Name"]	|TargetUserName
children.1.children.5["content"]	|Administrator
children.1.children.5["tag"]	|Data
children.1.children.6["attributes"]["Name"]	|TargetDomainName
children.1.children.6["content"]	|domain
children.1.children.6["tag"]	|Data
children.1.children.7["attributes"]["Name"]	|Status
children.1.children.7["content"]	|0xc000006d
children.1.children.7["tag"]	|Data
children.1.children.8["attributes"]["Name"]	|FailureReason
children.1.children.8["content"]	|%%2313
children.1.children.8["tag"]	|Data
children.1.children.9["attributes"]["Name"]	|SubStatus
children.1.children.9["content"]	|0xc000006a
children.1.children.9["tag"]	|Data
children.1.tag	|EventData
tag	|Event


This view is extremely opaque, and difficult to manipulate in OTTL. The current design also doesn't provide a stable path that can be used to access the data. For example, the path to the `EventID` is `children.0.children.1["content"]`, which is not intuitive.

### Proposed implementation:

The proposed implementation would parse the XML into nested maps. In the case where a node has multiple children with the same name, the children would be stored in an array. If a node has no attributes or children, its value would be stored as a string. Otherwise, it would be stored in the special key `xml_value`. The `xml_attributes` key would store the attributes of the node, and the special key `xml_ordering` would store the order of the children of the node, which is important for marshaling the nodes in the same order back into XML. For example, the schema definition for `<EventData>` in a [Windows Event log](https://learn.microsoft.com/en-us/windows/win32/wes/eventschema-eventdatatype-complextype) specifies that the `<Data>` nodes are a sequence (`<xs:sequence>`), so the order of the nodes should be preserved:

```XML
<xs:complexType name="EventDataType">
    <xs:sequence>
        <xs:choice
            minOccurs="0"
            maxOccurs="unbounded"
        >
            <xs:element name="Data"
                type="DataType"
             />
            <xs:element name="ComplexData"
                type="ComplexDataType"
             />
        </xs:choice>
        <xs:element name="Binary"
            type="hexBinary"
            minOccurs="0"
         />
    </xs:sequence>
    <xs:attribute name="Name"
        type="string"
        use="optional"
     />
</xs:complexType>
```

We prefix the special keys with `xml_` to avoid conflicts with the actual data. It is a limitation that if the original XML uses tags `xml_value`, `xml_attributes`, `xml_ordering`, or `xml_flattened_array`, it will not parse correctly. A future enhancement could be to add an optional parameter to the function to allow users to specify a different prefix.

|Path|Value|
|---|---|
Event.EventData.Data.0["xml_attributes"]["Name"]|	SubjectUserSid
Event.EventData.Data.0["xml_value"]|            	S-1-0-0
Event.EventData.Data.1["xml_attributes"]["Name"]|	SubjectUserName
Event.EventData.Data.10["xml_attributes"]["Name"]|	LogonType
Event.EventData.Data.10["xml_value"]        |   	3
Event.EventData.Data.11["xml_attributes"]["Name"]|	LogonProcessName
Event.EventData.Data.11["xml_value"]        |   	NtLmSsp
Event.EventData.Data.12["xml_attributes"]["Name"]|	AuthenticationPackageName
Event.EventData.Data.12["xml_value"]        |   	NTLM
Event.EventData.Data.13["xml_attributes"]["Name"]|	WorkstationName
Event.EventData.Data.14["xml_attributes"]["Name"]|	TransmittedServices
Event.EventData.Data.15["xml_attributes"]["Name"]|	LmPackageName
Event.EventData.Data.16["xml_attributes"]["Name"]|	KeyLength
Event.EventData.Data.16["xml_value"]        |   	0
Event.EventData.Data.17["xml_attributes"]["Name"]|	ProcessId
Event.EventData.Data.17["xml_value"]        |   	0x0
Event.EventData.Data.18["xml_attributes"]["Name"]|	ProcessName
Event.EventData.Data.19["xml_attributes"]["Name"]|	IpAddress
Event.EventData.Data.19["xml_value"]        |   	103.151.140.135
Event.EventData.Data.2["xml_attributes"]["Name"]|	SubjectDomainName
Event.EventData.Data.20["xml_attributes"]["Name"]|	IpPort
Event.EventData.Data.20["xml_value"]        |   	0
Event.EventData.Data.3["xml_attributes"]["Name"]|	SubjectLogonId
Event.EventData.Data.3["xml_value"]|            	0x0
Event.EventData.Data.4["xml_attributes"]["Name"]|	TargetUserSid
Event.EventData.Data.4["xml_value"]|            	S-1-0-0
Event.EventData.Data.5["xml_attributes"]["Name"]|	TargetUserName
Event.EventData.Data.5["xml_value"]|            	Administrator
Event.EventData.Data.6["xml_attributes"]["Name"]|	TargetDomainName
Event.EventData.Data.6["xml_value"]|            	domain
Event.EventData.Data.7["xml_attributes"]["Name"]|	Status
Event.EventData.Data.7["xml_value"]|            	0xc000006d
Event.EventData.Data.8["xml_attributes"]["Name"]|	FailureReason
Event.EventData.Data.8["xml_value"]|            	%%2313
Event.EventData.Data.9["xml_attributes"]["Name"]|	SubStatus
Event.EventData.Data.9["xml_value"]|            	0xc000006a
Event.EventData.xml_ordering	|Data.0,Data.1,Data.2,Data.3,Data.4,Data.5,Data.6,Data.7,Data.8,Data.9,Data.10,Data.11,Data.12,Data.13,Data.14,Data.15,Data.16,Data.17,Data.18,Data.19,Data.20
Event.System.Channel    |	Security
Event.System.Computer	|    samuel-windows
Event.System.Correlation.xml_attributes.ActivityID|	{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}
Event.System.EventID	|4625
Event.System.EventRecordID|	57220
Event.System.Execution.xml_attributes.ProcessID	|656
Event.System.Execution.xml_attributes.ThreadID	|4652
Event.System.Keywords	|0x8010000000000000
Event.System.Level|	0
Event.System.Opcode|	0
Event.System.Provider.xml_attributes.Guid	|{54849625-5478-4994-a5ba-3e3b0328c30d}
Event.System.Provider.xml_attributes.Name	|Microsoft-Windows-Security-Auditing
Event.System.Task	|12544
Event.System.TimeCreated.xml_attributes.SystemTime	|2024-08-15T20:03:15.9454501Z
Event.System.Version	|0
Event.System.xml_ordering|	Provider,EventID,Version,Level,Task,Opcode,Keywords,TimeCreated,EventRecordID,Correlation,Execution,Channel,Computer,Security
Event.xml_attributes.xmlns|	http://schemas.microsoft.com/win/2004/08/events/event
Event.xml_ordering	|System,EventData


Additionally, the proposed implementation can optionally "flatten" arrays, such as the `EventData` node in the XML, into a single map. The arrays must have a single, common attribute, and no other children (in this case, `EventData` has only `Data` children). This would allow users to access the data in a more intuitive way, and would allow for easier manipulation of the data in OTTL.

#### Flattened Parse

|Path|Value|
|---|---|
Event.EventData.Data.AuthenticationPackageName	|NTLM
Event.EventData.Data.FailureReason	|%%2313
Event.EventData.Data.IpAddress	|103.151.140.135
Event.EventData.Data.IpPort	|0
Event.EventData.Data.KeyLength	|0
Event.EventData.Data.LogonProcessName	|NtLmSsp
Event.EventData.Data.LogonType	|3
Event.EventData.Data.ProcessId	|0x0
Event.EventData.Data.Status	|0xc000006d
Event.EventData.Data.SubStatus	|0xc000006a
Event.EventData.Data.SubjectLogonId	|0x0
Event.EventData.Data.SubjectUserSid	|S-1-0-0
Event.EventData.Data.TargetDomainName	|domain
Event.EventData.Data.TargetUserName	|Administrator
Event.EventData.Data.TargetUserSid	|S-1-0-0
Event.EventData.Data.xml_flattened_array	|Name
Event.EventData.Data.xml_ordering	|SubjectUserSid,SubjectUserName,SubjectDomainName,SubjectLogonId,TargetUserSid,TargetUserName,TargetDomainName,Status,FailureReason,SubStatus,LogonType,LogonProcessName,AuthenticationPackageName,WorkstationName,TransmittedServices,LmPackageName,KeyLength,ProcessId,ProcessName,IpAddress,IpPort
Event.System.Channel	|Security
Event.System.Computer	|samuel-windows
Event.System.Correlation.xml_attributes.ActivityID	|{b67ee0c2-a671-0001-5f6b-82e8c1eeda01}
Event.System.EventID	|4625
Event.System.EventRecordID	|57220
Event.System.Execution.xml_attributes.ProcessID	|656
Event.System.Execution.xml_attributes.ThreadID	|4652
Event.System.Keywords	|0x8010000000000000
Event.System.Level	|0
Event.System.Opcode	|0
Event.System.Provider.xml_attributes.Guid	|{54849625-5478-4994-a5ba-3e3b0328c30d}
Event.System.Provider.xml_attributes.Name	|Microsoft-Windows-Security-Auditing
Event.System.Task	|12544
Event.System.TimeCreated.xml_attributes.SystemTime	|2024-08-15T20:03:15.9454501Z
Event.System.Version	|0
Event.System.xml_ordering	|Provider,EventID,Version,Level,Task,Opcode,Keywords,TimeCreated,EventRecordID,Correlation,Execution,Channel,Computer,Security
Event.xml_attributes.xmlns	|http://schemas.microsoft.com/win/2004/08/events/event
Event.xml_ordering	|System,EventData

### MarshalXML
The MarshalXML function is able to reliably reconstruct the XML, with the limitation imposed by the GO XML library, which doesn't support self closing tags (In this example, tags like `<Security />`.) The Unit tests for the MarshalXML function use the `ParseXML` function to parse the XML, and then compare the output of the `MarshalXML` function to the original XML. The test `XML` purposely omits self-closing tags.


## Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35076

## Testing:

Added Unit tests for the new version, previous tests still pass for version 1.

## Documentation: 

Added documentation for the new parse version to pkg/ottl/ottlfuncs/README.md