### PR TITLE
[chore] Skip flaky test on Windows

### DIFF
--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -179,6 +179,9 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 }
 
 func TestItemCardinalityFilter_FilterItems(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows due to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32397")
+	}
 	items := initialItemsWithSameTimestamp(t)
 	logger := zaptest.NewLogger(t)
 	filter, err := NewItemCardinalityFilter(metricName, totalLimit, limitByTimestamp, itemActivityPeriod, logger)

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -6,6 +6,7 @@ package filter
 import (
 	"testing"
 	"time"
+	"runtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -122,6 +123,9 @@ func TestItemCardinalityFilter_Shutdown(t *testing.T) {
 }
 
 func TestItemCardinalityFilter_Filter(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows due to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32397")
+	}
 	items := initialItems(t)
 	logger := zaptest.NewLogger(t)
 	filter, err := NewItemCardinalityFilter(metricName, totalLimit, limitByTimestamp, itemActivityPeriod, logger)

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -4,9 +4,9 @@
 package filter
 
 import (
+	"runtime"
 	"testing"
 	"time"
-	"runtime"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
**Description:**
Since `receiver/googlecloudspanner` is unmaintained I'm opting to simply skip the flaky test on Windows.

**Link to tracking Issue:**
Workaround for #32397

**Testing:**
N/A

**Documentation:**
N/A