### PR TITLE
[chore]: enable require-error rule from testifylint

### DIFF
--- a/confmap/provider/s3provider/provider_test.go
+++ b/confmap/provider/s3provider/provider_test.go
@@ -105,9 +105,9 @@ func TestUnsupportedScheme(t *testing.T) {
 func TestNonExistent(t *testing.T) {
 	fp := NewTestProvider("./testdata/non-existent.yaml")
 	_, err := fp.Retrieve(context.Background(), "s3://non-exist-bucket.s3.region.amazonaws.com/key", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = fp.Retrieve(context.Background(), "s3://bucket.s3.region.amazonaws.com/non-exist-key.yaml", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	_, err = fp.Retrieve(context.Background(), "s3://bucket.s3.non-exist-region.amazonaws.com/key", nil)
 	assert.Error(t, err)
 	require.NoError(t, fp.Shutdown(context.Background()))
@@ -116,7 +116,7 @@ func TestNonExistent(t *testing.T) {
 func TestInvalidYAML(t *testing.T) {
 	fp := NewTestProvider("./testdata/invalid-otel-config.yaml")
 	_, err := fp.Retrieve(context.Background(), "s3://bucket.s3.region.amazonaws.com/key", nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	require.NoError(t, fp.Shutdown(context.Background()))
 }
 

--- a/confmap/provider/secretsmanagerprovider/provider_test.go
+++ b/confmap/provider/secretsmanagerprovider/provider_test.go
@@ -41,7 +41,7 @@ func TestSecretsManagerFetchSecret(t *testing.T) {
 	assert.NoError(t, fp.Shutdown(context.Background()))
 
 	value, err := result.AsRaw()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, value)
 	assert.Equal(t, secretValue, value)
 }
@@ -58,7 +58,7 @@ func TestFetchSecretsManagerFieldValidJson(t *testing.T) {
 	assert.NoError(t, fp.Shutdown(context.Background()))
 
 	value, err := result.AsRaw()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, value)
 	assert.Equal(t, secretValue, value)
 }
@@ -70,7 +70,7 @@ func TestFetchSecretsManagerFieldInvalidJson(t *testing.T) {
 	fp := NewTestProvider(secretValue)
 	_, err := fp.Retrieve(context.Background(), "secretsmanager:"+secretName, nil)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.NoError(t, fp.Shutdown(context.Background()))
 }
 

--- a/connector/countconnector/config_test.go
+++ b/connector/countconnector/config_test.go
@@ -515,7 +515,7 @@ func TestConfigErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.input.Validate()
-			assert.Error(t, err)
+			require.Error(t, err)
 			assert.Contains(t, err.Error(), tc.expect)
 		})
 	}

--- a/connector/datadogconnector/benchmark_test.go
+++ b/connector/datadogconnector/benchmark_test.go
@@ -46,7 +46,7 @@ func BenchmarkPeerTags_Native(b *testing.B) {
 
 func BenchmarkPeerTags_Legacy(b *testing.B) {
 	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
-	assert.NoError(b, err)
+	require.NoError(b, err)
 	defer func() {
 		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
 	}()

--- a/connector/datadogconnector/connector_native_test.go
+++ b/connector/datadogconnector/connector_native_test.go
@@ -67,7 +67,7 @@ func creteConnectorNativeWithCfg(t *testing.T, cfg *Config) (*traceToMetricConne
 
 	cfg.Traces.BucketInterval = 1 * time.Second
 	tconn, err := factory.CreateTracesToMetrics(context.Background(), creationParams, cfg, metricsSink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	connector, ok := tconn.(*traceToMetricConnectorNative)
 	require.True(t, ok)
@@ -88,12 +88,12 @@ func TestContainerTagsNative(t *testing.T) {
 	trace1 := generateTrace()
 
 	err = connector.ConsumeTraces(context.Background(), trace1)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Send two traces to ensure unique container tags are added to the cache
 	trace2 := generateTrace()
 	err = connector.ConsumeTraces(context.Background(), trace2)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	for {
 		if len(metricsSink.AllMetrics()) > 0 {
@@ -178,7 +178,7 @@ func TestMeasuredAndClientKindNative(t *testing.T) {
 	s4.SetParentSpanID(testSpanID1)
 
 	err = connector.ConsumeTraces(context.Background(), td)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	timeout := time.Now().Add(1 * time.Minute)
 	for time.Now().Before(timeout) {

--- a/connector/datadogconnector/connector_test.go
+++ b/connector/datadogconnector/connector_test.go
@@ -50,7 +50,7 @@ func TestNewConnector(t *testing.T) {
 
 func TestTraceToTraceConnector(t *testing.T) {
 	err := featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() {
 		_ = featuregate.GlobalRegistry().Set(NativeIngestFeatureGate.ID(), true)
 	}()

--- a/connector/exceptionsconnector/connector_metrics_test.go
+++ b/connector/exceptionsconnector/connector_metrics_test.go
@@ -102,7 +102,7 @@ func TestConnectorConsumeTraces(t *testing.T) {
 		require.NoError(t, err)
 
 		err = p.ConsumeTraces(ctx, buildBadSampleTrace())
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		metrics := msink.AllMetrics()
 		assert.NotEmpty(t, metrics)
@@ -338,9 +338,9 @@ func TestBuildKeyWithDimensions(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			resAttr := pcommon.NewMap()
-			assert.NoError(t, resAttr.FromRaw(tc.resourceAttrMap))
+			require.NoError(t, resAttr.FromRaw(tc.resourceAttrMap))
 			span0 := ptrace.NewSpan()
-			assert.NoError(t, span0.Attributes().FromRaw(tc.spanAttrMap))
+			require.NoError(t, span0.Attributes().FromRaw(tc.spanAttrMap))
 			span0.SetName("c")
 			buf := &bytes.Buffer{}
 			buildKey(buf, "ab", span0, tc.optionalDims, pcommon.NewMap(), resAttr)

--- a/exporter/alertmanagerexporter/alertmanager_exporter_test.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter_test.go
@@ -324,10 +324,10 @@ func TestAlertManagerPostAlert(t *testing.T) {
 	am := newAlertManagerExporter(cfg, set.TelemetrySettings)
 	err := am.start(context.Background(), componenttest.NewNopHost())
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = am.postAlert(context.Background(), alerts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if mock.fooCalledSuccessfully == false {
 		t.Errorf("mock server wasn't called")
 	}

--- a/exporter/alertmanagerexporter/factory_test.go
+++ b/exporter/alertmanagerexporter/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
 )
@@ -24,6 +25,6 @@ func TestCreateTracesExporter(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	te, err := factory.CreateTracesExporter(context.Background(), exportertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, te)
 }

--- a/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter_test.go
@@ -45,12 +45,12 @@ func TestNewLogsExporter(t *testing.T) {
 		Project:  "demo-project",
 		Logstore: "demo-logstore",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.NotNil(t, got)
 
 	// This will put trace data to send buffer and return success.
 	err = got.ConsumeLogs(context.Background(), createSimpleLogData(3))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	time.Sleep(time.Second * 4)
 }
 

--- a/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
@@ -37,6 +37,6 @@ func TestNewTracesExporter(t *testing.T) {
 func TestNewFailsWithEmptyTracesExporterName(t *testing.T) {
 
 	got, err := newTracesExporter(exportertest.NewNopSettings(), &Config{})
-	assert.Error(t, err)
+	require.Error(t, err)
 	require.Nil(t, got)
 }

--- a/exporter/datadogexporter/factory_test.go
+++ b/exporter/datadogexporter/factory_test.go
@@ -211,7 +211,7 @@ func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 			exportertest.NewNopSettings(),
 			cfg,
 		)
-		assert.EqualError(t, err, "API Key validation failed")
+		require.EqualError(t, err, "API Key validation failed")
 		assert.Nil(t, mexp)
 
 		texp, err := factory.CreateTracesExporter(
@@ -219,7 +219,7 @@ func TestCreateAPIExporterFailOnInvalidKey(t *testing.T) {
 			exportertest.NewNopSettings(),
 			cfg,
 		)
-		assert.EqualError(t, err, "API Key validation failed")
+		require.EqualError(t, err, "API Key validation failed")
 		assert.Nil(t, texp)
 
 		lexp, err := factory.CreateLogsExporter(

--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -489,7 +489,7 @@ func TestIntegrationLogs(t *testing.T) {
 			var smap seriesSlice
 			gz := getGzipReader(t, metricsBytes)
 			dec := json.NewDecoder(gz)
-			assert.NoError(t, dec.Decode(&smap))
+			require.NoError(t, dec.Decode(&smap))
 			for _, s := range smap.Series {
 				if s.Metric == "otelcol_receiver_accepted_log_records" || s.Metric == "otelcol_exporter_sent_log_records" {
 					metricMap.Series = append(metricMap.Series, s)
@@ -523,7 +523,7 @@ func TestIntegrationLogs(t *testing.T) {
 func sendLogs(t *testing.T, numLogs int) {
 	ctx := context.Background()
 	logExporter, err := otlploggrpc.New(ctx, otlploggrpc.WithInsecure())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	lr := make([]log.Record, numLogs)
 	assert.NoError(t, logExporter.Export(ctx, lr))
 }

--- a/exporter/datadogexporter/integrationtest/no_race_integration_test.go
+++ b/exporter/datadogexporter/integrationtest/no_race_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIntegrationInternalMetrics(t *testing.T) {
@@ -85,7 +86,7 @@ func TestIntegrationInternalMetrics(t *testing.T) {
 			var metrics seriesSlice
 			gz := getGzipReader(t, metricsBytes)
 			dec := json.NewDecoder(gz)
-			assert.NoError(t, dec.Decode(&metrics))
+			require.NoError(t, dec.Decode(&metrics))
 			for _, s := range metrics.Series {
 				if _, ok := expectedMetrics[s.Metric]; ok {
 					metricMap[s.Metric] = s

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -300,7 +300,7 @@ func TestNewTracesExporter(t *testing.T) {
 	// The client should have been created correctly
 	f := NewFactory()
 	exp, err := f.CreateTracesExporter(context.Background(), params, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, exp)
 }
 

--- a/exporter/kafkaexporter/factory_test.go
+++ b/exporter/kafkaexporter/factory_test.go
@@ -90,7 +90,7 @@ func TestCreateMetricExporter(t *testing.T) {
 				assert.ErrorAs(t, err, &tc.err, "Must match the expected error")
 				return
 			}
-			assert.NoError(t, err, "Must not error")
+			require.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})
@@ -155,7 +155,7 @@ func TestCreateLogExporter(t *testing.T) {
 				assert.ErrorAs(t, err, &tc.err, "Must match the expected error")
 				return
 			}
-			assert.NoError(t, err, "Must not error")
+			require.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})
@@ -220,7 +220,7 @@ func TestCreateTraceExporter(t *testing.T) {
 				assert.ErrorAs(t, err, &tc.err, "Must match the expected error")
 				return
 			}
-			assert.NoError(t, err, "Must not error")
+			require.NoError(t, err, "Must not error")
 			assert.NotNil(t, exporter, "Must return valid exporter when no error is returned")
 			assert.NoError(t, exporter.Shutdown(context.Background()))
 		})

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -489,7 +489,7 @@ func TestTracesEncodingMarshaler(t *testing.T) {
 	}
 	assert.Equal(t, "trace_encoding", m.Encoding())
 	data, err := m.Marshal(ptrace.NewTraces(), "topic")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, data, 1)
 }
 
@@ -519,7 +519,7 @@ func TestMetricsEncodingMarshaler(t *testing.T) {
 	}
 	assert.Equal(t, "metric_encoding", m.Encoding())
 	data, err := m.Marshal(pmetric.NewMetrics(), "topic")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, data, 1)
 }
 
@@ -549,7 +549,7 @@ func TestLogsEncodingMarshaler(t *testing.T) {
 	}
 	assert.Equal(t, "log_encoding", m.Encoding())
 	data, err := m.Marshal(plog.NewLogs(), "topic")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, data, 1)
 }
 

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -126,7 +126,7 @@ func TestPrometheusExporter_WithTLS(t *testing.T) {
 		ServerName: "localhost",
 	}
 	tls, err := tlscs.LoadTLSConfig(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	httpClient := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tls,
@@ -149,7 +149,7 @@ func TestPrometheusExporter_WithTLS(t *testing.T) {
 	md := testdata.GenerateMetricsOneMetric()
 	assert.NotNil(t, md)
 
-	assert.NoError(t, exp.ConsumeMetrics(context.Background(), md))
+	require.NoError(t, exp.ConsumeMetrics(context.Background(), md))
 
 	rsp, err := httpClient.Get("https://localhost:7777/metrics")
 	require.NoError(t, err, "Failed to perform a scrape")
@@ -192,7 +192,7 @@ func TestPrometheusExporter_endToEndMultipleTargets(t *testing.T) {
 	factory := NewFactory()
 	set := exportertest.NewNopSettings()
 	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		require.NoError(t, exp.Shutdown(context.Background()))
@@ -276,7 +276,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 	factory := NewFactory()
 	set := exportertest.NewNopSettings()
 	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		require.NoError(t, exp.Shutdown(context.Background()))
@@ -295,7 +295,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 	assert.NoError(t, exp.ConsumeMetrics(context.Background(), metricBuilder(128, "metric_1_", "cpu-exporter", "localhost:8080")))
 
 	for delta := 0; delta <= 20; delta += 10 {
-		assert.NoError(t, exp.ConsumeMetrics(context.Background(), metricBuilder(int64(delta), "metric_2_", "cpu-exporter", "localhost:8080")))
+		require.NoError(t, exp.ConsumeMetrics(context.Background(), metricBuilder(int64(delta), "metric_2_", "cpu-exporter", "localhost:8080")))
 
 		res, err1 := http.Get("http://localhost:7777/metrics")
 		require.NoError(t, err1, "Failed to perform a scrape")
@@ -437,7 +437,7 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	factory := NewFactory()
 	set := exportertest.NewNopSettings()
 	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Cleanup(func() {
 		require.NoError(t, exp.Shutdown(context.Background()))

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -122,7 +122,7 @@ func Test_NewPRWExporter(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, prwe)
 			assert.NotNil(t, prwe.exporterSettings)
 			assert.NotNil(t, prwe.endpointURL)
@@ -963,7 +963,7 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 	}
 
 	prwe, perr := newPRWExporter(cfg, set)
-	assert.NoError(t, perr)
+	require.NoError(t, perr)
 
 	nopHost := componenttest.NewNopHost()
 	ctx := context.Background()
@@ -1005,9 +1005,9 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 
 	// Read all the indices.
 	firstIndex, ierr := wal.FirstIndex()
-	assert.NoError(t, ierr)
+	require.NoError(t, ierr)
 	lastIndex, ierr := wal.LastIndex()
-	assert.NoError(t, ierr)
+	require.NoError(t, ierr)
 
 	var reqs []*prompb.WriteRequest
 	for i := firstIndex; i <= lastIndex; i++ {

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Test_batchTimeSeries checks batchTimeSeries return the correct number of requests
@@ -65,7 +66,7 @@ func Test_batchTimeSeries(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Len(t, requests, tt.numExpectedRequests)
 			if tt.numExpectedRequests <= 1 {
 				assert.Equal(t, math.MaxInt, state.nextTimeSeriesBufferSize)

--- a/extension/asapauthextension/extension_test.go
+++ b/extension/asapauthextension/extension_test.go
@@ -11,6 +11,7 @@ import (
 
 	"bitbucket.org/atlassian/go-asap/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // mockRoundTripper copies the request headers to the response.
@@ -46,11 +47,11 @@ func TestRoundTripper(t *testing.T) {
 	}
 
 	asapAuth, err := createASAPClientAuthenticator(cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	base := &mockRoundTripper{}
 	roundTripper, err := asapAuth.RoundTripper(base)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, roundTripper)
 
 	req := &http.Request{Method: "Get", Header: map[string][]string{}}
@@ -73,11 +74,11 @@ func TestRPCAuth(t *testing.T) {
 	}
 
 	asapAuth, err := createASAPClientAuthenticator(cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Setup credentials
 	credentials, err := asapAuth.PerRPCCredentials()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, credentials)
 	assert.True(t, credentials.RequireTransportSecurity())
 
@@ -97,7 +98,7 @@ func validateAsapJWT(t *testing.T, cfg *Config, jwt string) {
 	)
 	token, err := asap.ParseToken(jwt)
 	assert.NotNil(t, token)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = validator.Validate(token)
 	assert.NoError(t, err)

--- a/extension/asapauthextension/factory_test.go
+++ b/extension/asapauthextension/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/extension/extensiontest"
 )
@@ -76,7 +77,7 @@ func TestCreateExtension(t *testing.T) {
 			if testcase.shouldError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, ext)
 			}
 		})

--- a/extension/awsproxy/extension_test.go
+++ b/extension/awsproxy/extension_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
 
@@ -25,8 +26,8 @@ func TestInvalidEndpoint(t *testing.T) {
 		},
 		componenttest.NewNopTelemetrySettings(),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = x.Start(context.Background(), componenttest.NewNopHost())
-	defer assert.NoError(t, x.Shutdown(context.Background()))
+	defer require.NoError(t, x.Shutdown(context.Background()))
 	assert.Error(t, err)
 }

--- a/extension/awsproxy/factory_test.go
+++ b/extension/awsproxy/factory_test.go
@@ -65,7 +65,7 @@ func TestFactory_CreateExtension(t *testing.T) {
 	ctx := context.Background()
 	cs := extensiontest.NewNopSettings()
 	ext, err := createExtension(ctx, cs, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, ext)
 
 	host := &nopHost{
@@ -75,7 +75,7 @@ func TestFactory_CreateExtension(t *testing.T) {
 	}
 
 	err = ext.Start(ctx, host)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var resp *http.Response
 	require.Eventually(t, func() bool {
@@ -86,7 +86,7 @@ func TestFactory_CreateExtension(t *testing.T) {
 		return err == nil
 	}, 3*time.Second, 10*time.Millisecond)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, "Passed", resp.Header.Get("Test"))

--- a/internal/aws/awsutil/conn_test.go
+++ b/internal/aws/awsutil/conn_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -109,11 +110,11 @@ func TestNewAWSSessionWithErr(t *testing.T) {
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 	conn := &Conn{}
 	se, err := conn.newAWSSession(logger, roleArn, region)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, se)
 	roleArn = ""
 	se, err = conn.newAWSSession(logger, roleArn, region)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, se)
 	t.Setenv("AWS_SDK_LOAD_CONFIG", "true")
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "regional")
@@ -151,7 +152,7 @@ func TestGetSTSCreds(t *testing.T) {
 	region := "fake_region"
 	roleArn := ""
 	_, err := getSTSCreds(logger, region, roleArn)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	t.Setenv("AWS_STS_REGIONAL_ENDPOINTS", "fake")
 	_, err = getSTSCreds(logger, region, roleArn)
 	assert.Error(t, err)

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -30,7 +31,7 @@ func TestValidateLogEventWithMutating(t *testing.T) {
 	logEvent := NewEvent(0, "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789")
 	logEvent.GeneratedTime = time.Now()
 	err := logEvent.Validate(zap.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Positive(t, *logEvent.InputLogEvent.Timestamp)
 	assert.Len(t, *logEvent.InputLogEvent.Message, 64-perEventHeaderBytes)
 
@@ -41,7 +42,7 @@ func TestValidateLogEventFailed(t *testing.T) {
 	logger := zap.NewNop()
 	logEvent := NewEvent(0, "")
 	err := logEvent.Validate(logger)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "empty log event message", err.Error())
 
 	invalidTimestamp := time.Now().AddDate(0, -1, 0)
@@ -251,7 +252,7 @@ func TestMultiStreamPusher(t *testing.T) {
 	assert.NoError(t, pusher.AddLogEntry(event))
 	assert.NoError(t, pusher.AddLogEntry(event))
 	mockCwAPI.AssertNumberOfCalls(t, "PutLogEvents", 0)
-	assert.NoError(t, pusher.ForceFlush())
+	require.NoError(t, pusher.ForceFlush())
 
 	mockCwAPI.AssertNumberOfCalls(t, "CreateLogStream", 1)
 	mockCwAPI.AssertNumberOfCalls(t, "PutLogEvents", 1)

--- a/internal/aws/ecsutil/metadata_provider_test.go
+++ b/internal/aws/ecsutil/metadata_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil/ecsutiltest"
@@ -33,7 +34,7 @@ func Test_ecsMetadata_fetchTask(t *testing.T) {
 	md := ecsMetadataProviderImpl{logger: zap.NewNop(), client: mockRestClient}
 	fetchResp, err := md.FetchTaskMetadata()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, fetchResp)
 	assert.Equal(t, "test200", fetchResp.Cluster)
 	assert.Equal(t, "arn:aws:ecs:us-west-2:803860917211:task/test200/d22aaa11bf0e4ab19c2c940a1cbabbee", fetchResp.TaskARN)
@@ -49,7 +50,7 @@ func Test_ecsMetadata_fetchContainer(t *testing.T) {
 	md := ecsMetadataProviderImpl{logger: zap.NewNop(), client: mockRestClient}
 	fetchResp, err := md.FetchContainerMetadata()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, fetchResp)
 	assert.Equal(t, "325c979aea914acd93be2fdd2429e1d9-3811061257", fetchResp.DockerID)
 	assert.Equal(t, "arn:aws:ecs:us-east-1:123456789123:an-image/123", fetchResp.ContainerARN)

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -136,7 +136,7 @@ func TestSplitMetricsOneResourceMetrics(t *testing.T) {
 
 	sink := new(consumertest.MetricsSink)
 	bpr := NewBatchPerResourceMetrics("attr_key", sink)
-	assert.NoError(t, bpr.ConsumeMetrics(context.Background(), inBatch))
+	require.NoError(t, bpr.ConsumeMetrics(context.Background(), inBatch))
 	outBatches := sink.AllMetrics()
 	require.Len(t, outBatches, 1)
 	assert.Equal(t, expected, outBatches[0])
@@ -176,7 +176,7 @@ func TestSplitMetricsSameResource(t *testing.T) {
 
 	sink := new(consumertest.MetricsSink)
 	bpr := NewBatchPerResourceMetrics("same_attr_val", sink)
-	assert.NoError(t, bpr.ConsumeMetrics(context.Background(), inBatch))
+	require.NoError(t, bpr.ConsumeMetrics(context.Background(), inBatch))
 	outBatches := sink.AllMetrics()
 	require.Len(t, outBatches, 1)
 	assert.Equal(t, expected, outBatches[0])
@@ -226,7 +226,7 @@ func TestSplitMetricsIntoDifferentBatchesWithMultipleKeys(t *testing.T) {
 
 	sink := new(consumertest.MetricsSink)
 	bpr := NewMultiBatchPerResourceMetrics([]string{"attr_key", "attr_key2"}, sink)
-	assert.NoError(t, bpr.ConsumeMetrics(context.Background(), inBatch))
+	require.NoError(t, bpr.ConsumeMetrics(context.Background(), inBatch))
 	outBatches := sink.AllMetrics()
 	require.Len(t, outBatches, 6)
 	sortMetrics(outBatches, "attr_key")

--- a/pkg/datadog/config/config_test.go
+++ b/pkg/datadog/config/config_test.go
@@ -29,7 +29,7 @@ func TestValidate(t *testing.T) {
 	maxIdleConnPerHost := 150
 	maxConnPerHost := 250
 	ty, err := component.NewType("ty")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	auth := configauth.Authentication{AuthenticatorID: component.NewID(ty)}
 
 	tests := []struct {
@@ -364,9 +364,9 @@ func TestUnmarshal(t *testing.T) {
 			cfg := CreateDefaultConfig().(*Config)
 			err := cfg.Unmarshal(testInstance.configMap)
 			if err != nil || testInstance.err != "" {
-				assert.ErrorContains(t, err, testInstance.err)
+				require.ErrorContains(t, err, testInstance.err)
 				if testInstance.field != "" {
-					assert.ErrorContains(t, err, testInstance.field)
+					require.ErrorContains(t, err, testInstance.field)
 				}
 			} else {
 				assert.Equal(t, testInstance.cfg, cfg)

--- a/processor/attributesprocessor/attributes_metric_test.go
+++ b/processor/attributesprocessor/attributes_metric_test.go
@@ -94,7 +94,7 @@ func TestMetricProcessor_NilEmptyData(t *testing.T) {
 	for i := range metricTestCases {
 		tc := metricTestCases[i]
 		t.Run(tc.name, func(t *testing.T) {
-			assert.NoError(t, mp.ConsumeMetrics(context.Background(), tc.input))
+			require.NoError(t, mp.ConsumeMetrics(context.Background(), tc.input))
 			assert.EqualValues(t, tc.output, tc.input)
 		})
 	}

--- a/processor/attributesprocessor/attributes_trace_test.go
+++ b/processor/attributesprocessor/attributes_trace_test.go
@@ -96,7 +96,7 @@ func TestSpanProcessor_NilEmptyData(t *testing.T) {
 	for i := range testCases {
 		tt := testCases[i]
 		t.Run(tt.name, func(t *testing.T) {
-			assert.NoError(t, tp.ConsumeTraces(context.Background(), tt.input))
+			require.NoError(t, tp.ConsumeTraces(context.Background(), tt.input))
 			assert.EqualValues(t, tt.output, tt.input)
 		})
 	}

--- a/processor/attributesprocessor/factory_test.go
+++ b/processor/attributesprocessor/factory_test.go
@@ -67,7 +67,7 @@ func TestFactoryCreateTracesProcessor(t *testing.T) {
 
 	tp, err := factory.CreateTracesProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
 	assert.NotNil(t, tp)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	oCfg.Actions = []attraction.ActionKeyValue{
 		{Action: attraction.DELETE},

--- a/processor/cumulativetodeltaprocessor/factory_test.go
+++ b/processor/cumulativetodeltaprocessor/factory_test.go
@@ -53,7 +53,7 @@ func TestCreateProcessors(t *testing.T) {
 				cfg,
 				consumertest.NewNop())
 			// Not implemented error
-			assert.Error(t, tErr)
+			require.Error(t, tErr)
 			assert.Nil(t, tp)
 
 			mp, mErr := factory.CreateMetricsProcessor(

--- a/processor/cumulativetodeltaprocessor/processor_test.go
+++ b/processor/cumulativetodeltaprocessor/processor_test.go
@@ -454,7 +454,7 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 				next,
 			)
 			assert.NotNil(t, mgp)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			caps := mgp.Capabilities()
 			assert.True(t, caps.MutatesData)
@@ -646,7 +646,7 @@ func BenchmarkConsumeMetrics(b *testing.B) {
 
 	// Load initial value
 	reset()
-	assert.NoError(b, p.ConsumeMetrics(context.Background(), metrics))
+	require.NoError(b, p.ConsumeMetrics(context.Background(), metrics))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/processor/probabilisticsamplerprocessor/factory_test.go
+++ b/processor/probabilisticsamplerprocessor/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processortest"
@@ -31,6 +32,6 @@ func TestCreateProcessorLogs(t *testing.T) {
 	cfg := createDefaultConfig()
 	set := processortest.NewNopSettings()
 	tp, err := createLogsProcessor(context.Background(), set, cfg, consumertest.NewNop())
-	assert.NoError(t, err, "cannot create logs processor")
+	require.NoError(t, err, "cannot create logs processor")
 	assert.NotNil(t, tp)
 }

--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -52,7 +52,7 @@ func TestNewLogsProcessor(t *testing.T) {
 				assert.Nil(t, got)
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.NotNil(t, got)
 			}
 		})

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -156,7 +156,7 @@ func Test_tracesamplerprocessor_SamplingPercentageRange(t *testing.T) {
 				return
 			}
 			for _, td := range genRandomTestData(tt.numBatches, tt.numTracesPerBatch, testSvcName, 1) {
-				assert.NoError(t, tsp.ConsumeTraces(context.Background(), td))
+				require.NoError(t, tsp.ConsumeTraces(context.Background(), td))
 			}
 			sampled := sink.spanCount
 			actualPercentageSamplingPercentage := float32(sampled) / float32(tt.numBatches*tt.numTracesPerBatch) * 100.0

--- a/processor/redactionprocessor/factory_test.go
+++ b/processor/redactionprocessor/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/processor/processortest"
 )
@@ -22,7 +23,7 @@ func TestCreateTestProcessor(t *testing.T) {
 	cfg := &Config{}
 
 	tp, err := createTracesProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tp)
 	assert.True(t, tp.Capabilities().MutatesData)
 }
@@ -40,7 +41,7 @@ func TestCreateTestMetricsProcessor(t *testing.T) {
 	cfg := &Config{}
 
 	tp, err := createMetricsProcessor(context.Background(), processortest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tp)
 	assert.True(t, tp.Capabilities().MutatesData)
 }

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -594,7 +594,7 @@ func runLogsTest(
 	// test
 	ctx := context.Background()
 	processor, err := newRedaction(ctx, config, zaptest.NewLogger(t))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	outBatch, err := processor.processLogs(ctx, inBatch)
 
 	// verify

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/cadvisor_linux_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/cadvisor/manager"
 	"github.com/google/cadvisor/utils/sysfs"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors"
@@ -87,7 +88,7 @@ func TestGetMetrics(t *testing.T) {
 
 	c, err := New("eks", hostInfo, zap.NewNop(), cadvisorManagerCreator(newMockCreateManager(t)), k8sdecoratorOption)
 	assert.NotNil(t, c)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, c.GetMetrics())
 }
 
@@ -107,7 +108,7 @@ func TestGetMetricsNoClusterName(t *testing.T) {
 
 	c, err := New("eks", hostInfo, zap.NewNop(), cadvisorManagerCreator(newMockCreateManager(t)), k8sdecoratorOption)
 	assert.NotNil(t, c)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Nil(t, c.GetMetrics())
 }
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/extractors/fs_extractor_test.go
@@ -10,6 +10,7 @@ import (
 
 	cinfo "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/containerinsight"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils"
@@ -121,7 +122,7 @@ func TestFSStatsWithAllowList(t *testing.T) {
 
 	var b bytes.Buffer
 	enc := json.NewEncoder(&b)
-	assert.NoError(t, enc.Encode(result))
+	require.NoError(t, enc.Encode(result))
 	containerType := containerinsight.TypeContainer
 	extractor := NewFileSystemMetricExtractor(nil)
 

--- a/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
+++ b/receiver/awscontainerinsightreceiver/internal/cadvisor/testutils/helpers.go
@@ -11,15 +11,16 @@ import (
 
 	cinfo "github.com/google/cadvisor/info/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func LoadContainerInfo(t *testing.T, file string) []*cinfo.ContainerInfo {
 	info, err := os.ReadFile(file)
-	assert.NoError(t, err, "Fail to read file content")
+	require.NoError(t, err, "Fail to read file content")
 
 	containers := map[string]*cinfo.ContainerInfo{}
 	err = json.Unmarshal(info, &containers)
-	assert.NoError(t, err, "Fail to parse json string")
+	require.NoError(t, err, "Fail to parse json string")
 
 	result := make([]*cinfo.ContainerInfo, len(containers))
 	i := 0

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/cgroup_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -51,7 +52,7 @@ func TestGetCGroupPathForTask(t *testing.T) {
 			if tt.err != nil {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantRes, got)
 			}
 		})
@@ -102,7 +103,7 @@ func TestGetCGroupPathFromARN(t *testing.T) {
 			if tt.err != nil {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantRes, got)
 			}
 		})
@@ -155,7 +156,7 @@ func TestGetCGroupMountPoint(t *testing.T) {
 			if tt.err != nil {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantRes, got)
 			}
 		})

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type mockHTTPClient struct {
@@ -69,7 +70,7 @@ func TestRequestSuccessWithKnownLength(t *testing.T) {
 
 	body, err := request(ctx, "0.0.0.0", MockHTTPClient)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.NotNil(t, body)
 
@@ -94,7 +95,7 @@ func TestRequestSuccessWithUnknownLength(t *testing.T) {
 
 	body, err := request(ctx, "0.0.0.0", MockHTTPClient)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.NotNil(t, body)
 

--- a/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/hostinfo_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
@@ -79,7 +80,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err := NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// test the case when aws session fails to initialize
 	nodeCapacityCreatorOpt = func(m *Info) {
@@ -94,7 +95,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// test normal case where everything is working
 	awsSessionCreatorOpt = func(m *Info) {
@@ -122,7 +123,7 @@ func TestInfo(t *testing.T) {
 	}
 	m, err = NewInfo(ci.EKS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, m)
 
 	// befoe ebsVolume and ec2Tags are initialized
@@ -153,7 +154,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err := NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt)
 	assert.Nil(t, m)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// test the case when aws session fails to initialize
 	nodeCapacityCreatorOpt = func(m *Info) {
@@ -168,7 +169,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), nodeCapacityCreatorOpt, awsSessionCreatorOpt)
 	assert.Nil(t, m)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// test normal case where everything is working
 	awsSessionCreatorOpt = func(m *Info) {
@@ -196,7 +197,7 @@ func TestInfoForECS(t *testing.T) {
 	}
 	m, err = NewInfo(ci.ECS, time.Minute, zap.NewNop(), awsSessionCreatorOpt,
 		nodeCapacityCreatorOpt, ec2MetadataCreatorOpt, ebsVolumeCreatorOpt, ec2TagsCreatorOpt)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, m)
 
 	// befoe ebsVolume and ec2Tags are initialized

--- a/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/host/nodeCapacity_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/shirou/gopsutil/v4/mem"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -24,7 +25,7 @@ func TestNodeCapacity(t *testing.T) {
 	}
 	nc, err := newNodeCapacity(zap.NewNop(), lstatOption)
 	assert.Nil(t, nc)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// can't set environment variables
 	lstatOption = func(nc *nodeCapacity) {
@@ -45,7 +46,7 @@ func TestNodeCapacity(t *testing.T) {
 	}
 	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, virtualMemOption, cpuInfoOption)
 	assert.NotNil(t, nc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(0), nc.getMemoryCapacity())
 	assert.Equal(t, int64(0), nc.getNumCores())
 
@@ -67,7 +68,7 @@ func TestNodeCapacity(t *testing.T) {
 	}
 	nc, err = newNodeCapacity(zap.NewNop(), lstatOption, virtualMemOption, cpuInfoOption)
 	assert.NotNil(t, nc)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, int64(1024), nc.getMemoryCapacity())
 	assert.Equal(t, int64(2), nc.getNumCores())
 }

--- a/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/k8sapiserver/k8sapiserver_test.go
@@ -162,7 +162,7 @@ func TestK8sAPIServer_New(t *testing.T) {
 
 func TestK8sAPIServer_GetMetrics(t *testing.T) {
 	hostName, err := os.Hostname()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	k8sClientOption := func(k *K8sAPIServer) {
 		k.k8sClient = &mockK8sClient{}
 	}
@@ -182,7 +182,7 @@ func TestK8sAPIServer_GetMetrics(t *testing.T) {
 		leadingOption, broadcasterOption, isLeadingCOption)
 
 	assert.NotNil(t, k8sAPIServer)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mockClient.On("NamespaceToRunningPodNum").Return(map[string]int{"default": 2})
 	mockClient.On("ClusterFailedNodeCount").Return(1)
@@ -230,12 +230,12 @@ func TestK8sAPIServer_init(t *testing.T) {
 	k8sAPIServer := &K8sAPIServer{}
 
 	err := k8sAPIServer.init()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "environment variable HOST_NAME is not set"))
 
 	t.Setenv("HOST_NAME", "hostname")
 
 	err = k8sAPIServer.init()
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "environment variable K8S_NAMESPACE is not set"))
 }

--- a/receiver/awsxrayreceiver/factory_test.go
+++ b/receiver/awsxrayreceiver/factory_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pipeline"

--- a/receiver/awsxrayreceiver/factory_test.go
+++ b/receiver/awsxrayreceiver/factory_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pipeline"
@@ -21,7 +23,7 @@ func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 
 	assert.Equal(t, metadata.Type, factory.Type())
 }
@@ -52,6 +54,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 		factory.CreateDefaultConfig().(*Config),
 		consumertest.NewNop(),
 	)
-	assert.Error(t, err, "a trace receiver factory should not create a metric receiver")
+	require.Error(t, err, "a trace receiver factory should not create a metric receiver")
 	assert.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
 }

--- a/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
+++ b/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	recvErr "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver/internal/errors"
 )
@@ -15,7 +16,7 @@ func TestSplitHeaderBodyWithSeparatorExists(t *testing.T) {
 	buf := []byte(`{"format":"json", "version":1}` + "\nBody")
 
 	header, body, err := SplitHeaderBody(buf)
-	assert.NoError(t, err, "should split correctly")
+	require.NoError(t, err, "should split correctly")
 
 	assert.Equal(t, &Header{
 		Format:  "json",
@@ -30,7 +31,7 @@ func TestSplitHeaderBodyWithSeparatorDoesNotExist(t *testing.T) {
 	_, _, err := SplitHeaderBody(buf)
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
+	require.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.EqualError(t, err,
 		fmt.Sprintf("unable to split incoming data as header and segment, incoming bytes: %v", buf),
 		"expected error messages")
@@ -40,7 +41,7 @@ func TestSplitHeaderBodyNilBuf(t *testing.T) {
 	_, _, err := SplitHeaderBody(nil)
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
+	require.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.EqualError(t, err, "buffer to split is nil",
 		"expected error messages")
 }
@@ -51,7 +52,7 @@ func TestSplitHeaderBodyNonJsonHeader(t *testing.T) {
 	_, _, err := SplitHeaderBody(buf)
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
+	require.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.Contains(t, err.Error(), "invalid character 'o'")
 }
 
@@ -59,7 +60,7 @@ func TestSplitHeaderBodyEmptyBody(t *testing.T) {
 	buf := []byte(`{"format":"json", "version":1}` + "\n")
 
 	header, body, err := SplitHeaderBody(buf)
-	assert.NoError(t, err, "should split correctly")
+	require.NoError(t, err, "should split correctly")
 
 	assert.Equal(t, &Header{
 		Format:  "json",
@@ -72,10 +73,10 @@ func TestSplitHeaderBodyInvalidJsonHeader(t *testing.T) {
 	buf := []byte(`{"format":"json", "version":20}` + "\n")
 
 	_, _, err := SplitHeaderBody(buf)
-	assert.Error(t, err, "should fail because version is invalid")
+	require.Error(t, err, "should fail because version is invalid")
 
 	var errRecv *recvErr.ErrRecoverable
-	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
+	require.ErrorAs(t, err, &errRecv, "should return recoverable error")
 	assert.Contains(t, err.Error(),
 		fmt.Sprintf("invalid header %+v", Header{
 			Format:  "json",

--- a/receiver/awsxrayreceiver/internal/translator/sql_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/sql_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSQLURL(t *testing.T) {
 	raw := "jdbc:postgresql://aawijb5u25wdoy.cpamxznpdoq8.us-west-2.rds.amazonaws.com:5432/ebdb"
 	url, dbName, err := splitSQLURL(raw)
-	assert.NoError(t, err, "should succeed")
+	require.NoError(t, err, "should succeed")
 	assert.Equal(t,
 		"jdbc:postgresql://aawijb5u25wdoy.cpamxznpdoq8.us-west-2.rds.amazonaws.com:5432",
 		url, "expected url to be the same")
@@ -24,7 +25,7 @@ func TestSQLURL(t *testing.T) {
 func TestSQLURLQueryParameter(t *testing.T) {
 	raw := "jdbc:postgresql://aawijb5u25wdoy.cpamxznpdoq8.us-west-2.rds.amazonaws.com:5432/ebdb?myInterceptor=foo"
 	url, dbName, err := splitSQLURL(raw)
-	assert.NoError(t, err, "should succeed")
+	require.NoError(t, err, "should succeed")
 	assert.Equal(t,
 		"jdbc:postgresql://aawijb5u25wdoy.cpamxznpdoq8.us-west-2.rds.amazonaws.com:5432",
 		url, "expected url to be the same")

--- a/receiver/awsxrayreceiver/internal/translator/translator_test.go
+++ b/receiver/awsxrayreceiver/internal/translator/translator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/xray"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -111,7 +112,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -164,7 +165,7 @@ func TestTranslation(t *testing.T) {
 				}
 				for k, v := range subseg7df6.Metadata {
 					m, err := json.Marshal(v)
-					assert.NoError(t, err, "metadata marshaling failed")
+					require.NoError(t, err, "metadata marshaling failed")
 					childSpan7df6Attrs.PutStr(awsxray.AWSXraySegmentMetadataAttributePrefix+k, string(m))
 				}
 				assert.Equal(t, 3, childSpan7df6Attrs.Len(), testCase+": childSpan7df6Attrs has incorrect size")
@@ -187,7 +188,7 @@ func TestTranslation(t *testing.T) {
 
 				subseg7318 := seg.Subsegments[0].Subsegments[0]
 				childSpan7318Attrs := pcommon.NewMap()
-				assert.NoError(t, childSpan7318Attrs.FromRaw(map[string]any{
+				require.NoError(t, childSpan7318Attrs.FromRaw(map[string]any{
 					awsxray.AWSServiceAttribute:                    *subseg7318.Name,
 					conventions.AttributeHTTPResponseContentLength: int64(subseg7318.HTTP.Response.ContentLength.(float64)),
 					conventions.AttributeHTTPStatusCode:            *subseg7318.HTTP.Response.Status,
@@ -249,7 +250,7 @@ func TestTranslation(t *testing.T) {
 				childSpan417bAttrs := pcommon.NewMap()
 				for k, v := range subseg417b.Metadata {
 					m, err := json.Marshal(v)
-					assert.NoError(t, err, "metadata marshaling failed")
+					require.NoError(t, err, "metadata marshaling failed")
 					childSpan417bAttrs.PutStr(awsxray.AWSXraySegmentMetadataAttributePrefix+k, string(m))
 				}
 				childSpan417b := perSpanProperties{
@@ -271,7 +272,7 @@ func TestTranslation(t *testing.T) {
 				childSpan0cabAttrs := pcommon.NewMap()
 				for k, v := range subseg0cab.Metadata {
 					m, err := json.Marshal(v)
-					assert.NoError(t, err, "metadata marshaling failed")
+					require.NoError(t, err, "metadata marshaling failed")
 					childSpan0cabAttrs.PutStr(awsxray.AWSXraySegmentMetadataAttributePrefix+k, string(m))
 				}
 				childSpan0cab := perSpanProperties{
@@ -293,7 +294,7 @@ func TestTranslation(t *testing.T) {
 				childSpanF8dbAttrs := pcommon.NewMap()
 				for k, v := range subsegF8db.Metadata {
 					m, err := json.Marshal(v)
-					assert.NoError(t, err, "metadata marshaling failed")
+					require.NoError(t, err, "metadata marshaling failed")
 					childSpanF8dbAttrs.PutStr(awsxray.AWSXraySegmentMetadataAttributePrefix+k, string(m))
 				}
 				childSpanF8db := perSpanProperties{
@@ -315,7 +316,7 @@ func TestTranslation(t *testing.T) {
 				childSpanE2deAttrs := pcommon.NewMap()
 				for k, v := range subsegE2de.Metadata {
 					m, err := json.Marshal(v)
-					assert.NoError(t, err, "metadata marshaling failed")
+					require.NoError(t, err, "metadata marshaling failed")
 					childSpanE2deAttrs.PutStr(awsxray.AWSXraySegmentMetadataAttributePrefix+k, string(m))
 				}
 				childSpanE2de := perSpanProperties{
@@ -383,7 +384,7 @@ func TestTranslation(t *testing.T) {
 
 				subseg7163 := seg.Subsegments[0].Subsegments[1]
 				childSpan7163Attrs := pcommon.NewMap()
-				assert.NoError(t, childSpan7163Attrs.FromRaw(map[string]any{
+				require.NoError(t, childSpan7163Attrs.FromRaw(map[string]any{
 					awsxray.AWSServiceAttribute:                    *subseg7163.Name,
 					conventions.AttributeHTTPStatusCode:            *subseg7163.HTTP.Response.Status,
 					conventions.AttributeHTTPResponseContentLength: int64(subseg7163.HTTP.Response.ContentLength.(float64)),
@@ -518,7 +519,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					"one segment should translate to 1 ResourceSpans")
 
@@ -558,7 +559,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -612,7 +613,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -652,7 +653,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -722,7 +723,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -771,7 +772,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -820,7 +821,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -889,7 +890,7 @@ func TestTranslation(t *testing.T) {
 			verification: func(testCase string,
 				_ *awsxray.Segment,
 				expectedRs ptrace.ResourceSpans, actualTraces ptrace.Traces, err error) {
-				assert.NoError(t, err, testCase+": translation should've succeeded")
+				require.NoError(t, err, testCase+": translation should've succeeded")
 				assert.Equal(t, 1, actualTraces.ResourceSpans().Len(),
 					testCase+": one segment should translate to 1 ResourceSpans")
 
@@ -947,7 +948,7 @@ func TestTranslation(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.testCase, func(t *testing.T) {
 			content, err := os.ReadFile(tc.samplePath)
-			assert.NoError(t, err, "can not read raw segment")
+			require.NoError(t, err, "can not read raw segment")
 			assert.NotEmpty(t, content, "content length is 0")
 
 			var (
@@ -958,7 +959,7 @@ func TestTranslation(t *testing.T) {
 				err = json.Unmarshal(content, &actualSeg)
 				// the correctness of the actual segment
 				// has been verified in the tracesegment_test.go
-				assert.NoError(t, err, "failed to unmarhal raw segment")
+				require.NoError(t, err, "failed to unmarhal raw segment")
 				expectedRs = initResourceSpans(t,
 					&actualSeg,
 					tc.expectedResourceAttrs(&actualSeg),
@@ -1033,7 +1034,7 @@ func initResourceSpans(t *testing.T, expectedSeg *awsxray.Segment,
 	rs := ptrace.NewResourceSpans()
 
 	if len(resourceAttrs) > 0 {
-		assert.NoError(t, rs.Resource().Attributes().FromRaw(resourceAttrs))
+		require.NoError(t, rs.Resource().Attributes().FromRaw(resourceAttrs))
 	} else {
 		rs.Resource().Attributes().Clear()
 		rs.Resource().Attributes().EnsureCapacity(initAttrCapacity)
@@ -1098,7 +1099,7 @@ func TestDecodeXRayTraceID(t *testing.T) {
 	// invalid format
 	traceID = "1-5f84c7a1-e7d1852db"
 	_, err = decodeXRayTraceID(&traceID)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// null point
 	_, err = decodeXRayTraceID(nil)
@@ -1117,7 +1118,7 @@ func TestDecodeXRaySpanID(t *testing.T) {
 	// invalid format
 	spanID = "12345566"
 	_, err = decodeXRaySpanID(&spanID)
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// null point
 	_, err = decodeXRaySpanID(nil)

--- a/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
+++ b/receiver/awsxrayreceiver/internal/udppoller/poller_test.go
@@ -56,10 +56,10 @@ func TestInvalidEndpoint(t *testing.T) {
 
 func TestUDPPortUnavailable(t *testing.T) {
 	addr, err := net.ResolveUDPAddr("udp", "localhost:0")
-	assert.NoError(t, err, "should resolve UDP address")
+	require.NoError(t, err, "should resolve UDP address")
 
 	sock, err := net.ListenUDP("udp", addr)
-	assert.NoError(t, err, "should be able to listen")
+	require.NoError(t, err, "should be able to listen")
 	defer sock.Close()
 	address := sock.LocalAddr().String()
 
@@ -72,7 +72,7 @@ func TestUDPPortUnavailable(t *testing.T) {
 		receivertest.NewNopSettings(),
 	)
 
-	assert.Error(t, err, "should have failed to create a new receiver")
+	require.Error(t, err, "should have failed to create a new receiver")
 	assert.True(t,
 		strings.Contains(err.Error(), "address already in use") || strings.Contains(err.Error(), "Only one usage of each socket address"),
 		"error message should complain about address in-use")
@@ -80,7 +80,7 @@ func TestUDPPortUnavailable(t *testing.T) {
 
 func TestCloseStopsPoller(t *testing.T) {
 	addr, err := findAvailableAddress()
-	assert.NoError(t, err, "there should be address available")
+	require.NoError(t, err, "there should be address available")
 
 	p, err := New(
 		&Config{
@@ -90,14 +90,14 @@ func TestCloseStopsPoller(t *testing.T) {
 		},
 		receivertest.NewNopSettings(),
 	)
-	assert.NoError(t, err, "poller should be created")
+	require.NoError(t, err, "poller should be created")
 
 	// start pollers
 	segChan := p.SegmentsChan()
 	p.Start(context.Background())
 
 	err = p.Close()
-	assert.NoError(t, err, "should be able to close the poller")
+	require.NoError(t, err, "should be able to close the poller")
 
 	assert.Eventuallyf(t, func() bool {
 		select {
@@ -115,7 +115,7 @@ func TestCloseStopsPoller(t *testing.T) {
 func TestSuccessfullyPollPacket(t *testing.T) {
 	receiverID := component.MustNewID("TestSuccessfullyPollPacket")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -126,7 +126,7 @@ func TestSuccessfullyPollPacket(t *testing.T) {
 	randString, _ := uuid.NewRandom()
 	rawData := []byte(`{"format": "json", "version": 1}` + "\n" + randString.String())
 	err = writePacket(t, addr, string(rawData))
-	assert.NoError(t, err, "can not write packet in the TestSuccessfullyPollPacket case")
+	require.NoError(t, err, "can not write packet in the TestSuccessfullyPollPacket case")
 
 	assert.Eventuallyf(t, func() bool {
 		select {
@@ -151,7 +151,7 @@ func TestSuccessfullyPollPacket(t *testing.T) {
 func TestIncompletePacketNoSeparator(t *testing.T) {
 	receiverID := component.MustNewID("TestIncompletePacketNoSeparator")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -161,7 +161,7 @@ func TestIncompletePacketNoSeparator(t *testing.T) {
 
 	rawData := []byte(`{"format": "json", "version": 1}`) // no separator
 	err = writePacket(t, addr, string(rawData))
-	assert.NoError(t, err, "can not write packet in the TestIncompletePacketNoSeparator case")
+	require.NoError(t, err, "can not write packet in the TestIncompletePacketNoSeparator case")
 	assert.Eventuallyf(t, func() bool {
 		logs := recordedLogs.All()
 		lastEntry := logs[len(logs)-1]
@@ -181,7 +181,7 @@ func TestIncompletePacketNoSeparator(t *testing.T) {
 func TestIncompletePacketNoBody(t *testing.T) {
 	receiverID := component.MustNewID("TestIncompletePacketNoBody")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -191,7 +191,7 @@ func TestIncompletePacketNoBody(t *testing.T) {
 
 	rawData := []byte(`{"format": "json", "version": 1}` + "\n") // no body
 	err = writePacket(t, addr, string(rawData))
-	assert.NoError(t, err, "can not write packet in the TestIncompletePacketNoBody case")
+	require.NoError(t, err, "can not write packet in the TestIncompletePacketNoBody case")
 	assert.Eventuallyf(t, func() bool {
 		logs := recordedLogs.All()
 		lastEntry := logs[len(logs)-1]
@@ -206,7 +206,7 @@ func TestIncompletePacketNoBody(t *testing.T) {
 func TestNonJsonHeader(t *testing.T) {
 	receiverID := component.MustNewID("TestNonJsonHeader")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -216,7 +216,7 @@ func TestNonJsonHeader(t *testing.T) {
 
 	// the header (i.e. the portion before \n) is invalid
 	err = writePacket(t, addr, "nonJson\nBody")
-	assert.NoError(t, err, "can not write packet in the TestNonJsonHeader case")
+	require.NoError(t, err, "can not write packet in the TestNonJsonHeader case")
 	assert.Eventuallyf(t, func() bool {
 		var errRecv *internalErr.ErrRecoverable
 		logs := recordedLogs.All()
@@ -236,7 +236,7 @@ func TestNonJsonHeader(t *testing.T) {
 func TestJsonInvalidHeader(t *testing.T) {
 	receiverID := component.MustNewID("TestJsonInvalidHeader")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -248,7 +248,7 @@ func TestJsonInvalidHeader(t *testing.T) {
 	// the header (i.e. the portion before \n) is invalid
 	err = writePacket(t, addr,
 		fmt.Sprintf(`{"format": "%s", "version": 1}`, randString.String())+"\nBody")
-	assert.NoError(t, err, "can not write packet in the TestJsonInvalidHeader case")
+	require.NoError(t, err, "can not write packet in the TestJsonInvalidHeader case")
 	assert.Eventuallyf(t, func() bool {
 		var errRecv *internalErr.ErrRecoverable
 		logs := recordedLogs.All()
@@ -272,7 +272,7 @@ func TestJsonInvalidHeader(t *testing.T) {
 func TestSocketReadIrrecoverableNetError(t *testing.T) {
 	receiverID := component.MustNewID("TestSocketReadIrrecoverableNetError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -309,7 +309,7 @@ func TestSocketReadIrrecoverableNetError(t *testing.T) {
 func TestSocketReadTimeOutNetError(t *testing.T) {
 	receiverID := component.MustNewID("TestSocketReadTimeOutNetError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -347,7 +347,7 @@ func TestSocketReadTimeOutNetError(t *testing.T) {
 func TestSocketGenericReadError(t *testing.T) {
 	receiverID := component.MustNewID("TestSocketGenericReadError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -432,7 +432,7 @@ func createAndOptionallyStartPoller(
 	start bool,
 	set receiver.Settings) (string, Poller, *observer.ObservedLogs) {
 	addr, err := findAvailableAddress()
-	assert.NoError(t, err, "there should be address available")
+	require.NoError(t, err, "there should be address available")
 
 	logger, recorded := logSetup()
 	set.Logger = logger

--- a/receiver/awsxrayreceiver/receiver_test.go
+++ b/receiver/awsxrayreceiver/receiver_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -40,7 +41,7 @@ const (
 
 func TestProxyCreationFailed(t *testing.T) {
 	addr, err := findAvailableUDPAddress()
-	assert.NoError(t, err, "there should be address available")
+	require.NoError(t, err, "there should be address available")
 
 	sink := new(consumertest.TracesSink)
 	_, err = newReceiver(
@@ -86,7 +87,7 @@ func TestSegmentsPassedToConsumer(t *testing.T) {
 
 	receiverID := component.MustNewID("TestSegmentsPassedToConsumer")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -99,10 +100,10 @@ func TestSegmentsPassedToConsumer(t *testing.T) {
 	}()
 
 	content, err := os.ReadFile(filepath.Join("../../internal/aws/xray", "testdata", "ddbSample.txt"))
-	assert.NoError(t, err, "can not read raw segment")
+	require.NoError(t, err, "can not read raw segment")
 
 	err = writePacket(t, addr, segmentHeader+string(content))
-	assert.NoError(t, err, "can not write packet in the happy case")
+	require.NoError(t, err, "can not write packet in the happy case")
 
 	sink := rcvr.(*xrayReceiver).consumer.(*consumertest.TracesSink)
 
@@ -117,7 +118,7 @@ func TestSegmentsPassedToConsumer(t *testing.T) {
 func TestTranslatorErrorsOut(t *testing.T) {
 	receiverID := component.MustNewID("TestTranslatorErrorsOut")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -130,7 +131,7 @@ func TestTranslatorErrorsOut(t *testing.T) {
 	}()
 
 	err = writePacket(t, addr, segmentHeader+"invalidSegment")
-	assert.NoError(t, err, "can not write packet in the "+receiverID.String()+" case")
+	require.NoError(t, err, "can not write packet in the "+receiverID.String()+" case")
 
 	assert.Eventuallyf(t, func() bool {
 		logs := recordedLogs.All()
@@ -144,7 +145,7 @@ func TestTranslatorErrorsOut(t *testing.T) {
 func TestSegmentsConsumerErrorsOut(t *testing.T) {
 	receiverID := component.MustNewID("TestSegmentsConsumerErrorsOut")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -157,10 +158,10 @@ func TestSegmentsConsumerErrorsOut(t *testing.T) {
 	}()
 
 	content, err := os.ReadFile(filepath.Join("../../internal/aws/xray", "testdata", "serverSample.txt"))
-	assert.NoError(t, err, "can not read raw segment")
+	require.NoError(t, err, "can not read raw segment")
 
 	err = writePacket(t, addr, segmentHeader+string(content))
-	assert.NoError(t, err, "can not write packet")
+	require.NoError(t, err, "can not write packet")
 
 	assert.Eventuallyf(t, func() bool {
 		logs := recordedLogs.All()
@@ -174,7 +175,7 @@ func TestSegmentsConsumerErrorsOut(t *testing.T) {
 func TestPollerCloseError(t *testing.T) {
 	receiverID := component.MustNewID("TestPollerCloseError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -192,7 +193,7 @@ func TestPollerCloseError(t *testing.T) {
 func TestProxyCloseError(t *testing.T) {
 	receiverID := component.MustNewID("TestPollerCloseError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -210,7 +211,7 @@ func TestProxyCloseError(t *testing.T) {
 func TestBothPollerAndProxyCloseError(t *testing.T) {
 	receiverID := component.MustNewID("TestBothPollerAndProxyCloseError")
 	tt, err := componenttest.SetupTelemetry(receiverID)
-	assert.NoError(t, err, "SetupTelemetry should succeed")
+	require.NoError(t, err, "SetupTelemetry should succeed")
 	defer func() {
 		assert.NoError(t, tt.Shutdown(context.Background()))
 	}()
@@ -223,7 +224,7 @@ func TestBothPollerAndProxyCloseError(t *testing.T) {
 	rcvr.(*xrayReceiver).poller = mPoller
 	rcvr.(*xrayReceiver).server = mProxy
 	err = rcvr.Shutdown(context.Background())
-	assert.ErrorIs(t, err, mPoller.closeErr, "expected error")
+	require.ErrorIs(t, err, mPoller.closeErr, "expected error")
 	assert.ErrorIs(t, err, mProxy.closeErr, "expected error")
 }
 
@@ -265,7 +266,7 @@ func createAndOptionallyStartReceiver(
 	start bool,
 	set receiver.Settings) (string, receiver.Traces, *observer.ObservedLogs) {
 	addr, err := findAvailableUDPAddress()
-	assert.NoError(t, err, "there should be address available")
+	require.NoError(t, err, "there should be address available")
 	tcpAddr := testutil.GetAvailableLocalAddress(t)
 
 	var sink consumer.Traces

--- a/receiver/azureblobreceiver/blobclient_test.go
+++ b/receiver/azureblobreceiver/blobclient_test.go
@@ -31,7 +31,7 @@ func TestNewBlobClientFromConnectionString(t *testing.T) {
 func TestNewBlobClientFromConnectionStringError(t *testing.T) {
 	blobClient, err := newBlobClientFromConnectionString(badConnectionString, zaptest.NewLogger(t))
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, blobClient)
 }
 

--- a/receiver/azureblobreceiver/config_test.go
+++ b/receiver/azureblobreceiver/config_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	factory := NewFactory()
 	factories.Receivers[metadata.Type] = factory
@@ -32,7 +32,7 @@ func TestLoadConfig(t *testing.T) {
 	assert.Len(t, cfg.Receivers, 2)
 
 	receiver := cfg.Receivers[component.NewID(metadata.Type)]
-	assert.NoError(t, componenttest.CheckConfigStruct(receiver))
+	require.NoError(t, componenttest.CheckConfigStruct(receiver))
 	assert.Equal(
 		t,
 		&Config{
@@ -45,7 +45,7 @@ func TestLoadConfig(t *testing.T) {
 		receiver)
 
 	receiver = cfg.Receivers[component.NewIDWithName(metadata.Type, "2")].(*Config)
-	assert.NoError(t, componenttest.CheckConfigStruct(receiver))
+	require.NoError(t, componenttest.CheckConfigStruct(receiver))
 	assert.Equal(
 		t,
 		&Config{

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	factories, err := otelcoltest.NopFactories()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	factory := NewFactory()
 	factories.Receivers[metadata.Type] = factory

--- a/receiver/azureeventhubreceiver/eventhubhandler_test.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler_test.go
@@ -127,7 +127,7 @@ func TestEventhubHandler_newMessageHandler(t *testing.T) {
 	}
 	ehHandler.hub = &mockHubWrapper{}
 
-	assert.NoError(t, ehHandler.run(context.Background(), componenttest.NewNopHost()))
+	require.NoError(t, ehHandler.run(context.Background(), componenttest.NewNopHost()))
 
 	now := time.Now()
 	err = ehHandler.newMessageHandler(context.Background(), &eventhub.Event{
@@ -145,7 +145,7 @@ func TestEventhubHandler_newMessageHandler(t *testing.T) {
 		},
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, sink.AllLogs(), 1)
 	assert.Equal(t, 1, sink.AllLogs()[0].LogRecordCount())
 	assert.Equal(t, []byte("hello"), sink.AllLogs()[0].ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Body().Bytes().AsRaw())

--- a/receiver/azureeventhubreceiver/factory_test.go
+++ b/receiver/azureeventhubreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -22,13 +23,13 @@ func Test_NewFactory(t *testing.T) {
 func Test_NewLogsReceiver(t *testing.T) {
 	f := NewFactory()
 	receiver, err := f.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), f.CreateDefaultConfig(), consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, receiver)
 }
 
 func Test_NewMetricsReceiver(t *testing.T) {
 	f := NewFactory()
 	receiver, err := f.CreateMetricsReceiver(context.Background(), receivertest.NewNopSettings(), f.CreateDefaultConfig(), consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, receiver)
 }

--- a/receiver/azureeventhubreceiver/persister_test.go
+++ b/receiver/azureeventhubreceiver/persister_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Azure/azure-event-hubs-go/v3/persist"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 )
 
@@ -20,7 +21,7 @@ func TestStorageOffsetPersisterUnknownCheckpoint(t *testing.T) {
 	s := storageCheckpointPersister{storageClient: client}
 	// check we have no match
 	checkpoint, err := s.Read("foo", "bar", "foobar", "foobarfoo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, checkpoint)
 	assert.Equal(t, "-1", checkpoint.Offset)
 }
@@ -34,9 +35,9 @@ func TestStorageOffsetPersisterWithKnownCheckpoint(t *testing.T) {
 		EnqueueTime:    time.Now(),
 	}
 	err := s.Write("foo", "bar", "foobar", "foobarfoo", checkpoint)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	read, err := s.Read("foo", "bar", "foobar", "foobarfoo")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, checkpoint.Offset, read.Offset)
 	assert.Equal(t, checkpoint.SequenceNumber, read.SequenceNumber)
 	assert.True(t, checkpoint.EnqueueTime.Equal(read.EnqueueTime))

--- a/receiver/carbonreceiver/factory_test.go
+++ b/receiver/carbonreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -26,6 +27,6 @@ func TestCreateReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := createMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/carbonreceiver/internal/transport/server_test.go
+++ b/receiver/carbonreceiver/internal/transport/server_test.go
@@ -72,11 +72,11 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			ts := time.Date(2020, 2, 20, 20, 20, 20, 20, time.UTC)
 			err = gc.SendMetric(client.Metric{
 				Name: "test.metric", Value: 1, Timestamp: ts})
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			runtime.Gosched()
 
 			err = gc.Disconnect()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			mr.wgMetricsProcessed.Wait()
 
@@ -87,7 +87,7 @@ func Test_Server_ListenAndServe(t *testing.T) {
 			}, 10*time.Second, 500*time.Millisecond)
 
 			err = svr.Close()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			wgListenAndServe.Wait()
 

--- a/receiver/carbonreceiver/protocol/plaintext_parser_test.go
+++ b/receiver/carbonreceiver/protocol/plaintext_parser_test.go
@@ -207,7 +207,7 @@ func TestPlaintextParser_parsePath(t *testing.T) {
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.wantName, got.MetricName)
 				assert.Equal(t, tt.wantAttributes, got.Attributes)
 				assert.Equal(t, DefaultMetricType, got.MetricType)

--- a/receiver/carbonreceiver/protocol/regex_parser_test.go
+++ b/receiver/carbonreceiver/protocol/regex_parser_test.go
@@ -72,12 +72,12 @@ func TestRegexParserConfigBuildParser(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := tt.config.BuildParser()
 			if tt.wantErr {
-				assert.Error(t, err)
+				require.Error(t, err)
 				assert.Nil(t, got)
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, got)
 		})
 	}

--- a/receiver/chronyreceiver/factory_test.go
+++ b/receiver/chronyreceiver/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -57,6 +58,6 @@ func TestCreatingMetricsReceiver(t *testing.T) {
 		},
 		consumertest.NewNop(),
 	)
-	assert.NoError(t, err, "Must not error creating metrics receiver")
+	require.NoError(t, err, "Must not error creating metrics receiver")
 	assert.NotNil(t, mem, "Must have a valid metrics receiver client")
 }

--- a/receiver/chronyreceiver/internal/chrony/client_test.go
+++ b/receiver/chronyreceiver/internal/chrony/client_test.go
@@ -27,7 +27,7 @@ func newMockConn(tb testing.TB, serverReaderFn, serverWriterFn func(net.Conn) er
 		wg.Wait()
 		assert.NoError(tb, server.Close(), "Must not error when closing server connection")
 	})
-	assert.NoError(tb, server.SetDeadline(time.Now().Add(time.Second)), "Must not error when assigning deadline")
+	require.NoError(tb, server.SetDeadline(time.Now().Add(time.Second)), "Must not error when assigning deadline")
 
 	go func() {
 		defer wg.Done()
@@ -71,10 +71,10 @@ func TestNew(t *testing.T) {
 			t.Parallel()
 			cl, err := New(tc.addr, time.Second)
 			if tc.toError {
-				assert.Error(t, err, "Must error")
+				require.Error(t, err, "Must error")
 				assert.Nil(t, cl, "Must have a nil client")
 			} else {
-				assert.NoError(t, err, "Must not error")
+				require.NoError(t, err, "Must not error")
 				assert.NotNil(t, cl, "Must have a client")
 			}
 		})

--- a/receiver/chronyreceiver/scraper_test.go
+++ b/receiver/chronyreceiver/scraper_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -120,7 +121,7 @@ func TestChronyScraper(t *testing.T) {
 
 			metrics, err := scraper.scrape(ctx)
 
-			assert.ErrorIs(t, err, tc.err, "Must match the expected error")
+			require.ErrorIs(t, err, tc.err, "Must match the expected error")
 			assert.EqualValues(t, tc.metrics, metrics, "Must match the expected metrics")
 			chronym.AssertExpectations(t)
 		})

--- a/receiver/cloudfoundryreceiver/factory_test.go
+++ b/receiver/cloudfoundryreceiver/factory_test.go
@@ -27,7 +27,7 @@ func TestCreateMetricsReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "metrics receiver creation failed")
 }
 
@@ -37,6 +37,6 @@ func TestCreateLogsReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateLogsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "logs receiver creation failed")
 }

--- a/receiver/collectdreceiver/collectd_test.go
+++ b/receiver/collectdreceiver/collectd_test.go
@@ -32,7 +32,7 @@ func TestDecodeEvent(t *testing.T) {
 
 	for _, cdr := range records {
 		err := cdr.appendToMetrics(zap.NewNop(), scopeMetrics, map[string]string{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, 0, metrics.MetricCount())
 	}
 }
@@ -49,7 +49,7 @@ func TestDecodeMetrics(t *testing.T) {
 
 	for _, cdr := range records {
 		err = cdr.appendToMetrics(zap.NewNop(), scopeMemtrics, map[string]string{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	assert.Equal(t, 10, metrics.MetricCount())
 

--- a/receiver/collectdreceiver/config_test.go
+++ b/receiver/collectdreceiver/config_test.go
@@ -57,7 +57,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, sub.Unmarshal(cfg))
 
 			if tt.wantErr == nil {
-				assert.NoError(t, component.ValidateConfig(cfg))
+				require.NoError(t, component.ValidateConfig(cfg))
 			} else {
 				assert.Equal(t, tt.wantErr, component.ValidateConfig(cfg))
 			}

--- a/receiver/collectdreceiver/factory_test.go
+++ b/receiver/collectdreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -26,6 +27,6 @@ func TestCreateReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/datadogreceiver/factory_test.go
+++ b/receiver/datadogreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
@@ -18,7 +19,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 	cfg.(*Config).Endpoint = "http://localhost:0"
 
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "traces receiver creation failed")
 }
 
@@ -28,6 +29,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	cfg.(*Config).Endpoint = "http://localhost:0"
 
 	tReceiver, err := factory.CreateMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "metrics receiver creation failed")
 }

--- a/receiver/datadogreceiver/internal/translator/stats_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/stats_translator_test.go
@@ -10,6 +10,7 @@ import (
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -97,7 +98,7 @@ func TestTranslateStats(t *testing.T) {
 	t.Run("same", func(t *testing.T) {
 		st := NewStatsTranslator()
 		mx, err := st.TranslateStats(want, lang, tracerVersion)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		var results []*pb.StatsPayload
 		for i := 0; i < mx.ResourceMetrics().Len(); i++ {
@@ -115,7 +116,7 @@ func TestTranslateStats(t *testing.T) {
 							results = append(results, stats)
 						}
 					}
-					assert.NoError(t, err)
+					require.NoError(t, err)
 				}
 			}
 		}

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -70,7 +70,7 @@ var data = [2]any{
 
 func getTraces(t *testing.T) (traces pb.Traces) {
 	payload, err := vmsgp.Marshal(&data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	if err2 := traces.UnmarshalMsgDictionary(payload); err2 != nil {
 		t.Fatal(err)
 	}

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -32,10 +32,10 @@ func TestDatadogTracesReceiver_Lifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	cfg.(*Config).Endpoint = "localhost:0"
 	ddr, err := factory.CreateTracesReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err, "Traces receiver should be created")
+	require.NoError(t, err, "Traces receiver should be created")
 
 	err = ddr.Start(context.Background(), componenttest.NewNopHost())
-	assert.NoError(t, err, "Server should start")
+	require.NoError(t, err, "Server should start")
 
 	err = ddr.Shutdown(context.Background())
 	assert.NoError(t, err, "Server should stop")
@@ -46,10 +46,10 @@ func TestDatadogMetricsReceiver_Lifecycle(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	cfg.(*Config).Endpoint = "localhost:0"
 	ddr, err := factory.CreateMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err, "Metrics receiver should be created")
+	require.NoError(t, err, "Metrics receiver should be created")
 
 	err = ddr.Start(context.Background(), componenttest.NewNopHost())
-	assert.NoError(t, err, "Server should start")
+	require.NoError(t, err, "Server should start")
 
 	err = ddr.Shutdown(context.Background())
 	assert.NoError(t, err, "Server should stop")
@@ -359,7 +359,7 @@ func TestDatadogMetricsV2_EndToEnd(t *testing.T) {
 	}
 
 	pb, err := metricsPayloadV2.Marshal()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(
 		http.MethodPost,
@@ -436,7 +436,7 @@ func TestDatadogSketches_EndToEnd(t *testing.T) {
 	}
 
 	pb, err := sketchPayload.Marshal()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(
 		http.MethodPost,
@@ -537,7 +537,7 @@ func TestStats_EndToEnd(t *testing.T) {
 	}
 
 	payload, err := clientStatsPayload.MarshalMsg(nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	req, err := http.NewRequest(
 		http.MethodPost,

--- a/receiver/dockerstatsreceiver/factory_test.go
+++ b/receiver/dockerstatsreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pipeline"
@@ -29,10 +30,10 @@ func TestCreateReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	traceReceiver, err := factory.CreateTracesReceiver(context.Background(), params, config, consumertest.NewNop())
-	assert.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
+	require.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
 	assert.Nil(t, traceReceiver)
 
 	metricReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, config, consumertest.NewNop())
-	assert.NoError(t, err, "Metric receiver creation failed")
+	require.NoError(t, err, "Metric receiver creation failed")
 	assert.NotNil(t, metricReceiver, "receiver creation failed")
 }

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -150,12 +150,12 @@ func TestErrorsInStart(t *testing.T) {
 
 	cfg.Endpoint = "..not/a/valid/endpoint"
 	err := recv.start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "unable to parse docker host")
 
 	cfg.Endpoint = unreachable
 	err = recv.start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "context deadline exceeded")
 }
 

--- a/receiver/fluentforwardreceiver/factory_test.go
+++ b/receiver/fluentforwardreceiver/factory_test.go
@@ -31,6 +31,6 @@ func TestCreateReceiver(t *testing.T) {
 	require.Equal(t, metadata.Type, factory.Type())
 
 	tReceiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 }

--- a/receiver/githubreceiver/factory_test.go
+++ b/receiver/githubreceiver/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pipeline"
@@ -37,7 +38,7 @@ func TestCreateReceiver(t *testing.T) {
 	assert.Nil(t, tReceiver)
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, mReceiver)
 
 	tLogs, err := factory.CreateLogsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())

--- a/receiver/githubreceiver/internal/scraper/githubscraper/factory_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -25,6 +26,6 @@ func TestCreateMetricsScraper(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 
 	mReceiver, err := factory.CreateMetricsScraper(context.Background(), creationSet, cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, mReceiver)
 }

--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Khan/genqlient/graphql"
 	"github.com/google/go-github/v65/github"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -717,7 +718,7 @@ func TestGetContributors(t *testing.T) {
 			client.UploadURL = url
 
 			contribs, err := ghs.getContributorCount(context.Background(), client, tc.repo)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tc.expectedCount, contribs)
 		})
 	}

--- a/receiver/googlecloudpubsubreceiver/config_test.go
+++ b/receiver/googlecloudpubsubreceiver/config_test.go
@@ -63,13 +63,13 @@ func TestLoadConfig(t *testing.T) {
 func TestConfigValidation(t *testing.T) {
 	factory := NewFactory()
 	c := factory.CreateDefaultConfig().(*Config)
-	assert.Error(t, c.validateForTrace())
-	assert.Error(t, c.validateForLog())
-	assert.Error(t, c.validateForMetric())
+	require.Error(t, c.validateForTrace())
+	require.Error(t, c.validateForLog())
+	require.Error(t, c.validateForMetric())
 	c.Subscription = "projects/000project/subscriptions/my-subscription"
-	assert.Error(t, c.validate())
+	require.Error(t, c.validate())
 	c.Subscription = "projects/my-project/topics/my-topic"
-	assert.Error(t, c.validate())
+	require.Error(t, c.validate())
 	c.Subscription = "projects/my-project/subscriptions/my-subscription"
 	assert.NoError(t, c.validate())
 }
@@ -78,16 +78,16 @@ func TestTraceConfigValidation(t *testing.T) {
 	factory := NewFactory()
 	c := factory.CreateDefaultConfig().(*Config)
 	c.Subscription = "projects/my-project/subscriptions/my-subscription"
-	assert.NoError(t, c.validateForTrace())
+	require.NoError(t, c.validateForTrace())
 
 	c.Encoding = "otlp_proto_metric"
-	assert.Error(t, c.validateForTrace())
+	require.Error(t, c.validateForTrace())
 	c.Encoding = "otlp_proto_log"
-	assert.Error(t, c.validateForTrace())
+	require.Error(t, c.validateForTrace())
 	c.Encoding = "raw_text"
-	assert.Error(t, c.validateForTrace())
+	require.Error(t, c.validateForTrace())
 	c.Encoding = "raw_json"
-	assert.Error(t, c.validateForTrace())
+	require.Error(t, c.validateForTrace())
 
 	c.Encoding = "otlp_proto_trace"
 	assert.NoError(t, c.validateForTrace())
@@ -97,16 +97,16 @@ func TestMetricConfigValidation(t *testing.T) {
 	factory := NewFactory()
 	c := factory.CreateDefaultConfig().(*Config)
 	c.Subscription = "projects/my-project/subscriptions/my-subscription"
-	assert.NoError(t, c.validateForMetric())
+	require.NoError(t, c.validateForMetric())
 
 	c.Encoding = "otlp_proto_trace"
-	assert.Error(t, c.validateForMetric())
+	require.Error(t, c.validateForMetric())
 	c.Encoding = "otlp_proto_log"
-	assert.Error(t, c.validateForMetric())
+	require.Error(t, c.validateForMetric())
 	c.Encoding = "raw_text"
-	assert.Error(t, c.validateForMetric())
+	require.Error(t, c.validateForMetric())
 	c.Encoding = "raw_json"
-	assert.Error(t, c.validateForMetric())
+	require.Error(t, c.validateForMetric())
 
 	c.Encoding = "otlp_proto_metric"
 	assert.NoError(t, c.validateForMetric())
@@ -116,12 +116,12 @@ func TestLogConfigValidation(t *testing.T) {
 	factory := NewFactory()
 	c := factory.CreateDefaultConfig().(*Config)
 	c.Subscription = "projects/my-project/subscriptions/my-subscription"
-	assert.NoError(t, c.validateForLog())
+	require.NoError(t, c.validateForLog())
 
 	c.Encoding = "otlp_proto_trace"
-	assert.Error(t, c.validateForLog())
+	require.Error(t, c.validateForLog())
 	c.Encoding = "otlp_proto_metric"
-	assert.Error(t, c.validateForLog())
+	require.Error(t, c.validateForLog())
 
 	c.Encoding = "raw_text"
 	assert.NoError(t, c.validateForLog())

--- a/receiver/googlecloudpubsubreceiver/factory_test.go
+++ b/receiver/googlecloudpubsubreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -34,7 +35,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "traces receiver creation failed")
 }
 
@@ -45,7 +46,7 @@ func TestCreateMetricsReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "metrics receiver creation failed")
 }
 
@@ -56,7 +57,7 @@ func TestCreateLogsReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateLogsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tReceiver, "logs receiver creation failed")
 }
 
@@ -66,11 +67,11 @@ func TestEnsureReceiver(t *testing.T) {
 
 	cfg.(*Config).Subscription = "projects/my-project/subscriptions/my-subscription"
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, tReceiver, mReceiver)
 	lReceiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, mReceiver, lReceiver)
 }

--- a/receiver/googlecloudpubsubreceiver/internal/handler_test.go
+++ b/receiver/googlecloudpubsubreceiver/internal/handler_test.go
@@ -12,6 +12,7 @@ import (
 	"cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"cloud.google.com/go/pubsub/pstest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 	"google.golang.org/api/option"
 	"google.golang.org/grpc"
@@ -27,29 +28,29 @@ func TestCancelStream(t *testing.T) {
 	var copts []option.ClientOption
 	var dialOpts []grpc.DialOption
 	conn, err := grpc.NewClient(srv.Addr, append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer func() { assert.NoError(t, conn.Close()) }()
 	copts = append(copts, option.WithGRPCConn(conn))
 	_, err = srv.GServer.CreateTopic(ctx, &pubsubpb.Topic{
 		Name: "projects/my-project/topics/otlp",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = srv.GServer.CreateSubscription(ctx, &pubsubpb.Subscription{
 		Topic:              "projects/my-project/topics/otlp",
 		Name:               "projects/my-project/subscriptions/otlp",
 		AckDeadlineSeconds: 10,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	client, err := pubsub.NewSubscriberClient(ctx, copts...)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	handler, err := NewHandler(ctx, zaptest.NewLogger(t), client, "client-id", "projects/my-project/subscriptions/otlp",
 		func(context.Context, *pubsubpb.ReceivedMessage) error {
 			return nil
 		})
 	handler.ackBatchWait = 10 * time.Millisecond
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	srv.Publish("projects/my-project/topics/otlp", []byte{}, map[string]string{
 		"ce-type":      "org.opentelemetry.otlp.traces.v1",
 		"content-type": "application/protobuf",

--- a/receiver/googlecloudpubsubreceiver/internal/log_entry_test.go
+++ b/receiver/googlecloudpubsubreceiver/internal/log_entry_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -31,7 +30,7 @@ type Log struct {
 
 func generateLog(t *testing.T, log Log) (pcommon.Resource, plog.LogRecord, error) {
 	res := pcommon.NewResource()
-	assert.NoError(t, res.Attributes().FromRaw(log.ResourceAttributes))
+	require.NoError(t, res.Attributes().FromRaw(log.ResourceAttributes))
 
 	lr := plog.NewLogRecord()
 	err := lr.Attributes().FromRaw(log.Attributes)
@@ -54,7 +53,7 @@ func generateLog(t *testing.T, log Log) (pcommon.Resource, plog.LogRecord, error
 		lr.SetObservedTimestamp(pcommon.NewTimestampFromTime(ots))
 	}
 
-	assert.NoError(t, lr.Body().FromRaw(log.Body))
+	require.NoError(t, lr.Body().FromRaw(log.Body))
 	lr.SetSeverityText(log.SeverityText)
 
 	lr.SetSpanID(spanIDStrToSpanIDBytes(log.SpanID))

--- a/receiver/googlecloudpubsubreceiver/receiver_test.go
+++ b/receiver/googlecloudpubsubreceiver/receiver_test.go
@@ -63,13 +63,13 @@ func TestReceiver(t *testing.T) {
 	_, err := srv.GServer.CreateTopic(ctx, &pb.Topic{
 		Name: "projects/my-project/topics/otlp",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = srv.GServer.CreateSubscription(ctx, &pb.Subscription{
 		Topic:              "projects/my-project/topics/otlp",
 		Name:               "projects/my-project/subscriptions/otlp",
 		AckDeadlineSeconds: 10,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	core, _ := observer.New(zap.WarnLevel)
 	params := receivertest.NewNopSettings()

--- a/receiver/googlecloudspannerreceiver/factory_test.go
+++ b/receiver/googlecloudspannerreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -37,6 +38,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 		consumertest.NewNop(),
 	)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, receiver, "failed to create metrics receiver")
 }

--- a/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/datasource/database_test.go
@@ -9,6 +9,7 @@ import (
 
 	"cloud.google.com/go/spanner"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDatabaseFromClient(t *testing.T) {
@@ -28,7 +29,7 @@ func TestNewDatabase(t *testing.T) {
 
 	database, err := NewDatabase(ctx, databaseID, "../../testdata/serviceAccount.json")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, database.Client())
 	assert.Equal(t, databaseID, database.DatabaseID())
 }
@@ -39,7 +40,7 @@ func TestNewDatabaseWithError(t *testing.T) {
 
 	database, err := NewDatabase(ctx, databaseID, "does not exist")
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, database)
 }
 
@@ -51,7 +52,7 @@ func TestNewDatabaseWithNoCredentialsFilePath(t *testing.T) {
 
 	database, err := NewDatabase(ctx, databaseID, "")
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, database.Client())
 	assert.Equal(t, databaseID, database.DatabaseID())
 }

--- a/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/statsreader/databasereader_test.go
@@ -44,7 +44,7 @@ func TestNewDatabaseReader(t *testing.T) {
 
 	reader, err := NewDatabaseReader(ctx, parsedMetadata, databaseID, serviceAccountPath, readerConfig, logger)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	defer executeShutdown(reader)
 
@@ -66,7 +66,7 @@ func TestNewDatabaseReaderWithError(t *testing.T) {
 
 	reader, err := NewDatabaseReader(ctx, parsedMetadata, databaseID, serviceAccountPath, readerConfig, logger)
 
-	assert.Error(t, err)
+	require.Error(t, err)
 	// Do not call executeShutdown() here because reader hasn't been created
 	assert.Nil(t, reader)
 }

--- a/receiver/hostmetricsreceiver/factory_test.go
+++ b/receiver/hostmetricsreceiver/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pipeline"
@@ -35,11 +36,11 @@ func TestCreateReceiver(t *testing.T) {
 	assert.Nil(t, tReceiver)
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, mReceiver)
 
 	tLogs, err := factory.CreateLogsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, tLogs)
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/cpu_scraper_test.go
@@ -91,7 +91,7 @@ func TestScrape(t *testing.T) {
 
 			md, err := scraper.scrape(context.Background())
 			if test.expectedErr != "" {
-				assert.EqualError(t, err, test.expectedErr)
+				require.EqualError(t, err, test.expectedErr)
 
 				isPartial := scrapererror.IsPartialScrapeError(err)
 				assert.True(t, isPartial)
@@ -227,7 +227,7 @@ func TestScrape_CpuUtilizationError(t *testing.T) {
 	// 2nd scrape will trigger utilization metrics calculation
 	md, err := scraper.scrape(context.Background())
 	var partialScrapeErr scrapererror.PartialScrapeError
-	assert.ErrorAs(t, err, &partialScrapeErr)
+	require.ErrorAs(t, err, &partialScrapeErr)
 	assert.Equal(t, 0, md.MetricCount())
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -23,6 +24,6 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/ucal/cpu_utilization_calculator_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/ucal/cpu_utilization_calculator_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -158,7 +159,7 @@ func TestCpuUtilizationCalculator_Calculate(t *testing.T) {
 				previousCPUTimes: test.previousCPUTimes,
 			}
 			err := calculator.CalculateAndRecord(test.now, test.cpuTimes, recorder.record)
-			assert.ErrorIs(t, err, test.expectedError)
+			require.ErrorIs(t, err, test.expectedError)
 			assert.Len(t, recorder.cpuUtilizations, len(test.expectedUtilizations))
 			for idx, expectedUtilization := range test.expectedUtilizations {
 				assert.Equal(t, expectedUtilization.CPU, recorder.cpuUtilizations[idx].CPU)
@@ -224,7 +225,7 @@ func Test_cpuTimeByCpu(t *testing.T) {
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
 			actualTimeStat, err := cpuTimeForCPU(test.cpuNum, test.times)
-			assert.ErrorIs(t, err, test.expectedErr)
+			require.ErrorIs(t, err, test.expectedErr)
 			assert.Equal(t, test.expectedTimeStat, actualTimeStat)
 		})
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/disk_scraper_others_test.go
@@ -48,7 +48,7 @@ func TestScrape_Others(t *testing.T) {
 			require.NoError(t, err, "Failed to initialize disk scraper: %v", err)
 
 			_, err = scraper.scrape(context.Background())
-			assert.EqualError(t, err, test.expectedErr)
+			require.EqualError(t, err, test.expectedErr)
 
 			isPartial := scrapererror.IsPartialScrapeError(err)
 			assert.True(t, isPartial)

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -23,7 +24,7 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -23,7 +24,7 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -412,7 +412,7 @@ func TestScrape(t *testing.T) {
 
 			metrics := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 			m, err := findMetricByName(metrics, "system.filesystem.usage")
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assertFileSystemUsageMetricValid(
 				t,
 				m,

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -23,6 +24,6 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/load_scraper_test.go
@@ -93,7 +93,7 @@ func TestScrape(t *testing.T) {
 
 		md, err := scraper.scrape(context.Background())
 		if test.expectedErr != "" {
-			assert.EqualError(t, err, test.expectedErr)
+			require.EqualError(t, err, test.expectedErr)
 
 			isPartial := scrapererror.IsPartialScrapeError(err)
 			assert.True(t, isPartial)
@@ -109,7 +109,7 @@ func TestScrape(t *testing.T) {
 
 		if test.bootTimeFunc != nil {
 			actualBootTime, err := scraper.bootTime(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, uint64(bootTime), actualBootTime)
 		}
 		// expect 3 metrics

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -23,6 +24,6 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/memory_scraper_test.go
@@ -103,7 +103,7 @@ func TestScrape(t *testing.T) {
 			require.NoError(t, err, "Failed to initialize memory scraper: %v", err)
 			md, err := scraper.scrape(context.Background())
 			if test.expectedErr != "" {
-				assert.EqualError(t, err, test.expectedErr)
+				require.EqualError(t, err, test.expectedErr)
 
 				isPartial := scrapererror.IsPartialScrapeError(err)
 				assert.True(t, isPartial)

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -23,7 +24,7 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }
 

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/network_scraper_test.go
@@ -174,7 +174,7 @@ func TestScrape(t *testing.T) {
 
 			md, err := scraper.scrape(context.Background())
 			if test.expectedErr != "" {
-				assert.EqualError(t, err, test.expectedErr)
+				require.EqualError(t, err, test.expectedErr)
 
 				isPartial := scrapererror.IsPartialScrapeError(err)
 				assert.True(t, isPartial)

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -22,6 +23,6 @@ func TestCreateMetricsScraper(t *testing.T) {
 	cfg := &Config{}
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/pagefile_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const validFile = `Filename				Type		Size		Used		Priority
@@ -25,7 +26,7 @@ const invalidFile = `INVALID				Type		Size		Used		Priority
 func TestGetPageFileStats_ValidFile(t *testing.T) {
 	assert := assert.New(t)
 	stats, err := parseSwapsFile(strings.NewReader(validFile))
-	assert.NoError(err)
+	require.NoError(t, err)
 
 	assert.Equal(pageFileStats{
 		deviceName: "/dev/dm-2",

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/paging_scraper_others_test.go
@@ -63,7 +63,7 @@ func TestScrape_Errors(t *testing.T) {
 			require.NoError(t, err, "Failed to initialize paging scraper: %v", err)
 
 			_, err = scraper.scrape(context.Background())
-			assert.EqualError(t, err, test.expectedError)
+			require.EqualError(t, err, test.expectedError)
 
 			isPartial := scrapererror.IsPartialScrapeError(err)
 			assert.True(t, isPartial)

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -23,6 +24,6 @@ func TestCreateMetricsScraper(t *testing.T) {
 
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, scraper)
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/processes_scraper_test.go
@@ -68,7 +68,7 @@ func TestScrape(t *testing.T) {
 				MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 			})
 			err := scraper.start(context.Background(), componenttest.NewNopHost())
-			assert.NoError(t, err, "Failed to initialize processes scraper: %v", err)
+			require.NoError(t, err, "Failed to initialize processes scraper: %v", err)
 
 			// Override scraper methods if we are mocking out for this test case
 			if test.getMiscStats != nil {
@@ -89,7 +89,7 @@ func TestScrape(t *testing.T) {
 			}
 
 			if (expectProcessesCountMetric || expectProcessesCreatedMetric) && test.expectedErr != "" {
-				assert.EqualError(t, err, test.expectedErr)
+				require.EqualError(t, err, test.expectedErr)
 
 				isPartial := scrapererror.IsPartialScrapeError(err)
 				assert.Truef(t, isPartial, "expected partial scrape error, have %+v", err)
@@ -103,7 +103,7 @@ func TestScrape(t *testing.T) {
 			}
 
 			if test.expectedErr == "" {
-				assert.NoErrorf(t, err, "Failed to scrape metrics: %v", err)
+				require.NoErrorf(t, err, "Failed to scrape metrics: %v", err)
 			}
 
 			assert.Equal(t, expectedMetricCount, md.MetricCount())
@@ -153,7 +153,7 @@ func validateRealData(t *testing.T, metrics pmetric.MetricSlice) {
 
 func validateStartTime(t *testing.T, metrics pmetric.MetricSlice) {
 	startTime, err := host.BootTime()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	for i := 0; i < metricsLength; i++ {
 		internal.AssertSumMetricStartTimeEquals(t, metrics.At(i), pcommon.Timestamp(startTime*1e9))
 	}

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/factory_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -25,10 +26,10 @@ func TestCreateResourceMetricsScraper(t *testing.T) {
 	scraper, err := factory.CreateMetricsScraper(context.Background(), receivertest.NewNopSettings(), cfg)
 
 	if runtime.GOOS == "linux" || runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, scraper)
 	} else {
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.Nil(t, scraper)
 	}
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_others_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/handlecount/handles_others_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUnsupportedManager(t *testing.T) {
 	m := NewManager()
 
 	err := m.Refresh()
-	assert.ErrorIs(t, err, ErrHandlesPlatformSupport)
+	require.ErrorIs(t, err, ErrHandlesPlatformSupport)
 
 	_, err = m.GetProcessHandleCount(0)
 	assert.ErrorIs(t, err, ErrHandlesPlatformSupport)

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -360,7 +360,7 @@ func TestScrapeMetrics_GetProcessesError(t *testing.T) {
 	require.NoError(t, err, "Failed to initialize process scraper: %v", err)
 
 	md, err := scraper.scrape(context.Background())
-	assert.EqualError(t, err, "err1")
+	require.EqualError(t, err, "err1")
 	assert.Equal(t, 0, md.ResourceMetrics().Len())
 	assert.False(t, scrapererror.IsPartialScrapeError(err))
 }
@@ -908,7 +908,7 @@ func TestScrapeMetrics_ProcessErrors(t *testing.T) {
 			assert.Equal(t, expectedResourceMetricsLen, md.ResourceMetrics().Len())
 			assert.Equal(t, expectedMetricsLen, md.MetricCount())
 
-			assert.EqualError(t, err, test.expectedError)
+			require.EqualError(t, err, test.expectedError)
 			isPartial := scrapererror.IsPartialScrapeError(err)
 			assert.True(t, isPartial)
 			if isPartial {
@@ -1266,11 +1266,11 @@ func TestScrapeMetrics_CpuUtilizationWhenCpuTimesIsDisabled(t *testing.T) {
 
 			// scrape the first time
 			_, err = scraper.scrape(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// scrape second time to get utilization
 			md, err := scraper.scrape(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			for k := 0; k < md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len(); k++ {
 				fmt.Println(md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(k).Name())

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal/cpu_utilization_calculator_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/ucal/cpu_utilization_calculator_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/shirou/gopsutil/v4/cpu"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
@@ -125,7 +126,7 @@ func TestCpuUtilizationCalculator_Calculate(t *testing.T) {
 			if test.shouldError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.InDelta(t, test.expectedUtilization.System, recorder.cpuUtilization.System, 0.00001)
 				assert.InDelta(t, test.expectedUtilization.User, recorder.cpuUtilization.User, 0.00001)
 				assert.InDelta(t, test.expectedUtilization.Iowait, recorder.cpuUtilization.Iowait, 0.00001)

--- a/receiver/iisreceiver/factory_others_test.go
+++ b/receiver/iisreceiver/factory_others_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
@@ -19,6 +20,6 @@ func TestCreateMetricsReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
 
-	assert.EqualError(t, err, "the windows perf counters receiver is only supported on Windows")
+	require.EqualError(t, err, "the windows perf counters receiver is only supported on Windows")
 	assert.Nil(t, mReceiver)
 }

--- a/receiver/jaegerreceiver/config_test.go
+++ b/receiver/jaegerreceiver/config_test.go
@@ -152,12 +152,12 @@ func TestFailedLoadConfig(t *testing.T) {
 	sub, err := cm.Sub(component.NewIDWithName(metadata.Type, "typo_default_proto_config").String())
 	require.NoError(t, err)
 	err = sub.Unmarshal(cfg)
-	assert.ErrorContains(t, err, "'protocols' has invalid keys: thrift_htttp")
+	require.ErrorContains(t, err, "'protocols' has invalid keys: thrift_htttp")
 
 	sub, err = cm.Sub(component.NewIDWithName(metadata.Type, "bad_proto_config").String())
 	require.NoError(t, err)
 	err = sub.Unmarshal(cfg)
-	assert.ErrorContains(t, err, "'protocols' has invalid keys: thrift_htttp")
+	require.ErrorContains(t, err, "'protocols' has invalid keys: thrift_htttp")
 
 	sub, err = cm.Sub(component.NewIDWithName(metadata.Type, "empty").String())
 	require.NoError(t, err)

--- a/receiver/jaegerreceiver/factory_test.go
+++ b/receiver/jaegerreceiver/factory_test.go
@@ -48,7 +48,7 @@ func TestCreateReceiver(t *testing.T) {
 	}
 	set := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, nil)
@@ -68,7 +68,7 @@ func TestCreateReceiverGeneralConfig(t *testing.T) {
 
 	set := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, nil)
@@ -90,7 +90,7 @@ func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 	set := receivertest.NewNopSettings()
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
-	assert.NoError(t, err, "unexpected error creating receiver")
+	require.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, "0.0.0.0:14250", r.(*jReceiver).config.GRPCServerConfig.NetAddr.Endpoint, "grpc port should be default")
 }
 
@@ -143,7 +143,7 @@ func TestCreateInvalidHTTPEndpoint(t *testing.T) {
 	set := receivertest.NewNopSettings()
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
-	assert.NoError(t, err, "unexpected error creating receiver")
+	require.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, "localhost:14268", r.(*jReceiver).config.HTTPServerConfig.Endpoint, "http port should be default")
 }
 
@@ -157,7 +157,7 @@ func TestCreateInvalidThriftBinaryEndpoint(t *testing.T) {
 	set := receivertest.NewNopSettings()
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
-	assert.NoError(t, err, "unexpected error creating receiver")
+	require.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, "0.0.0.0:6832", r.(*jReceiver).config.AgentBinaryThrift.Endpoint, "thrift port should be default")
 }
 
@@ -171,6 +171,6 @@ func TestCreateInvalidThriftCompactEndpoint(t *testing.T) {
 	set := receivertest.NewNopSettings()
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)
 
-	assert.NoError(t, err, "unexpected error creating receiver")
+	require.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, "0.0.0.0:6831", r.(*jReceiver).config.AgentCompactThrift.Endpoint, "thrift port should be default")
 }

--- a/receiver/jaegerreceiver/jaeger_agent_test.go
+++ b/receiver/jaegerreceiver/jaeger_agent_test.go
@@ -56,7 +56,7 @@ func TestJaegerAgentUDP_ThriftCompact_InvalidPort(t *testing.T) {
 	jr, err := newJaegerReceiver(jaegerAgent, config, nil, set)
 	require.NoError(t, err)
 
-	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
+	require.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
 
 	require.NoError(t, jr.Shutdown(context.Background()))
 }
@@ -89,7 +89,7 @@ func TestJaegerAgentUDP_ThriftBinary_PortInUse(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
 
 	l, err := net.Listen("udp", addr)
-	assert.Error(t, err, "should not have been able to listen to the port")
+	require.Error(t, err, "should not have been able to listen to the port")
 
 	if l != nil {
 		l.Close()
@@ -107,7 +107,7 @@ func TestJaegerAgentUDP_ThriftBinary_InvalidPort(t *testing.T) {
 	jr, err := newJaegerReceiver(jaegerAgent, config, nil, set)
 	require.NoError(t, err)
 
-	assert.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
+	require.Error(t, jr.Start(context.Background(), componenttest.NewNopHost()), "should not have been able to startTraceReception")
 
 	require.NoError(t, jr.Shutdown(context.Background()))
 }
@@ -146,7 +146,7 @@ func TestJaegerHTTP(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
 
-	assert.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()), "Start failed")
+	require.NoError(t, jr.Start(context.Background(), componenttest.NewNopHost()), "Start failed")
 
 	// allow http server to start
 	assert.Eventually(t, func() bool {
@@ -160,7 +160,7 @@ func TestJaegerHTTP(t *testing.T) {
 	}, 10*time.Second, 5*time.Millisecond, "failed to wait for the port to be open")
 
 	resp, err := http.Get(fmt.Sprintf("http://%s/sampling?service=test", endpoint))
-	assert.NoError(t, err, "should not have failed to make request")
+	require.NoError(t, err, "should not have failed to make request")
 	assert.NotNil(t, resp)
 	defer resp.Body.Close()
 	assert.Equal(t, 500, resp.StatusCode, "should have returned 200")

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -126,13 +126,13 @@ func TestPortsNotOpen(t *testing.T) {
 	//  this test may occasionally pass incorrectly, but it will not fail incorrectly
 	//  TODO: consider adding a way for a receiver to asynchronously signal that is ready to receive spans to eliminate races/arbitrary waits
 	l, err := net.Listen("tcp", "localhost:14250")
-	assert.NoError(t, err, "should have been able to listen on 14250.  jaeger receiver incorrectly started grpc")
+	require.NoError(t, err, "should have been able to listen on 14250.  jaeger receiver incorrectly started grpc")
 	if l != nil {
 		l.Close()
 	}
 
 	l, err = net.Listen("tcp", "localhost:14268")
-	assert.NoError(t, err, "should have been able to listen on 14268.  jaeger receiver incorrectly started thrift_http")
+	require.NoError(t, err, "should have been able to listen on 14268.  jaeger receiver incorrectly started thrift_http")
 	if l != nil {
 		l.Close()
 	}
@@ -174,7 +174,7 @@ func TestGRPCReception(t *testing.T) {
 	resp, err := cl.PostSpans(context.Background(), req, grpc.WaitForReady(true))
 
 	// verify
-	assert.NoError(t, err, "should not have failed to post spans")
+	require.NoError(t, err, "should not have failed to post spans")
 	assert.NotNil(t, resp, "response should not have been nil")
 
 	gotTraces := sink.AllTraces()
@@ -234,7 +234,7 @@ func TestGRPCReceptionWithTLS(t *testing.T) {
 	resp, err := cl.PostSpans(context.Background(), req, grpc.WaitForReady(true))
 
 	// verify
-	assert.NoError(t, err, "should not have failed to post spans")
+	require.NoError(t, err, "should not have failed to post spans")
 	assert.NotNil(t, resp, "response should not have been nil")
 
 	gotTraces := sink.AllTraces()
@@ -352,7 +352,7 @@ func TestSampling(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, jr.Shutdown(context.Background())) })
 
 	conn, err := grpc.NewClient(config.GRPCServerConfig.NetAddr.Endpoint, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer conn.Close()
 
 	cl := api_v2.NewSamplingManagerClient(conn)
@@ -360,7 +360,7 @@ func TestSampling(t *testing.T) {
 	resp, err := cl.GetSamplingStrategy(context.Background(), &api_v2.SamplingStrategyParameters{
 		ServiceName: "foo",
 	})
-	assert.Error(t, err, "expect: unknown service jaeger.api_v2.SamplingManager")
+	require.Error(t, err, "expect: unknown service jaeger.api_v2.SamplingManager")
 	assert.Nil(t, resp)
 }
 

--- a/receiver/jmxreceiver/config_test.go
+++ b/receiver/jmxreceiver/config_test.go
@@ -214,7 +214,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, sub.Unmarshal(cfg))
 
 			if tt.expectedErr != "" {
-				assert.ErrorContains(t, cfg.(*Config).Validate(), tt.expectedErr)
+				require.ErrorContains(t, cfg.(*Config).Validate(), tt.expectedErr)
 				assert.Equal(t, tt.expected, cfg)
 				return
 			}

--- a/receiver/journaldreceiver/factory_test.go
+++ b/receiver/journaldreceiver/factory_test.go
@@ -42,11 +42,11 @@ func TestCreateAndShutdown(t *testing.T) {
 	receiver, err := factory.CreateLogsReceiver(ctx, settings, cfg, sink)
 
 	if runtime.GOOS == "linux" {
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		require.NotNil(t, receiver)
 		assert.NoError(t, receiver.Shutdown(ctx))
 	} else {
-		assert.Error(t, err)
+		require.Error(t, err)
 		assert.IsType(t, pipeline.ErrSignalNotSupported, err)
 		assert.Nil(t, receiver)
 	}

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -84,7 +84,7 @@ func TestInvalidConfig(t *testing.T) {
 		CollectionInterval: 30 * time.Second,
 	}
 	err := component.ValidateConfig(cfg)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "invalid authType for kubernetes: ", err.Error())
 
 	// Wrong distro
@@ -94,6 +94,6 @@ func TestInvalidConfig(t *testing.T) {
 		CollectionInterval: 30 * time.Second,
 	}
 	err = component.ValidateConfig(cfg)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "\"wrong\" is not a supported distribution. Must be one of: \"openshift\", \"kubernetes\"", err.Error())
 }

--- a/receiver/k8sclusterreceiver/informer_transform_test.go
+++ b/receiver/k8sclusterreceiver/informer_transform_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -130,7 +131,7 @@ func TestTransformObject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := transformObject(tt.object)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.want, got)
 			if tt.same {
 				assert.Same(t, tt.object, got)

--- a/receiver/k8sclusterreceiver/watcher_test.go
+++ b/receiver/k8sclusterreceiver/watcher_test.go
@@ -126,7 +126,7 @@ func TestIsKindSupported(t *testing.T) {
 				logger: zap.NewNop(),
 			}
 			supported, err := rw.isKindSupported(tt.gvk)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.expected, supported)
 		})
 	}
@@ -195,7 +195,7 @@ func TestPrepareSharedInformerFactory(t *testing.T) {
 				config:        &Config{},
 			}
 
-			assert.NoError(t, rw.prepareSharedInformerFactory())
+			require.NoError(t, rw.prepareSharedInformerFactory())
 
 			// Make sure no warning or error logs are raised
 			assert.Equal(t, 0, logs.Len())

--- a/receiver/k8seventsreceiver/factory_test.go
+++ b/receiver/k8seventsreceiver/factory_test.go
@@ -45,7 +45,7 @@ func TestCreateReceiver(t *testing.T) {
 	)
 	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Override for test.
 	rCfg.makeClient = func(k8sconfig.APIConfig) (k8s.Interface, error) {

--- a/receiver/k8sobjectsreceiver/factory_test.go
+++ b/receiver/k8sobjectsreceiver/factory_test.go
@@ -43,9 +43,9 @@ func TestCreateReceiver(t *testing.T) {
 		context.Background(), receivertest.NewNopSettings(),
 		rCfg, consumertest.NewNop(),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	// Override for test.
 	rCfg.makeDynamicClient = newMockDynamicClient().getMockDynamicClient
@@ -55,6 +55,6 @@ func TestCreateReceiver(t *testing.T) {
 		receivertest.NewNopSettings(),
 		rCfg, consumertest.NewNop(),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, r)
 }

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
@@ -114,7 +114,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		}
 
 		logs, err := watchObjectsToLogData(event, time.Now(), config)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, 1, logs.LogRecordCount())
 
@@ -155,7 +155,7 @@ func TestUnstructuredListToLogData(t *testing.T) {
 
 		observedAt := time.Now()
 		logs, err := watchObjectsToLogData(event, observedAt, config)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Equal(t, 1, logs.LogRecordCount())
 

--- a/receiver/kafkametricsreceiver/broker_scraper_test.go
+++ b/receiver/kafkametricsreceiver/broker_scraper_test.go
@@ -51,7 +51,7 @@ func TestBrokerScraper_createBrokerScraper(t *testing.T) {
 	sc := sarama.NewConfig()
 	newSaramaClient = mockNewSaramaClient
 	bs, err := createBrokerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bs)
 }
 
@@ -59,7 +59,7 @@ func TestBrokerScraperStart(t *testing.T) {
 	newSaramaClient = mockNewSaramaClient
 	sc := sarama.NewConfig()
 	bs, err := createBrokerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bs)
 	assert.NoError(t, bs.Start(context.Background(), nil))
 }
@@ -70,7 +70,7 @@ func TestBrokerScraper_scrape_handles_client_error(t *testing.T) {
 	}
 	sc := sarama.NewConfig()
 	bs, err := createBrokerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bs)
 	_, err = bs.Scrape(context.Background())
 	assert.Error(t, err)
@@ -82,7 +82,7 @@ func TestBrokerScraper_shutdown_handles_nil_client(t *testing.T) {
 	}
 	sc := sarama.NewConfig()
 	bs, err := createBrokerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bs)
 	err = bs.Shutdown(context.Background())
 	assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestBrokerScraper_empty_resource_attribute(t *testing.T) {
 	}
 	require.NoError(t, bs.start(context.Background(), componenttest.NewNopHost()))
 	md, err := bs.scrape(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, md.ResourceMetrics().Len())
 	require.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().Len())
 	_, ok := md.ResourceMetrics().At(0).Resource().Attributes().Get("kafka.cluster.alias")
@@ -122,7 +122,7 @@ func TestBrokerScraper_scrape(t *testing.T) {
 	}
 	require.NoError(t, bs.start(context.Background(), componenttest.NewNopHost()))
 	md, err := bs.scrape(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, md.ResourceMetrics().Len())
 	require.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().Len())
 	if val, ok := md.ResourceMetrics().At(0).Resource().Attributes().Get("kafka.cluster.alias"); ok {
@@ -144,6 +144,6 @@ func TestBrokersScraper_createBrokerScraper(t *testing.T) {
 	sc := sarama.NewConfig()
 	newSaramaClient = mockNewSaramaClient
 	bs, err := createBrokerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bs)
 }

--- a/receiver/kafkametricsreceiver/consumer_scraper_test.go
+++ b/receiver/kafkametricsreceiver/consumer_scraper_test.go
@@ -47,7 +47,7 @@ func TestConsumerScraper_createConsumerScraper(t *testing.T) {
 	newSaramaClient = mockNewSaramaClient
 	newClusterAdmin = mockNewClusterAdmin
 	cs, err := createConsumerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cs)
 }
 
@@ -57,7 +57,7 @@ func TestConsumerScraper_scrape_handles_client_error(t *testing.T) {
 	}
 	sc := sarama.NewConfig()
 	cs, err := createConsumerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cs)
 	_, err = cs.Scrape(context.Background())
 	assert.Error(t, err)
@@ -69,7 +69,7 @@ func TestConsumerScraper_scrape_handles_nil_client(t *testing.T) {
 	}
 	sc := sarama.NewConfig()
 	cs, err := createConsumerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cs)
 	err = cs.Shutdown(context.Background())
 	assert.NoError(t, err)
@@ -87,7 +87,7 @@ func TestConsumerScraper_scrape_handles_clusterAdmin_error(t *testing.T) {
 	}
 	sc := sarama.NewConfig()
 	cs, err := createConsumerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cs)
 	_, err = cs.Scrape(context.Background())
 	assert.Error(t, err)
@@ -98,7 +98,7 @@ func TestConsumerScraperStart(t *testing.T) {
 	newClusterAdmin = mockNewClusterAdmin
 	sc := sarama.NewConfig()
 	cs, err := createConsumerScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, cs)
 	err = cs.Start(context.Background(), nil)
 	assert.NoError(t, err)
@@ -111,7 +111,7 @@ func TestConsumerScraper_createScraper_handles_invalid_topic_match(t *testing.T)
 	cs, err := createConsumerScraper(context.Background(), Config{
 		TopicMatch: "[",
 	}, sc, receivertest.NewNopSettings())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, cs)
 }
 
@@ -122,7 +122,7 @@ func TestConsumerScraper_createScraper_handles_invalid_group_match(t *testing.T)
 	cs, err := createConsumerScraper(context.Background(), Config{
 		GroupMatch: "[",
 	}, sc, receivertest.NewNopSettings())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, cs)
 }
 
@@ -137,7 +137,7 @@ func TestConsumerScraper_scrape(t *testing.T) {
 	}
 	require.NoError(t, cs.start(context.Background(), componenttest.NewNopHost()))
 	md, err := cs.scrape(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, md)
 }
 

--- a/receiver/kafkametricsreceiver/receiver_test.go
+++ b/receiver/kafkametricsreceiver/receiver_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/IBM/sarama"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -24,7 +25,7 @@ func TestNewReceiver_invalid_version_err(t *testing.T) {
 	c := createDefaultConfig().(*Config)
 	c.ProtocolVersion = "invalid"
 	r, err := newMetricsReceiver(context.Background(), *c, receivertest.NewNopSettings(), nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, r)
 }
 
@@ -53,7 +54,7 @@ func TestNewReceiver_invalid_auth_error(t *testing.T) {
 		},
 	}
 	r, err := newMetricsReceiver(context.Background(), *c, receivertest.NewNopSettings(), nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
 }
@@ -68,7 +69,7 @@ func TestNewReceiver(t *testing.T) {
 	}
 	allScrapers["brokers"] = mockScraper
 	r, err := newMetricsReceiver(context.Background(), *c, receivertest.NewNopSettings(), consumertest.NewNop())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, r)
 }
 
@@ -80,6 +81,6 @@ func TestNewReceiver_handles_scraper_error(t *testing.T) {
 	}
 	allScrapers["brokers"] = mockScraper
 	r, err := newMetricsReceiver(context.Background(), *c, receivertest.NewNopSettings(), consumertest.NewNop())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, r)
 }

--- a/receiver/kafkametricsreceiver/topic_scraper_test.go
+++ b/receiver/kafkametricsreceiver/topic_scraper_test.go
@@ -50,7 +50,7 @@ func TestTopicScraper_createsScraper(t *testing.T) {
 	sc := sarama.NewConfig()
 	newSaramaClient = mockNewSaramaClient
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, ms)
 }
 
@@ -61,7 +61,7 @@ func TestTopicScraper_ScrapeHandlesError(t *testing.T) {
 	sc := sarama.NewConfig()
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
 	assert.NotNil(t, ms)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = ms.Scrape(context.Background())
 	assert.Error(t, err)
 }
@@ -73,7 +73,7 @@ func TestTopicScraper_ShutdownHandlesNilClient(t *testing.T) {
 	sc := sarama.NewConfig()
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
 	assert.NotNil(t, ms)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = ms.Shutdown(context.Background())
 	assert.NoError(t, err)
 }
@@ -83,7 +83,7 @@ func TestTopicScraper_startScraperCreatesClient(t *testing.T) {
 	sc := sarama.NewConfig()
 	ms, err := createTopicsScraper(context.Background(), Config{}, sc, receivertest.NewNopSettings())
 	assert.NotNil(t, ms)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = ms.Start(context.Background(), nil)
 	assert.NoError(t, err)
 }
@@ -94,7 +94,7 @@ func TestTopicScraper_createScraperHandles_invalid_topicMatch(t *testing.T) {
 	ms, err := createTopicsScraper(context.Background(), Config{
 		TopicMatch: "[",
 	}, sc, receivertest.NewNopSettings())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, ms)
 }
 
@@ -113,7 +113,7 @@ func TestTopicScraper_scrapes(t *testing.T) {
 	}
 	require.NoError(t, scraper.start(context.Background(), componenttest.NewNopHost()))
 	md, err := scraper.scrape(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	require.Equal(t, 1, md.ResourceMetrics().Len())
 	require.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().Len())
 	if val, ok := md.ResourceMetrics().At(0).Resource().Attributes().Get("kafka.cluster.alias"); ok {

--- a/receiver/kafkareceiver/factory_test.go
+++ b/receiver/kafkareceiver/factory_test.go
@@ -21,7 +21,7 @@ import (
 func TestCreateDefaultConfig(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	assert.NotNil(t, cfg, "failed to create default config")
-	assert.NoError(t, componenttest.CheckConfigStruct(cfg))
+	require.NoError(t, componenttest.CheckConfigStruct(cfg))
 	assert.Equal(t, []string{defaultBroker}, cfg.Brokers)
 	assert.Equal(t, defaultGroupID, cfg.GroupID)
 	assert.Equal(t, defaultClientID, cfg.ClientID)

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -428,7 +428,7 @@ func TestNewMetricsExporter_err_auth_type(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 }
 
@@ -745,7 +745,7 @@ func TestNewLogsReceiver_encoding_err(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 }
 
@@ -768,7 +768,7 @@ func TestNewLogsExporter_err_auth_type(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 }
 

--- a/receiver/kubeletstatsreceiver/config_test.go
+++ b/receiver/kubeletstatsreceiver/config_test.go
@@ -300,7 +300,7 @@ func TestLoadConfig(t *testing.T) {
 			if tt.expectedValidationErr != "" {
 				assert.EqualError(t, err, tt.expectedValidationErr)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.expected, cfg)
 			}
 

--- a/receiver/lokireceiver/factory_test.go
+++ b/receiver/lokireceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configgrpc"
 	"go.opentelemetry.io/collector/config/confignet"
@@ -33,6 +34,6 @@ func TestCreateReceiver(t *testing.T) {
 	}
 	set := receivertest.NewNopSettings()
 	receiver, err := factory.CreateLogsReceiver(context.Background(), set, cfg, consumertest.NewNop())
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, receiver, "receiver creation failed")
 }

--- a/receiver/lokireceiver/loki_test.go
+++ b/receiver/lokireceiver/loki_test.go
@@ -353,7 +353,7 @@ func TestSendingPushRequestToGRPCEndpoint(t *testing.T) {
 	for i, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			resp, err := client.Push(context.Background(), tt.body)
-			assert.NoError(t, err, "should not have failed to post logs")
+			require.NoError(t, err, "should not have failed to post logs")
 			assert.NotNil(t, resp, "response should not have been nil")
 
 			gotLogs := sink.AllLogs()

--- a/receiver/mongodbatlasreceiver/access_logs_test.go
+++ b/receiver/mongodbatlasreceiver/access_logs_test.go
@@ -81,7 +81,7 @@ func TestAccessLogToLogRecord(t *testing.T) {
 	expectedLogs := plog.NewLogs()
 	rl := expectedLogs.ResourceLogs().AppendEmpty()
 
-	assert.NoError(t, rl.Resource().Attributes().FromRaw(map[string]any{
+	require.NoError(t, rl.Resource().Attributes().FromRaw(map[string]any{
 		"mongodbatlas.project.name":  testProjectName,
 		"mongodbatlas.project.id":    testProjectID,
 		"mongodbatlas.org.id":        testOrgID,
@@ -93,7 +93,7 @@ func TestAccessLogToLogRecord(t *testing.T) {
 	records := rl.ScopeLogs().AppendEmpty().LogRecords()
 	// First log is an example of a success, and tests that the timestamp works parsed from the log line
 	lr := records.AppendEmpty()
-	assert.NoError(t, lr.Attributes().FromRaw(map[string]any{
+	require.NoError(t, lr.Attributes().FromRaw(map[string]any{
 		"event.domain": "mongodbatlas",
 		"auth.result":  "success",
 		"auth.source":  "admin",
@@ -113,7 +113,7 @@ func TestAccessLogToLogRecord(t *testing.T) {
 
 	// Second log is an example of a failure, and tests that the timestamp is missing from the log line
 	lr = records.AppendEmpty()
-	assert.NoError(t, lr.Attributes().FromRaw(map[string]any{
+	require.NoError(t, lr.Attributes().FromRaw(map[string]any{
 		"event.domain":        "mongodbatlas",
 		"auth.result":         "failure",
 		"auth.failure_reason": "User not found",

--- a/receiver/mongodbatlasreceiver/log_decode_test.go
+++ b/receiver/mongodbatlasreceiver/log_decode_test.go
@@ -187,7 +187,7 @@ func TestDecode5_0InvalidLog(t *testing.T) {
 	require.NoError(t, gzipWriter.Close())
 
 	entries, err := decodeLogs(zaptest.NewLogger(t), "5.0", zippedBuffer)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, []model.LogEntry{
 		{
@@ -407,7 +407,7 @@ func TestDecodeAudit4_2InvalidLog(t *testing.T) {
 	require.NoError(t, gzipWriter.Close())
 
 	entries, err := decodeAuditJSON(zaptest.NewLogger(t), zippedBuffer)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, []model.AuditLog{
 		{
@@ -616,7 +616,7 @@ func TestDecodeAudit5_0InvalidLog(t *testing.T) {
 	require.NoError(t, gzipWriter.Close())
 
 	entries, err := decodeAuditJSON(zaptest.NewLogger(t), zippedBuffer)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	require.Equal(t, []model.AuditLog{
 		{

--- a/receiver/opencensusreceiver/factory_test.go
+++ b/receiver/opencensusreceiver/factory_test.go
@@ -32,7 +32,7 @@ func TestCreateReceiver(t *testing.T) {
 	set := receivertest.NewNopSettings()
 	tReceiver, err := createTracesReceiver(context.Background(), set, cfg, nil)
 	assert.NotNil(t, tReceiver)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mReceiver, err := createMetricsReceiver(context.Background(), set, cfg, nil)
 	assert.NotNil(t, mReceiver)

--- a/receiver/opencensusreceiver/internal/ocmetrics/opencensus_test.go
+++ b/receiver/opencensusreceiver/internal/ocmetrics/opencensus_test.go
@@ -54,7 +54,7 @@ func TestReceiver_endToEnd(t *testing.T) {
 	defer metricsClientDoneFn()
 	md := testdata.GenerateMetrics(1)
 	node, resource, metrics := opencensus.ResourceMetricsToOC(md.ResourceMetrics().At(0))
-	assert.NoError(t, metricsClient.Send(&agentmetricspb.ExportMetricsServiceRequest{Node: node, Resource: resource, Metrics: metrics}))
+	require.NoError(t, metricsClient.Send(&agentmetricspb.ExportMetricsServiceRequest{Node: node, Resource: resource, Metrics: metrics}))
 
 	assert.Eventually(t, func() bool {
 		return len(metricSink.AllMetrics()) != 0

--- a/receiver/opencensusreceiver/internal/octrace/opencensus_test.go
+++ b/receiver/opencensusreceiver/internal/octrace/opencensus_test.go
@@ -50,7 +50,7 @@ func TestReceiver_endToEnd(t *testing.T) {
 	defer traceClientDoneFn()
 	td := testdata.GenerateTraces(1)
 	node, resource, spans := opencensus.ResourceSpansToOC(td.ResourceSpans().At(0))
-	assert.NoError(t, traceClient.Send(&agenttracepb.ExportTraceServiceRequest{Node: node, Resource: resource, Spans: spans}))
+	require.NoError(t, traceClient.Send(&agenttracepb.ExportTraceServiceRequest{Node: node, Resource: resource, Spans: spans}))
 
 	assert.Eventually(t, func() bool {
 		return len(spanSink.AllTraces()) != 0

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -771,7 +771,7 @@ func TestInvalidTLSCredentials(t *testing.T) {
 	assert.NotNil(t, ocr)
 
 	srv, err := ocr.grpcServerSettings.ToServerWithOptions(context.Background(), componenttest.NewNopHost(), ocr.settings.TelemetrySettings)
-	assert.EqualError(t, err, `failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither`)
+	require.EqualError(t, err, `failed to load TLS config: failed to load TLS cert and key: for auth via TLS, provide both certificate and key, or neither`)
 	assert.Nil(t, srv)
 }
 

--- a/receiver/oracledbreceiver/factory_test.go
+++ b/receiver/oracledbreceiver/factory_test.go
@@ -34,16 +34,16 @@ func TestNewFactory(t *testing.T) {
 
 func TestGetInstanceName(t *testing.T) {
 	instanceName, err := getInstanceName("oracle://example.com:1521/mydb")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "example.com:1521/mydb", instanceName)
 
 	// Should fail on non-encoded special characters
 	_, err = getInstanceName("oracle://username1:p@ssw%rd@example1.com:1521/mydb")
-	assert.ErrorContains(t, err, "invalid URL escape")
+	require.ErrorContains(t, err, "invalid URL escape")
 
 	// Should succeed when special characters are encoded
 	instanceName, err = getInstanceName("oracle://username1:p@ssword%25-_1@example1.com:1521/mydb")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "example1.com:1521/mydb", instanceName)
 }
 

--- a/receiver/osqueryreceiver/config_test.go
+++ b/receiver/osqueryreceiver/config_test.go
@@ -7,12 +7,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Validate(t *testing.T) {
 	cfg := createDefaultConfig()
 	rc := cfg.(*Config)
-	assert.Error(t, rc.Validate())
+	require.Error(t, rc.Validate())
 
 	rc.Queries = []string{"select * from certificates"}
 	assert.NoError(t, rc.Validate())

--- a/receiver/otelarrowreceiver/config_test.go
+++ b/receiver/otelarrowreceiver/config_test.go
@@ -22,7 +22,7 @@ func TestUnmarshalDefaultConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(cfg))
+	require.NoError(t, cm.Unmarshal(cfg))
 	defaultCfg := factory.CreateDefaultConfig().(*Config)
 	assert.Equal(t, defaultCfg, cfg)
 }
@@ -32,7 +32,7 @@ func TestUnmarshalConfigOnlyGRPC(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(cfg))
+	require.NoError(t, cm.Unmarshal(cfg))
 
 	defaultOnlyGRPC := factory.CreateDefaultConfig().(*Config)
 	assert.Equal(t, defaultOnlyGRPC, cfg)
@@ -43,7 +43,7 @@ func TestUnmarshalConfig(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(cfg))
+	require.NoError(t, cm.Unmarshal(cfg))
 	assert.Equal(t,
 		&Config{
 			Protocols: Protocols{
@@ -91,7 +91,7 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 	require.NoError(t, err)
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
-	assert.NoError(t, cm.Unmarshal(cfg))
+	require.NoError(t, cm.Unmarshal(cfg))
 	assert.Equal(t,
 		&Config{
 			Protocols: Protocols{

--- a/receiver/otelarrowreceiver/factory_test.go
+++ b/receiver/otelarrowreceiver/factory_test.go
@@ -34,7 +34,7 @@ func TestCreateReceiver(t *testing.T) {
 	creationSet := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, tReceiver)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), creationSet, cfg, consumertest.NewNop())
 	assert.NotNil(t, mReceiver)
@@ -84,10 +84,10 @@ func TestCreateTracesReceiver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(consumertest.TracesSink)
 			tr, err := factory.CreateTracesReceiver(ctx, creationSet, tt.cfg, sink)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, tr)
 			if tt.wantErr {
-				assert.Error(t, tr.Start(context.Background(), componenttest.NewNopHost()))
+				require.Error(t, tr.Start(context.Background(), componenttest.NewNopHost()))
 				assert.NoError(t, tr.Shutdown(context.Background()))
 			} else {
 				assert.NoError(t, tr.Start(context.Background(), componenttest.NewNopHost()))
@@ -140,7 +140,7 @@ func TestCreateMetricReceiver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(consumertest.MetricsSink)
 			mr, err := factory.CreateMetricsReceiver(ctx, creationSet, tt.cfg, sink)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, mr)
 			if tt.wantErr {
 				assert.Error(t, mr.Start(context.Background(), componenttest.NewNopHost()))
@@ -202,11 +202,11 @@ func TestCreateLogReceiver(t *testing.T) {
 				assert.Error(t, err)
 				return
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			require.NotNil(t, mr)
 
 			if tt.wantStartErr {
-				assert.Error(t, mr.Start(context.Background(), componenttest.NewNopHost()))
+				require.Error(t, mr.Start(context.Background(), componenttest.NewNopHost()))
 				assert.NoError(t, mr.Shutdown(context.Background()))
 			} else {
 				require.NoError(t, mr.Start(context.Background(), componenttest.NewNopHost()))

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -482,7 +482,7 @@ func TestBoundedQueueWithPdataHeaders(t *testing.T) {
 					Name:  "otlp-pdata-size",
 					Value: tt.pdataSize,
 				})
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				batch.Headers = make([]byte, hpb.Len())
 				copy(batch.Headers, hpb.Bytes())
 			}

--- a/receiver/otelarrowreceiver/internal/logs/otlp_test.go
+++ b/receiver/otelarrowreceiver/internal/logs/otlp_test.go
@@ -43,7 +43,7 @@ func TestExport_EmptyRequest(t *testing.T) {
 
 	logClient := makeLogsServiceClient(t, logSink)
 	resp, err := logClient.Export(context.Background(), plogotlp.NewExportRequest())
-	assert.NoError(t, err, "Failed to export trace: %v", err)
+	require.NoError(t, err, "Failed to export trace: %v", err)
 	assert.NotNil(t, resp, "The response is missing")
 }
 
@@ -53,7 +53,7 @@ func TestExport_ErrorConsumer(t *testing.T) {
 
 	logClient := makeLogsServiceClient(t, consumertest.NewErr(errors.New("my error")))
 	resp, err := logClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Unknown desc = my error")
+	require.EqualError(t, err, "rpc error: code = Unknown desc = my error")
 	assert.Equal(t, plogotlp.ExportResponse{}, resp)
 }
 

--- a/receiver/otelarrowreceiver/internal/metrics/otlp_test.go
+++ b/receiver/otelarrowreceiver/internal/metrics/otlp_test.go
@@ -53,7 +53,7 @@ func TestExport_ErrorConsumer(t *testing.T) {
 
 	metricsClient := makeMetricsServiceClient(t, consumertest.NewErr(errors.New("my error")))
 	resp, err := metricsClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Unknown desc = my error")
+	require.EqualError(t, err, "rpc error: code = Unknown desc = my error")
 	assert.Equal(t, pmetricotlp.ExportResponse{}, resp)
 }
 

--- a/receiver/otelarrowreceiver/internal/trace/otlp_test.go
+++ b/receiver/otelarrowreceiver/internal/trace/otlp_test.go
@@ -51,7 +51,7 @@ func TestExport_ErrorConsumer(t *testing.T) {
 
 	traceClient := makeTraceServiceClient(t, consumertest.NewErr(errors.New("my error")))
 	resp, err := traceClient.Export(context.Background(), req)
-	assert.EqualError(t, err, "rpc error: code = Unknown desc = my error")
+	require.EqualError(t, err, "rpc error: code = Unknown desc = my error")
 	assert.Equal(t, ptraceotlp.ExportResponse{}, resp)
 }
 

--- a/receiver/otelarrowreceiver/otelarrow_test.go
+++ b/receiver/otelarrowreceiver/otelarrow_test.go
@@ -280,7 +280,7 @@ func TestStandardShutdown(t *testing.T) {
 	ctx, cancelFn := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancelFn()
 	err = r.Shutdown(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Remember how many spans the sink received. This number should not change after this
 	// point because after Shutdown() returns the component is not allowed to produce
@@ -390,7 +390,7 @@ func TestOTelArrowShutdown(t *testing.T) {
 			// Note that gRPC GracefulShutdown() does not actually use the context
 			// for cancelation.
 			err = r.Shutdown(context.Background())
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			// recvWG ensures the stream has been read before the test exits.
 			recvWG.Wait()
@@ -890,7 +890,7 @@ func TestOTelArrowHalfOpenShutdown(t *testing.T) {
 
 	// Now shutdown the receiver, while continuing sending traces to it.
 	err = r.Shutdown(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Ensure that calls to Recv() get canceled
 	for {

--- a/receiver/otlpjsonfilereceiver/file_test.go
+++ b/receiver/otlpjsonfilereceiver/file_test.go
@@ -43,17 +43,17 @@ func TestFileTracesReceiver(t *testing.T) {
 	cfg.Config.StartAt = "beginning"
 	sink := new(consumertest.TracesSink)
 	receiver, err := factory.CreateTracesReceiver(context.Background(), receivertest.NewNopSettings(), cfg, sink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = receiver.Start(context.Background(), nil)
 	require.NoError(t, err)
 
 	td := testdata.GenerateTraces(2)
 	marshaler := &ptrace.JSONMarshaler{}
 	b, err := marshaler.MarshalTraces(td)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	b = append(b, '\n')
 	err = os.WriteFile(filepath.Join(tempFolder, "traces.json"), b, 0600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 
 	require.Len(t, sink.AllTraces(), 1)
@@ -70,17 +70,17 @@ func TestFileMetricsReceiver(t *testing.T) {
 	cfg.Config.StartAt = "beginning"
 	sink := new(consumertest.MetricsSink)
 	receiver, err := factory.CreateMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, sink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = receiver.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	md := testdata.GenerateMetrics(5)
 	marshaler := &pmetric.JSONMarshaler{}
 	b, err := marshaler.MarshalMetrics(md)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	b = append(b, '\n')
 	err = os.WriteFile(filepath.Join(tempFolder, "metrics.json"), b, 0600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 
 	require.Len(t, sink.AllMetrics(), 1)
@@ -100,17 +100,17 @@ func TestFileMetricsReceiverWithReplay(t *testing.T) {
 
 	sink := new(consumertest.MetricsSink)
 	receiver, err := factory.CreateMetricsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, sink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = receiver.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	md := testdata.GenerateMetrics(5)
 	marshaler := &pmetric.JSONMarshaler{}
 	b, err := marshaler.MarshalMetrics(md)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	b = append(b, '\n')
 	err = os.WriteFile(filepath.Join(tempFolder, "metrics.json"), b, 0600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Wait for the first poll to complete.
 	time.Sleep(cfg.Config.PollInterval + time.Second)
@@ -135,17 +135,17 @@ func TestFileLogsReceiver(t *testing.T) {
 	cfg.Config.StartAt = "beginning"
 	sink := new(consumertest.LogsSink)
 	receiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, sink)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = receiver.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	ld := testdata.GenerateLogs(5)
 	marshaler := &plog.JSONMarshaler{}
 	b, err := marshaler.MarshalLogs(ld)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	b = append(b, '\n')
 	err = os.WriteFile(filepath.Join(tempFolder, "logs.json"), b, 0600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 
 	require.Len(t, sink.AllLogs(), 1)
@@ -200,39 +200,39 @@ func TestFileMixedSignals(t *testing.T) {
 	cs := receivertest.NewNopSettings()
 	ms := new(consumertest.MetricsSink)
 	mr, err := factory.CreateMetricsReceiver(context.Background(), cs, cfg, ms)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = mr.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ts := new(consumertest.TracesSink)
 	tr, err := factory.CreateTracesReceiver(context.Background(), cs, cfg, ts)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = tr.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ls := new(consumertest.LogsSink)
 	lr, err := factory.CreateLogsReceiver(context.Background(), cs, cfg, ls)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = lr.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	md := testdata.GenerateMetrics(5)
 	marshaler := &pmetric.JSONMarshaler{}
 	b, err := marshaler.MarshalMetrics(md)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	td := testdata.GenerateTraces(2)
 	tmarshaler := &ptrace.JSONMarshaler{}
 	b2, err := tmarshaler.MarshalTraces(td)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	ld := testdata.GenerateLogs(5)
 	lmarshaler := &plog.JSONMarshaler{}
 	b3, err := lmarshaler.MarshalLogs(ld)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	b = append(b, '\n')
 	b = append(b, b2...)
 	b = append(b, '\n')
 	b = append(b, b3...)
 	b = append(b, '\n')
 	err = os.WriteFile(filepath.Join(tempFolder, "metrics.json"), b, 0600)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	time.Sleep(1 * time.Second)
 
 	require.Len(t, ms.AllMetrics(), 1)
@@ -242,9 +242,9 @@ func TestFileMixedSignals(t *testing.T) {
 	require.Len(t, ls.AllLogs(), 1)
 	assert.EqualValues(t, ld, ls.AllLogs()[0])
 	err = mr.Shutdown(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = tr.Shutdown(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = lr.Shutdown(context.Background())
 	assert.NoError(t, err)
 }

--- a/receiver/podmanreceiver/factory_test.go
+++ b/receiver/podmanreceiver/factory_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pipeline"
@@ -31,10 +32,10 @@ func TestCreateReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	traceReceiver, err := factory.CreateTracesReceiver(context.Background(), params, config, consumertest.NewNop())
-	assert.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
+	require.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
 	assert.Nil(t, traceReceiver)
 
 	metricReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, config, consumertest.NewNop())
-	assert.NoError(t, err, "Metric receiver creation failed")
+	require.NoError(t, err, "Metric receiver creation failed")
 	assert.NotNil(t, metricReceiver, "Receiver creation failed")
 }

--- a/receiver/podmanreceiver/libpod_client_test.go
+++ b/receiver/podmanreceiver/libpod_client_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -65,7 +66,7 @@ func TestStats(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedStats := containerStats{
 		AvgCPU:        42.04781177856639,
@@ -89,7 +90,7 @@ func TestStats(t *testing.T) {
 	}
 
 	stats, err := cli.stats(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedStats, stats[0])
 }
 
@@ -121,7 +122,7 @@ func TestStatsError(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	stats, err := cli.stats(context.Background(), nil)
 	assert.Nil(t, stats)
@@ -155,7 +156,7 @@ func TestList(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedContainer := container{
 
@@ -186,7 +187,7 @@ func TestList(t *testing.T) {
 	}
 
 	containers, err := cli.list(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, expectedContainer, containers[0])
 }
 
@@ -226,7 +227,7 @@ func TestEvents(t *testing.T) {
 
 	cli, err := newLibpodClient(zap.NewNop(), config)
 	assert.NotNil(t, cli)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	expectedEvents := []event{
 		{ID: "49a4c52afb06e6b36b2941422a0adf47421dbfbf40503dbe17bd56b4570b6681", Status: "start"},

--- a/receiver/podmanreceiver/podman_connection_test.go
+++ b/receiver/podmanreceiver/podman_connection_test.go
@@ -14,13 +14,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
 func TestNewPodmanConnectionUnsupported(t *testing.T) {
 	logger := zap.NewNop()
 	c, err := newPodmanConnection(logger, "xyz://hello", "", "")
-	assert.EqualError(t, err, `unable to create connection. "xyz" is not a supported schema`)
+	require.EqualError(t, err, `unable to create connection. "xyz" is not a supported schema`)
 	assert.Nil(t, c)
 }
 
@@ -36,14 +37,14 @@ func TestNewPodmanConnectionUnix(t *testing.T) {
 
 	logger := zap.NewNop()
 	c, err := newPodmanConnection(logger, "unix:///"+socketPath, "", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, c)
 
 	tr, ok := c.Transport.(*http.Transport)
 	assert.True(t, ok)
 	assert.True(t, tr.DisableCompression)
 	conn, err := tr.DialContext(context.Background(), "", "")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, socketPath, conn.RemoteAddr().String())
 }
 
@@ -52,7 +53,7 @@ func TestNewPodmanConnectionSSH(t *testing.T) {
 	// Actual SSH connection to podman should be tested in an integration test if desired.
 	logger := zap.NewNop()
 	c, err := newPodmanConnection(logger, "ssh://otel-test-podman-server", "", "")
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.True(t, strings.HasPrefix(err.Error(), "connection to bastion host (ssh://otel-test-podman-server) failed:"))
 	assert.Nil(t, c)
 }

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -76,7 +76,7 @@ func TestWatchingTimeouts(t *testing.T) {
 	}
 
 	client, err := newLibpodClient(zap.NewNop(), config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cli := newContainerScraper(client, zap.NewNop(), config)
 	assert.NotNil(t, cli)
@@ -129,7 +129,7 @@ func TestEventLoopHandlesError(t *testing.T) {
 	}
 
 	client, err := newLibpodClient(zap.NewNop(), config)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	cli := newContainerScraper(client, zap.New(observed), config)
 	assert.NotNil(t, cli)

--- a/receiver/podmanreceiver/receiver_test.go
+++ b/receiver/podmanreceiver/receiver_test.go
@@ -62,11 +62,11 @@ func TestScraperLoop(t *testing.T) {
 		}
 	}()
 
-	assert.NoError(t, r.start(ctx, componenttest.NewNopHost()))
+	require.NoError(t, r.start(ctx, componenttest.NewNopHost()))
 	defer func() { assert.NoError(t, r.shutdown(ctx)) }()
 
 	md, err := r.scrape(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 1, md.ResourceMetrics().Len())
 
 	assertStatsEqualToMetrics(t, genContainerStats(), md)

--- a/receiver/podmanreceiver/receiver_windows_test.go
+++ b/receiver/podmanreceiver/receiver_windows_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
@@ -14,6 +15,6 @@ import (
 func TestNewReceiver(t *testing.T) {
 	mr, err := newMetricsReceiver(receivertest.NewNopSettings(), &Config{}, consumertest.NewNop(), nil)
 	assert.Nil(t, mr)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Equal(t, "podman receiver is not supported on windows", err.Error())
 }

--- a/receiver/prometheusreceiver/internal/logger_test.go
+++ b/receiver/prometheusreceiver/internal/logger_test.go
@@ -279,7 +279,7 @@ func TestE2E(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.NoError(t, tc.log())
+			require.NoError(t, tc.log())
 			entries := observed.TakeAll()
 			require.Len(t, entries, 1)
 			assert.Equal(t, tc.wantLevel, entries[0].Level)

--- a/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
@@ -713,7 +714,7 @@ func runScript(t *testing.T, ma MetricsAdjuster, job, instance string, tests []*
 			// Add the instance/job to the input metrics.
 			adjusted.ResourceMetrics().At(0).Resource().Attributes().PutStr(semconv.AttributeServiceInstanceID, instance)
 			adjusted.ResourceMetrics().At(0).Resource().Attributes().PutStr(semconv.AttributeServiceName, job)
-			assert.NoError(t, ma.AdjustMetrics(adjusted))
+			require.NoError(t, ma.AdjustMetrics(adjusted))
 
 			// Add the instance/job to the expected metrics as well.
 			test.adjusted.ResourceMetrics().At(0).Resource().Attributes().PutStr(semconv.AttributeServiceInstanceID, instance)

--- a/receiver/prometheusreceiver/internal/starttimemetricadjuster_test.go
+++ b/receiver/prometheusreceiver/internal/starttimemetricadjuster_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
@@ -118,7 +119,7 @@ func TestStartTimeMetricMatch(t *testing.T) {
 				assert.ErrorIs(t, stma.AdjustMetrics(tt.inputs), tt.expectedErr)
 				return
 			}
-			assert.NoError(t, stma.AdjustMetrics(tt.inputs))
+			require.NoError(t, stma.AdjustMetrics(tt.inputs))
 			for i := 0; i < tt.inputs.ResourceMetrics().Len(); i++ {
 				rm := tt.inputs.ResourceMetrics().At(i)
 				for j := 0; j < rm.ScopeMetrics().Len(); j++ {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -126,7 +126,7 @@ func testTransactionAppendNoMetricName(t *testing.T, enableNativeHistograms bool
 	})
 	tr := newTransaction(scrapeCtx, &startTimeAdjuster{startTime: startTimestamp}, consumertest.NewNop(), labels.EmptyLabels(), receivertest.NewNopSettings(), nopObsRecv(t), false, enableNativeHistograms)
 	_, err := tr.Append(0, jobNotFoundLb, time.Now().Unix()*1000, 1.0)
-	assert.ErrorIs(t, err, errMetricNameNotFound)
+	require.ErrorIs(t, err, errMetricNameNotFound)
 	assert.ErrorIs(t, tr.Commit(), errNoDataToBuild)
 }
 
@@ -164,7 +164,7 @@ func testTransactionAppendResource(t *testing.T, enableNativeHistograms bool) {
 		model.JobLabel:        "test",
 		model.MetricNameLabel: "counter_test",
 	}), time.Now().Unix()*1000, 1.0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = tr.Append(0, labels.FromMap(map[string]string{
 		model.InstanceLabel:   "localhost:8080",
 		model.JobLabel:        "test",
@@ -195,7 +195,7 @@ func testTransactionAppendMultipleResources(t *testing.T, enableNativeHistograms
 		model.JobLabel:        "test-1",
 		model.MetricNameLabel: "counter_test",
 	}), time.Now().Unix()*1000, 1.0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = tr.Append(0, labels.FromMap(map[string]string{
 		model.InstanceLabel:   "localhost:8080",
 		model.JobLabel:        "test-2",
@@ -278,7 +278,7 @@ func testTransactionCommitErrorWhenAdjusterError(t *testing.T, enableNativeHisto
 	adjusterErr := errors.New("adjuster error")
 	tr := newTransaction(scrapeCtx, &errorAdjuster{err: adjusterErr}, sink, labels.EmptyLabels(), receivertest.NewNopSettings(), nopObsRecv(t), false, enableNativeHistograms)
 	_, err := tr.Append(0, goodLabels, time.Now().Unix()*1000, 1.0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.ErrorIs(t, tr.Commit(), adjusterErr)
 }
 
@@ -344,7 +344,7 @@ func testTransactionAppendHistogramNoLe(t *testing.T, enableNativeHistograms boo
 	assert.Equal(t, 1, observedLogs.Len())
 	assert.Equal(t, 1, observedLogs.FilterMessage("failed to add datapoint").Len())
 
-	assert.NoError(t, tr.Commit())
+	require.NoError(t, tr.Commit())
 	assert.Empty(t, sink.AllMetrics())
 }
 
@@ -383,7 +383,7 @@ func testTransactionAppendSummaryNoQuantile(t *testing.T, enableNativeHistograms
 	assert.Equal(t, 1, observedLogs.Len())
 	assert.Equal(t, 1, observedLogs.FilterMessage("failed to add datapoint").Len())
 
-	assert.NoError(t, tr.Commit())
+	require.NoError(t, tr.Commit())
 	assert.Empty(t, sink.AllMetrics())
 }
 
@@ -417,7 +417,7 @@ func testTransactionAppendValidAndInvalid(t *testing.T, enableNativeHistograms b
 		model.JobLabel:        "test",
 		model.MetricNameLabel: "counter_test",
 	}), time.Now().Unix()*1000, 1.0)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// summary without quantiles, should be ignored
 	summarylabels := labels.FromStrings(
@@ -432,7 +432,7 @@ func testTransactionAppendValidAndInvalid(t *testing.T, enableNativeHistograms b
 	assert.Equal(t, 1, observedLogs.Len())
 	assert.Equal(t, 1, observedLogs.FilterMessage("failed to add datapoint").Len())
 
-	assert.NoError(t, tr.Commit())
+	require.NoError(t, tr.Commit())
 	expectedResource := CreateResource("test", "localhost:8080", labels.FromStrings(model.SchemeLabel, "http"))
 	mds := sink.AllMetrics()
 	require.Len(t, mds, 1)
@@ -1871,11 +1871,11 @@ func (tt buildTestData) run(t *testing.T, enableNativeHistograms bool) {
 			default:
 				_, err = tr.Append(0, pt.lb, pt.t, pt.v)
 			}
-			assert.NoError(t, err)
+			require.NoError(t, err)
 
 			for _, e := range pt.exemplars {
 				_, err := tr.AppendExemplar(0, pt.lb, e)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 		}
 		assert.NoError(t, tr.Commit())

--- a/receiver/prometheusreceiver/internal/util_test.go
+++ b/receiver/prometheusreceiver/internal/util_test.go
@@ -171,7 +171,7 @@ func TestGetBoundary(t *testing.T) {
 				return
 			}
 
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantValue, value)
 		})
 	}

--- a/receiver/prometheusreceiver/targetallocator/manager_test.go
+++ b/receiver/prometheusreceiver/targetallocator/manager_test.go
@@ -773,7 +773,7 @@ func TestConfigureSDHTTPClientConfigFromTA(t *testing.T) {
 
 	err := configureSDHTTPClientConfigFromTA(httpSD, ta)
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.False(t, httpSD.HTTPClientConfig.FollowRedirects)
 	assert.True(t, httpSD.HTTPClientConfig.TLSConfig.InsecureSkipVerify)

--- a/receiver/purefareceiver/factory_test.go
+++ b/receiver/purefareceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -32,7 +33,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	set := receivertest.NewNopSettings()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, nil)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)

--- a/receiver/purefareceiver/internal/bearertoken_test.go
+++ b/receiver/purefareceiver/internal/bearertoken_test.go
@@ -44,7 +44,7 @@ func TestBearerToken(t *testing.T) {
 	token, err := RetrieveBearerToken(cfgAuth, host.GetExtensions())
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "the-token", token)
 }
 

--- a/receiver/purefareceiver/internal/scraper_test.go
+++ b/receiver/purefareceiver/internal/scraper_test.go
@@ -53,7 +53,7 @@ func TestToPrometheusConfig(t *testing.T) {
 	scCfgs, err := scraper.ToPrometheusReceiverConfig(host, prFactory)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, scCfgs, 1)
 	assert.EqualValues(t, "the-token", scCfgs[0].HTTPClientConfig.BearerToken)
 	assert.Equal(t, "array01", scCfgs[0].Params.Get("endpoint"))

--- a/receiver/purefbreceiver/factory_test.go
+++ b/receiver/purefbreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -31,7 +32,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	set := receivertest.NewNopSettings()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, nil)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, cfg, nil)

--- a/receiver/purefbreceiver/internal/baerertoken_test.go
+++ b/receiver/purefbreceiver/internal/baerertoken_test.go
@@ -44,7 +44,7 @@ func TestBearerToken(t *testing.T) {
 	token, err := RetrieveBearerToken(cfgAuth, host.GetExtensions())
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "the-token", token)
 }
 

--- a/receiver/purefbreceiver/internal/scraper_test.go
+++ b/receiver/purefbreceiver/internal/scraper_test.go
@@ -53,7 +53,7 @@ func TestToPrometheusConfig(t *testing.T) {
 	scCfgs, err := scraper.ToPrometheusReceiverConfig(host, prFactory)
 
 	// verify
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Len(t, scCfgs, 1)
 	assert.EqualValues(t, "the-token", scCfgs[0].HTTPClientConfig.BearerToken)
 	assert.Equal(t, "fb01", scCfgs[0].Params.Get("endpoint"))

--- a/receiver/receivercreator/consumer_test.go
+++ b/receiver/receivercreator/consumer_test.go
@@ -193,10 +193,10 @@ func TestNewEnhancingConsumer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := newEnhancingConsumer(tt.args.resources, tt.args.resourceAttributes, tt.args.env, tt.args.endpoint, tt.args.nextLogs, tt.args.nextMetrics, tt.args.nextTraces)
 			if tt.expectedError != "" {
-				assert.EqualError(t, err, tt.expectedError)
+				require.EqualError(t, err, tt.expectedError)
 				assert.Nil(t, got)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.want, got)
 			}
 		})

--- a/receiver/receivercreator/factory_test.go
+++ b/receiver/receivercreator/factory_test.go
@@ -23,7 +23,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	lConsumer := consumertest.NewNop()
 	lReceiver, err := factory.CreateLogsReceiver(context.Background(), params, cfg, lConsumer)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, lReceiver, "receiver creation failed")
 
 	shared, ok := lReceiver.(*sharedcomponent.SharedComponent)
@@ -35,7 +35,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	mConsumer := consumertest.NewNop()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, mConsumer)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	shared, ok = mReceiver.(*sharedcomponent.SharedComponent)
@@ -48,7 +48,7 @@ func TestCreateReceiver(t *testing.T) {
 
 	tConsumer := consumertest.NewNop()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), params, cfg, tConsumer)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
 	shared, ok = tReceiver.(*sharedcomponent.SharedComponent)

--- a/receiver/receivercreator/receiver_test.go
+++ b/receiver/receivercreator/receiver_test.go
@@ -109,7 +109,7 @@ func TestMockedEndToEnd(t *testing.T) {
 		m.SetName("my-metric")
 		m.SetDescription("My metric")
 		m.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(123)
-		assert.NoError(t, example.ConsumeMetrics(context.Background(), md))
+		require.NoError(t, example.ConsumeMetrics(context.Background(), md))
 	}
 
 	// TODO: Will have to rework once receivers are started asynchronously to Start().

--- a/receiver/redisreceiver/redis_scraper_test.go
+++ b/receiver/redisreceiver/redis_scraper_test.go
@@ -39,7 +39,7 @@ func TestRedisRunnable(t *testing.T) {
 func TestNewReceiver_invalid_endpoint(t *testing.T) {
 	c := createDefaultConfig().(*Config)
 	_, err := createMetricsReceiver(context.Background(), receivertest.NewNopSettings(), c, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "invalid endpoint")
 }
 
@@ -51,7 +51,7 @@ func TestNewReceiver_invalid_auth_error(t *testing.T) {
 		},
 	}
 	r, err := createMetricsReceiver(context.Background(), receivertest.NewNopSettings(), c, nil)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to load TLS config")
 	assert.Nil(t, r)
 }

--- a/receiver/sapmreceiver/factory_test.go
+++ b/receiver/sapmreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pipeline"
 	"go.opentelemetry.io/collector/receiver/receivertest"
@@ -26,11 +27,11 @@ func TestCreateReceiver(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), params, cfg, nil)
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
 
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, nil)
-	assert.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
+	require.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
 	assert.Nil(t, mReceiver)
 }
 

--- a/receiver/sapmreceiver/trace_receiver_test.go
+++ b/receiver/sapmreceiver/trace_receiver_test.go
@@ -246,7 +246,7 @@ func compressZstd(reqBytes []byte) ([]byte, error) {
 func setupReceiver(t *testing.T, config *Config, sink *consumertest.TracesSink) receiver.Traces {
 	params := receivertest.NewNopSettings()
 	sr, err := newReceiver(params, config, sink)
-	assert.NoError(t, err, "should not have failed to create the SAPM receiver")
+	require.NoError(t, err, "should not have failed to create the SAPM receiver")
 	t.Log("Starting")
 
 	require.NoError(t, sr.Start(context.Background(), &nopHost{
@@ -346,7 +346,7 @@ func TestReception(t *testing.T) {
 			resp, err := sendSapm(tt.args.config.Endpoint, tt.args.sapm, tt.args.compression, tt.args.useTLS, "")
 			require.NoError(t, err)
 			assert.Equal(t, 200, resp.StatusCode)
-			assert.NoError(t, resp.Body.Close())
+			require.NoError(t, resp.Body.Close())
 			t.Log("SAPM Request Received")
 
 			// retrieve received traces
@@ -412,7 +412,7 @@ func TestAccessTokenPassthrough(t *testing.T) {
 			resp, err := sendSapm(config.Endpoint, sapm, "gzip", false, tt.token)
 			require.NoErrorf(t, err, "should not have failed when sending sapm %v", err)
 			assert.Equal(t, 200, resp.StatusCode)
-			assert.NoError(t, resp.Body.Close())
+			require.NoError(t, resp.Body.Close())
 
 			got := sink.AllTraces()
 			assert.Len(t, got, 1)

--- a/receiver/signalfxreceiver/factory_test.go
+++ b/receiver/signalfxreceiver/factory_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pipeline"
@@ -28,14 +29,14 @@ func TestCreateReceiverMetricsFirst(t *testing.T) {
 
 	params := receivertest.NewNopSettings()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	_, err = factory.CreateTracesReceiver(context.Background(), receivertest.NewNopSettings(), cfg, nil)
-	assert.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
+	require.ErrorIs(t, err, pipeline.ErrSignalNotSupported)
 
 	lReceiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, lReceiver, "receiver creation failed")
 
 	assert.Same(t, mReceiver, lReceiver)
@@ -47,12 +48,12 @@ func TestCreateReceiverLogsFirst(t *testing.T) {
 	cfg.Endpoint = "localhost:1" // Endpoint is required, not going to be used here.
 
 	lReceiver, err := factory.CreateLogsReceiver(context.Background(), receivertest.NewNopSettings(), cfg, consumertest.NewNop())
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, lReceiver, "receiver creation failed")
 
 	params := receivertest.NewNopSettings()
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), params, cfg, consumertest.NewNop())
-	assert.NoError(t, err, "receiver creation failed")
+	require.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, mReceiver, "receiver creation failed")
 
 	assert.Same(t, mReceiver, lReceiver)

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -606,11 +606,11 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 
 			resp := w.Result()
 			respBytes, err := io.ReadAll(resp.Body)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer resp.Body.Close()
 
 			var bodyStr string
-			assert.NoError(t, json.Unmarshal(respBytes, &bodyStr))
+			require.NoError(t, json.Unmarshal(respBytes, &bodyStr))
 
 			tt.assertResponse(t, resp.StatusCode, bodyStr)
 		})
@@ -681,7 +681,7 @@ func Test_sfxReceiver_TLS(t *testing.T) {
 		ServerName: "localhost",
 	}
 	tls, errTLS := tlscs.LoadTLSConfig(context.Background())
-	assert.NoError(t, errTLS)
+	require.NoError(t, errTLS)
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: tls,
@@ -794,11 +794,11 @@ func Test_sfxReceiver_DatapointAccessTokenPassthrough(t *testing.T) {
 
 			resp := w.Result()
 			respBytes, err := io.ReadAll(resp.Body)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer resp.Body.Close()
 
 			var bodyStr string
-			assert.NoError(t, json.Unmarshal(respBytes, &bodyStr))
+			require.NoError(t, json.Unmarshal(respBytes, &bodyStr))
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			assert.Equal(t, responseOK, bodyStr)
@@ -873,11 +873,11 @@ func Test_sfxReceiver_EventAccessTokenPassthrough(t *testing.T) {
 
 			resp := w.Result()
 			respBytes, err := io.ReadAll(resp.Body)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			defer resp.Body.Close()
 
 			var bodyStr string
-			assert.NoError(t, json.Unmarshal(respBytes, &bodyStr))
+			require.NoError(t, json.Unmarshal(respBytes, &bodyStr))
 
 			assert.Equal(t, http.StatusOK, resp.StatusCode)
 			assert.Equal(t, responseOK, bodyStr)

--- a/receiver/skywalkingreceiver/factory_test.go
+++ b/receiver/skywalkingreceiver/factory_test.go
@@ -50,12 +50,12 @@ func TestCreateReceiver(t *testing.T) {
 	traceSink := new(consumertest.TracesSink)
 	set := receivertest.NewNopSettings()
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, cfg, traceSink)
-	assert.NoError(t, err, "trace receiver creation failed")
+	require.NoError(t, err, "trace receiver creation failed")
 	assert.NotNil(t, tReceiver, "trace receiver creation failed")
 
 	metricSink := new(consumertest.MetricsSink)
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, metricSink)
-	assert.NoError(t, err, "metric receiver creation failed")
+	require.NoError(t, err, "metric receiver creation failed")
 	assert.NotNil(t, mReceiver, "metric receiver creation failed")
 
 }
@@ -73,12 +73,12 @@ func TestCreateReceiverGeneralConfig(t *testing.T) {
 	set := receivertest.NewNopSettings()
 	traceSink := new(consumertest.TracesSink)
 	tReceiver, err := factory.CreateTracesReceiver(context.Background(), set, cfg, traceSink)
-	assert.NoError(t, err, "trace receiver creation failed")
+	require.NoError(t, err, "trace receiver creation failed")
 	assert.NotNil(t, tReceiver, "trace receiver creation failed")
 
 	metricSink := new(consumertest.MetricsSink)
 	mReceiver, err := factory.CreateMetricsReceiver(context.Background(), set, cfg, metricSink)
-	assert.NoError(t, err, "metric receiver creation failed")
+	require.NoError(t, err, "metric receiver creation failed")
 	assert.NotNil(t, mReceiver, "metric receiver creation failed")
 }
 
@@ -95,7 +95,7 @@ func TestCreateDefaultGRPCEndpoint(t *testing.T) {
 	traceSink := new(consumertest.TracesSink)
 	set := receivertest.NewNopSettings()
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, traceSink)
-	assert.NoError(t, err, "unexpected error creating receiver")
+	require.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, 11800, r.(*sharedcomponent.SharedComponent).
 		Unwrap().(*swReceiver).config.CollectorGRPCPort, "grpc port should be default")
 }
@@ -152,7 +152,7 @@ func TestCreateInvalidHTTPEndpoint(t *testing.T) {
 	set := receivertest.NewNopSettings()
 	traceSink := new(consumertest.TracesSink)
 	r, err := factory.CreateTracesReceiver(context.Background(), set, cfg, traceSink)
-	assert.NoError(t, err, "unexpected error creating receiver")
+	require.NoError(t, err, "unexpected error creating receiver")
 	assert.Equal(t, 12800, r.(*sharedcomponent.SharedComponent).
 		Unwrap().(*swReceiver).config.CollectorHTTPPort, "http port should be default")
 }

--- a/receiver/skywalkingreceiver/skywalking_receiver_test.go
+++ b/receiver/skywalkingreceiver/skywalking_receiver_test.go
@@ -118,7 +118,7 @@ func TestGRPCReception(t *testing.T) {
 		t.Fatalf("cannot send data in sync mode: %v", err)
 	}
 	// verify
-	assert.NoError(t, err, "send skywalking segment successful.")
+	require.NoError(t, err, "send skywalking segment successful.")
 	assert.NotNil(t, commands)
 }
 
@@ -149,7 +149,7 @@ func TestHttpReception(t *testing.T) {
 		t.Fatalf("cannot send data in sync mode: %v", err)
 	}
 	// verify
-	assert.NoError(t, err, "send skywalking segment successful.")
+	require.NoError(t, err, "send skywalking segment successful.")
 	assert.NotNil(t, response)
 
 }

--- a/receiver/solacereceiver/factory_test.go
+++ b/receiver/solacereceiver/factory_test.go
@@ -41,7 +41,7 @@ func TestCreateTracesReceiver(t *testing.T) {
 		cfg,
 		consumertest.NewNop(),
 	)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	castedReceiver, ok := receiver.(*solaceTracesReceiver)
 	assert.True(t, ok)
 	assert.Equal(t, castedReceiver.config, cfg)
@@ -108,6 +108,6 @@ func TestCreateTracesReceiverBadMetrics(t *testing.T) {
 		cfg,
 		consumertest.NewNop(),
 	)
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Nil(t, receiver)
 }

--- a/receiver/solacereceiver/receiver_test.go
+++ b/receiver/solacereceiver/receiver_test.go
@@ -207,7 +207,7 @@ func TestReceiveMessage(t *testing.T) {
 			if testCase.expectedErr != nil {
 				assert.Equal(t, testCase.expectedErr, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.True(t, receiveMessagesCalled)
 			if testCase.receiveMessageErr == nil {
@@ -248,7 +248,7 @@ func TestReceiveMessagesTerminateWithCtxDone(t *testing.T) {
 		return trace, nil
 	}
 	err := receiver.receiveMessages(ctx, messagingService)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, receiveMessagesCalled)
 	assert.True(t, unmarshalCalled)
 	assert.True(t, ackCalled)
@@ -381,11 +381,11 @@ func TestReceiverLifecycle(t *testing.T) {
 	}
 	// start the receiver
 	err := receiver.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertChannelClosed(t, dialCalled)
 	assertChannelClosed(t, receiveMessagesCalled)
 	err = receiver.Shutdown(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assertChannelClosed(t, closeCalled)
 	// we error on receive message, so we should not report any additional metrics
 	tt.assertMetrics(t, []metricdata.Metrics{
@@ -490,7 +490,7 @@ func TestReceiverDialFailureContinue(t *testing.T) {
 	}
 	// start the receiver
 	err := receiver.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// expect factory to be called twice
 	assertChannelClosed(t, factoryDone)
@@ -501,7 +501,7 @@ func TestReceiverDialFailureContinue(t *testing.T) {
 	// assert failed reconnections
 
 	err = receiver.Shutdown(context.Background())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// we error on dial, should never get to receive messages
 	tt.assertMetrics(t, []metricdata.Metrics{
 		{
@@ -579,7 +579,7 @@ func TestReceiverUnmarshalVersionFailureExpectingDisable(t *testing.T) {
 	}
 	// start the receiver
 	err := receiver.Start(context.Background(), nil)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// expect dial to be called twice
 	assertChannelClosed(t, dialDone)
@@ -847,7 +847,7 @@ func TestReceiverFlowControlDelayedRetry(t *testing.T) {
 			case <-time.After(delay):
 				require.Fail(t, "receiveMessage did not return after delay interval")
 			case err := <-receiveMessageComplete:
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 			assert.True(t, ackCalled)
 			if tc.validation != nil {
@@ -1083,7 +1083,7 @@ func TestReceiverFlowControlDelayedRetryMultipleRetries(t *testing.T) {
 	case <-time.After(2 * retryInterval * time.Duration(retryCount)):
 		require.Fail(t, "receiveMessage did not return after some time")
 	case err := <-receiveMessageComplete:
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	}
 	assert.True(t, ackCalled)
 	tt.assertMetrics(t, []metricdata.Metrics{

--- a/receiver/solacereceiver/unmarshaller_egress_test.go
+++ b/receiver/solacereceiver/unmarshaller_egress_test.go
@@ -27,7 +27,7 @@ var msgWithAdditionalSpan = []byte{10, 48, 10, 16, 1, 2, 3, 4, 5, 6, 7, 8, 9, 8,
 func TestMsgWithUnknownOneof(t *testing.T) {
 	unmarshallerV1, _ := newTestEgressV1Unmarshaller(t)
 	spanData, err := unmarshallerV1.unmarshalToSpanData(amqp.NewMessage(msgWithAdditionalSpan))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	// expect one egress span
 	assert.Len(t, spanData.EgressSpans, 1)
 	assert.Nil(t, spanData.EgressSpans[0].GetSendSpan())
@@ -348,7 +348,7 @@ func TestEgressUnmarshallerSendSpanAttributes(t *testing.T) {
 		}
 		span := ptrace.NewSpan()
 		err := span.Attributes().FromRaw(base)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		span.SetName(name)
 		span.SetKind(ptrace.SpanKindProducer)
 		return span

--- a/receiver/solacereceiver/unmarshaller_receive_test.go
+++ b/receiver/solacereceiver/unmarshaller_receive_test.go
@@ -730,9 +730,9 @@ func TestReceiveUnmarshallerReceiveBaggageString(t *testing.T) {
 			u, _ := newTestReceiveV1Unmarshaller(t)
 			err := u.unmarshalBaggage(actual, testCase.baggage)
 			if testCase.errStr == "" {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			} else {
-				assert.ErrorContains(t, err, testCase.errStr)
+				require.ErrorContains(t, err, testCase.errStr)
 			}
 			if testCase.expected != nil {
 				expected := pcommon.NewMap()

--- a/receiver/solacereceiver/unmarshaller_test.go
+++ b/receiver/solacereceiver/unmarshaller_test.go
@@ -330,7 +330,7 @@ func TestSolaceMessageUnmarshallerUnmarshal(t *testing.T) {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.err.Error())
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 			}
 
 			if tt.want != nil {

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -426,7 +426,7 @@ func Test_consumer_err_metrics(t *testing.T) {
 	config := createDefaultConfig().(*Config)
 	config.Endpoint = "localhost:0" // Actually not creating the endpoint\
 	rcv, err := newMetricsReceiver(receivertest.NewNopSettings(), *config, consumertest.NewErr(errors.New("bad consumer")))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	r := rcv.(*splunkReceiver)
 	w := httptest.NewRecorder()

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -539,7 +539,7 @@ func TestConvertToValueMap(t *testing.T) {
 
 func TestConvertToValueArray(t *testing.T) {
 	value := pcommon.NewValueEmpty()
-	assert.NoError(t, convertToValue(zap.NewNop(), []any{"foo"}, value))
+	require.NoError(t, convertToValue(zap.NewNop(), []any{"foo"}, value))
 	arrValue := pcommon.NewValueSlice()
 	arr := arrValue.Slice()
 	arr.AppendEmpty().SetStr("foo")

--- a/receiver/sqlqueryreceiver/config_test.go
+++ b/receiver/sqlqueryreceiver/config_test.go
@@ -187,7 +187,7 @@ func TestConfig_Validate_Multierr(t *testing.T) {
 
 	err = component.ValidateConfig(cfg)
 
-	assert.ErrorContains(t, err, "invalid metric config with metric_name 'my.metric'")
+	require.ErrorContains(t, err, "invalid metric config with metric_name 'my.metric'")
 	assert.ErrorContains(t, err, "metric config has unsupported value_type: 'xint'")
 	assert.ErrorContains(t, err, "metric config has unsupported data_type: 'xgauge'")
 	assert.ErrorContains(t, err, "metric config has unsupported aggregation: 'xcumulative'")


### PR DESCRIPTION
#### Description

Testifylint is a linter that provides best practices with the use of testify.

This is only a partial application as there is much more files to modify but that worth another PR
The modification of golangci lint config file will happen when it can globallly be applied.

This PR enables [require-error](https://github.com/Antonboom/testifylint?tab=readme-ov-file#require-error) rule from [testifylint](https://github.com/Antonboom/testifylint)