### PR TITLE
mezmoexporter: migrate to latest semconv version

### DIFF
--- a/exporter/mezmoexporter/exporter_test.go
+++ b/exporter/mezmoexporter/exporter_test.go
@@ -20,7 +20,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.6.1 to v1.27.0

This is a trivial upgrade because only the test file has been modified. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator) resulting in 0 diffs.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed