### PR TITLE
tencentcloudlogserviceexporter: migrate to newer semconv version

### DIFF
--- a/exporter/tencentcloudlogserviceexporter/logs_exporter_test.go
+++ b/exporter/tencentcloudlogserviceexporter/logs_exporter_test.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func createSimpleLogData(numberOfLogs int) plog.Logs {

--- a/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice.go
+++ b/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice.go
@@ -10,7 +10,7 @@ import (
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"google.golang.org/protobuf/proto"
 
 	cls "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/tencentcloudlogserviceexporter/proto"

--- a/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice_test.go
+++ b/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 type logKeyValuePair struct {


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.6.1 to v1.27.0

This is a trivial upgrade. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator). All attributes used by this component have the same value in both versions.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed