### PR TITLE
skywalkingreceiver: migrate to latest semconv version

### DIFF
--- a/receiver/skywalkingreceiver/internal/metrics/skywalkingproto_to_metrics.go
+++ b/receiver/skywalkingreceiver/internal/metrics/skywalkingproto_to_metrics.go
@@ -8,7 +8,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	semconv "go.opentelemetry.io/collector/semconv/v1.18.0"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 	common "skywalking.apache.org/repo/goapi/collect/common/v3"
 	agent "skywalking.apache.org/repo/goapi/collect/language/agent/v3"
 )


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.18.0 to v1.27.0

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed