### PR TITLE
pulsarreceiver: migrate to latest semconv version

### DIFF
--- a/receiver/pulsarreceiver/zipkin_unmarshaler_test.go
+++ b/receiver/pulsarreceiver/zipkin_unmarshaler_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin/zipkinv2"
 )


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.6.1 to v1.27.0

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed