### PR TITLE
[processor/metricsgeneration] Fix panic when using a sum metric for calculations

### DIFF
--- a/.chloggen/metricsgeneration_relax_type_req.yaml
+++ b/.chloggen/metricsgeneration_relax_type_req.yaml
@@ -10,7 +10,7 @@ component: metricsgenerationprocessor
 note: Allow metric calculations to be done on sum metrics
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [35428]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/metricsgeneration_relax_type_req.yaml
+++ b/.chloggen/metricsgeneration_relax_type_req.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricsgenerationprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow metric calculations to be done on sum metrics
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/metricsgenerationprocessor/README.md
+++ b/processor/metricsgenerationprocessor/README.md
@@ -16,11 +16,13 @@
 
 ## Description
 
-The metrics generation processor (`experimental_metricsgenerationprocessor`) can be used to create new metrics using existing metrics following a given rule. Currently it supports following two approaches for creating a new metric.
+The metrics generation processor (`experimental_metricsgenerationprocessor`) can be used to create new metrics using existing metrics following a given rule. This processor currently supports the following two approaches for creating a new metric.
 
-1. It can create a new metric from two existing metrics by applying one of the following arithmetic operations: add, subtract, multiply, divide and percent. One use case is to calculate the `pod.memory.utilization` metric like the following equation-
+1. It can create a new metric from two existing metrics by applying one of the following arithmetic operations: add, subtract, multiply, divide, or percent. One use case is to calculate the `pod.memory.utilization` metric like the following equation-
 `pod.memory.utilization` = (`pod.memory.usage.bytes` / `node.memory.limit`)
 1. It can create a new metric by scaling the value of an existing metric with a given constant number. One use case is to convert `pod.memory.usage` metric values from Megabytes to Bytes (multiply the existing metric's value by 1,048,576)
+
+Note: The created metric's type is inherited from the metric configured as `metric1`.
 
 ## Configuration
 
@@ -43,10 +45,10 @@ processors:
               # type describes how the new metric will be generated. It can be one of `calculate` or `scale`.  calculate generates a metric applying the given operation on two operand metrics. scale operates only on operand1 metric to generate the new metric.
               type: {calculate, scale}
 
-              # This is a required field.
+              # This is a required field. This must be a gauge or sum metric.
               metric1: <first_operand_metric>
 
-              # This field is required only if the type is "calculate".
+              # This field is required only if the type is "calculate". When required, this must be a gauge or sum metric.
               metric2: <second_operand_metric>
 
               # Operation specifies which arithmetic operation to apply. It must be one of the five supported operations.

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.110.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.0.0-00010101000000-000000000000
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.110.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.110.0
 	go.opentelemetry.io/collector/confmap v1.16.0

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -3,6 +3,8 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/metri
 go 1.22.0
 
 require (
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.110.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.0.0-00010101000000-000000000000
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.110.0
 	go.opentelemetry.io/collector/confmap v1.16.0
@@ -15,6 +17,7 @@ require (
 )
 
 require (
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
@@ -29,6 +32,7 @@ require (
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.110.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
 	go.opentelemetry.io/collector/component/componentstatus v0.110.0 // indirect
@@ -59,3 +63,7 @@ retract (
 	v0.76.1
 	v0.65.0
 )
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest

--- a/processor/metricsgenerationprocessor/go.mod
+++ b/processor/metricsgenerationprocessor/go.mod
@@ -67,3 +67,5 @@ retract (
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden => ../../pkg/golden
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest => ../../pkg/pdatatest
+
+replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil

--- a/processor/metricsgenerationprocessor/go.sum
+++ b/processor/metricsgenerationprocessor/go.sum
@@ -1,3 +1,5 @@
+github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
+github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -38,6 +40,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.110.0 h1:KYBzbgQyCz4i5zjzs0iBOFuNh2vagaw2seqvZ7Lftxk=
+github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.110.0/go.mod h1:zLtbGLswPAKzTHM4C1Pcxb+PgNHgo6aGVZQtQaeBtec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/processor/metricsgenerationprocessor/go.sum
+++ b/processor/metricsgenerationprocessor/go.sum
@@ -40,8 +40,6 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.110.0 h1:KYBzbgQyCz4i5zjzs0iBOFuNh2vagaw2seqvZ7Lftxk=
-github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.110.0/go.mod h1:zLtbGLswPAKzTHM4C1Pcxb+PgNHgo6aGVZQtQaeBtec=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -427,5 +427,9 @@ func TestSumCalculateNewMetric(t *testing.T) {
 	expected, err := golden.ReadMetrics(filepath.Join(".", "testdata", "filesystem_metrics_expected.yaml"))
 	assert.NoError(t, err)
 	assert.Len(t, got, 1)
-	pmetrictest.CompareMetrics(expected, got[0])
+	err = pmetrictest.CompareMetrics(expected, got[0],
+		pmetrictest.IgnoreMetricDataPointsOrder(),
+		pmetrictest.IgnoreStartTimestamp(),
+		pmetrictest.IgnoreTimestamp())
+	assert.NoError(t, err)
 }

--- a/processor/metricsgenerationprocessor/testdata/filesystem_metrics_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/filesystem_metrics_expected.yaml
@@ -797,7 +797,8 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: system.filesystem.utilization
             unit: "1"
-          - gauge:
+          - name: system.filesystem.capacity
+            sum:
               dataPoints:
                 - asDouble: 4.046309679639759e+11
                   attributes:
@@ -1198,7 +1199,6 @@ resourceMetrics:
                         stringValue: autofs
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: system.filesystem.capacity
             unit: bytes
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper

--- a/processor/metricsgenerationprocessor/testdata/filesystem_metrics_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/filesystem_metrics_expected.yaml
@@ -1,0 +1,1205 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: FileSystem inodes used.
+            name: system.filesystem.inodes.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "2183953600"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4770142"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2183953600"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1813"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2183953600"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "404475"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2183953600"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "24"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2183953600"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "666"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: '{inodes}'
+          - description: Filesystem bytes used.
+            name: system.filesystem.usage
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "223636848640"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "276326326272"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "223636848640"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "276326326272"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "223636848640"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "276326326272"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "223636848640"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "276326326272"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "223636848640"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "276326326272"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "197120"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: Fraction of filesystem bytes used.
+            gauge:
+              dataPoints:
+                - asDouble: 0.5526933585071281
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.5526933585071281
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.5526933585071281
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.5526933585071281
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0.5526933585071281
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 1
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: system.filesystem.utilization
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: 4.046309679639759e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.99963174912e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s1
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.046309679639759e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.99963174912e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s2
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Preboot
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.046309679639759e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.99963174912e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s4s1
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: /
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.046309679639759e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.99963174912e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s5
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Update
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.046309679639759e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 4.99963174912e+11
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: /dev/disk1s6
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/VM
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 356653.46247770725
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /dev
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: free
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: reserved
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: /System/Volumes/Data/home
+                    - key: state
+                      value:
+                        stringValue: used
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: system.filesystem.capacity
+            unit: bytes
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: 0.110.0-dev

--- a/processor/metricsgenerationprocessor/testdata/filesystem_metrics_input.yaml
+++ b/processor/metricsgenerationprocessor/testdata/filesystem_metrics_input.yaml
@@ -1,0 +1,802 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: 0.110.0-dev
+        metrics:
+          - name: system.filesystem.inodes.usage
+            description: FileSystem inodes used.
+            unit: "{inodes}"
+            sum:
+              dataPoints:
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s4s1"
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: "/"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '404475'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s4s1"
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: "/"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '2183953600'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/dev"
+                    - key: type
+                      value:
+                        stringValue: devfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '666'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/dev"
+                    - key: type
+                      value:
+                        stringValue: devfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s2"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Preboot"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '1813'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s2"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Preboot"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '2183953600'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s6"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/VM"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '4'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s6"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/VM"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '2183953600'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s5"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Update"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '24'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s5"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Update"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '2183953600'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s1"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '4770142'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s1"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '2183953600'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data/home"
+                    - key: type
+                      value:
+                        stringValue: autofs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data/home"
+                    - key: type
+                      value:
+                        stringValue: autofs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+              aggregationTemporality: 2
+          - name: system.filesystem.usage
+            description: Filesystem bytes used.
+            unit: By
+            sum:
+              dataPoints:
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s4s1"
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: "/"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '276326326272'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s4s1"
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: "/"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '223636848640'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s4s1"
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: "/"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: reserved
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/dev"
+                    - key: type
+                      value:
+                        stringValue: devfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '197120'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/dev"
+                    - key: type
+                      value:
+                        stringValue: devfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/dev"
+                    - key: type
+                      value:
+                        stringValue: devfs
+                    - key: state
+                      value:
+                        stringValue: reserved
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s2"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Preboot"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '276326326272'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s2"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Preboot"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '223636848640'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s2"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Preboot"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: reserved
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s6"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/VM"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '276326326272'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s6"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/VM"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '223636848640'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s6"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/VM"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: reserved
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s5"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Update"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '276326326272'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s5"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Update"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '223636848640'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s5"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Update"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: reserved
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s1"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '276326326272'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s1"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '223636848640'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s1"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                    - key: state
+                      value:
+                        stringValue: reserved
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data/home"
+                    - key: type
+                      value:
+                        stringValue: autofs
+                    - key: state
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data/home"
+                    - key: type
+                      value:
+                        stringValue: autofs
+                    - key: state
+                      value:
+                        stringValue: free
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data/home"
+                    - key: type
+                      value:
+                        stringValue: autofs
+                    - key: state
+                      value:
+                        stringValue: reserved
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asInt: '0'
+              aggregationTemporality: 2
+          - name: system.filesystem.utilization
+            description: Fraction of filesystem bytes used.
+            unit: '1'
+            gauge:
+              dataPoints:
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s4s1"
+                    - key: mode
+                      value:
+                        stringValue: ro
+                    - key: mountpoint
+                      value:
+                        stringValue: "/"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asDouble: 0.5526933585071281
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: devfs
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/dev"
+                    - key: type
+                      value:
+                        stringValue: devfs
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asDouble: 1
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s2"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Preboot"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asDouble: 0.5526933585071281
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s6"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/VM"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asDouble: 0.5526933585071281
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s5"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Update"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asDouble: 0.5526933585071281
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: "/dev/disk1s1"
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data"
+                    - key: type
+                      value:
+                        stringValue: apfs
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asDouble: 0.5526933585071281
+                - attributes:
+                    - key: device
+                      value:
+                        stringValue: map auto_home
+                    - key: mode
+                      value:
+                        stringValue: rw
+                    - key: mountpoint
+                      value:
+                        stringValue: "/System/Volumes/Data/home"
+                    - key: type
+                      value:
+                        stringValue: autofs
+                  startTimeUnixNano: '1726497870000000000'
+                  timeUnixNano: '1727303734559741000'
+                  asDouble: 0
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0

--- a/processor/metricsgenerationprocessor/testdata/metric_types/add_gauge_gauge_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/add_gauge_gauge_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: 100
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: new_metric
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/add_gauge_sum_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/add_gauge_sum_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: 1050
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: new_metric
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/add_sum_gauge_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/add_sum_gauge_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - name: new_metric
+            sum:
+              dataPoints:
+                - asDouble: 1050
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/add_sum_sum_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/add_sum_sum_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - name: new_metric
+            sum:
+              dataPoints:
+                - asDouble: 2000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/divide_gauge_sum_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/divide_gauge_sum_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: 50000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: new_metric
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/divide_sum_gauge_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/divide_sum_gauge_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - name: new_metric
+            sum:
+              dataPoints:
+                - asDouble: 20
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/gauge_sum_metrics_config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/gauge_sum_metrics_config.yaml
@@ -1,0 +1,96 @@
+experimental_metricsgeneration/add_sum_sum:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: sum
+      metric2: sum
+      operation: add
+experimental_metricsgeneration/add_gauge_gauge:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: gauge
+      metric2: gauge
+      operation: add
+experimental_metricsgeneration/add_gauge_sum:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: gauge
+      metric2: sum
+      operation: add
+experimental_metricsgeneration/add_sum_gauge:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: sum
+      metric2: gauge
+      operation: add
+experimental_metricsgeneration/multiply_gauge_sum:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: gauge
+      metric2: sum
+      operation: multiply
+experimental_metricsgeneration/multiply_sum_gauge:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: sum
+      metric2: gauge
+      operation: multiply
+experimental_metricsgeneration/divide_gauge_sum:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: gauge
+      metric2: sum
+      operation: multiply
+experimental_metricsgeneration/divide_sum_gauge:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: sum
+      metric2: gauge
+      operation: divide
+experimental_metricsgeneration/subtract_gauge_sum:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: gauge
+      metric2: sum
+      operation: subtract
+experimental_metricsgeneration/subtract_sum_gauge:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: sum
+      metric2: gauge
+      operation: subtract
+experimental_metricsgeneration/percent_gauge_sum:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: gauge
+      metric2: sum
+      operation: percent
+experimental_metricsgeneration/percent_sum_gauge:
+  rules:
+    - name: new_metric
+      unit: percent
+      type: calculate
+      metric1: sum
+      metric2: gauge
+      operation: percent

--- a/processor/metricsgenerationprocessor/testdata/metric_types/gauge_sum_metrics_input.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/gauge_sum_metrics_input.yaml
@@ -1,0 +1,25 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: "50"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/multiply_gauge_sum_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/multiply_gauge_sum_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: 50000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: new_metric
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/multiply_sum_gauge_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/multiply_sum_gauge_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - name: new_metric
+            sum:
+              dataPoints:
+                - asDouble: 50000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/percent_gauge_sum_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/percent_gauge_sum_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: 5
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: new_metric
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/percent_sum_gauge_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/percent_sum_gauge_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - name: new_metric
+            sum:
+              dataPoints:
+                - asDouble: 2000
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/subtract_gauge_sum_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/subtract_gauge_sum_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - gauge:
+              dataPoints:
+                - asDouble: -950
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: new_metric
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/testdata/metric_types/subtract_sum_gauge_expected.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric_types/subtract_sum_gauge_expected.yaml
@@ -1,0 +1,32 @@
+resourceMetrics:
+  - resource: {}
+    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    scopeMetrics:
+      - metrics:
+          - description: foo
+            name: sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - asInt: "1000"
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: By
+          - description: bar
+            gauge:
+              dataPoints:
+                - asDouble: 50
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: gauge
+            unit: "1"
+          - name: new_metric
+            sum:
+              dataPoints:
+                - asDouble: 950
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            unit: percent
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper
+          version: latest

--- a/processor/metricsgenerationprocessor/utils.go
+++ b/processor/metricsgenerationprocessor/utils.go
@@ -4,6 +4,8 @@
 package metricsgenerationprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 )
@@ -25,24 +27,31 @@ func getNameToMetricMap(rm pmetric.ResourceMetrics) map[string]pmetric.Metric {
 
 // getMetricValue returns the value of the first data point from the given metric.
 func getMetricValue(metric pmetric.Metric) float64 {
-	if metric.Type() == pmetric.MetricTypeGauge {
-		dataPoints := metric.Gauge().DataPoints()
-		if dataPoints.Len() > 0 {
-			switch dataPoints.At(0).ValueType() {
-			case pmetric.NumberDataPointValueTypeDouble:
-				return dataPoints.At(0).DoubleValue()
-			case pmetric.NumberDataPointValueTypeInt:
-				return float64(dataPoints.At(0).IntValue())
-			}
-		}
+	var dataPoints pmetric.NumberDataPointSlice
+
+	switch metricType := metric.Type(); metricType {
+	case pmetric.MetricTypeGauge:
+		dataPoints = metric.Gauge().DataPoints()
+	case pmetric.MetricTypeSum:
+		dataPoints = metric.Sum().DataPoints()
+	default:
 		return 0
 	}
+
+	if dataPoints.Len() > 0 {
+		switch dataPoints.At(0).ValueType() {
+		case pmetric.NumberDataPointValueTypeDouble:
+			return dataPoints.At(0).DoubleValue()
+		case pmetric.NumberDataPointValueTypeInt:
+			return float64(dataPoints.At(0).IntValue())
+		}
+	}
+
 	return 0
 }
 
 // generateMetrics creates a new metric based on the given rule and add it to the Resource Metric.
-// The value for newly calculated metrics is always a floating point number and the dataType is set
-// as MetricTypeDoubleGauge.
+// The value for newly calculated metrics is always a floating point number.
 func generateMetrics(rm pmetric.ResourceMetrics, operand2 float64, rule internalRule, logger *zap.Logger) {
 	ilms := rm.ScopeMetrics()
 	for i := 0; i < ilms.Len(); i++ {
@@ -52,22 +61,25 @@ func generateMetrics(rm pmetric.ResourceMetrics, operand2 float64, rule internal
 			metric := metricSlice.At(j)
 			if metric.Name() == rule.metric1 {
 				newMetric := appendMetric(ilm, rule.name, rule.unit)
-				newMetric.SetEmptyGauge()
 				addDoubleDataPoints(metric, newMetric, operand2, rule.operation, logger)
 			}
 		}
 	}
 }
 
-// Note: the to metric must be a gauge.
 func addDoubleDataPoints(from pmetric.Metric, to pmetric.Metric, operand2 float64, operation string, logger *zap.Logger) {
 	var dataPoints pmetric.NumberDataPointSlice
 
 	switch metricType := from.Type(); metricType {
 	case pmetric.MetricTypeGauge:
+		to.SetEmptyGauge()
 		dataPoints = from.Gauge().DataPoints()
 	case pmetric.MetricTypeSum:
+		to.SetEmptySum()
 		dataPoints = from.Sum().DataPoints()
+	default:
+		logger.Debug(fmt.Sprintf("Calculations are only supported on gauge or sum metric types. Given metric '%s' is of type `%s`", from.Name(), metricType.String()))
+		return
 	}
 
 	for i := 0; i < dataPoints.Len(); i++ {
@@ -80,7 +92,14 @@ func addDoubleDataPoints(from pmetric.Metric, to pmetric.Metric, operand2 float6
 			operand1 = float64(fromDataPoint.IntValue())
 		}
 
-		neweDoubleDataPoint := to.Gauge().DataPoints().AppendEmpty()
+		var neweDoubleDataPoint pmetric.NumberDataPoint
+		switch to.Type() {
+		case pmetric.MetricTypeGauge:
+			neweDoubleDataPoint = to.Gauge().DataPoints().AppendEmpty()
+		case pmetric.MetricTypeSum:
+			neweDoubleDataPoint = to.Sum().DataPoints().AppendEmpty()
+		}
+
 		fromDataPoint.CopyTo(neweDoubleDataPoint)
 		value := calculateValue(operand1, operand2, operation, logger, to.Name())
 		neweDoubleDataPoint.SetDoubleValue(value)

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_test.go
@@ -3,6 +3,7 @@
 package metadata
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics_test.go
@@ -3,7 +3,6 @@
 package metadata
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	"testing"
 
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The metrics generation processor would previously hit a panic when the calculation rule was operating on a `sum` metric, instead of a `gauge`. The [component proposal](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/2722), [initial implementation](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/3433), nor the [README](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/metricsgenerationprocessor) state that it's a requirement for the metric to be a `gauge`, nor do I think this requirement makes sense.

I've updated the logic to account for sum metrics being used and added a test.

**Testing:** <Describe what testing was performed and which tests were added.>
Added a test for this situation, the test panics before the change and passes after.