### PR TITLE
[processor/redaction] fix index-out-of-bounds panic when used in logs pipeline.

### DIFF
--- a/.chloggen/redaction-fix-logs.yaml
+++ b/.chloggen/redaction-fix-logs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: redactionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic when using the redaction processor in a logs pipeline
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35331]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -106,7 +106,7 @@ func (s *redaction) processResourceLog(ctx context.Context, rl plog.ResourceLogs
 
 	for j := 0; j < rl.ScopeLogs().Len(); j++ {
 		ils := rl.ScopeLogs().At(j)
-		for k := 0; k < rl.ScopeLogs().Len(); k++ {
+		for k := 0; k < ils.LogRecords().Len(); k++ {
 			log := ils.LogRecords().At(k)
 			s.processAttrs(ctx, log.Attributes())
 		}

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -565,6 +565,7 @@ func runLogsTest(
 	inBatch := plog.NewLogs()
 	rl := inBatch.ResourceLogs().AppendEmpty()
 	ils := rl.ScopeLogs().AppendEmpty()
+	_ = rl.ScopeLogs().AppendEmpty()
 
 	library := ils.Scope()
 	library.SetName("first-library")


### PR DESCRIPTION
**Description:** 
Fixes an index issue caused by an incorrect for loop condition.

**Link to tracking Issue:**
closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35316

**Testing:** <Describe what testing was performed and which tests were added.>
Updated unit test. The updated test panics without the fix