### PR TITLE
[cmd/opampsupervisor] Conditionally use TLS config

### DIFF
--- a/.chloggen/fix-opampsupervisor-tls-settings.yaml
+++ b/.chloggen/fix-opampsupervisor-tls-settings.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Only use TLS config when connecting to OpAMP server if using `wss` or `https` protocols.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35283]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -396,11 +396,11 @@ func (s *Supervisor) startOpAMPClient() error {
 
 	// determine if we need to load a TLS config or not
 	var tlsConfig *tls.Config
-	url, err := url.Parse(s.config.Server.Endpoint)
+	parsedUrl, err := url.Parse(s.config.Server.Endpoint)
 	if err != nil {
 		return fmt.Errorf("parse server endpoint: %w", err)
 	}
-	if url.Scheme == "wss" || url.Scheme == "https" {
+	if parsedUrl.Scheme == "wss" || parsedUrl.Scheme == "https" {
 		tlsConfig, err = s.config.Server.TLSSetting.LoadTLSConfig(context.Background())
 		if err != nil {
 			return err

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -396,11 +396,11 @@ func (s *Supervisor) startOpAMPClient() error {
 
 	// determine if we need to load a TLS config or not
 	var tlsConfig *tls.Config
-	parsedUrl, err := url.Parse(s.config.Server.Endpoint)
+	parsedURL, err := url.Parse(s.config.Server.Endpoint)
 	if err != nil {
 		return fmt.Errorf("parse server endpoint: %w", err)
 	}
-	if parsedUrl.Scheme == "wss" || parsedUrl.Scheme == "https" {
+	if parsedURL.Scheme == "wss" || parsedURL.Scheme == "https" {
 		tlsConfig, err = s.config.Server.TLSSetting.LoadTLSConfig(context.Background())
 		if err != nil {
 			return err

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_accepts_conn.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_accepts_conn.yaml
@@ -1,7 +1,5 @@
 server:
   endpoint: ws://{{.url}}/v1/opamp
-  tls:
-    insecure: true
 
 capabilities:
   reports_effective_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
@@ -1,7 +1,5 @@
 server:
   endpoint: ws://{{.url}}/v1/opamp
-  tls:
-    insecure: true
 
 capabilities:
   reports_effective_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_basic.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_basic.yaml
@@ -1,7 +1,5 @@
 server:
   endpoint: ws://{{.url}}/v1/opamp
-  tls:
-    insecure: true
 
 capabilities:
   reports_effective_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
@@ -1,7 +1,5 @@
 server:
   endpoint: ws://{{.url}}/v1/opamp
-  tls:
-    insecure: true
 
 capabilities:
   reports_effective_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_nocap.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_nocap.yaml
@@ -1,7 +1,5 @@
 server:
   endpoint: ws://{{.url}}/v1/opamp
-  tls:
-    insecure: true
 
 capabilities:
   reports_effective_config: false

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_persistence.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_persistence.yaml
@@ -1,7 +1,5 @@
 server:
   endpoint: ws://{{.url}}/v1/opamp
-  tls:
-    insecure: true
 
 capabilities:
   reports_effective_config: true


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Fixes an issue where TLS would be used despite the opamp server using `ws` or `http` protocols. 

Before a TLS config would always get created, causing the connection to always use TLS settings. This change first checks which protocol we're using before creating a TLS config.

**Link to tracking Issue:** <Issue number if applicable> Fixes #35283 

**Testing:** <Describe what testing was performed and which tests were added.>
Removed `tls.insecure_skip_verify: true` from e2e test configs which were using `ws` protocol since they are no longer needed.

**Documentation:** <Describe the documentation added.>