### PR TITLE
feat: [receiver/datadog] add container id to v0.5 requests

### DIFF
--- a/.chloggen/dd-container-id.yaml
+++ b/.chloggen/dd-container-id.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add container id from v0.5 request header"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35345]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/datadogreceiver/internal/translator/header/headers.go
+++ b/receiver/datadogreceiver/internal/translator/header/headers.go
@@ -16,4 +16,7 @@ const (
 	// TracerVersion specifies the name of the header which contains the version
 	// of the tracer sending the payload.
 	TracerVersion = "Datadog-Meta-Tracer-Version"
+
+	// ContainerID specifies uuid of the container.
+	ContainerID = "Datadog-Container-Id"
 )

--- a/receiver/datadogreceiver/internal/translator/traces_translator.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator.go
@@ -221,6 +221,7 @@ func HandleTracesPayload(req *http.Request) (tp []*pb.TracerPayload, err error) 
 			LanguageName:    req.Header.Get(header.Lang),
 			LanguageVersion: req.Header.Get(header.LangVersion),
 			TracerVersion:   req.Header.Get(header.TracerVersion),
+			ContainerID:     req.Header.Get(header.ContainerID),
 			Chunks:          traceChunks,
 			AppVersion:      appVersion,
 		}

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -181,6 +181,7 @@ func agentPayloadFromTraces(traces *pb.Traces) (agentPayload pb.AgentPayload) {
 		payload := &pb.TracerPayload{
 			LanguageName:    fmt.Sprintf("%d", i),
 			LanguageVersion: fmt.Sprintf("%d", i),
+			ContainerID:     fmt.Sprintf("%d", i),
 			Chunks:          traceChunksFromTraces(*traces),
 			TracerVersion:   fmt.Sprintf("%d", i),
 		}


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Add parsing of Container ID from DD v0.5 request.

I've got a hold of an example request:
```
Sending request: PUT v0.5/traces {'Datadog-Meta-Lang': 'python', 'Datadog-Meta-Lang-Version': '3.10.14', 'Datadog-Meta-Lang-Interpreter': 'CPython', 'Datadog-Meta-Tracer-Version': '2.7.2', 'Datadog-Client-Computed-Top-Level': 'yes', 'Datadog-Container-Id': '7d0f62eb396bd016230ebc53d525bd6bc9ce734894fcf70b39f268b62001a79d', 'Datadog-Entity-ID': 'cid-7d0f62eb396bd016230ebc53d525bd6bc9ce734894fcf70b39f268b62001a79d', 'Content-Type': 'application/msgpack', 'X-Datadog-Trace-Count': '1'}
```
**Link to tracking Issue:** 

https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35345

**Testing:** <Describe what testing was performed and which tests were added.>
-  updated unit test

**Documentation:** <Describe the documentation added.>
-