### PR TITLE
pkg/translator/prometheus: Allow not normalizing UTF8 characters

### DIFF
--- a/.chloggen/allowutf-prometheustranslator.yaml
+++ b/.chloggen/allowutf-prometheustranslator.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/translator/prometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow UTF-8 characters in Prometheus metric names and labels.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35459]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user, api]

--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -60,6 +60,10 @@ Given the example, metrics will be available at `https://1.2.3.4:1234/metrics`.
 
 OpenTelemetry metric names and attributes are normalized to be compliant with Prometheus naming rules. [Details on this normalization process are described in the Prometheus translator module](../../pkg/translator/prometheus/).
 
+Prometheus 2.55.0 introduced support for UTF-8 characters behind the feature-flag `utf8-names`. Prometheus 3.0.0 and later accept UTF-8 by default. This means that name and attribute normalization is not required if you're using those versions. To allow UTF-8 characters to be exposed without normalization, start the collector with the feature gate: `--feature-gates=pkg.translator.prometheus.allow_utf8`.
+
+The scraper must include `scaping=allow-utf-8` in the `Accept` header for UTF-8 characters to be exposed.
+
 ## Setting resource attributes as metric labels
 
 By default, resource attributes are added to a special metric called `target_info`. To select and group by metrics by resource attributes, you [need to do join on `target_info`](https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches). For example, to select metrics with `k8s_namespace_name` attribute equal to `my-namespace`:

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -11,9 +11,12 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	prometheustranslator "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
 )
 
 type prometheusExporter struct {
@@ -30,6 +33,10 @@ type prometheusExporter struct {
 var errBlankPrometheusAddress = errors.New("expecting a non-blank address to run the Prometheus metrics handler")
 
 func newPrometheusExporter(config *Config, set exporter.Settings) (*prometheusExporter, error) {
+	if prometheustranslator.AllowUTF8FeatureGate.IsEnabled() {
+		model.NameValidationScheme = model.UTF8Validation
+	}
+
 	addr := strings.TrimSpace(config.Endpoint)
 	if strings.TrimSpace(config.Endpoint) == "" {
 		return nil, errBlankPrometheusAddress

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -111,6 +111,8 @@ To enable it run collector with enabled feature gate `exporter.prometheusremotew
 
 OpenTelemetry metric names and attributes are normalized to be compliant with Prometheus naming rules. [Details on this normalization process are described in the Prometheus translator module](../../pkg/translator/prometheus/).
 
+Prometheus 2.55.0 introduced support for UTF-8 characters behind the feature-flag `utf8-names`. Prometheus 3.0.0 and later accept UTF-8 by default. This means that name and attribute normalization is not required if you're using those versions. To allow UTF-8 characters to be exposed without normalization, start the collector with the feature gate: `--feature-gates=pkg.translator.prometheus.allow_utf8`.
+
 ## Setting resource attributes as metric labels
 
 By default, resource attributes are added to a special metric called `target_info`. To select and group by metrics by resource attributes, you [need to do join on `target_info`](https://prometheus.io/docs/prometheus/latest/querying/operators/#many-to-one-and-one-to-many-vector-matches). For example, to select metrics with `k8s_namespace_name` attribute equal to `my-namespace`:

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/prompb"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -88,6 +89,10 @@ func newPRWTelemetry(set exporter.Settings) (prwTelemetry, error) {
 
 // newPRWExporter initializes a new prwExporter instance and sets fields accordingly.
 func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
+	if prometheustranslator.AllowUTF8FeatureGate.IsEnabled() {
+		model.NameValidationScheme = model.UTF8Validation
+	}
+
 	sanitizedLabels, err := validateAndSanitizeExternalLabels(cfg)
 	if err != nil {
 		return nil, err

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.111.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus v0.111.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheusremotewrite v0.111.0
+	github.com/prometheus/common v0.60.0
 	github.com/prometheus/prometheus v0.54.1
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/wal v1.1.7
@@ -55,7 +56,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
-	github.com/prometheus/common v0.60.0 // indirect
 	github.com/rs/cors v1.11.1 // indirect
 	github.com/tidwall/gjson v1.10.2 // indirect
 	github.com/tidwall/match v1.1.1 // indirect

--- a/pkg/translator/prometheus/feature_gates.go
+++ b/pkg/translator/prometheus/feature_gates.go
@@ -1,0 +1,53 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package prometheus // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/prometheus"
+
+import (
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+var (
+	dropSanitizationGate = featuregate.GlobalRegistry().MustRegister(
+		"pkg.translator.prometheus.PermissiveLabelSanitization",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("Controls whether to change labels starting with '_' to 'key_'."),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950"),
+	)
+
+	normalizeNameGate = featuregate.GlobalRegistry().MustRegister(
+		"pkg.translator.prometheus.NormalizeName",
+		featuregate.StageBeta,
+		featuregate.WithRegisterDescription("Controls whether metrics names are automatically normalized to follow Prometheus naming convention. Attention: if 'pkg.translator.prometheus.allowUTF8' is enabled, UTF-8 characters will not be normalized."),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/8950"),
+	)
+
+	// AllowUTF8FeatureGate could be a private variable, it is used mostly to toogle the
+	// value of a global variable and it's intended usage is:
+	/*
+		import "github.com/prometheus/common/model"
+
+		if AllowUTF8FeatureGate.IsEnabled() {
+			model.NameValidationScheme = model.UTF8Validation
+		}
+	*/
+	// We could do this with a init function in the translator package, but we can't guarantee that
+	// the featuregate.GlobalRegistry is initialized before the init function here.
+	//
+	// Components that want to respect this feature gate behavior should check if it is enabled and
+	// set the model.NameValidationScheme accordingly.
+	//
+	// WARNING: Since it's a global variable, if one component enables it then it works for all components
+	// that are using this package.
+	AllowUTF8FeatureGate = featuregate.GlobalRegistry().MustRegister(
+		"pkg.translator.prometheus.allowUTF8",
+		featuregate.StageAlpha,
+		featuregate.WithRegisterDescription("When enabled, UTF-8 characters will not be translated to underscores."),
+		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35459"),
+		featuregate.WithRegisterFromVersion("v0.110.0"),
+	)
+)
+
+func init() {
+
+}


### PR DESCRIPTION
## **Description:** <Describe what has changed.>

Update the Prometheus translation package to optionally allow UTF-8 characters in metric and label names. Motivated by Prometheus 2.55.0 and 3.0.0 finally accepting UTF8 characters 🙂 

## **Link to tracking Issue:** 
Fixes #35459 

## **Testing:** <Describe what testing was performed and which tests were added.>

Beyond the unit tests, I'm doing manual tests with this branch.

#### exporter/prometheus:

```console
$ curl -H 'Accept: application/openmetrics-text; escaping=allow-utf-8' localhost:8889/metrics
# HELP "run.total" The number of times the iteration ran
# TYPE "run.total" counter
{"run.total","attr.A"="chocolate.cake","attr.B"="raspberry","attr.C"="vanilla",job="test-service"} 10

$ curl -H 'Accept: application/openmetrics-text' localhost:8889/metrics
# HELP run_total The number of times the iteration ran
# TYPE run_total counter
run_total{attr_A="chocolate.cake",attr_B="raspberry",attr_C="vanilla",job="test-service"} 10
```

Metrics that don't have UTF8 characters are exposed as is, metrics that have follow the new exposition format

#### exporter/prometheusremotewrite

TODO

**Documentation:** <Describe the documentation added.>


