### PR TITLE
[chore]: enable go-require rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,8 @@ run:
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  formats: colored-line-number
+  formats: 
+    - format: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -136,7 +137,6 @@ linters-settings:
     disable:
       - float-compare
       - formatter
-      - go-require
       - require-error
       - suite-subtest-run
       - useless-assert
@@ -178,3 +178,12 @@ issues:
     - text: "G402:"
       linters:
         - gosec
+    
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,8 +45,7 @@ run:
 # output configuration options
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
-  formats: 
-    - format: colored-line-number
+  formats: colored-line-number
 
   # print lines of code with issue, default is true
   print-issued-lines: true
@@ -178,12 +177,3 @@ issues:
     - text: "G402:"
       linters:
         - gosec
-    
-  # Maximum issues count per one linter.
-  # Set to 0 to disable.
-  # Default: 50
-  max-issues-per-linter: 0
-  # Maximum count of issues with the same text.
-  # Set to 0 to disable.
-  # Default: 3
-  max-same-issues: 0

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -77,7 +77,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,go-require,require-error,suite-subtest-run,useless-assert
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,formatter,require-error,suite-subtest-run,useless-assert
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/cmd/telemetrygen/internal/e2etest/e2e_test.go
+++ b/cmd/telemetrygen/internal/e2etest/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -53,7 +54,7 @@ func TestGenerateTraces(t *testing.T) {
 	}
 	go func() {
 		err = traces.Start(cfg)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	require.Eventually(t, func() bool {
 		return len(sink.AllTraces()) > 0

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -659,7 +659,7 @@ func TestConcurrentShutdown(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		go func() {
 			err := p.Shutdown(ctx)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			wg.Done()
 		}()
 	}

--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -142,7 +142,7 @@ func TestConsumeMetrics(t *testing.T) {
 					defer writersWG.Done()
 					<-startCh
 					for j := 0; j < tt.writesPerProducer; j++ {
-						require.NoError(t, exp.ConsumeMetrics(context.Background(), tt.md))
+						assert.NoError(t, exp.ConsumeMetrics(context.Background(), tt.md))
 					}
 				}()
 			}
@@ -332,10 +332,10 @@ func (cs *carbonServer) start(t *testing.T, numExpectedReq int) {
 				// Close is expected to cause error.
 				return
 			}
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			go func(conn net.Conn) {
 				defer func() {
-					require.NoError(t, conn.Close())
+					assert.NoError(t, conn.Close())
 				}()
 
 				reader := bufio.NewReader(conn)
@@ -344,7 +344,7 @@ func (cs *carbonServer) start(t *testing.T, numExpectedReq int) {
 					if errors.Is(err, io.EOF) {
 						return
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 
 					if cs.expectedContainsValue != "" {
 						assert.Contains(t, string(buf), cs.expectedContainsValue)

--- a/exporter/datadogexporter/internal/hostmetadata/metadata_test.go
+++ b/exporter/datadogexporter/internal/hostmetadata/metadata_test.go
@@ -190,13 +190,13 @@ func TestPushMetadata(t *testing.T) {
 		assert.Equal(t, "apikey", r.Header.Get("DD-Api-Key"))
 		assert.Equal(t, "otelcontribcol/1.0", r.Header.Get("User-Agent"))
 		reader, err := gzip.NewReader(r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		body, err := io.ReadAll(reader)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		var recvMetadata payload.HostMetadata
 		err = json.Unmarshal(body, &recvMetadata)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, mockMetadata, recvMetadata)
 	})
 

--- a/exporter/honeycombmarkerexporter/logs_exporter_test.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter_test.go
@@ -124,7 +124,7 @@ func TestExportMarkers(t *testing.T) {
 				decodedBody := map[string]any{}
 				err := json.NewDecoder(req.Body).Decode(&decodedBody)
 
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				assert.Equal(t, len(tt.attributeMap), len(decodedBody))
 

--- a/exporter/loadbalancingexporter/log_exporter_test.go
+++ b/exporter/loadbalancingexporter/log_exporter_test.go
@@ -466,7 +466,7 @@ func TestRollingUpdatesWhenConsumeLogs(t *testing.T) {
 				return
 			case <-ticker.C:
 				go func() {
-					require.NoError(t, p.ConsumeLogs(ctx, randomLogs()))
+					assert.NoError(t, p.ConsumeLogs(ctx, randomLogs()))
 				}()
 			}
 		}

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -847,7 +847,7 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 				return
 			case <-ticker.C:
 				go func() {
-					require.NoError(t, p.ConsumeMetrics(ctx, randomMetrics(t, 1, 1, 1, 1)))
+					assert.NoError(t, p.ConsumeMetrics(ctx, randomMetrics(t, 1, 1, 1, 1)))
 				}()
 			}
 		}

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -569,7 +569,7 @@ func TestRollingUpdatesWhenConsumeTraces(t *testing.T) {
 				return
 			case <-ticker.C:
 				go func() {
-					require.NoError(t, p.ConsumeTraces(ctx, randomTraces()))
+					assert.NoError(t, p.ConsumeTraces(ctx, randomTraces()))
 				}()
 			}
 		}

--- a/exporter/lokiexporter/exporter_test.go
+++ b/exporter/lokiexporter/exporter_test.go
@@ -65,13 +65,13 @@ func TestPushLogData(t *testing.T) {
 			// prepare
 			ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				encPayload, err := io.ReadAll(r.Body)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				decPayload, err := snappy.Decode(nil, encPayload)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				err = proto.Unmarshal(decPayload, actualPushRequest)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}))
 			defer ts.Close()
 
@@ -241,14 +241,14 @@ func TestLogsToLokiRequestWithGroupingByTenant(t *testing.T) {
 			// prepare
 			ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 				encPayload, err := io.ReadAll(r.Body)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				decPayload, err := snappy.Decode(nil, encPayload)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				pr := &push.PushRequest{}
 				err = proto.Unmarshal(decPayload, pr)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				actualPushRequestPerTenant[r.Header.Get("X-Scope-OrgID")] = pr
 			}))

--- a/exporter/opensearchexporter/integration_test.go
+++ b/exporter/opensearchexporter/integration_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumererror"
@@ -112,13 +113,13 @@ func TestOpenSearchTraceExporter(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var err error
 			docs := getReceivedDocuments(r.Body)
-			require.LessOrEqualf(t, requestCount, len(tc.RequestHandlers), "Test case generated more requests than it has response for.")
+			assert.LessOrEqualf(t, requestCount, len(tc.RequestHandlers), "Test case generated more requests than it has response for.")
 			tc.RequestHandlers[requestCount].ValidateReceivedDocuments(t, requestCount, docs)
 
 			w.WriteHeader(200)
 			response, _ := os.ReadFile(tc.RequestHandlers[requestCount].ResponseJSONPath)
 			_, err = w.Write(response)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			requestCount++
 		}))
@@ -242,13 +243,13 @@ func TestOpenSearchLogExporter(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			var err error
 			docs := getReceivedDocuments(r.Body)
-			require.LessOrEqualf(t, requestCount, len(tc.RequestHandlers), "Test case generated more requests than it has response for.")
+			assert.LessOrEqualf(t, requestCount, len(tc.RequestHandlers), "Test case generated more requests than it has response for.")
 			tc.RequestHandlers[requestCount].ValidateReceivedDocuments(t, requestCount, docs)
 
 			w.WriteHeader(200)
 			response, _ := os.ReadFile(tc.RequestHandlers[requestCount].ResponseJSONPath)
 			_, err = w.Write(response)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			requestCount++
 		}))

--- a/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -505,11 +505,11 @@ func TestArrowExporterStreamRace(t *testing.T) {
 			defer wg.Done()
 			// This blocks until the cancelation.
 			_, err := tc.exporter.SendAndWait(callctx, twoTraces)
-			require.Error(t, err)
+			assert.Error(t, err)
 
 			stat, is := status.FromError(err)
-			require.True(t, is, "is a gRPC status error: %v", err)
-			require.Equal(t, codes.Canceled, stat.Code())
+			assert.True(t, is, "is a gRPC status error: %v", err)
+			assert.Equal(t, codes.Canceled, stat.Code())
 		}()
 	}
 
@@ -547,8 +547,8 @@ func TestArrowExporterStreaming(t *testing.T) {
 				defer wg.Done()
 				for data := range channel.sendChannel() {
 					traces, err := testCon.TracesFrom(data)
-					require.NoError(t, err)
-					require.Len(t, traces, 1)
+					assert.NoError(t, err)
+					assert.Len(t, traces, 1)
 					actualOutput = append(actualOutput, traces[0])
 					channel.recv <- statusOKFor(data.BatchId)
 				}
@@ -606,7 +606,7 @@ func TestArrowExporterHeaders(t *testing.T) {
 						actualOutput = append(actualOutput, nil)
 					} else {
 						_, err := hpd.Write(data.Headers)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						actualOutput = append(actualOutput, md)
 						md = metadata.MD{}
 					}
@@ -698,7 +698,7 @@ func TestArrowExporterIsTraced(t *testing.T) {
 						actualOutput = append(actualOutput, nil)
 					} else {
 						_, err := hpd.Write(data.Headers)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						actualOutput = append(actualOutput, md)
 						md = metadata.MD{}
 					}
@@ -786,8 +786,8 @@ func TestArrowExporterStreamLifetimeAndShutdown(t *testing.T) {
 
 							for data := range channel.sendChannel() {
 								traces, err := testCon.TracesFrom(data)
-								require.NoError(t, err)
-								require.Len(t, traces, 1)
+								assert.NoError(t, err)
+								assert.Len(t, traces, 1)
 								atomic.AddUint64(&actualCount, 1)
 								channel.recv <- statusOKFor(data.BatchId)
 							}

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -38,7 +39,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	dropWizardServer := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 		// Serve back the metrics as if they were from DropWizard.
 		_, err := rw.Write([]byte(dropWizardResponse))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		currentScrapeIndex++
 		if currentScrapeIndex == 8 { // We shall let the Prometheus receiver scrape the DropWizard mock server, at least 8 times.
 			wg.Done() // done scraping dropWizardResponse 8 times

--- a/exporter/sapmexporter/exporter_test.go
+++ b/exporter/sapmexporter/exporter_test.go
@@ -365,11 +365,11 @@ func TestCompression(t *testing.T) {
 							assert.EqualValues(t, compression, tt.receivedCompression)
 
 							payload, err := decompress(r.Body, compression)
-							require.NoError(t, err)
+							assert.NoError(t, err)
 
 							var sapm splunksapm.PostSpansRequest
 							err = sapm.Unmarshal(payload)
-							require.NoError(t, err)
+							assert.NoError(t, err)
 
 							w.WriteHeader(200)
 							tracesReceived = true

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -229,7 +229,7 @@ func runMetricsExport(cfg *Config, metrics pmetric.Metrics, expectedBatchesNum i
 	defer s.Close()
 	go func() {
 		if e := s.Serve(listener); e != http.ErrServerClosed {
-			require.NoError(t, e)
+			assert.NoError(t, e)
 		}
 	}()
 
@@ -282,7 +282,7 @@ func runTraceExport(testConfig *Config, traces ptrace.Traces, expectedBatchesNum
 	defer s.Close()
 	go func() {
 		if e := s.Serve(listener); e != http.ErrServerClosed {
-			require.NoError(t, e)
+			assert.NoError(t, e)
 		}
 	}()
 
@@ -342,7 +342,7 @@ func runLogExport(cfg *Config, ld plog.Logs, expectedBatchesNum int, t *testing.
 	defer s.Close()
 	go func() {
 		if e := s.Serve(listener); e != http.ErrServerClosed {
-			require.NoError(t, e)
+			assert.NoError(t, e)
 		}
 	}()
 
@@ -1287,7 +1287,7 @@ func TestErrorReceived(t *testing.T) {
 	defer s.Close()
 	go func() {
 		if e := s.Serve(listener); e != http.ErrServerClosed {
-			require.NoError(t, e)
+			assert.NoError(t, e)
 		}
 	}()
 
@@ -1376,7 +1376,7 @@ func TestHeartbeatStartupFailed(t *testing.T) {
 	defer s.Close()
 	go func() {
 		if e := s.Serve(listener); e != http.ErrServerClosed {
-			require.NoError(t, e)
+			assert.NoError(t, e)
 		}
 	}()
 	factory := NewFactory()
@@ -1415,7 +1415,7 @@ func TestHeartbeatStartupPass_Disabled(t *testing.T) {
 	defer s.Close()
 	go func() {
 		if e := s.Serve(listener); e != http.ErrServerClosed {
-			require.NoError(t, e)
+			assert.NoError(t, e)
 		}
 	}()
 	factory := NewFactory()
@@ -1450,7 +1450,7 @@ func TestHeartbeatStartupPass(t *testing.T) {
 	defer s.Close()
 	go func() {
 		if e := s.Serve(listener); e != http.ErrServerClosed {
-			require.NoError(t, e)
+			assert.NoError(t, e)
 		}
 	}()
 	factory := NewFactory()

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -335,7 +335,7 @@ func TestSendLogsSplitFailedOne(t *testing.T) {
 				`{"id":"1TIRY-KGIVX-TPQRJ","errors":[{"code":"internal.error","message":"Internal server error."}]}`,
 			)
 
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			body := extractBody(t, req)
 			assert.Equal(t, "Example log", body)
@@ -987,7 +987,7 @@ func TestSendCompressGzip(t *testing.T) {
 			res.WriteHeader(200)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
-				assert.FailNow(t, "err: %v", err)
+				assert.Fail(t, "err: %v", err)
 				return
 			}
 			body := decodeGzip(t, req.Body)
@@ -1008,7 +1008,7 @@ func TestSendCompressGzipDeprecated(t *testing.T) {
 			res.WriteHeader(200)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
-				assert.FailNow(t, "err: %v", err)
+				assert.Fail(t, "err: %v", err)
 				return
 			}
 			body := decodeGzip(t, req.Body)
@@ -1029,7 +1029,7 @@ func TestSendCompressZstd(t *testing.T) {
 			res.WriteHeader(200)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
-				assert.FailNow(t, "err: %v", err)
+				assert.Fail(t, "err: %v", err)
 				return
 			}
 			body := decodeZstd(t, req.Body)
@@ -1050,7 +1050,7 @@ func TestSendCompressDeflate(t *testing.T) {
 			res.WriteHeader(200)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
-				assert.FailNow(t, "err: %v", err)
+				assert.Fail(t, "err: %v", err)
 				return
 			}
 			body := decodeZlib(t, req.Body)
@@ -1126,9 +1126,9 @@ func TestSendOTLPHistogram(t *testing.T) {
 		func(_ http.ResponseWriter, req *http.Request) {
 			unmarshaler := pmetric.ProtoUnmarshaler{}
 			body, err := io.ReadAll(req.Body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			metrics, err := unmarshaler.UnmarshalMetrics(body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 3, metrics.MetricCount())
 			assert.Equal(t, 16, metrics.DataPointCount())
 		},

--- a/exporter/syslogexporter/exporter_test.go
+++ b/exporter/syslogexporter/exporter_test.go
@@ -37,7 +37,7 @@ func exampleLog(t *testing.T) plog.LogRecord {
 	buffer.Body().SetStr(originalForm)
 	timestamp := "2003-08-24T05:14:15-07:00"
 	timeStr, err := time.Parse(time.RFC3339, timestamp)
-	require.NoError(t, err, "failed to start test syslog server")
+	assert.NoError(t, err, "failed to start test syslog server")
 	ts := pcommon.NewTimestampFromTime(timeStr)
 	buffer.SetTimestamp(ts)
 	attrMap := map[string]any{"proc_id": "8710", "message": "It's time to make the do-nuts.",
@@ -148,7 +148,7 @@ func TestSyslogExportSuccess(t *testing.T) {
 		buffer := exampleLog(t)
 		logs := logRecordsToLogs(buffer)
 		err := test.exp.pushLogsData(context.Background(), logs)
-		require.NoError(t, err, "could not send message")
+		assert.NoError(t, err, "could not send message")
 	}()
 	err := test.srv.SetDeadline(time.Now().Add(time.Second * 1))
 	require.NoError(t, err, "cannot set deadline")

--- a/extension/jaegerremotesampling/extension_test.go
+++ b/extension/jaegerremotesampling/extension_test.go
@@ -92,7 +92,7 @@ func TestRemote(t *testing.T) {
 
 			go func() {
 				err = server.Serve(lis)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}()
 			defer func() { server.Stop() }()
 

--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -100,7 +100,7 @@ func TestBasicStart(t *testing.T) {
 
 			// register
 			case 1:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 				_, err := w.Write([]byte(`{
 					"collectorCredentialID": "collectorId",
 					"collectorCredentialKey": "collectorKey",
@@ -162,7 +162,7 @@ func TestStoreCredentials(t *testing.T) {
 
 				// register
 				case 1:
-					require.Equal(t, registerURL, req.URL.Path)
+					assert.Equal(t, registerURL, req.URL.Path)
 					_, err := w.Write([]byte(`{
 						"collectorCredentialID": "collectorId",
 						"collectorCredentialKey": "collectorKey",
@@ -317,12 +317,12 @@ func TestStoreCredentials_PreexistingCredentialsAreUsed(t *testing.T) {
 				switch reqNum {
 				// heartbeat
 				case 1:
-					require.Equal(t, heartbeatURL, req.URL.Path)
+					assert.Equal(t, heartbeatURL, req.URL.Path)
 					w.WriteHeader(204)
 
 				// metadata
 				case 2:
-					require.Equal(t, metadataURL, req.URL.Path)
+					assert.Equal(t, metadataURL, req.URL.Path)
 					w.WriteHeader(200)
 
 				// should not produce any more requests
@@ -405,7 +405,7 @@ func TestLocalFSCredentialsStore_WorkCorrectlyForMultipleExtensions(t *testing.T
 
 				// register
 				case 1:
-					require.Equal(t, registerURL, req.URL.Path)
+					assert.Equal(t, registerURL, req.URL.Path)
 					_, err := w.Write([]byte(`{
 						"collectorCredentialID": "collectorId",
 						"collectorCredentialKey": "collectorKey",
@@ -509,7 +509,7 @@ func TestRegisterEmptyCollectorName(t *testing.T) {
 
 			// register
 			case 1:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 
 				authHeader := req.Header.Get("Authorization")
 				assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -578,7 +578,7 @@ func TestRegisterEmptyCollectorNameForceRegistration(t *testing.T) {
 
 			// register
 			case 1:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 
 				authHeader := req.Header.Get("Authorization")
 				assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -601,7 +601,7 @@ func TestRegisterEmptyCollectorNameForceRegistration(t *testing.T) {
 
 			// register again because force registration was set
 			case 3:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 
 				authHeader := req.Header.Get("Authorization")
 				assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -672,7 +672,7 @@ func TestCollectorSendsBasicAuthHeadersOnRegistration(t *testing.T) {
 
 			// register
 			case 1:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 
 				authHeader := req.Header.Get("Authorization")
 				assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -776,7 +776,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// heatbeat
 						case 1:
-							require.NotEqual(t, registerURL, req.URL.Path,
+							assert.NotEqual(t, registerURL, req.URL.Path,
 								"collector shouldn't call the register API when credentials locally retrieved")
 
 							assert.Equal(t, heartbeatURL, req.URL.Path)
@@ -824,7 +824,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// failing heatbeat
 						case 1:
-							require.NotEqual(t, registerURL, req.URL.Path,
+							assert.NotEqual(t, registerURL, req.URL.Path,
 								"collector shouldn't call the register API when credentials locally retrieved")
 
 							assert.Equal(t, heartbeatURL, req.URL.Path)
@@ -840,7 +840,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// successful heatbeat
 						case 2:
-							require.NotEqual(t, registerURL, req.URL.Path,
+							assert.NotEqual(t, registerURL, req.URL.Path,
 								"collector shouldn't call the register API when credentials locally retrieved")
 
 							assert.Equal(t, heartbeatURL, req.URL.Path)
@@ -888,7 +888,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// failing heatbeat
 						case 1:
-							require.NotEqual(t, registerURL, req.URL.Path,
+							assert.NotEqual(t, registerURL, req.URL.Path,
 								"collector shouldn't call the register API when credentials locally retrieved")
 
 							assert.Equal(t, heartbeatURL, req.URL.Path)
@@ -904,7 +904,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// register
 						case 2:
-							require.Equal(t, registerURL, req.URL.Path)
+							assert.Equal(t, registerURL, req.URL.Path)
 
 							authHeader := req.Header.Get("Authorization")
 							assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -956,7 +956,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// register
 						case 1:
-							require.Equal(t, registerURL, req.URL.Path)
+							assert.Equal(t, registerURL, req.URL.Path)
 
 							authHeader := req.Header.Get("Authorization")
 							assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -1047,7 +1047,7 @@ func TestRegisterEmptyCollectorNameWithBackoff(t *testing.T) {
 
 			// register
 			case reqNum <= retriesLimit:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 
 				authHeader := req.Header.Get("Authorization")
 				assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -1113,7 +1113,7 @@ func TestRegisterEmptyCollectorNameUnrecoverableError(t *testing.T) {
 	srv := httptest.NewServer(func() http.HandlerFunc {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 			// TODO Add payload verification - verify if collectorName is set properly
-			require.Equal(t, registerURL, req.URL.Path)
+			assert.Equal(t, registerURL, req.URL.Path)
 
 			authHeader := req.Header.Get("Authorization")
 			assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -1129,7 +1129,7 @@ func TestRegisterEmptyCollectorNameUnrecoverableError(t *testing.T) {
 					}
 				]
 			}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		})
 	}())
 
@@ -1166,7 +1166,7 @@ func TestRegistrationRedirect(t *testing.T) {
 
 			// register
 			case 1:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 
 				authHeader := req.Header.Get("Authorization")
 
@@ -1209,7 +1209,7 @@ func TestRegistrationRedirect(t *testing.T) {
 
 			// should not produce any more requests
 			default:
-				require.Fail(t,
+				assert.Fail(t,
 					"extension should not make more than 5 requests to the destination server",
 				)
 			}
@@ -1224,12 +1224,12 @@ func TestRegistrationRedirect(t *testing.T) {
 
 			// register
 			case 1:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 				http.Redirect(w, req, destSrv.URL, http.StatusMovedPermanently)
 
 			// should not produce any more requests
 			default:
-				require.Fail(t,
+				assert.Fail(t,
 					"extension should not make more than 1 request to the original server",
 				)
 			}
@@ -1398,22 +1398,22 @@ func TestRegistrationRequestPayload(t *testing.T) {
 			switch reqNum {
 			// register
 			case 1:
-				require.Equal(t, registerURL, req.URL.Path)
+				assert.Equal(t, registerURL, req.URL.Path)
 
 				var reqPayload api.OpenRegisterRequestPayload
-				require.NoError(t, json.NewDecoder(req.Body).Decode(&reqPayload))
-				require.True(t, reqPayload.Clobber)
-				require.Equal(t, hostname, reqPayload.Hostname)
-				require.Equal(t, "my description", reqPayload.Description)
-				require.Equal(t, "my category/", reqPayload.Category)
-				require.EqualValues(t,
+				assert.NoError(t, json.NewDecoder(req.Body).Decode(&reqPayload))
+				assert.True(t, reqPayload.Clobber)
+				assert.Equal(t, hostname, reqPayload.Hostname)
+				assert.Equal(t, "my description", reqPayload.Description)
+				assert.Equal(t, "my category/", reqPayload.Category)
+				assert.EqualValues(t,
 					map[string]any{
 						"field1": "value1",
 						"field2": "value2",
 					},
 					reqPayload.Fields,
 				)
-				require.Equal(t, "PST", reqPayload.TimeZone)
+				assert.Equal(t, "PST", reqPayload.TimeZone)
 
 				authHeader := req.Header.Get("Authorization")
 				assert.Equal(t, "Bearer dummy_install_token", authHeader,
@@ -1425,7 +1425,7 @@ func TestRegistrationRequestPayload(t *testing.T) {
 					"collectorId": "0000000001231231",
 					"collectorName": "otc-test-123456123123"
 					}`))
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
@@ -1526,24 +1526,24 @@ func TestUpdateMetadataRequestPayload(t *testing.T) {
 
 	srv := httptest.NewServer(func() http.HandlerFunc {
 		return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-			require.Equal(t, metadataURL, req.URL.Path)
+			assert.Equal(t, metadataURL, req.URL.Path)
 
 			var reqPayload api.OpenMetadataRequestPayload
-			require.NoError(t, json.NewDecoder(req.Body).Decode(&reqPayload))
-			require.NotEmpty(t, reqPayload.HostDetails.Name)
-			require.NotEmpty(t, reqPayload.HostDetails.OsName)
+			assert.NoError(t, json.NewDecoder(req.Body).Decode(&reqPayload))
+			assert.NotEmpty(t, reqPayload.HostDetails.Name)
+			assert.NotEmpty(t, reqPayload.HostDetails.OsName)
 			// @sumo-drosiek: It happened to be empty OsVersion on my machine
 			// require.NotEmpty(t, reqPayload.HostDetails.OsVersion)
-			require.NotEmpty(t, reqPayload.NetworkDetails.HostIPAddress)
-			require.EqualValues(t, "EKS-1.20.2", reqPayload.HostDetails.Environment)
-			require.EqualValues(t, "1.0.0", reqPayload.CollectorDetails.RunningVersion)
-			require.EqualValues(t, "A", reqPayload.TagDetails["team"])
-			require.EqualValues(t, "linux", reqPayload.TagDetails["app"])
-			require.EqualValues(t, "true", reqPayload.TagDetails["sumo.disco.enabled"])
+			assert.NotEmpty(t, reqPayload.NetworkDetails.HostIPAddress)
+			assert.EqualValues(t, "EKS-1.20.2", reqPayload.HostDetails.Environment)
+			assert.EqualValues(t, "1.0.0", reqPayload.CollectorDetails.RunningVersion)
+			assert.EqualValues(t, "A", reqPayload.TagDetails["team"])
+			assert.EqualValues(t, "linux", reqPayload.TagDetails["app"])
+			assert.EqualValues(t, "true", reqPayload.TagDetails["sumo.disco.enabled"])
 
 			_, err := w.Write([]byte(``))
 
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		})
 	}())
 

--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 
 	"github.com/docker/go-connections/nat"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"go.opentelemetry.io/collector/component"
@@ -142,7 +143,7 @@ func (it *IntegrationTest) createContainers(t *testing.T) *ContainerInfo {
 	for _, cr := range it.containerRequests {
 		go func(req testcontainers.ContainerRequest) {
 			var errs error
-			require.Eventuallyf(t, func() bool {
+			assert.Eventuallyf(t, func() bool {
 				c, err := testcontainers.GenericContainer(
 					context.Background(),
 					testcontainers.GenericContainerRequest{

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -184,7 +184,7 @@ func TestEventLoopHandlesError(t *testing.T) {
 			wg.Done()
 		}
 		_, err := w.Write([]byte{})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	defer srv.Close()
 

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -105,9 +105,9 @@ func TestDefaultTLSClient(t *testing.T) {
 func TestSvcAcctClient(t *testing.T) {
 	server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		// Check if call is authenticated using token from test file
-		require.Equal(t, "Bearer s3cr3t", req.Header.Get("Authorization"))
+		assert.Equal(t, "Bearer s3cr3t", req.Header.Get("Authorization"))
 		_, err := rw.Write([]byte(`OK`))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 	cert, err := tls.LoadX509KeyPair(certPath, keyFile)
 	require.NoError(t, err)
@@ -174,11 +174,11 @@ func TestNewKubeConfigClient(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewUnstartedServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				// Check if call is authenticated using provided kubeconfig
-				require.Equal(t, "Bearer my-token", req.Header.Get("Authorization"))
-				require.Equal(t, "/api/v1/nodes/nodename/proxy/", req.URL.EscapedPath())
+				assert.Equal(t, "Bearer my-token", req.Header.Get("Authorization"))
+				assert.Equal(t, "/api/v1/nodes/nodename/proxy/", req.URL.EscapedPath())
 				// Send response to be tested
 				_, err := rw.Write([]byte(`OK`))
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}))
 			server.StartTLS()
 			defer server.Close()

--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -16,7 +16,8 @@ import (
 	"time"
 
 	"github.com/open-telemetry/otel-arrow/pkg/datagen"
-	"github.com/open-telemetry/otel-arrow/pkg/otel/assert"
+	otel_assert "github.com/open-telemetry/otel-arrow/pkg/otel/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -175,18 +176,18 @@ func testIntegrationTraces(ctx context.Context, t *testing.T, tp testParams, cfg
 	// Run the receiver, shutdown after exporter does.
 	go func() {
 		defer receiverShutdownWG.Done()
-		require.NoError(t, receiver.Start(ctx, host))
+		assert.NoError(t, receiver.Start(ctx, host))
 		exporterShutdownWG.Wait()
-		require.NoError(t, receiver.Shutdown(ctx))
+		assert.NoError(t, receiver.Shutdown(ctx))
 	}()
 
 	// Run the exporter and wait for clients to finish
 	go func() {
 		defer exporterShutdownWG.Done()
-		require.NoError(t, exporter.Start(ctx, host))
+		assert.NoError(t, exporter.Start(ctx, host))
 		startWG.Done()
 		startExporterShutdownWG.Wait()
-		require.NoError(t, exporter.Shutdown(ctx))
+		assert.NoError(t, exporter.Shutdown(ctx))
 	}()
 
 	// wait for the exporter to start
@@ -287,8 +288,8 @@ func standardEnding(t *testing.T, _ testParams, testCon *testConsumer, expect []
 	for _, td := range testCon.sink.AllTraces() {
 		receivedJSON = append(receivedJSON, ptraceotlp.NewExportRequestFromTraces(td))
 	}
-	asserter := assert.NewStdUnitTest(t)
-	assert.Equiv(asserter, expectJSON, receivedJSON)
+	asserter := otel_assert.NewStdUnitTest(t)
+	otel_assert.Equiv(asserter, expectJSON, receivedJSON)
 
 	rops = map[string]int{}
 	eops = map[string]int{}

--- a/pkg/stanza/adapter/integration_test.go
+++ b/pkg/stanza/adapter/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -159,7 +160,7 @@ func TestEmitterToConsumer(t *testing.T) {
 	go func() {
 		ctx := context.Background()
 		for _, e := range entries {
-			require.NoError(t, logsReceiver.emitter.Process(ctx, e))
+			assert.NoError(t, logsReceiver.emitter.Process(ctx, e))
 		}
 	}()
 

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -139,12 +139,12 @@ func TestShutdownFlush(t *testing.T) {
 		for {
 			select {
 			case <-closeCh:
-				require.NoError(t, logsReceiver.Shutdown(context.Background()))
+				assert.NoError(t, logsReceiver.Shutdown(context.Background()))
 				fmt.Println(">> Shutdown called")
 				return
 			default:
 				err := stanzaReceiver.emitter.Process(context.Background(), entry.New())
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 			consumedLogCount.Add(1)
 		}

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 
@@ -210,12 +211,12 @@ func BenchmarkFileInput(b *testing.B) {
 					// Write the other half of the content while running
 					for i := 0; i < b.N/2; i++ {
 						_, err := f.WriteString(severalLines)
-						require.NoError(b, err)
+						assert.NoError(b, err)
 					}
 					// Signal end of file
 					_, err := f.WriteString("\n")
-					require.NoError(b, err)
-					require.NoError(b, f.Sync())
+					assert.NoError(b, err)
+					assert.NoError(b, f.Sync())
 				}(file)
 			}
 

--- a/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
@@ -202,7 +202,7 @@ func sinkTest(t *testing.T, opts ...SinkOpt) (*Sink, []*Call) {
 	}
 	go func() {
 		for _, c := range testCalls {
-			require.NoError(t, s.Callback(context.Background(), c.Token, c.Attrs))
+			assert.NoError(t, s.Callback(context.Background(), c.Token, c.Attrs))
 		}
 	}()
 	return s, testCalls

--- a/pkg/stanza/fileconsumer/rotation_test.go
+++ b/pkg/stanza/fileconsumer/rotation_test.go
@@ -69,16 +69,16 @@ func TestCopyTruncate(t *testing.T) {
 					filetest.WriteString(t, file, getMessage(fn, rotationNum, messageNum)+"\n")
 					time.Sleep(10 * time.Millisecond)
 				}
-				require.NoError(t, file.Sync())
+				assert.NoError(t, file.Sync())
 				_, err := file.Seek(0, 0)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				dst := filetest.OpenFile(t, fileName(fn, rotationNum))
 				_, err = io.Copy(dst, file)
-				require.NoError(t, err)
-				require.NoError(t, dst.Close())
-				require.NoError(t, file.Truncate(0))
+				assert.NoError(t, err)
+				assert.NoError(t, dst.Close())
+				assert.NoError(t, file.Truncate(0))
 				_, err = file.Seek(0, 0)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}(fileNum)
 	}
@@ -130,8 +130,8 @@ func TestMoveCreate(t *testing.T) {
 					filetest.WriteString(t, file, getMessage(fn, rotationNum, messageNum)+"\n")
 					time.Sleep(10 * time.Millisecond)
 				}
-				require.NoError(t, file.Close())
-				require.NoError(t, os.Rename(baseFileName(fn), fileName(fn, rotationNum)))
+				assert.NoError(t, file.Close())
+				assert.NoError(t, os.Rename(baseFileName(fn), fileName(fn, rotationNum)))
 			}
 		}(fileNum)
 	}

--- a/pkg/stanza/operator/helper/emitter_test.go
+++ b/pkg/stanza/operator/helper/emitter_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 
@@ -27,7 +28,7 @@ func TestLogEmitter(t *testing.T) {
 	in := entry.New()
 
 	go func() {
-		require.NoError(t, emitter.Process(context.Background(), in))
+		assert.NoError(t, emitter.Process(context.Background(), in))
 	}()
 
 	select {
@@ -55,7 +56,7 @@ func TestLogEmitterEmitsOnMaxBatchSize(t *testing.T) {
 	go func() {
 		ctx := context.Background()
 		for _, e := range entries {
-			require.NoError(t, emitter.Process(ctx, e))
+			assert.NoError(t, emitter.Process(ctx, e))
 		}
 	}()
 
@@ -85,7 +86,7 @@ func TestLogEmitterEmitsOnFlushInterval(t *testing.T) {
 
 	go func() {
 		ctx := context.Background()
-		require.NoError(t, emitter.Process(ctx, entry))
+		assert.NoError(t, emitter.Process(ctx, entry))
 	}()
 
 	timeoutChan := time.After(timeout)

--- a/pkg/stanza/operator/input/tcp/input_test.go
+++ b/pkg/stanza/operator/input/tcp/input_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -435,13 +436,13 @@ func BenchmarkTCPInput(b *testing.B) {
 	done := make(chan struct{})
 	go func() {
 		conn, err := net.Dial("tcp", tcpInput.listener.Addr().String())
-		require.NoError(b, err)
+		assert.NoError(b, err)
 		defer func() {
 			err := tcpInput.Stop()
-			require.NoError(b, err, "expected to stop tcp input operator without error")
+			assert.NoError(b, err, "expected to stop tcp input operator without error")
 
 			err = conn.Close()
-			require.NoError(b, err, "expected to close connection without error")
+			assert.NoError(b, err, "expected to close connection without error")
 		}()
 		message := []byte("message\n")
 		for {
@@ -450,7 +451,7 @@ func BenchmarkTCPInput(b *testing.B) {
 				return
 			default:
 				_, err := conn.Write(message)
-				require.NoError(b, err)
+				assert.NoError(b, err)
 			}
 		}
 	}()

--- a/pkg/stanza/operator/input/udp/input_test.go
+++ b/pkg/stanza/operator/input/udp/input_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -229,9 +230,9 @@ func BenchmarkUDPInput(b *testing.B) {
 	done := make(chan struct{})
 	go func() {
 		conn, err := net.Dial("udp", udpInput.connection.LocalAddr().String())
-		require.NoError(b, err)
+		assert.NoError(b, err)
 		defer func() {
-			require.NoError(b, udpInput.Stop())
+			assert.NoError(b, udpInput.Stop())
 		}()
 		defer conn.Close()
 		message := []byte("message\n")
@@ -241,7 +242,7 @@ func BenchmarkUDPInput(b *testing.B) {
 				return
 			default:
 				_, err := conn.Write(message)
-				require.NoError(b, err)
+				assert.NoError(b, err)
 			}
 		}
 	}()

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 
@@ -898,7 +899,7 @@ func TestTimeoutWhenAggregationKeepHappen(t *testing.T) {
 				ticker.Stop()
 				return
 			case <-ticker.C:
-				require.NoError(t, recombine.Process(ctx, next))
+				assert.NoError(t, recombine.Process(ctx, next))
 
 			}
 		}

--- a/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection_test.go
@@ -221,7 +221,7 @@ func TestDetectResource_Parallel(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			detected, _, err := p.Get(context.Background(), http.DefaultClient)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, expectedResourceAttrs, detected.Attributes().AsRaw())
 		}()
 	}

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -235,13 +235,13 @@ func TestConcurrentTraceArrival(t *testing.T) {
 		wg.Add(2)
 		concurrencyLimiter <- struct{}{}
 		go func(td ptrace.Traces) {
-			require.NoError(t, sp.ConsumeTraces(context.Background(), td))
+			assert.NoError(t, sp.ConsumeTraces(context.Background(), td))
 			wg.Done()
 			<-concurrencyLimiter
 		}(batch)
 		concurrencyLimiter <- struct{}{}
 		go func(td ptrace.Traces) {
-			require.NoError(t, sp.ConsumeTraces(context.Background(), td))
+			assert.NoError(t, sp.ConsumeTraces(context.Background(), td))
 			wg.Done()
 			<-concurrencyLimiter
 		}(batch)
@@ -292,12 +292,12 @@ func TestConcurrentArrivalAndEvaluation(t *testing.T) {
 		wg.Add(1)
 		go func(td ptrace.Traces) {
 			for i := 0; i < 10; i++ {
-				require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+				assert.NoError(t, tsp.ConsumeTraces(context.Background(), td))
 			}
 			<-evalStarted
 			close(continueEvaluation)
 			for i := 0; i < 10; i++ {
-				require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+				assert.NoError(t, tsp.ConsumeTraces(context.Background(), td))
 			}
 			wg.Done()
 		}(batch)
@@ -357,7 +357,7 @@ func TestConcurrentTraceMapSize(t *testing.T) {
 	for _, batch := range batches {
 		wg.Add(1)
 		go func(td ptrace.Traces) {
-			require.NoError(t, sp.ConsumeTraces(context.Background(), td))
+			assert.NoError(t, sp.ConsumeTraces(context.Background(), td))
 			wg.Done()
 		}(batch)
 	}

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -189,7 +190,7 @@ Load15: 0.3
 Total Duration: 1501
 Scoreboard: S_DD_L_GGG_____W__IIII_C________________W__________________________________.........................____WR______W____W________________________C______________________________________W_W____W______________R_________R________C_________WK_W________K_____W__C__________W___R______.............................................................................................................................
 `))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 		rw.WriteHeader(404)

--- a/receiver/apachesparkreceiver/client_test.go
+++ b/receiver/apachesparkreceiver/client_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -82,7 +83,7 @@ func TestClusterStats(t *testing.T) {
 						w.WriteHeader(http.StatusUnauthorized)
 					} else {
 						_, err := w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}))
 				defer ts.Close()
@@ -102,11 +103,11 @@ func TestClusterStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "/metrics/json") {
 						_, err = w.Write([]byte("[{}]"))
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -125,9 +126,9 @@ func TestClusterStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "/metrics/json") {
 						_, err = w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -165,7 +166,7 @@ func TestApplications(t *testing.T) {
 						w.WriteHeader(http.StatusUnauthorized)
 					} else {
 						_, err := w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}))
 				defer ts.Close()
@@ -185,11 +186,11 @@ func TestApplications(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "applications") {
 						_, err = w.Write([]byte(""))
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -208,9 +209,9 @@ func TestApplications(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "applications") {
 						_, err = w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -248,7 +249,7 @@ func TestStageStats(t *testing.T) {
 						w.WriteHeader(http.StatusUnauthorized)
 					} else {
 						_, err := w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}))
 				defer ts.Close()
@@ -268,11 +269,11 @@ func TestStageStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "stages") {
 						_, err = w.Write([]byte(""))
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -291,9 +292,9 @@ func TestStageStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "stages") {
 						_, err = w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -331,7 +332,7 @@ func TestExecutorStats(t *testing.T) {
 						w.WriteHeader(http.StatusUnauthorized)
 					} else {
 						_, err := w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}))
 				defer ts.Close()
@@ -351,11 +352,11 @@ func TestExecutorStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "executors") {
 						_, err = w.Write([]byte(""))
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -374,9 +375,9 @@ func TestExecutorStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "executors") {
 						_, err = w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -414,7 +415,7 @@ func TestJobStats(t *testing.T) {
 						w.WriteHeader(http.StatusUnauthorized)
 					} else {
 						_, err := w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}))
 				defer ts.Close()
@@ -434,11 +435,11 @@ func TestJobStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "jobs") {
 						_, err = w.Write([]byte(""))
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -457,9 +458,9 @@ func TestJobStats(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "jobs") {
 						_, err = w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 

--- a/receiver/bigipreceiver/client_test.go
+++ b/receiver/bigipreceiver/client_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -127,7 +128,7 @@ func TestGetNewToken(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("[{}]"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -147,7 +148,7 @@ func TestGetNewToken(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write(data)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -181,7 +182,7 @@ func TestGetVirtualServers(t *testing.T) {
 						w.WriteHeader(http.StatusUnauthorized)
 					} else {
 						_, err := w.Write(data)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}))
 				defer ts.Close()
@@ -202,11 +203,11 @@ func TestGetVirtualServers(t *testing.T) {
 					var err error
 					if strings.HasSuffix(r.RequestURI, "stats") {
 						_, err = w.Write([]byte("[{}]"))
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -229,7 +230,7 @@ func TestGetVirtualServers(t *testing.T) {
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -249,7 +250,7 @@ func TestGetVirtualServers(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if strings.HasSuffix(r.RequestURI, "stats") {
 						_, err := w.Write(statsData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						w.WriteHeader(http.StatusUnauthorized)
 					}
@@ -279,7 +280,7 @@ func TestGetVirtualServers(t *testing.T) {
 					} else {
 						_, err = w.Write([]byte("[{}]"))
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -306,7 +307,7 @@ func TestGetVirtualServers(t *testing.T) {
 					} else {
 						_, err = w.Write([]byte("{}"))
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -335,7 +336,7 @@ func TestGetVirtualServers(t *testing.T) {
 					} else {
 						_, err = w.Write(data)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -358,7 +359,7 @@ func TestGetVirtualServers(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("{}"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -404,7 +405,7 @@ func TestGetPools(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("[{}]"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -423,7 +424,7 @@ func TestGetPools(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write(data)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -445,7 +446,7 @@ func TestGetPools(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("{}"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -495,7 +496,7 @@ func TestGetPoolMembers(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("[{}]"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -519,7 +520,7 @@ func TestGetPoolMembers(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if strings.Contains(r.RequestURI, "~Common~dev") {
 						_, err := w.Write(data1)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						w.WriteHeader(http.StatusUnauthorized)
 					}
@@ -547,7 +548,7 @@ func TestGetPoolMembers(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if strings.Contains(r.RequestURI, "~Common~dev") {
 						_, err := w.Write([]byte("{}"))
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					} else {
 						w.WriteHeader(http.StatusUnauthorized)
 					}
@@ -581,7 +582,7 @@ func TestGetPoolMembers(t *testing.T) {
 					} else {
 						_, err = w.Write(data2)
 					}
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -607,7 +608,7 @@ func TestGetPoolMembers(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("{}"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -657,7 +658,7 @@ func TestGetNodes(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("[{}]"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -676,7 +677,7 @@ func TestGetNodes(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write(data)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -698,7 +699,7 @@ func TestGetNodes(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("{}"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 

--- a/receiver/bigipreceiver/integration_test.go
+++ b/receiver/bigipreceiver/integration_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 
@@ -85,12 +86,12 @@ func setupMockIControlServer(t *testing.T) *httptest.Server {
 		if strings.HasSuffix(r.RequestURI, loginURISuffix) {
 			var body loginBody
 			err = json.NewDecoder(r.Body).Decode(&body)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			if body.Username == "" || body.Password == "" || r.Method != "POST" {
 				w.WriteHeader(http.StatusUnauthorized)
 			} else {
 				_, err = w.Write(mockLoginResponse)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 
 			return
@@ -122,7 +123,7 @@ func setupMockIControlServer(t *testing.T) *httptest.Server {
 			w.WriteHeader(http.StatusBadRequest)
 			err = nil
 		}
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 
 	return server

--- a/receiver/couchdbreceiver/client_test.go
+++ b/receiver/couchdbreceiver/client_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -145,13 +146,13 @@ func TestGetNodeStats(t *testing.T) {
 		if strings.Contains(r.URL.Path, "/invalid_json") {
 			w.WriteHeader(200)
 			_, err := w.Write([]byte(`{"}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 		if strings.Contains(r.URL.Path, "/_stats/couchdb") {
 			w.WriteHeader(200)
 			_, err := w.Write([]byte(`{"key":["value"]}`))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 		w.WriteHeader(404)

--- a/receiver/elasticsearchreceiver/client_test.go
+++ b/receiver/elasticsearchreceiver/client_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -638,14 +639,14 @@ func newMockServer(t *testing.T, opts ...mockServerOption) *httptest.Server {
 		if req.URL.Path == "/" {
 			rw.WriteHeader(200)
 			_, err := rw.Write(mock.metadata)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 		for prefix, payload := range mock.prefixes {
 			if strings.HasPrefix(req.URL.Path, prefix) {
 				rw.WriteHeader(200)
 				_, err := rw.Write(payload)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 				return
 			}
 		}

--- a/receiver/expvarreceiver/scraper_test.go
+++ b/receiver/expvarreceiver/scraper_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -89,7 +90,7 @@ func newMockServer(tb testing.TB, responseBodyFile string) *httptest.Server {
 		if req.URL.Path == defaultPath {
 			rw.WriteHeader(http.StatusOK)
 			_, err := rw.Write(fileContents)
-			require.NoError(tb, err)
+			assert.NoError(tb, err)
 			return
 		}
 		rw.WriteHeader(http.StatusNotFound)

--- a/receiver/flinkmetricsreceiver/client_test.go
+++ b/receiver/flinkmetricsreceiver/client_test.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -142,7 +143,7 @@ func TestGetJobmanagerMetrics(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("{"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -159,7 +160,7 @@ func TestGetJobmanagerMetrics(t *testing.T) {
 				jobmanagerMetricValuesData := loadAPIResponseData(t, apiResponses, jobmanagerMetricValues)
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write(jobmanagerMetricValuesData)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -211,7 +212,7 @@ func TestGetTaskmanagersMetrics(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte(`{`))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -229,12 +230,12 @@ func TestGetTaskmanagersMetrics(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if match, _ := regexp.MatchString(taskmanagerIDsRegex, r.URL.Path); match {
 						_, err := w.Write(taskmanagerIDs)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 
 					_, err := w.Write([]byte("{"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -253,13 +254,13 @@ func TestGetTaskmanagersMetrics(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if match, _ := regexp.MatchString(taskmanagerIDsRegex, r.URL.Path); match {
 						_, err := w.Write(taskmanagerIDs)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 
 					if match, _ := regexp.MatchString(taskmanagerMetricNamesRegex, r.URL.Path); match {
 						_, err := w.Write(taskmanagerMetricValuesData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 				}))
@@ -312,7 +313,7 @@ func TestGetJobsMetrics(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte(`{`))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -330,11 +331,11 @@ func TestGetJobsMetrics(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if r.URL.Path == jobsOverviewEndpoint {
 						_, err := w.Write(jobsOverviewData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					_, err := w.Write([]byte(`{`))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -353,12 +354,12 @@ func TestGetJobsMetrics(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if r.URL.Path == jobsOverviewEndpoint {
 						_, err := w.Write(jobsOverviewData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					if match, _ := regexp.MatchString(jobsMetricNamesRegex, r.URL.Path); match {
 						_, err := w.Write(jobsMetricValuesData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 				}))
@@ -414,7 +415,7 @@ func TestGetSubtasksMetrics(t *testing.T) {
 			testFunc: func(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("{"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -432,11 +433,11 @@ func TestGetSubtasksMetrics(t *testing.T) {
 					jobsData := loadAPIResponseData(t, apiResponses, jobsIDs)
 					if r.URL.Path == jobsEndpoint {
 						_, err := w.Write(jobsData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					_, err := w.Write([]byte("{"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -455,16 +456,16 @@ func TestGetSubtasksMetrics(t *testing.T) {
 					jobsWithIDData := loadAPIResponseData(t, apiResponses, jobsWithID)
 					if r.URL.Path == jobsEndpoint {
 						_, err := w.Write(jobsData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					if match, _ := regexp.MatchString(jobsWithIDRegex, r.URL.Path); match {
 						_, err := w.Write(jobsWithIDData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					_, err := w.Write([]byte("{"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -484,21 +485,21 @@ func TestGetSubtasksMetrics(t *testing.T) {
 					verticesData := loadAPIResponseData(t, apiResponses, vertices)
 					if r.URL.Path == jobsEndpoint {
 						_, err := w.Write(jobsData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					if match, _ := regexp.MatchString(jobsWithIDRegex, r.URL.Path); match {
 						_, err := w.Write(jobsWithIDData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					if match, _ := regexp.MatchString(verticesRegex, r.URL.Path); match {
 						_, err := w.Write(verticesData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					_, err := w.Write([]byte("{"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -519,22 +520,22 @@ func TestGetSubtasksMetrics(t *testing.T) {
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					if r.URL.Path == jobsEndpoint {
 						_, err := w.Write(jobsData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					if match, _ := regexp.MatchString(jobsWithIDRegex, r.URL.Path); match {
 						_, err := w.Write(jobsWithIDData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					if match, _ := regexp.MatchString(verticesRegex, r.URL.Path); match {
 						_, err := w.Write(verticesData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 					if match, _ := regexp.MatchString(subtaskMetricNamesRegex, r.URL.Path); match {
 						_, err := w.Write(subtaskMetricValuesData)
-						require.NoError(t, err)
+						assert.NoError(t, err)
 						return
 					}
 				}))

--- a/receiver/fluentforwardreceiver/receiver_test.go
+++ b/receiver/fluentforwardreceiver/receiver_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tinylib/msgp/msgp"
 	"go.opentelemetry.io/collector/consumer/consumertest"
@@ -51,7 +52,7 @@ func setupServer(t *testing.T) (func() net.Conn, *consumertest.LogsSink, *observ
 
 	go func() {
 		<-ctx.Done()
-		require.NoError(t, receiver.Shutdown(ctx))
+		assert.NoError(t, receiver.Shutdown(ctx))
 	}()
 
 	return connect, next, logObserver, cancel
@@ -381,10 +382,10 @@ func TestHighVolume(t *testing.T) {
 			for j := 0; j < totalMessagesPerRoutine; j++ {
 				eventBytes := makeSampleEvent(fmt.Sprintf("tag-%d-%d", num, j))
 				n, err := conn.Write(eventBytes)
-				require.NoError(t, err)
-				require.Equal(t, len(eventBytes), n)
+				assert.NoError(t, err)
+				assert.Equal(t, len(eventBytes), n)
 			}
-			require.NoError(t, conn.Close())
+			assert.NoError(t, conn.Close())
 			wg.Done()
 		}(i)
 	}

--- a/receiver/haproxyreceiver/scraper_test.go
+++ b/receiver/haproxyreceiver/scraper_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -28,22 +29,22 @@ func Test_scraper_readStats(t *testing.T) {
 
 	go func() {
 		c, err2 := l.Accept()
-		require.NoError(t, err2)
+		assert.NoError(t, err2)
 
 		buf := make([]byte, 512)
 		nr, err2 := c.Read(buf)
-		require.NoError(t, err2)
+		assert.NoError(t, err2)
 
 		data := string(buf[0:nr])
 		switch data {
 		case "show stat\n":
 			stats, err2 := os.ReadFile(filepath.Join("testdata", "stats.txt"))
-			require.NoError(t, err2)
+			assert.NoError(t, err2)
 			_, err2 = c.Write(stats)
-			require.NoError(t, err2)
-			require.NoError(t, c.Close())
+			assert.NoError(t, err2)
+			assert.NoError(t, c.Close())
 		default:
-			require.Fail(t, fmt.Sprintf("invalid message: %v", data))
+			assert.Fail(t, fmt.Sprintf("invalid message: %v", data))
 		}
 	}()
 
@@ -72,22 +73,22 @@ func Test_scraper_readStatsWithIncompleteValues(t *testing.T) {
 
 	go func() {
 		c, err2 := l.Accept()
-		require.NoError(t, err2)
+		assert.NoError(t, err2)
 
 		buf := make([]byte, 512)
 		nr, err2 := c.Read(buf)
-		require.NoError(t, err2)
+		assert.NoError(t, err2)
 
 		data := string(buf[0:nr])
 		switch data {
 		case "show stat\n":
 			stats, err2 := os.ReadFile(filepath.Join("testdata", "30252_stats.txt"))
-			require.NoError(t, err2)
+			assert.NoError(t, err2)
 			_, err2 = c.Write(stats)
-			require.NoError(t, err2)
-			require.NoError(t, c.Close())
+			assert.NoError(t, err2)
+			assert.NoError(t, c.Close())
 		default:
-			require.Fail(t, fmt.Sprintf("invalid message: %v", data))
+			assert.Fail(t, fmt.Sprintf("invalid message: %v", data))
 		}
 	}()
 
@@ -116,22 +117,22 @@ func Test_scraper_readStatsWithNoValues(t *testing.T) {
 
 	go func() {
 		c, err2 := l.Accept()
-		require.NoError(t, err2)
+		assert.NoError(t, err2)
 
 		buf := make([]byte, 512)
 		nr, err2 := c.Read(buf)
-		require.NoError(t, err2)
+		assert.NoError(t, err2)
 
 		data := string(buf[0:nr])
 		switch data {
 		case "show stat\n":
 			stats, err2 := os.ReadFile(filepath.Join("testdata", "empty_stats.txt"))
-			require.NoError(t, err2)
+			assert.NoError(t, err2)
 			_, err2 = c.Write(stats)
-			require.NoError(t, err2)
-			require.NoError(t, c.Close())
+			assert.NoError(t, err2)
+			assert.NoError(t, c.Close())
 		default:
-			require.Fail(t, fmt.Sprintf("invalid message: %v", data))
+			assert.Fail(t, fmt.Sprintf("invalid message: %v", data))
 		}
 	}()
 

--- a/receiver/httpcheckreceiver/scraper_test.go
+++ b/receiver/httpcheckreceiver/scraper_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -27,7 +28,7 @@ func newMockServer(t *testing.T, responseCode int) *httptest.Server {
 		// This could be expanded if the checks for the server include
 		// parsing the response content
 		_, err := rw.Write([]byte(``))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}))
 }
 

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -119,7 +119,7 @@ func initializeGRPCTestServer(t *testing.T, beforeServe func(server *grpc.Server
 	beforeServe(server)
 	go func() {
 		err := server.Serve(lis)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 	}()
 	return server, lis.Addr()
 }

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -179,7 +179,7 @@ func TestTracesConsumerGroupHandler(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		require.NoError(t, c.ConsumeClaim(testSession, groupClaim))
+		assert.NoError(t, c.ConsumeClaim(testSession, groupClaim))
 		wg.Done()
 	}()
 
@@ -223,7 +223,7 @@ func TestTracesConsumerGroupHandler_session_done(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		require.NoError(t, c.ConsumeClaim(testSession, groupClaim))
+		assert.NoError(t, c.ConsumeClaim(testSession, groupClaim))
 		wg.Done()
 	}()
 
@@ -255,7 +255,7 @@ func TestTracesConsumerGroupHandler_error_unmarshal(t *testing.T) {
 	}
 	go func() {
 		err := c.ConsumeClaim(testConsumerGroupSession{ctx: context.Background()}, groupClaim)
-		require.Error(t, err)
+		assert.Error(t, err)
 		wg.Done()
 	}()
 	groupClaim.messageChan <- &sarama.ConsumerMessage{Value: []byte("!@#")}
@@ -519,7 +519,7 @@ func TestMetricsConsumerGroupHandler(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		require.NoError(t, c.ConsumeClaim(testSession, groupClaim))
+		assert.NoError(t, c.ConsumeClaim(testSession, groupClaim))
 		wg.Done()
 	}()
 
@@ -562,7 +562,7 @@ func TestMetricsConsumerGroupHandler_session_done(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		require.NoError(t, c.ConsumeClaim(testSession, groupClaim))
+		assert.NoError(t, c.ConsumeClaim(testSession, groupClaim))
 		wg.Done()
 	}()
 
@@ -594,7 +594,7 @@ func TestMetricsConsumerGroupHandler_error_unmarshal(t *testing.T) {
 	}
 	go func() {
 		err := c.ConsumeClaim(testConsumerGroupSession{ctx: context.Background()}, groupClaim)
-		require.Error(t, err)
+		assert.Error(t, err)
 		wg.Done()
 	}()
 	groupClaim.messageChan <- &sarama.ConsumerMessage{Value: []byte("!@#")}
@@ -872,7 +872,7 @@ func TestLogsConsumerGroupHandler(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		require.NoError(t, c.ConsumeClaim(testSession, groupClaim))
+		assert.NoError(t, c.ConsumeClaim(testSession, groupClaim))
 		wg.Done()
 	}()
 
@@ -915,7 +915,7 @@ func TestLogsConsumerGroupHandler_session_done(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	go func() {
-		require.NoError(t, c.ConsumeClaim(testSession, groupClaim))
+		assert.NoError(t, c.ConsumeClaim(testSession, groupClaim))
 		wg.Done()
 	}()
 
@@ -947,7 +947,7 @@ func TestLogsConsumerGroupHandler_error_unmarshal(t *testing.T) {
 	}
 	go func() {
 		err := c.ConsumeClaim(testConsumerGroupSession{ctx: context.Background()}, groupClaim)
-		require.Error(t, err)
+		assert.Error(t, err)
 		wg.Done()
 	}()
 	groupClaim.messageChan <- &sarama.ConsumerMessage{Value: []byte("!@#")}

--- a/receiver/nginxreceiver/scraper_test.go
+++ b/receiver/nginxreceiver/scraper_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -108,7 +109,7 @@ server accepts handled requests
  16630948 16630946 31070465
 Reading: 6 Writing: 179 Waiting: 106
 `))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 		rw.WriteHeader(404)

--- a/receiver/nsxtreceiver/client_test.go
+++ b/receiver/nsxtreceiver/client_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -309,56 +310,56 @@ func mockServer(t *testing.T) *httptest.Server {
 		if req.URL.Path == "/api/v1/transport-nodes" {
 			rw.WriteHeader(200)
 			_, err = rw.Write(tNodeBytes)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == "/api/v1/cluster/nodes" {
 			rw.WriteHeader(200)
 			_, err = rw.Write(cNodeBytes)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/cluster/nodes/%s/network/interfaces", managerNode1) {
 			rw.WriteHeader(200)
 			_, err = rw.Write(mNodeInterfaces)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/transport-nodes/%s/status", transportNode1) {
 			rw.WriteHeader(200)
 			_, err = rw.Write(tNodeStatus)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/transport-nodes/%s/network/interfaces", transportNode1) {
 			rw.WriteHeader(200)
 			_, err = rw.Write(tNodeInterfaces)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/transport-nodes/%s/network/interfaces/%s/stats", transportNode1, transportNodeNic1) {
 			rw.WriteHeader(200)
 			_, err = rw.Write(tNodeInterfaceStats)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/cluster/nodes/%s/network/interfaces/%s/stats", managerNode1, managerNodeNic1) {
 			rw.WriteHeader(200)
 			_, err = rw.Write(mNodeInterfaceStats)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/cluster/nodes/%s/status", managerNode1) {
 			rw.WriteHeader(200)
 			_, err = rw.Write(mNodeStatus)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			return
 		}
 

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -784,7 +784,7 @@ func TestReceiverEOF(t *testing.T) {
 			expectData = append(expectData, td)
 
 			batch, err := ctc.testProducer.BatchArrowRecordsFromTraces(td)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			batch = copyBatch(batch)
 
@@ -797,7 +797,7 @@ func TestReceiverEOF(t *testing.T) {
 	wg.Add(1)
 
 	go func() {
-		require.NoError(t, ctc.wait())
+		assert.NoError(t, ctc.wait())
 		wg.Done()
 	}()
 
@@ -851,7 +851,7 @@ func testReceiverHeaders(t *testing.T, includeMeta bool) {
 			td := testdata.GenerateTraces(2)
 
 			batch, err := ctc.testProducer.BatchArrowRecordsFromTraces(td)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			batch = copyBatch(batch)
 
@@ -863,7 +863,7 @@ func testReceiverHeaders(t *testing.T, includeMeta bool) {
 							Name:  key,
 							Value: val,
 						})
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}
 
@@ -879,7 +879,7 @@ func testReceiverHeaders(t *testing.T, includeMeta bool) {
 	wg.Add(1)
 
 	go func() {
-		require.NoError(t, ctc.wait())
+		assert.NoError(t, ctc.wait())
 		wg.Done()
 	}()
 
@@ -1243,7 +1243,7 @@ func testReceiverAuthHeaders(t *testing.T, includeMeta bool, dataAuth bool) {
 			td := testdata.GenerateTraces(2)
 
 			batch, err := ctc.testProducer.BatchArrowRecordsFromTraces(td)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 
 			batch = copyBatch(batch)
 
@@ -1256,7 +1256,7 @@ func testReceiverAuthHeaders(t *testing.T, includeMeta bool, dataAuth bool) {
 							Name:  strings.ToLower(key),
 							Value: val,
 						})
-						require.NoError(t, err)
+						assert.NoError(t, err)
 					}
 				}
 

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -354,12 +354,12 @@ func TestOTelArrowShutdown(t *testing.T) {
 				for time.Since(start) < 5*time.Second {
 					td := testdata.GenerateTraces(1)
 					batch, batchErr := producer.BatchArrowRecordsFromTraces(td)
-					require.NoError(t, batchErr)
-					require.NoError(t, stream.Send(batch))
+					assert.NoError(t, batchErr)
+					assert.NoError(t, stream.Send(batch))
 				}
 
 				if cooperative {
-					require.NoError(t, stream.CloseSend())
+					assert.NoError(t, stream.CloseSend())
 				}
 			}()
 
@@ -746,7 +746,7 @@ func TestConcurrentArrowReceiver(t *testing.T) {
 
 			client := arrowpb.NewArrowTracesServiceClient(cc)
 			stream, err := client.ArrowTraces(ctx, grpc.WaitForReady(true))
-			require.NoError(t, err)
+			assert.NoError(t, err)
 			producer := arrowRecord.NewProducer()
 
 			var headerBuf bytes.Buffer
@@ -762,21 +762,21 @@ func TestConcurrentArrowReceiver(t *testing.T) {
 					Name:  "seq",
 					Value: fmt.Sprint(i),
 				})
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				batch, err := producer.BatchArrowRecordsFromTraces(td)
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				batch.Headers = headerBuf.Bytes()
 
 				err = stream.Send(batch)
 
-				require.NoError(t, err)
+				assert.NoError(t, err)
 
 				resp, err := stream.Recv()
-				require.NoError(t, err)
-				require.Equal(t, batch.BatchId, resp.BatchId)
-				require.Equal(t, arrowpb.StatusCode_OK, resp.StatusCode)
+				assert.NoError(t, err)
+				assert.Equal(t, batch.BatchId, resp.BatchId)
+				assert.Equal(t, arrowpb.StatusCode_OK, resp.StatusCode)
 			}
 		}()
 	}
@@ -854,17 +854,17 @@ func TestOTelArrowHalfOpenShutdown(t *testing.T) {
 			}
 			td := testdata.GenerateTraces(1)
 			batch, batchErr := producer.BatchArrowRecordsFromTraces(td)
-			require.NoError(t, batchErr)
+			assert.NoError(t, batchErr)
 
 			sendErr := stream.Send(batch)
 			select {
 			case <-ctx.Done():
 				if sendErr != nil {
-					require.ErrorIs(t, sendErr, io.EOF)
+					assert.ErrorIs(t, sendErr, io.EOF)
 				}
 				return
 			default:
-				require.NoError(t, sendErr)
+				assert.NoError(t, sendErr)
 			}
 		}
 	}()

--- a/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
+++ b/receiver/prometheusreceiver/internal/staleness_end_to_end_test.go
@@ -84,14 +84,14 @@ jvm_memory_pool_bytes_used{pool="CodeHeap 'non-nmethods'"} %.1f`, float64(i))
 	prweServer := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, req *http.Request) {
 		// Snappy decode the uploads.
 		payload, rerr := io.ReadAll(req.Body)
-		require.NoError(t, rerr)
+		assert.NoError(t, rerr)
 
 		recv := make([]byte, len(payload))
 		decoded, derr := snappy.Decode(recv, payload)
-		require.NoError(t, derr)
+		assert.NoError(t, derr)
 
 		writeReq := new(prompb.WriteRequest)
-		require.NoError(t, proto.Unmarshal(decoded, writeReq))
+		assert.NoError(t, proto.Unmarshal(decoded, writeReq))
 
 		select {
 		case <-ctx.Done():

--- a/receiver/rabbitmqreceiver/client_test.go
+++ b/receiver/rabbitmqreceiver/client_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -117,7 +118,7 @@ func TestGetQueuesDetails(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write([]byte("{}"))
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 
@@ -136,7 +137,7 @@ func TestGetQueuesDetails(t *testing.T) {
 				// Setup test server
 				ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 					_, err := w.Write(data)
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}))
 				defer ts.Close()
 

--- a/receiver/riakreceiver/client_test.go
+++ b/receiver/riakreceiver/client_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -101,7 +102,7 @@ func TestGetStatsDetails(t *testing.T) {
 		// Setup test server
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			_, err := w.Write(data)
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}))
 		defer ts.Close()
 

--- a/receiver/sshcheckreceiver/scraper_test.go
+++ b/receiver/sshcheckreceiver/scraper_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/pkg/sftp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -68,7 +69,7 @@ func (s *sshServer) runSSHServer(t *testing.T) string {
 				case <-s.done:
 					return
 				default:
-					require.NoError(t, err)
+					assert.NoError(t, err)
 				}
 			}
 			_, chans, reqs, err := ssh.NewServerConn(conn, config)

--- a/receiver/vcenterreceiver/internal/mockserver/client_mock.go
+++ b/receiver/vcenterreceiver/internal/mockserver/client_mock.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	xj "github.com/basgys/goxml2json"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,17 +39,17 @@ func MockServer(t *testing.T, useTLS bool) *httptest.Server {
 	handlerFunc := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// converting to JSON in order to iterate over map keys
 		jsonified, err := xj.Convert(r.Body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		sr := &soapRequest{}
 		err = json.Unmarshal(jsonified.Bytes(), sr)
-		require.NoError(t, err)
-		require.Len(t, sr.Envelope.Body, 1)
+		assert.NoError(t, err)
+		assert.Len(t, sr.Envelope.Body, 1)
 
 		var requestType string
 		for k := range sr.Envelope.Body {
 			requestType = k
 		}
-		require.NotEmpty(t, requestType)
+		assert.NotEmpty(t, requestType)
 
 		body, err := routeBody(t, requestType, sr.Envelope.Body)
 		if errors.Is(err, errNotFound) {

--- a/receiver/zookeeperreceiver/scraper_test.go
+++ b/receiver/zookeeperreceiver/scraper_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -362,7 +363,7 @@ func (ms *mockedServer) mockZKServer(t *testing.T, cmdToFileMap map[string]strin
 			case <-ms.quit:
 				return
 			default:
-				require.NoError(t, err)
+				assert.NoError(t, err)
 			}
 		}
 		reader := bufio.NewReader(conn)
@@ -372,13 +373,13 @@ func (ms *mockedServer) mockZKServer(t *testing.T, cmdToFileMap map[string]strin
 			continue
 		}
 
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		filename := cmdToFileMap[cmd]
 		out, err := os.ReadFile(filepath.Join("testdata", filename))
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		_, err = conn.Write(out)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		conn.Close()
 	}


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [go-require](https://github.com/Antonboom/testifylint?tab=readme-ov-file#go-require) rule from [testifylint](https://github.com/Antonboom/testifylint)