### PR TITLE
Add support for MongoDB direct connection

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'mongodbreceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for MongoDB direct connection
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35427]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/mongodbreceiver/README.md
+++ b/receiver/mongodbreceiver/README.md
@@ -46,6 +46,7 @@ The following settings are optional:
 - `replica_set`: If the deployment of MongoDB is a replica set then this allows users to specify the replica set name which allows for autodiscovery of other nodes in the replica set.
 - `timeout`: (default = `1m`) The timeout of running commands against mongo.
 - `tls`: (defaults defined [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/README.md)): TLS control. By default insecure settings are rejected and certificate verification is on.
+- `direct_connection`: If true, then the driver will not try to autodiscover other nodes, and perform instead a direct connection o the host.
 
 ### Example Configuration
 

--- a/receiver/mongodbreceiver/config.go
+++ b/receiver/mongodbreceiver/config.go
@@ -26,11 +26,12 @@ type Config struct {
 	// MetricsBuilderConfig defines which metrics/attributes to enable for the scraper
 	metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	// Deprecated - Transport option will be removed in v0.102.0
-	Hosts      []confignet.TCPAddrConfig `mapstructure:"hosts"`
-	Username   string                    `mapstructure:"username"`
-	Password   configopaque.String       `mapstructure:"password"`
-	ReplicaSet string                    `mapstructure:"replica_set,omitempty"`
-	Timeout    time.Duration             `mapstructure:"timeout"`
+	Hosts            []confignet.TCPAddrConfig `mapstructure:"hosts"`
+	Username         string                    `mapstructure:"username"`
+	Password         configopaque.String       `mapstructure:"password"`
+	ReplicaSet       string                    `mapstructure:"replica_set,omitempty"`
+	Timeout          time.Duration             `mapstructure:"timeout"`
+	DirectConnection bool                      `mapstructure:"direct_connection"`
 }
 
 func (c *Config) Validate() error {
@@ -74,6 +75,10 @@ func (c *Config) ClientOptions() *options.ClientOptions {
 
 	if c.ReplicaSet != "" {
 		clientOptions.SetReplicaSet(c.ReplicaSet)
+	}
+
+	if c.DirectConnection {
+		clientOptions.SetDirect(c.DirectConnection)
 	}
 
 	if c.Username != "" && c.Password != "" {


### PR DESCRIPTION
Introduced `DirectConnection` configuration option to enable direct connection settings in the MongoDB receiver. This allows users to specify whether to connect directly to a MongoDB server instance.

This is needed when working with the `mongodb/mongodb-atlas-local` docker image [0] for local Atlas Search development.

[0] https://www.mongodb.com/docs/atlas/cli/current/atlas-cli-deploy-docker/
