### PR TITLE
loadbalancingexporter: migrate to latest semconv version

### DIFF
--- a/exporter/loadbalancingexporter/helpers_test.go
+++ b/exporter/loadbalancingexporter/helpers_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func TestMergeTracesTwoEmpty(t *testing.T) {

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/multierr"
 

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"gopkg.in/yaml.v2"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 )


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.6.1 and v1.9.0 to v1.27.0

This is a trivial upgrade. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator) resulting in 0 diffs.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed