### PR TITLE
[cmd/opampsupervisor] Add configurable supervisor logging

### DIFF
--- a/.chloggen/configurable-supervisor-logging.yaml
+++ b/.chloggen/configurable-supervisor-logging.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add configurable logging for the supervisor.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35466]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1,14 +1,14 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build e2e
-
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -40,10 +40,12 @@ import (
 	"github.com/stretchr/testify/require"
 	semconv "go.opentelemetry.io/collector/semconv/v1.21.0"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/telemetry"
 )
 
 var _ clientTypes.Logger = testLogger{}
@@ -1352,6 +1354,78 @@ func TestSupervisorStopsAgentProcessWithEmptyConfigMap(t *testing.T) {
 		require.ErrorContains(t, err, "No connection could be made")
 	}
 
+}
+
+type LogEntry struct {
+	Level string `json:"level"`
+}
+
+func TestSupervisorInfoLoggingLevel(t *testing.T) {
+	storageDir := t.TempDir()
+	remoteCfgFilePath := filepath.Join(storageDir, "last_recv_remote_config.dat")
+
+	collectorCfg, hash, _, _ := createSimplePipelineCollectorConf(t)
+	remoteCfgProto := &protobufs.AgentRemoteConfig{
+		Config: &protobufs.AgentConfigMap{
+			ConfigMap: map[string]*protobufs.AgentConfigFile{
+				"": {Body: collectorCfg.Bytes()},
+			},
+		},
+		ConfigHash: hash,
+	}
+	marshalledRemoteCfg, err := proto.Marshal(remoteCfgProto)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(remoteCfgFilePath, marshalledRemoteCfg, 0600))
+
+	connected := atomic.Bool{}
+	server := newUnstartedOpAMPServer(t, defaultConnectingHandler, server.ConnectionCallbacksStruct{
+		OnConnectedFunc: func(ctx context.Context, conn types.Connection) {
+			connected.Store(true)
+		},
+	})
+	defer server.shutdown()
+
+	supervisorLogFilePath := filepath.Join(storageDir, "supervisor_log.log")
+	cfgFile := getSupervisorConfig(t, "logging", map[string]string{
+		"url":         server.addr,
+		"storage_dir": storageDir,
+		"log_level":   "0",
+		"log_file":    supervisorLogFilePath,
+	})
+
+	cfg, err := config.Load(cfgFile.Name())
+	require.NoError(t, err)
+	logger, err := telemetry.NewLogger(cfg.Telemetry.Logs)
+	require.NoError(t, err)
+
+	s, err := supervisor.NewSupervisor(logger, cfg)
+	require.NoError(t, err)
+	require.Nil(t, s.Start())
+
+	// Start the server and wait for the supervisor to connect
+	server.start()
+	waitForSupervisorConnection(server.supervisorConnected, true)
+	require.True(t, connected.Load(), "Supervisor failed to connect")
+
+	s.Shutdown()
+
+	// Read from log file checking for Info level logs
+	logFile, err := os.Open(supervisorLogFilePath)
+	require.NoError(t, err)
+	defer logFile.Close()
+
+	scanner := bufio.NewScanner(logFile)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var log LogEntry
+		err := json.Unmarshal(line, &log)
+		require.NoError(t, err)
+
+		level, err := zapcore.ParseLevel(log.Level)
+		require.NoError(t, err)
+		require.GreaterOrEqual(t, level, zapcore.InfoLevel)
+	}
 }
 
 func findRandomPort() (int, error) {

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1,6 +1,8 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build e2e
+
 package main
 
 import (
@@ -1415,8 +1417,12 @@ func TestSupervisorInfoLoggingLevel(t *testing.T) {
 	defer logFile.Close()
 
 	scanner := bufio.NewScanner(logFile)
-
+	check := false
 	for scanner.Scan() {
+		if !check {
+			check = true
+		}
+
 		line := scanner.Bytes()
 		var log LogEntry
 		err := json.Unmarshal(line, &log)
@@ -1426,6 +1432,8 @@ func TestSupervisorInfoLoggingLevel(t *testing.T) {
 		require.NoError(t, err)
 		require.GreaterOrEqual(t, level, zapcore.InfoLevel)
 	}
+	// verify at least 1 log was read
+	require.True(t, check)
 }
 
 func findRandomPort() (int, error) {

--- a/cmd/opampsupervisor/main.go
+++ b/cmd/opampsupervisor/main.go
@@ -10,13 +10,14 @@ import (
 	"os/signal"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/telemetry"
 )
 
 func main() {
 	configFlag := flag.String("config", "", "Path to a supervisor configuration file")
 	flag.Parse()
 
-<<<<<<< HEAD
 	// load & validate config
 	cfg, err := config.Load(*configFlag)
 	if err != nil {
@@ -34,11 +35,6 @@ func main() {
 		logger.Error(err.Error())
 		os.Exit(-1)
 		return
-=======
-	supervisor, err := supervisor.NewSupervisor(*configFlag)
-	if err != nil {
-		log.Fatal("failed to create new supervisor: %w", err)
->>>>>>> 4aa3ba6ab9 (create logger in NewSupervisor)
 	}
 
 	err = supervisor.Start()

--- a/cmd/opampsupervisor/main.go
+++ b/cmd/opampsupervisor/main.go
@@ -4,25 +4,19 @@
 package main
 
 import (
-	"errors"
 	"flag"
-	"fmt"
 	"log"
 	"os"
 	"os/signal"
 
-	"github.com/knadh/koanf/parsers/yaml"
-	"github.com/knadh/koanf/providers/file"
-	"github.com/knadh/koanf/v2"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/telemetry"
 )
 
 func main() {
 	configFlag := flag.String("config", "", "Path to a supervisor configuration file")
 	flag.Parse()
 
+<<<<<<< HEAD
 	// load & validate config
 	cfg, err := config.Load(*configFlag)
 	if err != nil {
@@ -40,39 +34,20 @@ func main() {
 		logger.Error(err.Error())
 		os.Exit(-1)
 		return
+=======
+	supervisor, err := supervisor.NewSupervisor(*configFlag)
+	if err != nil {
+		log.Fatal("failed to create new supervisor: %w", err)
+>>>>>>> 4aa3ba6ab9 (create logger in NewSupervisor)
 	}
 
 	err = supervisor.Start()
 	if err != nil {
-		logger.Error(err.Error())
-		os.Exit(-1)
-		return
+		log.Fatal("failed to start supervisor: %w", err)
 	}
 
 	interrupt := make(chan os.Signal, 1)
 	signal.Notify(interrupt, os.Interrupt)
 	<-interrupt
 	supervisor.Shutdown()
-}
-
-func loadConfig(configFile string) (config.Supervisor, error) {
-	if configFile == "" {
-		return config.Supervisor{}, errors.New("path to config file cannot be empty")
-	}
-
-	k := koanf.New("::")
-	if err := k.Load(file.Provider(configFile), yaml.Parser()); err != nil {
-		return config.Supervisor{}, err
-	}
-
-	decodeConf := koanf.UnmarshalConf{
-		Tag: "mapstructure",
-	}
-
-	cfg := config.DefaultSupervisor()
-	if err := k.UnmarshalWithConf("", &cfg, decodeConf); err != nil {
-		return config.Supervisor{}, fmt.Errorf("cannot parse %v: %w", configFile, err)
-	}
-
-	return cfg, nil
 }

--- a/cmd/opampsupervisor/main.go
+++ b/cmd/opampsupervisor/main.go
@@ -18,13 +18,11 @@ func main() {
 	configFlag := flag.String("config", "", "Path to a supervisor configuration file")
 	flag.Parse()
 
-	// load & validate config
 	cfg, err := config.Load(*configFlag)
 	if err != nil {
 		log.Fatal("failed to load config: %w", err)
 	}
 
-	// create logger
 	logger, err := telemetry.NewLogger(cfg.Telemetry.Logs)
 	if err != nil {
 		log.Fatal("failed to create logger: %w", err)

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/knadh/koanf/v2"
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"go.opentelemetry.io/collector/config/configtls"
+	"go.uber.org/zap/zapcore"
 )
 
 // Supervisor is the Supervisor config file format.
@@ -26,6 +27,7 @@ type Supervisor struct {
 	Agent        Agent
 	Capabilities Capabilities `mapstructure:"capabilities"`
 	Storage      Storage      `mapstructure:"storage"`
+	Telemetry    Telemetry    `mapstructure:"telemetry"`
 }
 
 // Load loads the Supervisor config from a file.
@@ -183,6 +185,16 @@ func (a Agent) Validate() error {
 type AgentDescription struct {
 	IdentifyingAttributes    map[string]string `mapstructure:"identifying_attributes"`
 	NonIdentifyingAttributes map[string]string `mapstructure:"non_identifying_attributes"`
+}
+
+type Telemetry struct {
+	// TODO: flesh out other configurable telemetry options
+	Logs Logs `mapstructure:"logs"`
+}
+
+type Logs struct {
+	Level       zapcore.Level `mapstructure:"level"`
+	OutputPaths []string      `mapstructure:"output_paths"`
 }
 
 // DefaultSupervisor returns the default supervisor config

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -188,7 +188,8 @@ type AgentDescription struct {
 }
 
 type Telemetry struct {
-	// TODO: flesh out other configurable telemetry options
+	// TODO: Add more telemetry options
+	// Issue here: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35582
 	Logs Logs `mapstructure:"logs"`
 }
 

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -237,3 +237,25 @@ func DefaultSupervisor() Supervisor {
 		},
 	}
 }
+
+func LoadConfig(configFile string) (Supervisor, error) {
+	if configFile == "" {
+		return Supervisor{}, errors.New("path to config file cannot be empty")
+	}
+
+	k := koanf.New("::")
+	if err := k.Load(file.Provider(configFile), yaml.Parser()); err != nil {
+		return Supervisor{}, err
+	}
+
+	decodeConf := koanf.UnmarshalConf{
+		Tag: "mapstructure",
+	}
+
+	cfg := DefaultSupervisor()
+	if err := k.UnmarshalWithConf("", &cfg, decodeConf); err != nil {
+		return Supervisor{}, fmt.Errorf("cannot parse %v: %w", configFile, err)
+	}
+
+	return cfg, nil
+}

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -237,25 +237,3 @@ func DefaultSupervisor() Supervisor {
 		},
 	}
 }
-
-func LoadConfig(configFile string) (Supervisor, error) {
-	if configFile == "" {
-		return Supervisor{}, errors.New("path to config file cannot be empty")
-	}
-
-	k := koanf.New("::")
-	if err := k.Load(file.Provider(configFile), yaml.Parser()); err != nil {
-		return Supervisor{}, err
-	}
-
-	decodeConf := koanf.UnmarshalConf{
-		Tag: "mapstructure",
-	}
-
-	cfg := DefaultSupervisor()
-	if err := k.UnmarshalWithConf("", &cfg, decodeConf); err != nil {
-		return Supervisor{}, fmt.Errorf("cannot parse %v: %w", configFile, err)
-	}
-
-	return cfg, nil
-}

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -229,5 +229,11 @@ func DefaultSupervisor() Supervisor {
 			OrphanDetectionInterval: 5 * time.Second,
 			BootstrapTimeout:        3 * time.Second,
 		},
+		Telemetry: Telemetry{
+			Logs: Logs{
+				Level:       zapcore.InfoLevel,
+				OutputPaths: []string{"stdout", "stderr"},
+			},
+		},
 	}
 }

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -25,7 +25,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/knadh/koanf/maps"
 	"github.com/knadh/koanf/parsers/yaml"
-	"github.com/knadh/koanf/providers/file"
 	"github.com/knadh/koanf/providers/rawbytes"
 	"github.com/knadh/koanf/v2"
 	"github.com/open-telemetry/opamp-go/client"
@@ -254,28 +253,6 @@ func (s *Supervisor) createTemplates() error {
 	}
 	if s.ownTelemetryTemplate, err = template.New("owntelemetry").Parse(ownTelemetryTpl); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func (s *Supervisor) loadConfig(configFile string) error {
-	if configFile == "" {
-		return errors.New("path to config file cannot be empty")
-	}
-
-	k := koanf.New("::")
-	if err := k.Load(file.Provider(configFile), yaml.Parser()); err != nil {
-		return err
-	}
-
-	decodeConf := koanf.UnmarshalConf{
-		Tag: "mapstructure",
-	}
-
-	s.config = config.DefaultSupervisor()
-	if err := k.UnmarshalWithConf("", &s.config, decodeConf); err != nil {
-		return fmt.Errorf("cannot parse %v: %w", configFile, err)
 	}
 
 	return nil

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -150,6 +150,7 @@ type Supervisor struct {
 
 func NewSupervisor(logger *zap.Logger, cfg config.Supervisor) (*Supervisor, error) {
 	s := &Supervisor{
+		config:                       cfg,
 		logger:                       logger,
 		pidProvider:                  defaultPIDProvider{},
 		hasNewConfig:                 make(chan struct{}, 1),

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -42,7 +42,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/commander"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/healthchecker"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/telemetry"
 )
 
 var (
@@ -150,8 +149,10 @@ type Supervisor struct {
 	opampServerPort int
 }
 
-func NewSupervisor(configFile string) (*Supervisor, error) {
+func NewSupervisor(logger *zap.Logger, cfg config.Supervisor) (*Supervisor, error) {
 	s := &Supervisor{
+		config:                       cfg,
+		logger:                       logger,
 		pidProvider:                  defaultPIDProvider{},
 		hasNewConfig:                 make(chan struct{}, 1),
 		agentConfigOwnMetricsSection: &atomic.Value{},
@@ -166,32 +167,14 @@ func NewSupervisor(configFile string) (*Supervisor, error) {
 		return nil, err
 	}
 
-<<<<<<< HEAD
 	if err := cfg.Validate(); err != nil {
 		return nil, fmt.Errorf("error validating config: %w", err)
 	}
-
 	s.config = cfg
 
-=======
-	if err := s.loadConfig(configFile); err != nil {
-		return nil, fmt.Errorf("error loading config: %w", err)
-	}
-
-	if err := s.config.Validate(); err != nil {
-		return nil, fmt.Errorf("error validating config: %w", err)
-	}
-
->>>>>>> 4aa3ba6ab9 (create logger in NewSupervisor)
 	if err := os.MkdirAll(s.config.Storage.Directory, 0700); err != nil {
 		return nil, fmt.Errorf("error creating storage dir: %w", err)
 	}
-
-	logger, err := telemetry.NewLogger(s.config.Telemetry.Logs)
-	if err != nil {
-		return nil, fmt.Errorf("error creating logger: %w", err)
-	}
-	s.logger = logger
 
 	return s, nil
 }

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -150,7 +150,6 @@ type Supervisor struct {
 
 func NewSupervisor(logger *zap.Logger, cfg config.Supervisor) (*Supervisor, error) {
 	s := &Supervisor{
-		config:                       cfg,
 		logger:                       logger,
 		pidProvider:                  defaultPIDProvider{},
 		hasNewConfig:                 make(chan struct{}, 1),
@@ -200,7 +199,7 @@ func (s *Supervisor) Start() error {
 
 	s.agentHealthCheckEndpoint = fmt.Sprintf("localhost:%d", healthCheckPort)
 
-	s.logger.Debug("Supervisor starting",
+	s.logger.Info("Supervisor starting",
 		zap.String("id", s.persistentState.InstanceID.String()))
 
 	err = s.loadAndWriteInitialMergedConfig()

--- a/cmd/opampsupervisor/supervisor/telemetry/logger.go
+++ b/cmd/opampsupervisor/supervisor/telemetry/logger.go
@@ -4,8 +4,9 @@
 package telemetry
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
 )
 
 func NewLogger(cfg config.Logs) (*zap.Logger, error) {

--- a/cmd/opampsupervisor/supervisor/telemetry/logger.go
+++ b/cmd/opampsupervisor/supervisor/telemetry/logger.go
@@ -7,6 +7,7 @@ import (
 
 func NewLogger(cfg config.Logs) (*zap.Logger, error) {
 	zapCfg := zap.NewProductionConfig()
+
 	zapCfg.Level = zap.NewAtomicLevelAt(cfg.Level)
 	zapCfg.OutputPaths = cfg.OutputPaths
 

--- a/cmd/opampsupervisor/supervisor/telemetry/logger.go
+++ b/cmd/opampsupervisor/supervisor/telemetry/logger.go
@@ -1,0 +1,18 @@
+package telemetry
+
+import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/opampsupervisor/supervisor/config"
+	"go.uber.org/zap"
+)
+
+func NewLogger(cfg config.Logs) (*zap.Logger, error) {
+	zapCfg := zap.NewProductionConfig()
+	zapCfg.Level = zap.NewAtomicLevelAt(cfg.Level)
+	zapCfg.OutputPaths = cfg.OutputPaths
+
+	logger, err := zapCfg.Build()
+	if err != nil {
+		return nil, err
+	}
+	return logger, nil
+}

--- a/cmd/opampsupervisor/supervisor/telemetry/logger.go
+++ b/cmd/opampsupervisor/supervisor/telemetry/logger.go
@@ -1,3 +1,6 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package telemetry
 
 import (

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_logging.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_logging.yaml
@@ -1,0 +1,21 @@
+server:
+  endpoint: ws://{{.url}}/v1/opamp
+
+capabilities:
+  reports_effective_config: true
+  reports_own_metrics: true
+  reports_health: true
+  accepts_remote_config: true
+  reports_remote_config: true
+  accepts_restart_command: true
+
+storage:
+  directory: '{{.storage_dir}}'
+
+agent:
+  executable: ../../bin/otelcontribcol_{{.goos}}_{{.goarch}}{{.extension}}
+
+telemetry:
+  logs:
+    level: {{.log_level}} # info level logs
+    output_paths: ['{{.log_file}}']


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Adds configurable logging for the supervisor. Lays ground work to expand with more config options and to configure other telemetry signals. Meant to mimic how collector telemetry/logging is configured.

**Link to tracking Issue:** <Issue number if applicable> Closes #35466 

**Testing:** <Describe what testing was performed and which tests were added.>
Tested running the supervisor with default and different log levels and outputs specified.

**Documentation:** <Describe the documentation added.>