### PR TITLE
receivercreator: migrate to latest semconv version

### DIFF
--- a/receiver/receivercreator/receiver_test.go
+++ b/receiver/receivercreator/receiver_test.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.18.0 to v1.27.0

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed