### PR TITLE
[chore] Use assert/assert instead of require/assert

### DIFF
--- a/receiver/windowseventlogreceiver/receiver_windows_test.go
+++ b/receiver/windowseventlogreceiver/receiver_windows_test.go
@@ -152,7 +152,8 @@ func TestReadWindowsEventLogger(t *testing.T) {
 	err = logger.Info(10, logMessage)
 	require.NoError(t, err)
 
-	records := requireExpectedLogRecords(t, sink, src, 1)
+	records := assertExpectedLogRecords(t, sink, src, 1)
+	require.Len(t, records, 1)
 	record := records[0]
 	body := record.Body().Map().AsRaw()
 
@@ -205,7 +206,8 @@ func TestReadWindowsEventLoggerRaw(t *testing.T) {
 	err = logger.Info(10, logMessage)
 	require.NoError(t, err)
 
-	records := requireExpectedLogRecords(t, sink, src, 1)
+	records := assertExpectedLogRecords(t, sink, src, 1)
+	require.Len(t, records, 1)
 	record := records[0]
 	body := record.Body().AsString()
 	bodyStruct := struct {
@@ -272,8 +274,8 @@ func TestExcludeProvider(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			records := requireExpectedLogRecords(t, sink, notExcludedSrc, 1)
-			assert.NotEmpty(t, records)
+			records := assertExpectedLogRecords(t, sink, notExcludedSrc, 1)
+			assert.Len(t, records, 1)
 
 			records = filterAllLogRecordsBySource(t, sink, excludedSrc)
 			assert.Empty(t, records)
@@ -319,13 +321,13 @@ func assertEventSourceInstallation(t *testing.T, src string) (uninstallEventSour
 	return
 }
 
-func requireExpectedLogRecords(t *testing.T, sink *consumertest.LogsSink, expectedEventSrc string, expectedEventCount int) []plog.LogRecord {
+func assertExpectedLogRecords(t *testing.T, sink *consumertest.LogsSink, expectedEventSrc string, expectedEventCount int) []plog.LogRecord {
 	var actualLogRecords []plog.LogRecord
 
 	// logs sometimes take a while to be written, so a substantial wait buffer is needed
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		actualLogRecords = filterAllLogRecordsBySource(t, sink, expectedEventSrc)
-		require.Len(c, actualLogRecords, expectedEventCount)
+		assert.Len(c, actualLogRecords, expectedEventCount)
 	}, 10*time.Second, 250*time.Millisecond)
 
 	return actualLogRecords


### PR DESCRIPTION
The combination require-eventually-assert in tests causing some issues on the test, use the established pattern assert-eventually-assert instead.

cc @djaglowski 