### PR TITLE
Replace @ycombinator with @lahsivjar as codeowner for elasticsearchexporter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,7 @@ exporter/coralogixexporter/                                         @open-teleme
 exporter/datadogexporter/                                           @open-telemetry/collector-contrib-approvers @mx-psi @dineshg13 @liustanley @songy23 @mackjmr @ankitpatel96
 exporter/datasetexporter/                                           @open-telemetry/collector-contrib-approvers @atoulme @martin-majlis-s1 @zdaratom-s1 @tomaz-s1
 exporter/dorisexporter/                                             @open-telemetry/collector-contrib-approvers @atoulme @joker-star-l
-exporter/elasticsearchexporter/                                     @open-telemetry/collector-contrib-approvers @JaredTan95 @ycombinator @carsonip
+exporter/elasticsearchexporter/                                     @open-telemetry/collector-contrib-approvers @JaredTan95 @carsonip @lahsivjar
 exporter/fileexporter/                                              @open-telemetry/collector-contrib-approvers @atingchen
 exporter/googlecloudexporter/                                       @open-telemetry/collector-contrib-approvers @aabmass @dashpole @jsuereth @punya @damemi @psx95
 exporter/googlecloudpubsubexporter/                                 @open-telemetry/collector-contrib-approvers @alexvanboxel

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -7,7 +7,7 @@
 |               | [beta]: traces, logs   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Felasticsearch%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Felasticsearch) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Felasticsearch%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Felasticsearch) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@JaredTan95](https://www.github.com/JaredTan95), [@ycombinator](https://www.github.com/ycombinator), [@carsonip](https://www.github.com/carsonip) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@JaredTan95](https://www.github.com/JaredTan95), [@carsonip](https://www.github.com/carsonip), [@lahsivjar](https://www.github.com/lahsivjar) |
 
 [development]: https://github.com/open-telemetry/opentelemetry-collector#development
 [beta]: https://github.com/open-telemetry/opentelemetry-collector#beta

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -7,7 +7,7 @@ status:
     development: [metrics]
   distributions: [contrib]
   codeowners:
-    active: [JaredTan95, ycombinator, carsonip]
+    active: [JaredTan95, carsonip, lahsivjar]
 
 tests:
   config:


### PR DESCRIPTION
**Description:** 

This PR replaces @ycombinator with @lahsivjar as one of the codeowners for the `elasticsearchexporter` component.

Over the past few months, @lahsivjar has been a far more active contributor to this component than @ycombinator.