### PR TITLE
[pkg/stanza] Move filelog.container.removeOriginalTimeField feature gate to beta

### DIFF
--- a/.chloggen/container_parser_featuregate_beta.yaml
+++ b/.chloggen/container_parser_featuregate_beta.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Move `filelog.container.removeOriginalTimeField` feature gate to beta
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33389]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Disable the `filelog.container.removeOriginalTimeField` feature gate to get the old behavior.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/operator/parser/container/config.go
+++ b/pkg/stanza/operator/parser/container/config.go
@@ -27,7 +27,7 @@ const (
 
 var removeOriginalTimeField = featuregate.GlobalRegistry().MustRegister(
 	removeOriginalTimeFieldFeatureFlag,
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, deletes the original `time` field from the Log Attributes. Time is parsed to Timestamp field, which should be used instead."),
 	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33389"),
 )

--- a/pkg/stanza/operator/parser/container/parser_test.go
+++ b/pkg/stanza/operator/parser/container/parser_test.go
@@ -115,7 +115,6 @@ func TestProcess(t *testing.T) {
 			},
 			&entry.Entry{
 				Attributes: map[string]any{
-					"time":         "2029-03-30T08:31:20.545192187Z",
 					"log.iostream": "stdout",
 				},
 				Body:      "INFO: log line here",
@@ -135,7 +134,6 @@ func TestProcess(t *testing.T) {
 			},
 			&entry.Entry{
 				Attributes: map[string]any{
-					"time":         "2029-03-30T08:31:20.545192187Z",
 					"log.iostream": "stdout",
 				},
 				Body:      "INFO: log line here",
@@ -158,7 +156,6 @@ func TestProcess(t *testing.T) {
 			},
 			&entry.Entry{
 				Attributes: map[string]any{
-					"time":          "2029-03-30T08:31:20.545192187Z",
 					"log.iostream":  "stdout",
 					"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
 				},
@@ -215,7 +212,6 @@ func TestRecombineProcess(t *testing.T) {
 			[]*entry.Entry{
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169-10:00",
 						"log.iostream":  "stdout",
 						"logtag":        "F",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -251,7 +247,6 @@ func TestRecombineProcess(t *testing.T) {
 			[]*entry.Entry{
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169Z",
 						"log.iostream":  "stdout",
 						"logtag":        "F",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -293,7 +288,6 @@ func TestRecombineProcess(t *testing.T) {
 			[]*entry.Entry{
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169-10:00",
 						"log.iostream":  "stdout",
 						"logtag":        "P",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -335,7 +329,6 @@ func TestRecombineProcess(t *testing.T) {
 			[]*entry.Entry{
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169Z",
 						"log.iostream":  "stdout",
 						"logtag":        "P",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -418,7 +411,6 @@ func TestCRIRecombineProcessWithFailedDownstreamOperator(t *testing.T) {
 			[]*entry.Entry{
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169-10:00",
 						"log.iostream":  "stdout",
 						"logtag":        "P",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -435,7 +427,6 @@ func TestCRIRecombineProcessWithFailedDownstreamOperator(t *testing.T) {
 				},
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169-10:00",
 						"log.iostream":  "stdout",
 						"logtag":        "F",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -483,7 +474,6 @@ func TestCRIRecombineProcessWithFailedDownstreamOperator(t *testing.T) {
 			[]*entry.Entry{
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169Z",
 						"log.iostream":  "stdout",
 						"logtag":        "P",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -500,7 +490,6 @@ func TestCRIRecombineProcessWithFailedDownstreamOperator(t *testing.T) {
 				},
 				{
 					Attributes: map[string]any{
-						"time":          "2024-04-13T07:59:37.505201169Z",
 						"log.iostream":  "stdout",
 						"logtag":        "F",
 						"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
@@ -545,11 +534,11 @@ func TestCRIRecombineProcessWithFailedDownstreamOperator(t *testing.T) {
 	}
 }
 
-func TestProcessWithTimeRemovalFlag(t *testing.T) {
+func TestProcessWithTimeRemovalFlagDisabled(t *testing.T) {
 
-	require.NoError(t, featuregate.GlobalRegistry().Set(removeOriginalTimeField.ID(), true))
+	require.NoError(t, featuregate.GlobalRegistry().Set(removeOriginalTimeField.ID(), false))
 	t.Cleanup(func() {
-		require.NoError(t, featuregate.GlobalRegistry().Set(removeOriginalTimeField.ID(), false))
+		require.NoError(t, featuregate.GlobalRegistry().Set(removeOriginalTimeField.ID(), true))
 	})
 
 	cases := []struct {
@@ -572,6 +561,7 @@ func TestProcessWithTimeRemovalFlag(t *testing.T) {
 			},
 			&entry.Entry{
 				Attributes: map[string]any{
+					"time":         "2029-03-30T08:31:20.545192187Z",
 					"log.iostream": "stdout",
 				},
 				Body:      "INFO: log line here",
@@ -591,6 +581,7 @@ func TestProcessWithTimeRemovalFlag(t *testing.T) {
 			},
 			&entry.Entry{
 				Attributes: map[string]any{
+					"time":         "2029-03-30T08:31:20.545192187Z",
 					"log.iostream": "stdout",
 				},
 				Body:      "INFO: log line here",
@@ -614,6 +605,7 @@ func TestProcessWithTimeRemovalFlag(t *testing.T) {
 			&entry.Entry{
 				Attributes: map[string]any{
 					"log.iostream":  "stdout",
+					"time":          "2029-03-30T08:31:20.545192187Z",
 					"log.file.path": "/var/log/pods/some_kube-scheduler-kind-control-plane_49cc7c1fd3702c40b2686ea7486091d3/kube-scheduler44/1.log",
 				},
 				Body: "INFO: log line here",


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

This PR moves the feature gate to delete the original time field from parsed container logs to beta as part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33389.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>