### PR TITLE
[chore] Failure on 1st test run should not cause 2nd run to fail

### DIFF
--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/xml"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -301,6 +302,10 @@ func createTestConfig() *WindowsLogConfig {
 // It returns a function that can be used to uninstall the event source, that function is never nil
 func assertEventSourceInstallation(t *testing.T, src string) (uninstallEventSource func(), err error) {
 	err = eventlog.InstallAsEventCreate(src, eventlog.Info|eventlog.Warning|eventlog.Error)
+	if err != nil && strings.HasSuffix(err.Error(), " registry key already exists") {
+		// If the event source already exists ignore the error
+		err = nil
+	}
 	uninstallEventSource = func() {
 		assert.NoError(t, eventlog.Remove(src))
 	}


### PR DESCRIPTION
**Description:**
If the first run of the tests fails without running the deferred code, the second run will fail on the registry entry already being present so no second run. This change ensures that if the event log source "leaked" from the first run the second run doesn't fail because the source is already present. Related conversation at https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35032#issuecomment-2342400746

**Testing:**
Local runs.

**Documentation:**
N/A