### PR TITLE
Revert "[chore] Force require.EventuallyWithT to fail properly"

### DIFF
--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -325,7 +325,7 @@ func requireExpectedLogRecords(t *testing.T, sink *consumertest.LogsSink, expect
 	// logs sometimes take a while to be written, so a substantial wait buffer is needed
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
 		actualLogRecords = filterAllLogRecordsBySource(t, sink, expectedEventSrc)
-		require.Len(c, actualLogRecords, expectedEventCount)
+		assert.Len(c, actualLogRecords, expectedEventCount)
 	}, 10*time.Second, 250*time.Millisecond)
 
 	return actualLogRecords


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#35032 this is failing consistently on CI. cc @djaglowski 