### PR TITLE
pulsarexporter: migrate to latest semconv version

### DIFF
--- a/exporter/pulsarexporter/marshaler_test.go
+++ b/exporter/pulsarexporter/marshaler_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func TestDefaultTracesMarshalers(t *testing.T) {


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.6.1 to v1.27.0

This is a trivial upgrade because only the test file has been modified. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator) resulting in 0 diffs.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed