### PR TITLE
[exporter/elasticsearch] Drop cumulative temporality histogram and exponential histogram

### DIFF
--- a/.chloggen/elasticsearchexporter_drop-cumulative-histogram-exponential-histogram.yaml
+++ b/.chloggen/elasticsearchexporter_drop-cumulative-histogram-exponential-histogram.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Drop cumulative temporality histogram and exponential histogram
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35442]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Cumulative temporality histogram and exponential histogram are not supported by Elasticsearch
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/elasticsearchexporter_drop-non-delta-histogram-exponential-histogram.yaml
+++ b/.chloggen/elasticsearchexporter_drop-non-delta-histogram-exponential-histogram.yaml
@@ -15,7 +15,7 @@ issues: [35442]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Cumulative temporality histogram and exponential histogram are not supported by Elasticsearch
+subtext: Cumulative temporality histogram and exponential histogram are not supported by Elasticsearch. Use cumulativetodeltaprocessor to convert cumulative temporality to delta temporality. 
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/elasticsearchexporter_drop-non-delta-histogram-exponential-histogram.yaml
+++ b/.chloggen/elasticsearchexporter_drop-non-delta-histogram-exponential-histogram.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Drop non-delta temporality histogram and exponential histogram
+note: Drop cumulative temporality histogram and exponential histogram
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [35442]

--- a/.chloggen/elasticsearchexporter_drop-non-delta-histogram-exponential-histogram.yaml
+++ b/.chloggen/elasticsearchexporter_drop-non-delta-histogram-exponential-histogram.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Drop cumulative temporality histogram and exponential histogram
+note: Drop non-delta temporality histogram and exponential histogram
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [35442]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -235,8 +235,8 @@ The metric types supported are:
 
 - Gauge
 - Sum
-- Histogram
-- Exponential histogram
+- Histogram (Delta temporality only)
+- Exponential histogram (Delta temporality only)
 - Summary
 
 [confighttp]: https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp/README.md#http-configuration-settings

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -238,6 +238,10 @@ func (e *elasticsearchExporter) pushMetricsData(
 						}
 					}
 				case pmetric.MetricTypeExponentialHistogram:
+					if metric.ExponentialHistogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+						errs = append(errs, errors.New("cumulative temporality exponential histograms are not supported"))
+						continue
+					}
 					dps := metric.ExponentialHistogram().DataPoints()
 					for l := 0; l < dps.Len(); l++ {
 						dp := dps.At(l)
@@ -247,6 +251,10 @@ func (e *elasticsearchExporter) pushMetricsData(
 						}
 					}
 				case pmetric.MetricTypeHistogram:
+					if metric.Histogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+						errs = append(errs, errors.New("cumulative temporality histograms are not supported"))
+						continue
+					}
 					dps := metric.Histogram().DataPoints()
 					for l := 0; l < dps.Len(); l++ {
 						dp := dps.At(l)

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -252,7 +252,7 @@ func (e *elasticsearchExporter) pushMetricsData(
 					}
 				case pmetric.MetricTypeHistogram:
 					if metric.Histogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-						errs = append(errs, errors.New("dropping cumulative temporality histogram"))
+						errs = append(errs, fmt.Errorf("dropping cumulative temporality histogram %s", metric.Name()))
 						continue
 					}
 					dps := metric.Histogram().DataPoints()

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -239,7 +239,7 @@ func (e *elasticsearchExporter) pushMetricsData(
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					if metric.ExponentialHistogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-						errs = append(errs, fmt.Errorf("dropping cumulative temporality exponential histogram %s", metric.Name()))
+						errs = append(errs, fmt.Errorf("dropping cumulative temporality exponential histogram %q", metric.Name()))
 						continue
 					}
 					dps := metric.ExponentialHistogram().DataPoints()
@@ -252,7 +252,7 @@ func (e *elasticsearchExporter) pushMetricsData(
 					}
 				case pmetric.MetricTypeHistogram:
 					if metric.Histogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-						errs = append(errs, fmt.Errorf("dropping cumulative temporality histogram %s", metric.Name()))
+						errs = append(errs, fmt.Errorf("dropping cumulative temporality histogram %q", metric.Name()))
 						continue
 					}
 					dps := metric.Histogram().DataPoints()

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -238,8 +238,8 @@ func (e *elasticsearchExporter) pushMetricsData(
 						}
 					}
 				case pmetric.MetricTypeExponentialHistogram:
-					if metric.ExponentialHistogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-						errs = append(errs, errors.New("cumulative temporality exponential histograms are not supported"))
+					if metric.ExponentialHistogram().AggregationTemporality() != pmetric.AggregationTemporalityDelta {
+						errs = append(errs, errors.New("dropping non-delta temporality exponential histogram"))
 						continue
 					}
 					dps := metric.ExponentialHistogram().DataPoints()
@@ -251,8 +251,8 @@ func (e *elasticsearchExporter) pushMetricsData(
 						}
 					}
 				case pmetric.MetricTypeHistogram:
-					if metric.Histogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-						errs = append(errs, errors.New("cumulative temporality histograms are not supported"))
+					if metric.Histogram().AggregationTemporality() != pmetric.AggregationTemporalityDelta {
+						errs = append(errs, errors.New("dropping non-delta temporality histogram"))
 						continue
 					}
 					dps := metric.Histogram().DataPoints()

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -238,8 +238,8 @@ func (e *elasticsearchExporter) pushMetricsData(
 						}
 					}
 				case pmetric.MetricTypeExponentialHistogram:
-					if metric.ExponentialHistogram().AggregationTemporality() != pmetric.AggregationTemporalityDelta {
-						errs = append(errs, errors.New("dropping non-delta temporality exponential histogram"))
+					if metric.ExponentialHistogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+						errs = append(errs, errors.New("dropping cumulative temporality exponential histogram"))
 						continue
 					}
 					dps := metric.ExponentialHistogram().DataPoints()
@@ -251,8 +251,8 @@ func (e *elasticsearchExporter) pushMetricsData(
 						}
 					}
 				case pmetric.MetricTypeHistogram:
-					if metric.Histogram().AggregationTemporality() != pmetric.AggregationTemporalityDelta {
-						errs = append(errs, errors.New("dropping non-delta temporality histogram"))
+					if metric.Histogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
+						errs = append(errs, errors.New("dropping cumulative temporality histogram"))
 						continue
 					}
 					dps := metric.Histogram().DataPoints()

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -239,7 +239,7 @@ func (e *elasticsearchExporter) pushMetricsData(
 					}
 				case pmetric.MetricTypeExponentialHistogram:
 					if metric.ExponentialHistogram().AggregationTemporality() == pmetric.AggregationTemporalityCumulative {
-						errs = append(errs, errors.New("dropping cumulative temporality exponential histogram"))
+						errs = append(errs, fmt.Errorf("dropping cumulative temporality exponential histogram %s", metric.Name()))
 						continue
 					}
 					dps := metric.ExponentialHistogram().DataPoints()

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -802,7 +802,7 @@ func TestExporterMetrics(t *testing.T) {
 	})
 
 	t.Run("publish histogram cumulative temporality", func(t *testing.T) {
-		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+		server := newESTestServer(t, func(_ []itemRequest) ([]itemResponse, error) {
 			require.Fail(t, "unexpected request")
 			return nil, nil
 		})
@@ -829,7 +829,7 @@ func TestExporterMetrics(t *testing.T) {
 	})
 
 	t.Run("publish exponential histogram cumulative temporality", func(t *testing.T) {
-		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+		server := newESTestServer(t, func(_ []itemRequest) ([]itemResponse, error) {
 			require.Fail(t, "unexpected request")
 			return nil, nil
 		})

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -825,7 +825,7 @@ func TestExporterMetrics(t *testing.T) {
 		fooDp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 
 		err := exporter.ConsumeMetrics(context.Background(), metrics)
-		assert.ErrorContains(t, err, "dropping cumulative temporality histogram")
+		assert.ErrorContains(t, err, "dropping cumulative temporality histogram \"metric.foo\"")
 	})
 
 	t.Run("publish exponential histogram cumulative temporality", func(t *testing.T) {
@@ -856,7 +856,7 @@ func TestExporterMetrics(t *testing.T) {
 		fooDp.Negative().BucketCounts().FromRaw([]uint64{1, 0, 0, 1})
 
 		err := exporter.ConsumeMetrics(context.Background(), metrics)
-		assert.ErrorContains(t, err, "dropping cumulative temporality exponential histogram")
+		assert.ErrorContains(t, err, "dropping cumulative temporality exponential histogram \"metric.foo\"")
 	})
 
 	t.Run("publish only valid data points", func(t *testing.T) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -825,7 +825,7 @@ func TestExporterMetrics(t *testing.T) {
 		fooDp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 
 		err := exporter.ConsumeMetrics(context.Background(), metrics)
-		assert.ErrorContains(t, err, "dropping non-delta temporality histogram")
+		assert.ErrorContains(t, err, "dropping cumulative temporality histogram")
 	})
 
 	t.Run("publish exponential histogram cumulative temporality", func(t *testing.T) {
@@ -856,7 +856,7 @@ func TestExporterMetrics(t *testing.T) {
 		fooDp.Negative().BucketCounts().FromRaw([]uint64{1, 0, 0, 1})
 
 		err := exporter.ConsumeMetrics(context.Background(), metrics)
-		assert.ErrorContains(t, err, "dropping non-delta temporality exponential histogram")
+		assert.ErrorContains(t, err, "dropping cumulative temporality exponential histogram")
 	})
 
 	t.Run("publish only valid data points", func(t *testing.T) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -797,6 +797,64 @@ func TestExporterMetrics(t *testing.T) {
 		assertItemsEqual(t, expected, rec.Items(), false)
 	})
 
+	t.Run("publish histogram cumulative temporality", func(t *testing.T) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+			require.Fail(t, "unexpected request")
+			return nil, nil
+		})
+
+		exporter := newTestMetricsExporter(t, server.URL, func(cfg *Config) {
+			cfg.Mapping.Mode = "ecs"
+		})
+
+		metrics := pmetric.NewMetrics()
+		resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+		scopeA := resourceMetrics.ScopeMetrics().AppendEmpty()
+		metricSlice := scopeA.Metrics()
+		fooMetric := metricSlice.AppendEmpty()
+		fooMetric.SetName("metric.foo")
+		fooHistogram := fooMetric.SetEmptyHistogram()
+		fooHistogram.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		fooDps := fooHistogram.DataPoints()
+		fooDp := fooDps.AppendEmpty()
+		fooDp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 3.0})
+		fooDp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
+
+		err := exporter.ConsumeMetrics(context.Background(), metrics)
+		assert.ErrorContains(t, err, "cumulative temporality histograms are not supported")
+	})
+
+	t.Run("publish exponential histogram cumulative temporality", func(t *testing.T) {
+		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
+			require.Fail(t, "unexpected request")
+			return nil, nil
+		})
+
+		exporter := newTestMetricsExporter(t, server.URL, func(cfg *Config) {
+			cfg.Mapping.Mode = "ecs"
+		})
+
+		metrics := pmetric.NewMetrics()
+		resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+		scopeA := resourceMetrics.ScopeMetrics().AppendEmpty()
+		metricSlice := scopeA.Metrics()
+		fooMetric := metricSlice.AppendEmpty()
+		fooMetric.SetName("metric.foo")
+		fooHistogram := fooMetric.SetEmptyExponentialHistogram()
+		fooHistogram.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		fooDps := fooHistogram.DataPoints()
+		fooDp := fooDps.AppendEmpty()
+		fooDp.SetZeroCount(2)
+		fooDp.Positive().SetOffset(1)
+		fooDp.Positive().BucketCounts().FromRaw([]uint64{0, 1, 1, 0})
+
+		fooDp.Negative().SetOffset(1)
+		fooDp.Negative().BucketCounts().FromRaw([]uint64{1, 0, 0, 1})
+
+		err := exporter.ConsumeMetrics(context.Background(), metrics)
+		assert.ErrorContains(t, err, "cumulative temporality exponential histograms are not supported")
+	})
+
 	t.Run("publish only valid data points", func(t *testing.T) {
 		rec := newBulkRecorder()
 		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -730,7 +730,9 @@ func TestExporterMetrics(t *testing.T) {
 		metricSlice := scopeA.Metrics()
 		fooMetric := metricSlice.AppendEmpty()
 		fooMetric.SetName("metric.foo")
-		fooDps := fooMetric.SetEmptyHistogram().DataPoints()
+		fooHistogram := fooMetric.SetEmptyHistogram()
+		fooHistogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+		fooDps := fooHistogram.DataPoints()
 		fooDp := fooDps.AppendEmpty()
 		fooDp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 3.0})
 		fooDp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
@@ -774,7 +776,9 @@ func TestExporterMetrics(t *testing.T) {
 		metricSlice := scopeA.Metrics()
 		fooMetric := metricSlice.AppendEmpty()
 		fooMetric.SetName("metric.foo")
-		fooDps := fooMetric.SetEmptyExponentialHistogram().DataPoints()
+		fooHistogram := fooMetric.SetEmptyExponentialHistogram()
+		fooHistogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+		fooDps := fooHistogram.DataPoints()
 		fooDp := fooDps.AppendEmpty()
 		fooDp.SetZeroCount(2)
 		fooDp.Positive().SetOffset(1)
@@ -821,7 +825,7 @@ func TestExporterMetrics(t *testing.T) {
 		fooDp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})
 
 		err := exporter.ConsumeMetrics(context.Background(), metrics)
-		assert.ErrorContains(t, err, "cumulative temporality histograms are not supported")
+		assert.ErrorContains(t, err, "dropping non-delta temporality histogram")
 	})
 
 	t.Run("publish exponential histogram cumulative temporality", func(t *testing.T) {
@@ -852,7 +856,7 @@ func TestExporterMetrics(t *testing.T) {
 		fooDp.Negative().BucketCounts().FromRaw([]uint64{1, 0, 0, 1})
 
 		err := exporter.ConsumeMetrics(context.Background(), metrics)
-		assert.ErrorContains(t, err, "cumulative temporality exponential histograms are not supported")
+		assert.ErrorContains(t, err, "dropping non-delta temporality exponential histogram")
 	})
 
 	t.Run("publish only valid data points", func(t *testing.T) {
@@ -872,7 +876,9 @@ func TestExporterMetrics(t *testing.T) {
 		metricSlice := scopeA.Metrics()
 		fooMetric := metricSlice.AppendEmpty()
 		fooMetric.SetName("metric.foo")
-		fooDps := fooMetric.SetEmptyHistogram().DataPoints()
+		fooHistogram := fooMetric.SetEmptyHistogram()
+		fooHistogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+		fooDps := fooHistogram.DataPoints()
 		fooDp := fooDps.AppendEmpty()
 		fooDp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 3.0})
 		fooDp.BucketCounts().FromRaw([]uint64{})
@@ -925,7 +931,9 @@ func TestExporterMetrics(t *testing.T) {
 		metricSlice := scopeA.Metrics()
 		fooMetric := metricSlice.AppendEmpty()
 		fooMetric.SetName("metric.foo")
-		fooDps := fooMetric.SetEmptyHistogram().DataPoints()
+		fooHistogram := fooMetric.SetEmptyHistogram()
+		fooHistogram.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+		fooDps := fooHistogram.DataPoints()
 		fooDp := fooDps.AppendEmpty()
 		fooDp.ExplicitBounds().FromRaw([]float64{1.0, 2.0, 3.0})
 		fooDp.BucketCounts().FromRaw([]uint64{1, 2, 3, 4})


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
Drop histogram and exponential histogram with cumulative temporality as they are not supported by Elasticsearch

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
