### PR TITLE
[processor/groupbytrace] ensure metric has unit

### DIFF
--- a/.chloggen/codeboten_add-unit.yaml
+++ b/.chloggen/codeboten_add-unit.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: groupbytraceprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ensure processor_groupbytrace_incomplete_releases metric has a unit.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35221]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/groupbytraceprocessor/documentation.md
+++ b/processor/groupbytraceprocessor/documentation.md
@@ -28,7 +28,7 @@ Releases that are suspected to have been incomplete
 
 | Unit | Metric Type | Value Type | Monotonic |
 | ---- | ----------- | ---------- | --------- |
-| <nil> | Sum | Int | true |
+| {releases} | Sum | Int | true |
 
 ### otelcol_processor_groupbytrace_num_events_in_queue
 

--- a/processor/groupbytraceprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/groupbytraceprocessor/internal/metadata/generated_telemetry.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/otel/metric"
-	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/component"

--- a/processor/groupbytraceprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/groupbytraceprocessor/internal/metadata/generated_telemetry.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 
 	"go.opentelemetry.io/collector/component"
@@ -67,7 +68,7 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...teleme
 	builder.ProcessorGroupbytraceIncompleteReleases, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_groupbytrace_incomplete_releases",
 		metric.WithDescription("Releases that are suspected to have been incomplete"),
-		metric.WithUnit("<nil>"),
+		metric.WithUnit("{releases}"),
 	)
 	errs = errors.Join(errs, err)
 	builder.ProcessorGroupbytraceNumEventsInQueue, err = builder.meters[configtelemetry.LevelBasic].Int64Gauge(

--- a/processor/groupbytraceprocessor/metadata.yaml
+++ b/processor/groupbytraceprocessor/metadata.yaml
@@ -57,6 +57,7 @@ telemetry:
     processor_groupbytrace_incomplete_releases:
       enabled: true
       description: Releases that are suspected to have been incomplete
+      unit: "{releases}"
       sum:
         value_type: int
         monotonic: true


### PR DESCRIPTION
A missing unit will break validation when mdatagen is updated
