### PR TITLE
Migrate 7x receiver to latest semconv version

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil"

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil"

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator.go
@@ -6,7 +6,7 @@ package awsecscontainermetrics // import "github.com/open-telemetry/opentelemetr
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.21.0"
 )
 
 func convertToOTLPMetrics(prefix string, m ECSMetrics, r pcommon.Resource, timestamp pcommon.Timestamp) pmetric.Metrics {

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator_test.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/translator_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.21.0"
 )
 
 func TestConvertToOTMetrics(t *testing.T) {

--- a/receiver/awsxrayreceiver/internal/translator/aws.go
+++ b/receiver/awsxrayreceiver/internal/translator/aws.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )

--- a/receiver/awsxrayreceiver/internal/translator/aws_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/aws_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )

--- a/receiver/awsxrayreceiver/internal/translator/cause.go
+++ b/receiver/awsxrayreceiver/internal/translator/cause.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )

--- a/receiver/awsxrayreceiver/internal/translator/http.go
+++ b/receiver/awsxrayreceiver/internal/translator/http.go
@@ -5,7 +5,7 @@ package translator // import "github.com/open-telemetry/opentelemetry-collector-
 
 import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/tracetranslator"

--- a/receiver/awsxrayreceiver/internal/translator/sdk.go
+++ b/receiver/awsxrayreceiver/internal/translator/sdk.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )

--- a/receiver/awsxrayreceiver/internal/translator/sql.go
+++ b/receiver/awsxrayreceiver/internal/translator/sql.go
@@ -8,7 +8,7 @@ import (
 	"regexp"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )

--- a/receiver/awsxrayreceiver/internal/translator/translator.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator.go
@@ -10,7 +10,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/telemetry"

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray/telemetry"

--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver/internal/metadata"

--- a/receiver/datadogreceiver/internal/translator/tags.go
+++ b/receiver/datadogreceiver/internal/translator/tags.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.16.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 )
 
 // See:

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -19,7 +19,7 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	semconv "go.opentelemetry.io/collector/semconv/v1.16.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator/header"

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	vmsgp "github.com/vmihailenco/msgpack/v5"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	semconv "go.opentelemetry.io/collector/semconv/v1.16.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/datadogreceiver/internal/translator/header"

--- a/receiver/dockerstatsreceiver/integration_test.go
+++ b/receiver/dockerstatsreceiver/integration_test.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	rcvr "go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.18.0"
 )
 
 type metricContainerBlockioIoMergedRecursive struct {

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -9,7 +9,7 @@ status:
     active: [rmfitzpatrick, jamesmoessis]
   unsupported_platforms: [darwin, windows]
 
-sem_conv_version: 1.6.1
+sem_conv_version: 1.18.0
 
 # Note: there are other, additional resource attributes that the user can configure through the yaml
 resource_attributes:

--- a/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
         - key: container.runtime
           value:
             stringValue: docker
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
         - key: container.runtime
           value:
             stringValue: docker
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
         - key: container.runtime
           value:
             stringValue: docker
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
         - key: env-var-metric-label-2
           value:
             stringValue: env-var-2
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.
@@ -807,7 +807,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var2
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.18.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeState specifies the a value state attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/cpu
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   cpu:

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeDirection specifies the a value direction attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/disk
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeState specifies the a value state attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/filesystem
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 type metricSystemCPULoadAverage15m struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/load
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 metrics:
   system.cpu.load_average.1m:

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeState specifies the a value state attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/memory
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   state:

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeDirection specifies the a value direction attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/network
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeDirection specifies the a value direction attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/paging
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeStatus specifies the a value status attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/processes
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   status:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeContextSwitchType specifies the a value context_switch_type attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/process
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 resource_attributes:
   process.pid:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"

--- a/receiver/hostmetricsreceiver/testdata/e2e/expected_process.yaml
+++ b/receiver/hostmetricsreceiver/testdata/e2e/expected_process.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: process.pid
           value:
             intValue: "95041"
-    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Total CPU seconds broken down by different states.
@@ -97,7 +97,7 @@ resourceMetrics:
         - key: process.pid
           value:
             intValue: "4668"
-    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Total CPU seconds broken down by different states.

--- a/receiver/hostmetricsreceiver/testdata/e2e/expected_process_separate_proc.yaml
+++ b/receiver/hostmetricsreceiver/testdata/e2e/expected_process_separate_proc.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: process.pid
           value:
             intValue: "4668"
-    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Total CPU seconds broken down by different states.


### PR DESCRIPTION
Description: The following components  has been modified:

- receiver/awsecscontainermetricsreceiver
- receiver/awsfirehosereceiver
- receiver/awsxrayreceiver
- receiver/azureeventhubreceiver
- receiver/datadogreceiver
- receiver/dockerstatsreceiver
- receiver/hostmetricsreceiver

The version of semconv is upgraded to the latest possible.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed