### PR TITLE
Fix: Ensure publisher does not include token in exported data

### DIFF
--- a/.chloggen/msg_fix-token-removal.yaml
+++ b/.chloggen/msg_fix-token-removal.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure token is not sent through for event data
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35154]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2.go
@@ -84,6 +84,8 @@ func convertLogRecord(lr plog.LogRecord, resourceAttrs pcommon.Map, logger *zap.
 			return true
 		case splunk.SFxEventPropertiesKey:
 			return true
+		case splunk.SFxAccessTokenLabel:
+			return true
 		case splunk.SFxEventType:
 			if v.Type() == pcommon.ValueTypeStr {
 				event.EventType = v.Str()

--- a/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2_test.go
+++ b/exporter/signalfxexporter/internal/translation/logdata_to_signalfxv2_test.go
@@ -48,6 +48,7 @@ func TestLogDataToSignalFxEvents(t *testing.T) {
 		resourceLog.Resource().Attributes().PutStr("k0", "should use ILL attr value instead")
 		resourceLog.Resource().Attributes().PutStr("k3", "v3")
 		resourceLog.Resource().Attributes().PutInt("k4", 123)
+		resourceLog.Resource().Attributes().PutStr("com.splunk.signalfx.access_token", "hunter2")
 
 		ilLogs := resourceLog.ScopeLogs()
 		logSlice := ilLogs.AppendEmpty().LogRecords()


### PR DESCRIPTION
**Description:**

This will ensure that tokens are not leaked through the event API.

**Link to tracking Issue:**


**Testing:**

Updated the tests to ensure that the token isn't include in the final data.
