### PR TITLE
[chore]: enable useless-assert rule from testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,7 +137,6 @@ linters-settings:
       - float-compare
       - require-error
       - suite-subtest-run
-      - useless-assert
     enable-all: true
 
 linters:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -77,7 +77,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subtest-run,useless-assert
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subtest-run
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release

--- a/exporter/kineticaexporter/exporter_metric_test.go
+++ b/exporter/kineticaexporter/exporter_metric_test.go
@@ -34,8 +34,6 @@ func TestExporter_pushMetricsData(t *testing.T) {
 	t.Run("push success", func(t *testing.T) {
 		exporter := newTestMetricsExporter(t)
 		mustPushMetricsData(t, exporter, simpleMetrics(3))
-
-		require.Equal(t, 15, 15)
 	})
 }
 

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -79,7 +79,6 @@ func TestClientBatchOperations(t *testing.T) {
 	// Make sure nothing is there
 	err = client.Batch(ctx, testGetEntries...)
 	require.NoError(t, err)
-	require.Equal(t, testGetEntries, testGetEntries)
 
 	// Set it
 	err = client.Batch(ctx, testSetEntries...)

--- a/pkg/translator/opencensus/resource_to_oc_test.go
+++ b/pkg/translator/opencensus/resource_to_oc_test.go
@@ -211,7 +211,6 @@ func TestResourceToOCAndBack(t *testing.T) {
 						assert.Equal(t, strconv.FormatInt(v.Int(), 10), a.Str())
 					}
 				case pcommon.ValueTypeMap, pcommon.ValueTypeSlice:
-					assert.Equal(t, a, a)
 				default:
 					assert.Equal(t, v, a)
 				}


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This PR enables [useless-assert](https://github.com/Antonboom/testifylint?tab=readme-ov-file#useless-assert) rule from [testifylint](https://github.com/Antonboom/testifylint)