### PR TITLE
[chore] Parallel test make unrelated test show up as failure on CI

### DIFF
--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -53,8 +53,6 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestCreateWithInvalidInputConfig(t *testing.T) {
-	t.Parallel()
-
 	cfg := &WindowsLogConfig{
 		BaseConfig: adapter.BaseConfig{},
 		InputConfig: func() windows.Config {


### PR DESCRIPTION
Running `TestCreateWithInvalidInputConfig` in parallel make it show up as failure when other tests fail, while its failure is unrelated, e.g.:  https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/10851621842/job/30115793372#step:7:227
