### PR TITLE
[processor/resourcedetection] Remove processor.resourcedetection.hostCPUModelAndFamilyAsString feature gate

### DIFF
--- a/.chloggen/remove_host_cpu_model_family_fg.yaml
+++ b/.chloggen/remove_host_cpu_model_family_fg.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `processor.resourcedetection.hostCPUModelAndFamilyAsString` feature gate.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29025]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -24,14 +24,6 @@ import (
 
 var (
 	_ = featuregate.GlobalRegistry().MustRegister(
-		"processor.resourcedetection.hostCPUModelAndFamilyAsString",
-		featuregate.StageStable,
-		featuregate.WithRegisterDescription("Change type of host.cpu.model.id and host.cpu.model.family to string."),
-		featuregate.WithRegisterFromVersion("v0.89.0"),
-		featuregate.WithRegisterToVersion("v0.101.0"),
-		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/semantic-conventions/issues/495"),
-	)
-	_ = featuregate.GlobalRegistry().MustRegister(
 		"processor.resourcedetection.hostCPUSteppingAsString",
 		featuregate.StageStable,
 		featuregate.WithRegisterDescription("Change type of host.cpu.stepping to string."),


### PR DESCRIPTION
Description:

Follows #33077, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29152 and https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29462. The feature gate has been stable since v0.101.0.

Link to tracking Issue: Relates to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29025 and to
https://github.com/open-telemetry/semantic-conventions/issues/495


/cc @mx-psi 