### PR TITLE
[pkg/stanza] Windows input operator should resubscribe when remote host restarts

### DIFF
--- a/.chloggen/stanza-windows-remote-resubscribe.yaml
+++ b/.chloggen/stanza-windows-remote-resubscribe.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: "bug_fix"
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: windowseventlogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: If collecting from a remote host, the receiver will stop collecting if the host restarts. This change resubscribes when the host restarts.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35175]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -216,10 +216,7 @@ func (i *Input) read(ctx context.Context) int {
 	events, err := i.subscription.Read(i.maxReads)
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
-		i.Logger().Info("Error is: ", zap.Error(err))
-		i.Logger().Info("windowserr is: ", zap.Error(windows.ERROR_INVALID_HANDLE))
-		i.Logger().Info("notopenerror is: ", zap.Error(ErrHandleNotOpen))
-		if i.isRemote() && (errors.Is(err, windows.ERROR_INVALID_HANDLE) || errors.Is(err, ErrHandleNotOpen)) {
+		if i.isRemote() && (errors.Is(err, windows.ERROR_INVALID_HANDLE) || errors.Is(err, errSubscriptionHandleNotOpen)) {
 			i.Logger().Info("Resubscribing, closing remote subscription")
 			closeErr := i.subscription.Close()
 			if closeErr != nil {

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -217,13 +217,13 @@ func (i *Input) read(ctx context.Context) int {
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
 		if i.isRemote() && (err.Error() == "The handle is invalid." || err.Error() == "subscription handle is not open") {
-			i.Logger().Info("Resubscribing, closing subscription")
+			i.Logger().Info("Resubscribing, closing remote subscription")
 			closeErr := i.subscription.Close()
 			if closeErr != nil {
-				i.Logger().Error("Failed to close subscription", zap.Error(closeErr))
+				i.Logger().Error("Failed to close remote subscription", zap.Error(closeErr))
 				return 0
 			}
-			i.Logger().Info("Resubscribing, creating subscription")
+			i.Logger().Info("Resubscribing, creating remote subscription")
 			i.subscription = NewRemoteSubscription(i.remote.Server)
 		}
 		return 0

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -216,7 +216,9 @@ func (i *Input) read(ctx context.Context) int {
 	events, err := i.subscription.Read(i.maxReads)
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
-		if i.isRemote() {
+		i.Logger().Info("The error is:")
+		i.Logger().Info(err.Error())
+		if i.isRemote() && (err.Error() == "The handle is invalid." || err.Error() == "subscription handle is not open") {
 			i.Logger().Info("Resubscribing, closing subscription")
 			closeErr := i.subscription.Close()
 			if closeErr != nil {

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -218,7 +218,8 @@ func (i *Input) read(ctx context.Context) int {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
 		i.Logger().Info("Error is: ", zap.Error(err))
 		i.Logger().Info("windowserr is: ", zap.Error(windows.ERROR_INVALID_HANDLE))
-		if i.isRemote() && (errors.Is(err, windows.ERROR_INVALID_HANDLE) || err.Error() == "subscription handle is not open") {
+		i.Logger().Info("notopenerror is: ", zap.Error(ErrHandleNotOpen))
+		if i.isRemote() && (errors.Is(err, windows.ERROR_INVALID_HANDLE) || errors.Is(err, ErrHandleNotOpen)) {
 			i.Logger().Info("Resubscribing, closing remote subscription")
 			closeErr := i.subscription.Close()
 			if closeErr != nil {

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -216,12 +216,13 @@ func (i *Input) read(ctx context.Context) int {
 	events, err := i.subscription.Read(i.maxReads)
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
+		i.Logger().Info("Closing subscription")
 		closeErr := i.subscription.Close()
 		if closeErr != nil {
 			i.Logger().Error("Failed to close subscription", zap.Error(closeErr))
 			return 0
 		}
-		i.Logger().Info("Recreating subscription")
+		i.Logger().Info("Resubscribing")
 		i.subscription = NewRemoteSubscription(i.remote.Server)
 		return 0
 	}

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -216,8 +216,6 @@ func (i *Input) read(ctx context.Context) int {
 	events, err := i.subscription.Read(i.maxReads)
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
-		i.Logger().Info("The error is:")
-		i.Logger().Info(err.Error())
 		if i.isRemote() && (err.Error() == "The handle is invalid." || err.Error() == "subscription handle is not open") {
 			i.Logger().Info("Resubscribing, closing subscription")
 			closeErr := i.subscription.Close()

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -216,7 +216,9 @@ func (i *Input) read(ctx context.Context) int {
 	events, err := i.subscription.Read(i.maxReads)
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
-		if i.isRemote() && (err.Error() == "The handle is invalid." || err.Error() == "subscription handle is not open") {
+		i.Logger().Info("Error is: ", zap.Error(err))
+		i.Logger().Info("windowserr is: ", zap.Error(windows.ERROR_INVALID_HANDLE))
+		if i.isRemote() && (errors.Is(err, windows.ERROR_INVALID_HANDLE) || err.Error() == "subscription handle is not open") {
 			i.Logger().Info("Resubscribing, closing remote subscription")
 			closeErr := i.subscription.Close()
 			if closeErr != nil {

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -220,12 +220,14 @@ func (i *Input) read(ctx context.Context) int {
 		i.Logger().Info(err.Error())
 		if err.Error() == "The remote procedure call was cancelled." {
 			i.Logger().Info("Attempting to restart remote session due to RPC cancellation")
-			if stopErr := i.stopRemoteSession(); stopErr != nil {
+			if stopErr := i.Stop(); stopErr != nil {
 				i.Logger().Error("Failed to stop remote session", zap.Error(stopErr))
 				return 0
 			}
 			for {
-				if startErr := i.startRemoteSession(); startErr != nil {
+				i.Logger().Info("Waiting 30 seconds before retrying remote session")
+				time.Sleep(30 * time.Second)
+				if startErr := i.Start(i.persister); startErr != nil {
 					i.Logger().Error("Failed to start remote session", zap.Error(startErr))
 					continue // Retry until the connection is re-established
 				}

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -216,9 +216,13 @@ func (i *Input) read(ctx context.Context) int {
 	events, err := i.subscription.Read(i.maxReads)
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
-		i.subscription.Close()
+		closeErr := i.subscription.Close()
+		if closeErr != nil {
+			i.Logger().Error("Failed to close subscription", zap.Error(closeErr))
+			return 0
+		}
+		i.Logger().Info("Recreating subscription")
 		i.subscription = NewRemoteSubscription(i.remote.Server)
-		i.Logger().Info("Reopening subscription")
 		return 0
 	}
 

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -197,10 +197,17 @@ func (i *Input) readToEnd(ctx context.Context) {
 		default:
 			if count := i.read(ctx); count == 0 {
 				if i.isRemote() {
+					i.Logger().Info("Stopping remote session", zap.String("server", i.remote.Server))
+					if err := i.stopRemoteSession(); err != nil {
+						i.Logger().Error("Failed to stop remote session", zap.String("server", i.remote.Server), zap.Error(err))
+						return
+					}
+					i.Logger().Info("Start remote session", zap.String("server", i.remote.Server))
 					if err := i.startRemoteSession(); err != nil {
 						i.Logger().Error("Failed to re-establish remote session", zap.String("server", i.remote.Server), zap.Error(err))
 						return
 					}
+					i.Logger().Info("Open")
 					if err := i.subscription.Open(i.startAt, uintptr(i.remoteSessionHandle), i.channel, i.bookmark); err != nil {
 						i.Logger().Error("Failed to re-open subscription for remote server", zap.String("server", i.remote.Server), zap.Error(err))
 					}

--- a/pkg/stanza/operator/input/windows/input.go
+++ b/pkg/stanza/operator/input/windows/input.go
@@ -216,25 +216,6 @@ func (i *Input) read(ctx context.Context) int {
 	events, err := i.subscription.Read(i.maxReads)
 	if err != nil {
 		i.Logger().Error("Failed to read events from subscription", zap.Error(err))
-		i.Logger().Info("The error is:")
-		i.Logger().Info(err.Error())
-		if err.Error() == "The remote procedure call was cancelled." {
-			i.Logger().Info("Attempting to restart remote session due to RPC cancellation")
-			if err := i.stopRemoteSession(); err != nil {
-				i.Logger().Error("Failed to stop remote session", zap.Error(err))
-				return 0
-			}
-			for {
-				i.Logger().Info("Waiting 30 seconds before attempting to restart remote session")
-				time.Sleep(30 * time.Second)
-				i.Logger().Info("Attempting to start remote session")
-				if err := i.startRemoteSession(); err != nil {
-					i.Logger().Error("Failed to start remote session", zap.Error(err))
-					continue
-				}
-				return 0
-			}
-		}
 		return 0
 	}
 

--- a/pkg/stanza/operator/input/windows/subscription.go
+++ b/pkg/stanza/operator/input/windows/subscription.go
@@ -64,12 +64,12 @@ func (s *Subscription) Close() error {
 	return nil
 }
 
-var ErrHandleNotOpen = fmt.Errorf("subscription handle is not open")
+var errSubscriptionHandleNotOpen = errors.New("subscription handle is not open")
 
 // Read will read events from the subscription.
 func (s *Subscription) Read(maxReads int) ([]Event, error) {
 	if s.handle == 0 {
-		return nil, ErrHandleNotOpen
+		return nil, errSubscriptionHandleNotOpen
 	}
 
 	if maxReads < 1 {

--- a/pkg/stanza/operator/input/windows/subscription.go
+++ b/pkg/stanza/operator/input/windows/subscription.go
@@ -64,10 +64,12 @@ func (s *Subscription) Close() error {
 	return nil
 }
 
+var ErrHandleNotOpen = fmt.Errorf("subscription handle is not open")
+
 // Read will read events from the subscription.
 func (s *Subscription) Read(maxReads int) ([]Event, error) {
 	if s.handle == 0 {
-		return nil, fmt.Errorf("subscription handle is not open")
+		return nil, ErrHandleNotOpen
 	}
 
 	if maxReads < 1 {


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

While collecting Windows Event Logs from a remote host, if that host restarts or shuts off, the collector begins logging errors and stops collecting WE logs, even after the remote host is back up. Restarting the collector fixes this. 

To fix this without restarting the collector, the stanza input operator needs to resubscribe if the remote host restarts. 

Error log:
```
"Failed to read events from subscription","error":"The handle is invalid."
```


**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

Manually tested with a build of the collector, and confirmed logs continue being collected after the remote host restarts. 

**Documentation:** <Describe the documentation added.>

N/A, this change is expected behavior