### PR TITLE
[chore]: enable formatter rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -135,7 +135,6 @@ linters-settings:
   testifylint:
     disable:
       - float-compare
-      - formatter
       - require-error
       - suite-subtest-run
       - useless-assert

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -77,7 +77,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,require-error,suite-subtest-run,useless-assert
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/cmd/telemetrygen/internal/traces/worker_test.go
+++ b/cmd/telemetrygen/internal/traces/worker_test.go
@@ -235,7 +235,7 @@ func TestSpanStatuses(t *testing.T) {
 				require.NoError(t, Run(cfg, zap.NewNop()))
 				// verify that the default the span status is set as expected
 				for _, span := range syncer.spans {
-					assert.Equal(t, span.Status().Code, tt.spanStatus, fmt.Sprintf("span status: %v and expected status %v", span.Status().Code, tt.spanStatus))
+					assert.Equalf(t, span.Status().Code, tt.spanStatus, "span status: %v and expected status %v", span.Status().Code, tt.spanStatus)
 				}
 			} else {
 				require.Error(t, Run(cfg, zap.NewNop()))

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
@@ -156,7 +156,7 @@ func Test_rawMetricsToAdxMetrics(t *testing.T) {
 				// Metric assertions
 				assert.Equal(t, expectedMetric.MetricName, actualMetrics[i].MetricName)
 				assert.Equal(t, expectedMetric.MetricType, actualMetrics[i].MetricType)
-				assert.Equal(t, expectedMetric.MetricValue, actualMetrics[i].MetricValue, fmt.Sprintf("Mismatch for value for test %s", tt.name))
+				assert.Equalf(t, expectedMetric.MetricValue, actualMetrics[i].MetricValue, "Mismatch for value for test %s", tt.name)
 				assert.Equal(t, expectedMetric.MetricDescription, actualMetrics[i].MetricDescription)
 				assert.Equal(t, expectedMetric.MetricUnit, actualMetrics[i].MetricUnit)
 				assert.Equal(t, expectedMetric.MetricAttributes, actualMetrics[i].MetricAttributes)
@@ -556,7 +556,7 @@ func Test_mapToAdxMetric(t *testing.T) {
 				// Metric assertions
 				assert.Equal(t, expectedMetric.MetricName, actualMetrics[i].MetricName)
 				assert.Equal(t, expectedMetric.MetricType, actualMetrics[i].MetricType)
-				assert.Equal(t, expectedMetric.MetricValue, actualMetrics[i].MetricValue, fmt.Sprintf("Mismatch for value for test %s", tt.name))
+				assert.Equalf(t, expectedMetric.MetricValue, actualMetrics[i].MetricValue, "Mismatch for value for test %s", tt.name)
 				assert.Equal(t, expectedMetric.MetricDescription, actualMetrics[i].MetricDescription)
 				assert.Equal(t, expectedMetric.MetricUnit, actualMetrics[i].MetricUnit)
 				assert.Equal(t, expectedMetric.MetricAttributes, actualMetrics[i].MetricAttributes)

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -461,7 +461,7 @@ func TestOTLPTracesJsonMarshaling(t *testing.T) {
 			Encoding:            test.encoding,
 			PartitionTracesByID: test.partitionTracesByID,
 		})
-		require.NoError(t, err, fmt.Sprintf("Must have %s marshaler", test.encoding))
+		require.NoErrorf(t, err, "Must have %s marshaler", test.encoding)
 
 		msg, err := marshaler.Marshal(traces, t.Name())
 		require.NoError(t, err, "Must have marshaled the data without error")

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -1446,7 +1446,7 @@ func TestDefaultSystemCPUTimeExcludedAndTranslated(t *testing.T) {
 	for _, dp := range dps {
 		if dp.Metric == "cpu.num_processors" || dp.Metric == "cpu.idle" {
 			intVal := dp.Value.IntValue
-			require.NotNil(t, intVal, fmt.Sprintf("unexpected nil IntValue for %q", dp.Metric))
+			require.NotNilf(t, intVal, "unexpected nil IntValue for %q", dp.Metric)
 			found[dp.Metric] = *intVal
 		} else {
 			// account for unexpected w/ test-failing placeholder

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -6,7 +6,6 @@ package signalfxexporter
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -520,7 +519,7 @@ func TestDefaultCPUTranslations(t *testing.T) {
 	cpuStateMetrics := []string{"cpu.idle", "cpu.interrupt", "cpu.system", "cpu.user"}
 	for _, metric := range cpuStateMetrics {
 		dps, ok := m[metric]
-		require.True(t, ok, fmt.Sprintf("%s metrics not found", metric))
+		require.Truef(t, ok, "%s metrics not found", metric)
 		require.Len(t, dps, 9)
 	}
 }

--- a/exporter/syslogexporter/rfc5424_formatter_test.go
+++ b/exporter/syslogexporter/rfc5424_formatter_test.go
@@ -80,7 +80,7 @@ func TestRFC5424Formatter(t *testing.T) {
 	assert.NoError(t, err)
 	matched, err := regexp.MatchString(expectedRegex, actual)
 	assert.NoError(t, err)
-	assert.True(t, matched, fmt.Sprintf("unexpected form of formatted message, formatted message: %s, regexp: %s", actual, expectedRegex))
+	assert.Truef(t, matched, "unexpected form of formatted message, formatted message: %s, regexp: %s", actual, expectedRegex)
 	assert.True(t, strings.Contains(actual, "Realm=\"SecureAuth0\""))
 	assert.True(t, strings.Contains(actual, "UserHostAddress=\"192.168.2.132\""))
 	assert.True(t, strings.Contains(actual, "UserID=\"Tester2\""))

--- a/internal/aws/xray/tracesegment_test.go
+++ b/internal/aws/xray/tracesegment_test.go
@@ -627,9 +627,9 @@ func TestTraceBodyUnMarshalling(t *testing.T) {
 
 	for _, tc := range tests {
 		content, err := os.ReadFile(tc.samplePath)
-		assert.NoError(t, err, fmt.Sprintf("[%s] can not read raw segment", tc.testCase))
+		assert.NoErrorf(t, err, "[%s] can not read raw segment", tc.testCase)
 
-		assert.NotEmpty(t, content, fmt.Sprintf("[%s] content length is 0", tc.testCase))
+		assert.NotEmptyf(t, content, "[%s] content length is 0", tc.testCase)
 
 		var actualSeg Segment
 		err = json.Unmarshal(content, &actualSeg)

--- a/pkg/stanza/fileconsumer/internal/emittest/sink.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink.go
@@ -119,7 +119,7 @@ func (s *Sink) ExpectTokens(t *testing.T, expected ...[]byte) {
 			return
 		}
 	}
-	require.ElementsMatch(t, expected, actual, fmt.Sprintf("expected: %v, actual: %v", expected, actual))
+	require.ElementsMatchf(t, expected, actual, "expected: %v, actual: %v", expected, actual)
 }
 
 func (s *Sink) ExpectCall(t *testing.T, expected []byte, attrs map[string]any) {

--- a/pkg/stanza/fileconsumer/internal/trie/trie_test.go
+++ b/pkg/stanza/fileconsumer/internal/trie/trie_test.go
@@ -330,7 +330,7 @@ func get(key string, expect any, why string) testOp {
 func put(key string, val any) testOp {
 	return func(t *testing.T, trie *Trie[any]) {
 		trie.Put([]byte(key), val)
-		assert.Equalf(t, val, trie.Get([]byte(key)), "called Put(%s, %d) but HasKey(%s) does not return %d", key, key)
+		assert.Equalf(t, val, trie.Get([]byte(key)), "called Put(%s, %d) but HasKey(%s) does not return %d", key, val, key, val)
 	}
 }
 
@@ -342,7 +342,7 @@ func del(key string, why string) testOp {
 			assert.Falsef(t, trie.Delete([]byte(key)), why)
 		} else {
 			assert.Truef(t, trie.Delete([]byte(key)), why)
-			assert.Falsef(t, trie.Delete([]byte(key)), "called Del(%s) twice in a row and got true both times")
+			assert.Falsef(t, trie.Delete([]byte(key)), "called Del(%s) twice in a row and got true both times", key)
 		}
 	}
 }

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1502,14 +1502,14 @@ func TestStartStop(t *testing.T) {
 
 func assertResourceHasStringAttribute(t *testing.T, r pcommon.Resource, k, v string) {
 	got, ok := r.Attributes().Get(k)
-	require.True(t, ok, fmt.Sprintf("resource does not contain attribute %s", k))
+	require.Truef(t, ok, "resource does not contain attribute %s", k)
 	assert.EqualValues(t, pcommon.ValueTypeStr, got.Type(), "attribute %s is not of type string", k)
 	assert.EqualValues(t, v, got.Str(), "attribute %s is not equal to %s", k, v)
 }
 
 func assertResourceHasStringSlice(t *testing.T, r pcommon.Resource, k string, v []string) {
 	got, ok := r.Attributes().Get(k)
-	require.True(t, ok, fmt.Sprintf("resource does not contain attribute %s", k))
+	require.Truef(t, ok, "resource does not contain attribute %s", k)
 	assert.EqualValues(t, pcommon.ValueTypeSlice, got.Type(), "attribute %s is not of type slice", k)
 	slice := got.Slice()
 	for i := 0; i < slice.Len(); i++ {

--- a/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/perfcounters/perfcounter_scraper_test.go
@@ -165,7 +165,7 @@ func Test_PerfCounterScraper(t *testing.T) {
 					break
 				}
 			}
-			assert.Equalf(t, test.includeTotal, includesTotal, "_Total was returned: %v (expected the opposite)", test.includeTotal, includesTotal)
+			assert.Equalf(t, test.includeTotal, includesTotal, "_Total was returned: %v (expected the opposite)", includesTotal)
 		})
 	}
 }

--- a/receiver/jmxreceiver/internal/subprocess/integration_test.go
+++ b/receiver/jmxreceiver/internal/subprocess/integration_test.go
@@ -87,7 +87,7 @@ func (suite *SubprocessIntegrationSuite) prepareSubprocess(conf *Config) (*Subpr
 			return false
 		}
 		require.NoError(t, err)
-		require.True(t, strings.HasPrefix(cmdline, expectedExecutable), fmt.Sprintf("%v doesn't have prefix %v", cmdline, expectedExecutable))
+		require.Truef(t, strings.HasPrefix(cmdline, expectedExecutable), "%v doesn't have prefix %v", cmdline, expectedExecutable)
 		procInfo = proc
 		return true
 	}

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -231,5 +231,5 @@ service:
 	//    * The first scrape will NOT return stale markers
 	//    * (N-1 / alternatives) = ((10-1) / 2) = ~40% chance of stale markers being emitted.
 	chance := float64(staleMarkerCount) / float64(totalSamples)
-	require.GreaterOrEqual(t, chance, 0.4, fmt.Sprintf("Expected at least one stale marker: %.3f", chance))
+	require.GreaterOrEqualf(t, chance, 0.4, "Expected at least one stale marker: %.3f", chance)
 }

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -663,7 +663,7 @@ func Test_sfxReceiver_TLS(t *testing.T) {
 
 	sfxMsg := buildSFxDatapointMsg(msec, 13, 3)
 	body, err := sfxMsg.Marshal()
-	require.NoError(t, err, fmt.Sprintf("failed to marshal SFx message: %v", err))
+	require.NoErrorf(t, err, "failed to marshal SFx message: %v", err)
 
 	url := fmt.Sprintf("https://%s/v2/datapoint", addr)
 

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -500,7 +500,7 @@ func Test_splunkhecReceiver_TLS(t *testing.T) {
 	t.Log("Sending Splunk HEC data Request")
 
 	body, err := json.Marshal(buildSplunkHecMsg(sec, 0))
-	require.NoError(t, err, fmt.Sprintf("failed to marshal Splunk message: %v", err))
+	require.NoErrorf(t, err, "failed to marshal Splunk message: %v", err)
 
 	url := fmt.Sprintf("https://%s", addr)
 

--- a/receiver/sqlserverreceiver/recorders_test.go
+++ b/receiver/sqlserverreceiver/recorders_test.go
@@ -25,7 +25,7 @@ func TestPerfCounterRecorders(t *testing.T) {
 			for counterPath := range counter.recorders {
 				counterFullName := fmt.Sprintf("%s:%s %s", defaultObjectName, counter.object, counterPath)
 				_, ok := expectedCounters[counterFullName]
-				require.True(t, ok, fmt.Sprintf("counter %s not found", counterFullName))
+				require.Truef(t, ok, "counter %s not found", counterFullName)
 			}
 		}
 	})
@@ -37,7 +37,7 @@ func TestPerfCounterRecorders(t *testing.T) {
 			for counterPath := range counter.recorders {
 				counterFullName := fmt.Sprintf("MSSQL$TEST_NAME:%s %s", counter.object, counterPath)
 				_, ok := expectedCounters[counterFullName]
-				require.True(t, ok, fmt.Sprintf("counter %s not found", counterFullName))
+				require.Truef(t, ok, "counter %s not found", counterFullName)
 			}
 		}
 	})


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [formatter](https://github.com/Antonboom/testifylint?tab=readme-ov-file#formatter) rule from [testifylint](https://github.com/Antonboom/testifylint)