### PR TITLE
docs(attributeprocessor): Note it does not handle resource attributes

### DIFF
--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -191,8 +191,8 @@ must be specified with a non-empty value for a valid configuration. The `log_bod
 - For logs, one of `log_bodies`, `log_severity_texts`, `log_severity_number`, `attributes`, `resources`
 or `libraries` must be specified with a non-empty value for a valid configuration. The `span_names`, 
 `span_kinds`, `metric_names` and `services` fields are invalid.
-- For metrics, one of `metric_names` or `resources` must be specified with a valid non-empty value for
-a valid configuration. The `span_names`, `span_kinds`, `log_bodies`, `log_severity_texts`, 
+- For metrics, `metric_names` must be specified with a valid non-empty value for
+a valid configuration. The `span_names`, `span_kinds`, `resources`, `log_bodies`, `log_severity_texts`,
 `log_severity_number`, `services`, `attributes` and `libraries` fields are invalid.
 
 


### PR DESCRIPTION
Right now, the README in the attribute processor seems to indicate that it should match resource attributes. However, looking at the implementation of the filter processor, this doesn't do anything. Specifically, the function in filtermetric.go:

    newExpr(...)

Doesn't handle resource metrics at all. While they deserialize (and likely should continue to do so, so they do not break things), they do not work.
