### PR TITLE
instanaexporter: migrate to latest semconv version

### DIFF
--- a/exporter/instanaexporter/internal/converter/span_converter.go
+++ b/exporter/instanaexporter/internal/converter/span_converter.go
@@ -8,7 +8,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.8.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter/internal/backend"

--- a/exporter/instanaexporter/internal/converter/span_converter_test.go
+++ b/exporter/instanaexporter/internal/converter/span_converter_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.8.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter/internal/backend"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/instanaexporter/internal/converter/model"


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.8.0 to v1.27.0

This is a trivial migration. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator) resulting in 0 diffs (all attributes of 1.8.0 exists with the same value inside 1.27.0)

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed