### PR TITLE
[exporter/datadog] Map deployment.environment.name to env

### DIFF
--- a/.chloggen/dd-con-new-env-conv.yaml
+++ b/.chloggen/dd-con-new-env-conv.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Map the new OTel semantic convention `deployment.environment.name` to `env` for OTLP traces in APM stats."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "The old convention `deployment.environment` still works"
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dd-con-new-env-conv.yaml
+++ b/.chloggen/dd-con-new-env-conv.yaml
@@ -10,7 +10,7 @@ component: datadogconnector
 note: "Map the new OTel semantic convention `deployment.environment.name` to `env` for OTLP traces in APM stats."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [35147]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/dd-exp-new-env-conv.yaml
+++ b/.chloggen/dd-exp-new-env-conv.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Map the new OTel semantic convention `deployment.environment.name` to `env` for OTLP traces, metrics and logs."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "The old convention `deployment.environment` still works"
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/dd-exp-new-env-conv.yaml
+++ b/.chloggen/dd-exp-new-env-conv.yaml
@@ -10,7 +10,7 @@ component: datadogexporter
 note: "Map the new OTel semantic convention `deployment.environment.name` to `env` for OTLP traces, metrics and logs."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [35147]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/cmd/otelcontribcol/go.mod
+++ b/cmd/otelcontribcol/go.mod
@@ -327,12 +327,12 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 // indirect
 	github.com/DataDog/datadog-agent/pkg/proto v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.57.0 // indirect
@@ -353,7 +353,7 @@ require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.30.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.5.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe // indirect
-	github.com/DataDog/go-sqllexer v0.0.13 // indirect
+	github.com/DataDog/go-sqllexer v0.0.14 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.20.0 // indirect

--- a/cmd/otelcontribcol/go.sum
+++ b/cmd/otelcontribcol/go.sum
@@ -803,8 +803,8 @@ github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 h1:Eva4HkFvDgE7Aa
 github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0/go.mod h1:p2NTG+cIhVGlKELJfRteGCec37ICptIpeB2x/MsRkbw=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0 h1:0pLKObDzamFpFDJrdxBhQd7bqxMepfcQ35OQs94A+kc=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0/go.mod h1:R5MP3l673Jqi3sbpXMgjnwsT+qLn6x1RxwGYDHHC6OY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qcg03KcP2v/dkFnuEy+qC0jWgZi1SP4jfx/BOpL0ayY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:icOxQ1JBek3L0WCQXsKD+VhRc3S0rn71/bUkt6tKVSY=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 h1:+jlg745q9znKME0F2Y51QuPT9crQ02oIjUj3qVtV8IU=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:MfDvphBMmEMwE3a30h27AtPO7OzmvdoVTiGY1alEmo4=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0 h1:6Yys68K+pzr+/sV7xYUptS6POZVVWF+hDUksx1+NwHY=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0/go.mod h1:sRjG8CCK1sei7qR9vLLNZ3hx3fcZ1IzroLkpfLNDuDA=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 h1:LplNAmMgZvGU7kKA0+4c1xWOjz828xweW5TCi8Mw9Q0=
@@ -813,8 +813,8 @@ github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 h1:kPAij96+yH3cqx/uj6
 github.com/DataDog/datadog-agent/pkg/status/health v0.57.0/go.mod h1:EkC/SgFR03BKwBitVV4dIuP+ofwPlUCkVi5K5k1Dh2Y=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 h1:rczdF3VVpYjcBAHqPRN+SoWaBqjkxmJEElgJRGiHJA4=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0/go.mod h1:ydRQtflWJbhL3q9WjrmPs7lSX2G5z/KOzDoOVp/7nGo=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qEUqimASiw9IfkDKxHqcZ6M6w0TREBGPVlePP3Ng/No=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:6oieT7MVbPg52r1pHQkiNavDIK7pN1ZKsudT9s0kLzY=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85 h1:NenBahnbhBDEMLwR5AfK54VLFidK34xcr61BX/t/8vo=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:SXT+/FonH8qi6U6YzrBERefqPXuxo4UTu4CEH6dU49M=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0 h1:m02/fGmSImKS4H8mqvMVJPJEqem0dgWDv0Iuu2wCh+s=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0/go.mod h1:2RMfdYkKyeh8hXs6WgaamkkEyK35Xo55C4rFG4dO1k8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.57.0 h1:SDWaVn+cJ9ChVj2SXdoDw9mGgIcbvSFf1vXuj539qLI=
@@ -860,8 +860,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe h1:efzxujZ7VHWFxjmWjcJyUEpPrN8qdiZPYb+dBw547Wo=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
-github.com/DataDog/go-sqllexer v0.0.13 h1:9mKfe+3s73GI/7dWBxi2Ds7+xZynJqMKK9cIUBrutak=
-github.com/DataDog/go-sqllexer v0.0.13/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
+github.com/DataDog/go-sqllexer v0.0.14 h1:xUQh2tLr/95LGxDzLmttLgTo/1gzFeOyuwrQa/Iig4Q=
+github.com/DataDog/go-sqllexer v0.0.14/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
 github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/connector/datadogconnector/connector_native_test.go
+++ b/connector/datadogconnector/connector_native_test.go
@@ -18,6 +18,7 @@ import (
 	"go.opentelemetry.io/collector/connector/connectortest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	conventions127 "go.opentelemetry.io/collector/semconv/v1.27.0"
 	semconv "go.opentelemetry.io/collector/semconv/v1.5.0"
 	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
@@ -145,6 +146,8 @@ func TestMeasuredAndClientKindNative(t *testing.T) {
 	td := ptrace.NewTraces()
 	res := td.ResourceSpans().AppendEmpty().Resource()
 	res.Attributes().PutStr("service.name", "svc")
+	res.Attributes().PutStr(conventions127.AttributeDeploymentEnvironmentName, "my-env")
+
 	ss := td.ResourceSpans().At(0).ScopeSpans().AppendEmpty().Spans()
 	// Root span
 	s1 := ss.AppendEmpty()
@@ -200,6 +203,7 @@ func TestMeasuredAndClientKindNative(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, sp.Stats, 1)
 	assert.Len(t, sp.Stats[0].Stats, 1)
+	assert.Equal(t, "my-env", sp.Stats[0].Env)
 	assert.Len(t, sp.Stats[0].Stats[0].Stats, 3)
 	cgss := sp.Stats[0].Stats[0].Stats
 	sort.Slice(cgss, func(i, j int) bool {

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/metricsclient v0.57.0
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.57.0
 	github.com/DataDog/datadog-agent/pkg/proto v0.57.0
-	github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951
+	github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85
 	github.com/DataDog/datadog-go/v5 v5.5.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.20.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.20.0
@@ -71,7 +71,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 // indirect
@@ -94,7 +94,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.57.0 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.30.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe // indirect
-	github.com/DataDog/go-sqllexer v0.0.13 // indirect
+	github.com/DataDog/go-sqllexer v0.0.14 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.20.0 // indirect

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -148,8 +148,8 @@ github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 h1:Eva4HkFvDgE7Aa
 github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0/go.mod h1:p2NTG+cIhVGlKELJfRteGCec37ICptIpeB2x/MsRkbw=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0 h1:0pLKObDzamFpFDJrdxBhQd7bqxMepfcQ35OQs94A+kc=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0/go.mod h1:R5MP3l673Jqi3sbpXMgjnwsT+qLn6x1RxwGYDHHC6OY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qcg03KcP2v/dkFnuEy+qC0jWgZi1SP4jfx/BOpL0ayY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:icOxQ1JBek3L0WCQXsKD+VhRc3S0rn71/bUkt6tKVSY=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 h1:+jlg745q9znKME0F2Y51QuPT9crQ02oIjUj3qVtV8IU=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:MfDvphBMmEMwE3a30h27AtPO7OzmvdoVTiGY1alEmo4=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0 h1:6Yys68K+pzr+/sV7xYUptS6POZVVWF+hDUksx1+NwHY=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0/go.mod h1:sRjG8CCK1sei7qR9vLLNZ3hx3fcZ1IzroLkpfLNDuDA=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 h1:LplNAmMgZvGU7kKA0+4c1xWOjz828xweW5TCi8Mw9Q0=
@@ -158,8 +158,8 @@ github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 h1:kPAij96+yH3cqx/uj6
 github.com/DataDog/datadog-agent/pkg/status/health v0.57.0/go.mod h1:EkC/SgFR03BKwBitVV4dIuP+ofwPlUCkVi5K5k1Dh2Y=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 h1:rczdF3VVpYjcBAHqPRN+SoWaBqjkxmJEElgJRGiHJA4=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0/go.mod h1:ydRQtflWJbhL3q9WjrmPs7lSX2G5z/KOzDoOVp/7nGo=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qEUqimASiw9IfkDKxHqcZ6M6w0TREBGPVlePP3Ng/No=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:6oieT7MVbPg52r1pHQkiNavDIK7pN1ZKsudT9s0kLzY=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85 h1:NenBahnbhBDEMLwR5AfK54VLFidK34xcr61BX/t/8vo=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:SXT+/FonH8qi6U6YzrBERefqPXuxo4UTu4CEH6dU49M=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0 h1:m02/fGmSImKS4H8mqvMVJPJEqem0dgWDv0Iuu2wCh+s=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0/go.mod h1:2RMfdYkKyeh8hXs6WgaamkkEyK35Xo55C4rFG4dO1k8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.57.0 h1:SDWaVn+cJ9ChVj2SXdoDw9mGgIcbvSFf1vXuj539qLI=
@@ -204,8 +204,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe h1:efzxujZ7VHWFxjmWjcJyUEpPrN8qdiZPYb+dBw547Wo=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
-github.com/DataDog/go-sqllexer v0.0.13 h1:9mKfe+3s73GI/7dWBxi2Ds7+xZynJqMKK9cIUBrutak=
-github.com/DataDog/go-sqllexer v0.0.13/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
+github.com/DataDog/go-sqllexer v0.0.14 h1:xUQh2tLr/95LGxDzLmttLgTo/1gzFeOyuwrQa/Iig4Q=
+github.com/DataDog/go-sqllexer v0.0.14/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
 github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/proto v0.57.0
 	github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951
+	github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.57.0
 	github.com/DataDog/datadog-agent/pkg/util/startstop v0.57.0 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.30.0
@@ -117,7 +117,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/processor v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/sender v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0 // indirect
@@ -136,7 +136,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/version v0.57.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe // indirect
-	github.com/DataDog/go-sqllexer v0.0.13 // indirect
+	github.com/DataDog/go-sqllexer v0.0.14 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/viper v1.13.5 // indirect
 	github.com/DataDog/zstd v1.5.5 // indirect

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -155,8 +155,8 @@ github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 h1:Eva4HkFvDgE7Aa
 github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0/go.mod h1:p2NTG+cIhVGlKELJfRteGCec37ICptIpeB2x/MsRkbw=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0 h1:0pLKObDzamFpFDJrdxBhQd7bqxMepfcQ35OQs94A+kc=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0/go.mod h1:R5MP3l673Jqi3sbpXMgjnwsT+qLn6x1RxwGYDHHC6OY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qcg03KcP2v/dkFnuEy+qC0jWgZi1SP4jfx/BOpL0ayY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:icOxQ1JBek3L0WCQXsKD+VhRc3S0rn71/bUkt6tKVSY=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 h1:+jlg745q9znKME0F2Y51QuPT9crQ02oIjUj3qVtV8IU=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:MfDvphBMmEMwE3a30h27AtPO7OzmvdoVTiGY1alEmo4=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0 h1:6Yys68K+pzr+/sV7xYUptS6POZVVWF+hDUksx1+NwHY=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0/go.mod h1:sRjG8CCK1sei7qR9vLLNZ3hx3fcZ1IzroLkpfLNDuDA=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 h1:LplNAmMgZvGU7kKA0+4c1xWOjz828xweW5TCi8Mw9Q0=
@@ -165,8 +165,8 @@ github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 h1:kPAij96+yH3cqx/uj6
 github.com/DataDog/datadog-agent/pkg/status/health v0.57.0/go.mod h1:EkC/SgFR03BKwBitVV4dIuP+ofwPlUCkVi5K5k1Dh2Y=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 h1:rczdF3VVpYjcBAHqPRN+SoWaBqjkxmJEElgJRGiHJA4=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0/go.mod h1:ydRQtflWJbhL3q9WjrmPs7lSX2G5z/KOzDoOVp/7nGo=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qEUqimASiw9IfkDKxHqcZ6M6w0TREBGPVlePP3Ng/No=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:6oieT7MVbPg52r1pHQkiNavDIK7pN1ZKsudT9s0kLzY=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85 h1:NenBahnbhBDEMLwR5AfK54VLFidK34xcr61BX/t/8vo=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:SXT+/FonH8qi6U6YzrBERefqPXuxo4UTu4CEH6dU49M=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0 h1:m02/fGmSImKS4H8mqvMVJPJEqem0dgWDv0Iuu2wCh+s=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0/go.mod h1:2RMfdYkKyeh8hXs6WgaamkkEyK35Xo55C4rFG4dO1k8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.57.0 h1:SDWaVn+cJ9ChVj2SXdoDw9mGgIcbvSFf1vXuj539qLI=
@@ -212,8 +212,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe h1:efzxujZ7VHWFxjmWjcJyUEpPrN8qdiZPYb+dBw547Wo=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
-github.com/DataDog/go-sqllexer v0.0.13 h1:9mKfe+3s73GI/7dWBxi2Ds7+xZynJqMKK9cIUBrutak=
-github.com/DataDog/go-sqllexer v0.0.13/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
+github.com/DataDog/go-sqllexer v0.0.14 h1:xUQh2tLr/95LGxDzLmttLgTo/1gzFeOyuwrQa/Iig4Q=
+github.com/DataDog/go-sqllexer v0.0.14/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
 github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -80,11 +80,11 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/sources v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 // indirect
+	github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 // indirect
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.57.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.57.0 // indirect
@@ -105,7 +105,7 @@ require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.30.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.5.0 // indirect
 	github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe // indirect
-	github.com/DataDog/go-sqllexer v0.0.13 // indirect
+	github.com/DataDog/go-sqllexer v0.0.14 // indirect
 	github.com/DataDog/go-tuf v1.1.0-0.5.2 // indirect
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee // indirect
 	github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata v0.20.0 // indirect

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -153,8 +153,8 @@ github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0 h1:Eva4HkFvDgE7Aa
 github.com/DataDog/datadog-agent/pkg/logs/status/utils v0.57.0/go.mod h1:p2NTG+cIhVGlKELJfRteGCec37ICptIpeB2x/MsRkbw=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0 h1:0pLKObDzamFpFDJrdxBhQd7bqxMepfcQ35OQs94A+kc=
 github.com/DataDog/datadog-agent/pkg/logs/util/testutils v0.57.0/go.mod h1:R5MP3l673Jqi3sbpXMgjnwsT+qLn6x1RxwGYDHHC6OY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qcg03KcP2v/dkFnuEy+qC0jWgZi1SP4jfx/BOpL0ayY=
-github.com/DataDog/datadog-agent/pkg/obfuscate v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:icOxQ1JBek3L0WCQXsKD+VhRc3S0rn71/bUkt6tKVSY=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85 h1:+jlg745q9znKME0F2Y51QuPT9crQ02oIjUj3qVtV8IU=
+github.com/DataDog/datadog-agent/pkg/obfuscate v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:MfDvphBMmEMwE3a30h27AtPO7OzmvdoVTiGY1alEmo4=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0 h1:6Yys68K+pzr+/sV7xYUptS6POZVVWF+hDUksx1+NwHY=
 github.com/DataDog/datadog-agent/pkg/proto v0.57.0/go.mod h1:sRjG8CCK1sei7qR9vLLNZ3hx3fcZ1IzroLkpfLNDuDA=
 github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.57.0 h1:LplNAmMgZvGU7kKA0+4c1xWOjz828xweW5TCi8Mw9Q0=
@@ -163,8 +163,8 @@ github.com/DataDog/datadog-agent/pkg/status/health v0.57.0 h1:kPAij96+yH3cqx/uj6
 github.com/DataDog/datadog-agent/pkg/status/health v0.57.0/go.mod h1:EkC/SgFR03BKwBitVV4dIuP+ofwPlUCkVi5K5k1Dh2Y=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0 h1:rczdF3VVpYjcBAHqPRN+SoWaBqjkxmJEElgJRGiHJA4=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.57.0/go.mod h1:ydRQtflWJbhL3q9WjrmPs7lSX2G5z/KOzDoOVp/7nGo=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951 h1:qEUqimASiw9IfkDKxHqcZ6M6w0TREBGPVlePP3Ng/No=
-github.com/DataDog/datadog-agent/pkg/trace v0.58.0-devel.0.20240830155027-f44a9da12951/go.mod h1:6oieT7MVbPg52r1pHQkiNavDIK7pN1ZKsudT9s0kLzY=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85 h1:NenBahnbhBDEMLwR5AfK54VLFidK34xcr61BX/t/8vo=
+github.com/DataDog/datadog-agent/pkg/trace v0.59.0-devel.0.20240911192058-0c2181220f85/go.mod h1:SXT+/FonH8qi6U6YzrBERefqPXuxo4UTu4CEH6dU49M=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0 h1:m02/fGmSImKS4H8mqvMVJPJEqem0dgWDv0Iuu2wCh+s=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.57.0/go.mod h1:2RMfdYkKyeh8hXs6WgaamkkEyK35Xo55C4rFG4dO1k8=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.57.0 h1:SDWaVn+cJ9ChVj2SXdoDw9mGgIcbvSFf1vXuj539qLI=
@@ -210,8 +210,8 @@ github.com/DataDog/datadog-go/v5 v5.5.0 h1:G5KHeB8pWBNXT4Jtw0zAkhdxEAWSpWH00geHI
 github.com/DataDog/datadog-go/v5 v5.5.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe h1:efzxujZ7VHWFxjmWjcJyUEpPrN8qdiZPYb+dBw547Wo=
 github.com/DataDog/dd-sensitive-data-scanner/sds-go/go v0.0.0-20240419161837-f1b2f553edfe/go.mod h1:TX7CTOQ3LbQjfAi4SwqUoR5gY1zfUk7VRBDTuArjaDc=
-github.com/DataDog/go-sqllexer v0.0.13 h1:9mKfe+3s73GI/7dWBxi2Ds7+xZynJqMKK9cIUBrutak=
-github.com/DataDog/go-sqllexer v0.0.13/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
+github.com/DataDog/go-sqllexer v0.0.14 h1:xUQh2tLr/95LGxDzLmttLgTo/1gzFeOyuwrQa/Iig4Q=
+github.com/DataDog/go-sqllexer v0.0.14/go.mod h1:KwkYhpFEVIq+BfobkTC1vfqm4gTi65skV/DpDBXtexc=
 github.com/DataDog/go-tuf v1.1.0-0.5.2 h1:4CagiIekonLSfL8GMHRHcHudo1fQnxELS9g4tiAupQ4=
 github.com/DataDog/go-tuf v1.1.0-0.5.2/go.mod h1:zBcq6f654iVqmkk8n2Cx81E1JnNTMOAx1UEO/wZR+P0=
 github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee h1:tXibLZk3G6HncIFJKaNItsdzcrk4YqILNDZlXPTNt4k=

--- a/exporter/datadogexporter/logs_exporter_test.go
+++ b/exporter/datadogexporter/logs_exporter_test.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/plog"
+	conventions127 "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/testdata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
@@ -498,6 +499,41 @@ func TestLogsAgentExporter(t *testing.T) {
 					},
 					"ddsource": "otlp_log_ingestion",
 					"ddtags":   "otel_source:datadog_exporter",
+					"service":  "",
+					"status":   "Info",
+				},
+			},
+		},
+		{
+			name: "new-env-convention",
+			args: args{
+				ld: func() plog.Logs {
+					lrr := testdata.GenerateLogsOneLogRecord()
+					lrr.ResourceLogs().At(0).Resource().Attributes().PutStr(conventions127.AttributeDeploymentEnvironmentName, "new_env")
+					return lrr
+				}(),
+				retry: false,
+			},
+			want: testutil.JSONLogs{
+				{
+					"message": testutil.JSONLog{
+						"@timestamp":                  testdata.TestLogTime.Format(timeFormatString),
+						"app":                         "server",
+						"dd.span_id":                  fmt.Sprintf("%d", spanIDToUint64(ld.SpanID())),
+						"dd.trace_id":                 fmt.Sprintf("%d", traceIDToUint64(ld.TraceID())),
+						"deployment.environment.name": "new_env",
+						"instance_num":                "1",
+						"message":                     ld.Body().AsString(),
+						"otel.severity_number":        "9",
+						"otel.severity_text":          "Info",
+						"otel.span_id":                traceutil.SpanIDToHexOrEmptyString(ld.SpanID()),
+						"otel.timestamp":              fmt.Sprintf("%d", testdata.TestLogTime.UnixNano()),
+						"otel.trace_id":               traceutil.TraceIDToHexOrEmptyString(ld.TraceID()),
+						"resource-attr":               "resource-attr-val-1",
+						"status":                      "Info",
+					},
+					"ddsource": "otlp_log_ingestion",
+					"ddtags":   "env:new_env,otel_source:datadog_exporter",
 					"service":  "",
 					"status":   "Info",
 				},

--- a/exporter/datadogexporter/metrics_exporter_test.go
+++ b/exporter/datadogexporter/metrics_exporter_test.go
@@ -28,6 +28,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	conventions127 "go.opentelemetry.io/collector/semconv/v1.27.0"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	"go.uber.org/zap"
 )
@@ -156,6 +157,64 @@ func Test_metricsExporter_PushMetricsData(t *testing.T) {
 						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
 						"resources": []any{map[string]any{"name": "test-host", "type": "host"}},
 						"tags":      []any{"env:dev"},
+					},
+					map[string]any{
+						"metric":    "otel.datadog_exporter.metrics.running",
+						"points":    []any{map[string]any{"timestamp": float64(0), "value": float64(1)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []any{map[string]any{"name": "test-host", "type": "host"}},
+						"tags":      []any{"version:latest", "command:otelcol"},
+					},
+				},
+			},
+		},
+		{
+			metrics: createTestMetrics(map[string]string{
+				conventions127.AttributeDeploymentEnvironmentName: "new_env",
+				"custom_attribute": "custom_value",
+			}),
+			source: source.Source{
+				Kind:       source.HostnameKind,
+				Identifier: "test-host",
+			},
+			histogramMode: HistogramModeCounters,
+			hostTags:      []string{"key1:value1", "key2:value2"},
+			expectedSeries: map[string]any{
+				"series": []any{
+					map[string]any{
+						"metric":    "int.gauge",
+						"points":    []any{map[string]any{"timestamp": float64(0), "value": float64(222)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []any{map[string]any{"name": "test-host", "type": "host"}},
+						"tags":      []any{"env:new_env"},
+					},
+					map[string]any{
+						"metric":    "otel.system.filesystem.utilization",
+						"points":    []any{map[string]any{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []any{map[string]any{"name": "test-host", "type": "host"}},
+						"tags":      []any{"env:new_env"},
+					},
+					map[string]any{
+						"metric":    "double.histogram.bucket",
+						"points":    []any{map[string]any{"timestamp": float64(0), "value": float64(2)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
+						"resources": []any{map[string]any{"name": "test-host", "type": "host"}},
+						"tags":      []any{"lower_bound:-inf", "upper_bound:0", "env:new_env"},
+					},
+					map[string]any{
+						"metric":    "double.histogram.bucket",
+						"points":    []any{map[string]any{"timestamp": float64(0), "value": float64(18)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_COUNT),
+						"resources": []any{map[string]any{"name": "test-host", "type": "host"}},
+						"tags":      []any{"lower_bound:0", "upper_bound:inf", "env:new_env"},
+					},
+					map[string]any{
+						"metric":    "system.disk.in_use",
+						"points":    []any{map[string]any{"timestamp": float64(0), "value": float64(333)}},
+						"type":      float64(datadogV2.METRICINTAKETYPE_GAUGE),
+						"resources": []any{map[string]any{"name": "test-host", "type": "host"}},
+						"tags":      []any{"env:new_env"},
 					},
 					map[string]any{
 						"metric":    "otel.datadog_exporter.metrics.running",
@@ -477,6 +536,64 @@ func Test_metricsExporter_PushMetricsData_Zorkian(t *testing.T) {
 						"type":   "gauge",
 						"host":   "test-host",
 						"tags":   []any{"env:dev"},
+					},
+					map[string]any{
+						"metric": "otel.datadog_exporter.metrics.running",
+						"points": []any{[]any{float64(0), float64(1)}},
+						"type":   "gauge",
+						"host":   "test-host",
+						"tags":   []any{"version:latest", "command:otelcol"},
+					},
+				},
+			},
+		},
+		{
+			metrics: createTestMetrics(map[string]string{
+				conventions127.AttributeDeploymentEnvironmentName: "new_env",
+				"custom_attribute": "custom_value",
+			}),
+			source: source.Source{
+				Kind:       source.HostnameKind,
+				Identifier: "test-host",
+			},
+			histogramMode: HistogramModeCounters,
+			hostTags:      []string{"key1:value1", "key2:value2"},
+			expectedSeries: map[string]any{
+				"series": []any{
+					map[string]any{
+						"metric": "int.gauge",
+						"points": []any{[]any{float64(0), float64(222)}},
+						"type":   "gauge",
+						"host":   "test-host",
+						"tags":   []any{"env:new_env"},
+					},
+					map[string]any{
+						"metric": "otel.system.filesystem.utilization",
+						"points": []any{[]any{float64(0), float64(333)}},
+						"type":   "gauge",
+						"host":   "test-host",
+						"tags":   []any{"env:new_env"},
+					},
+					map[string]any{
+						"metric": "double.histogram.bucket",
+						"points": []any{[]any{float64(0), float64(2)}},
+						"type":   "count",
+						"host":   "test-host",
+						"tags":   []any{"lower_bound:-inf", "upper_bound:0", "env:new_env"},
+					},
+					map[string]any{
+						"metric": "double.histogram.bucket",
+						"points": []any{[]any{float64(0), float64(18)}},
+						"type":   "count",
+						"host":   "test-host",
+						"tags":   []any{"lower_bound:0", "upper_bound:inf", "env:new_env"},
+					},
+					map[string]any{
+						"metric": "system.disk.in_use",
+						"points": []any{[]any{float64(0), float64(333)}},
+						"type":   "gauge",
+						"host":   "test-host",
+						"tags":   []any{"env:new_env"},
 					},
 					map[string]any{
 						"metric": "otel.datadog_exporter.metrics.running",

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
+	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	tracelog "github.com/DataDog/datadog-agent/pkg/trace/log"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
@@ -25,7 +27,9 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
+	conventions127 "go.opentelemetry.io/collector/semconv/v1.27.0"
 	semconv "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"google.golang.org/protobuf/proto"
 )
 
 func setupTestMain(m *testing.M) {
@@ -329,6 +333,46 @@ func TestPushTraceData(t *testing.T) {
 
 	recvMetadata := <-server.MetadataChan
 	assert.Equal(t, "custom-hostname", recvMetadata.InternalHostname)
+}
+
+func TestPushTraceData_NewEnvConvention(t *testing.T) {
+	tracesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.TraceEndpoint, ReqChan: make(chan []byte)}
+	server := testutil.DatadogServerMock(tracesRec.HandlerFunc)
+	defer server.Close()
+	cfg := &Config{
+		API: APIConfig{
+			Key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		TagsConfig: TagsConfig{
+			Hostname: "test-host",
+		},
+		Metrics: MetricsConfig{
+			TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+		},
+		Traces: TracesConfig{
+			TCPAddrConfig: confignet.TCPAddrConfig{Endpoint: server.URL},
+			flushInterval: 0.1,
+		},
+	}
+
+	params := exportertest.NewNopSettings()
+	f := NewFactory()
+	exp, err := f.CreateTracesExporter(context.Background(), params, cfg)
+	assert.NoError(t, err)
+
+	err = exp.ConsumeTraces(context.Background(), simpleTracesWithAttributes(map[string]any{conventions127.AttributeDeploymentEnvironmentName: "new_env"}))
+	assert.NoError(t, err)
+
+	reqBytes := <-tracesRec.ReqChan
+	buf := bytes.NewBuffer(reqBytes)
+	reader, err := gzip.NewReader(buf)
+	require.NoError(t, err)
+	slurp, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	var traces pb.AgentPayload
+	require.NoError(t, proto.Unmarshal(slurp, &traces))
+	assert.Len(t, traces.TracerPayloads, 1)
+	assert.Equal(t, "new_env", traces.TracerPayloads[0].GetEnv())
 }
 
 func simpleTraces() ptrace.Traces {


### PR DESCRIPTION
**Description:** 
Map the new OTel semantic convention `deployment.environment.name` to `env`