### PR TITLE
[chore]: use ErrorContains and EqualError

### DIFF
--- a/connector/countconnector/config_test.go
+++ b/connector/countconnector/config_test.go
@@ -515,8 +515,7 @@ func TestConfigErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.input.Validate()
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), tc.expect)
+			assert.ErrorContains(t, err, tc.expect)
 		})
 	}
 }

--- a/connector/sumconnector/config_test.go
+++ b/connector/sumconnector/config_test.go
@@ -574,8 +574,7 @@ func TestConfigErrors(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.input.Validate()
-			assert.Error(t, err)
-			assert.Contains(t, err.Error(), tc.expect)
+			assert.ErrorContains(t, err, tc.expect)
 		})
 	}
 }

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -40,8 +40,7 @@ func TestLogsExporter_New(t *testing.T) {
 
 	failWithMsg := func(msg string) validate {
 		return func(t *testing.T, _ *logsExporter, err error) {
-			require.Error(t, err)
-			require.Contains(t, err.Error(), msg)
+			require.ErrorContains(t, err, msg)
 		}
 	}
 

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -131,18 +131,15 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 	texp := newTracesExporter(c, exportertest.NewNopSettings())
 	require.NotNil(t, texp)
 	err := texp.start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 	mexp := newMetricsExporter(c, exportertest.NewNopSettings())
 	require.NotNil(t, mexp)
 	err = mexp.start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 	lexp := newLogsExporter(c, exportertest.NewNopSettings())
 	require.NotNil(t, lexp)
 	err = lexp.start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 
 }
 
@@ -157,7 +154,7 @@ func TestNewExporter_err_compression(t *testing.T) {
 	require.NotNil(t, texp)
 	err := texp.start(context.Background(), componenttest.NewNopHost())
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "producer.compression should be one of 'none', 'gzip', 'snappy', 'lz4', or 'zstd'. configured value idk")
+	assert.ErrorContains(t, err, "producer.compression should be one of 'none', 'gzip', 'snappy', 'lz4', or 'zstd'. configured value idk")
 }
 
 func TestTracesExporter_encoding_extension(t *testing.T) {
@@ -249,8 +246,7 @@ func TestTracesPusher_marshal_error(t *testing.T) {
 	}
 	td := testdata.GenerateTraces(2)
 	err := p.tracesPusher(context.Background(), td)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), expErr.Error())
+	assert.ErrorContains(t, err, expErr.Error())
 }
 
 func TestMetricsDataPusher(t *testing.T) {
@@ -331,8 +327,7 @@ func TestMetricsDataPusher_marshal_error(t *testing.T) {
 	}
 	md := testdata.GenerateMetrics(2)
 	err := p.metricsDataPusher(context.Background(), md)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), expErr.Error())
+	assert.ErrorContains(t, err, expErr.Error())
 }
 
 func TestLogsDataPusher(t *testing.T) {
@@ -413,8 +408,7 @@ func TestLogsDataPusher_marshal_error(t *testing.T) {
 	}
 	ld := testdata.GenerateLogs(1)
 	err := p.logsDataPusher(context.Background(), ld)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), expErr.Error())
+	assert.ErrorContains(t, err, expErr.Error())
 }
 
 type tracesErrorMarshaler struct {

--- a/exporter/lokiexporter/config_test.go
+++ b/exporter/lokiexporter/config_test.go
@@ -122,8 +122,7 @@ func TestConfigValidate(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := tc.cfg.Validate()
 			if tc.err != nil {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tc.err.Error())
+				assert.ErrorContains(t, err, tc.err.Error())
 			} else {
 				require.NoError(t, err)
 			}

--- a/exporter/otelarrowexporter/internal/arrow/stream_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream_test.go
@@ -247,12 +247,10 @@ func TestStreamStatusUnavailableInvalid(t *testing.T) {
 			}()
 			// sender should get "test unavailable" once, success second time.
 			err := tc.mustSendAndWait()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "test unavailable")
+			require.ErrorContains(t, err, "test unavailable")
 
 			err = tc.mustSendAndWait()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "test invalid")
+			require.ErrorContains(t, err, "test invalid")
 
 			err = tc.mustSendAndWait()
 			require.NoError(t, err)
@@ -282,8 +280,7 @@ func TestStreamStatusUnrecognized(t *testing.T) {
 				channel.recv <- statusUnrecognizedFor(batch.BatchId)
 			}()
 			err := tc.mustSendAndWait()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), "test unrecognized")
+			require.ErrorContains(t, err, "test unrecognized")
 
 			// Note: do not cancel the context, the stream should be
 			// shutting down due to the error.

--- a/exporter/otelarrowexporter/metadata_test.go
+++ b/exporter/otelarrowexporter/metadata_test.go
@@ -121,9 +121,8 @@ func TestDuplicateMetadataKeys(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.MetadataKeys = []string{"myTOKEN", "mytoken"}
 	err := cfg.Validate()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "duplicate")
-	require.Contains(t, err.Error(), "mytoken")
+	require.ErrorContains(t, err, "duplicate")
+	require.ErrorContains(t, err, "mytoken")
 }
 
 func TestMetadataExporterCardinalityLimit(t *testing.T) {
@@ -196,7 +195,7 @@ func TestMetadataExporterCardinalityLimit(t *testing.T) {
 	err = exp.ConsumeTraces(ctx, td)
 	require.Error(t, err)
 	assert.True(t, consumererror.IsPermanent(err))
-	assert.Contains(t, err.Error(), "too many")
+	assert.ErrorContains(t, err, "too many")
 
 	assert.Eventually(t, func() bool {
 		return rcv.requestCount.Load() == int32(cardLimit)

--- a/exporter/otelarrowexporter/otelarrow_test.go
+++ b/exporter/otelarrowexporter/otelarrow_test.go
@@ -1133,8 +1133,7 @@ func TestSendArrowFailedTraces(t *testing.T) {
 	// Send two trace items.
 	td := testdata.GenerateTraces(2)
 	err = exp.ConsumeTraces(context.Background(), td)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "test failed")
+	assert.ErrorContains(t, err, "test failed")
 
 	// Wait until it is received.
 	assert.Eventually(t, func() bool {

--- a/exporter/signalfxexporter/exporter_test.go
+++ b/exporter/signalfxexporter/exporter_test.go
@@ -218,7 +218,7 @@ func TestConsumeMetrics(t *testing.T) {
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
 				assert.True(t, strings.HasPrefix(err.Error(), tt.expectedErrorMsg))
-				assert.Contains(t, err.Error(), "response content")
+				assert.ErrorContains(t, err, "response content")
 				return
 			}
 
@@ -1843,7 +1843,7 @@ func TestConsumeMixedMetrics(t *testing.T) {
 				assert.Error(t, err)
 				assert.True(t, consumererror.IsPermanent(err))
 				assert.True(t, strings.HasPrefix(err.Error(), tt.expectedErrorMsg))
-				assert.Contains(t, err.Error(), "response content")
+				assert.ErrorContains(t, err, "response content")
 				return
 			}
 

--- a/exporter/signalfxexporter/internal/correlation/correlation_test.go
+++ b/exporter/signalfxexporter/internal/correlation/correlation_test.go
@@ -81,7 +81,7 @@ func TestTrackerStart(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				if tt.errMsg != "" {
-					require.Contains(t, err.Error(), tt.errMsg)
+					require.ErrorContains(t, err, tt.errMsg)
 				}
 			} else {
 				require.NoError(t, err)

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1608,9 +1608,9 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	// Sending logs using the client.
 	err := splunkClient.pushLogData(context.Background(), logs)
 	require.True(t, consumererror.IsPermanent(err), "Expecting permanent error")
-	require.Contains(t, err.Error(), "HTTP/0.0 400")
+	require.ErrorContains(t, err, "HTTP/0.0 400")
 	// The returned error should contain the response body responseBody.
-	assert.Contains(t, err.Error(), responseBody)
+	assert.ErrorContains(t, err, responseBody)
 
 	// An HTTP client that returns some other status code other than 400 and response body responseBody.
 	httpClient, _ = newTestClient(500, responseBody)
@@ -1618,7 +1618,7 @@ func Test_pushLogData_ShouldAddResponseTo400Error(t *testing.T) {
 	// Sending logs using the client.
 	err = splunkClient.pushLogData(context.Background(), logs)
 	require.False(t, consumererror.IsPermanent(err), "Expecting non-permanent error")
-	require.Contains(t, err.Error(), "HTTP 500")
+	require.ErrorContains(t, err, "HTTP 500")
 	// The returned error should not contain the response body responseBody.
 	assert.NotContains(t, err.Error(), responseBody)
 }
@@ -1953,7 +1953,7 @@ func Test_pushLogData_Small_MaxContentLength(t *testing.T) {
 		require.Error(t, err)
 
 		assert.True(t, consumererror.IsPermanent(err))
-		assert.Contains(t, err.Error(), "dropped log event")
+		assert.ErrorContains(t, err, "dropped log event")
 	}
 }
 

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -82,8 +82,7 @@ func TestOAuthClientSettings(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			rc, err := newClientAuthenticator(test.settings, zap.NewNop())
 			if test.shouldError {
-				assert.Error(t, err)
-				assert.Contains(t, err.Error(), test.expectedError)
+				assert.ErrorContains(t, err, test.expectedError)
 				return
 			}
 			assert.NoError(t, err)
@@ -296,7 +295,7 @@ func TestFailContactingOAuth(t *testing.T) {
 
 	_, err = credential.GetRequestMetadata(context.Background())
 	assert.ErrorIs(t, err, errFailedToGetSecurityToken)
-	assert.Contains(t, err.Error(), serverURL.String())
+	assert.ErrorContains(t, err, serverURL.String())
 
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	baseRoundTripper := (http.RoundTripper)(transport)
@@ -311,5 +310,5 @@ func TestFailContactingOAuth(t *testing.T) {
 	require.NoError(t, err)
 	_, err = client.Do(req)
 	assert.ErrorIs(t, err, errFailedToGetSecurityToken)
-	assert.Contains(t, err.Error(), serverURL.String())
+	assert.ErrorContains(t, err, serverURL.String())
 }

--- a/extension/observer/dockerobserver/config_test.go
+++ b/extension/observer/dockerobserver/config_test.go
@@ -99,8 +99,7 @@ func TestApiVersionCustomError(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	err := sub.Unmarshal(cfg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(),
+	assert.ErrorContains(t, err,
 		`Hint: You may want to wrap the 'api_version' value in quotes (api_version: "1.40")`,
 	)
 

--- a/extension/observer/ecsobserver/task_test.go
+++ b/extension/observer/ecsobserver/task_test.go
@@ -90,7 +90,7 @@ func TestTask_PrivateIP(t *testing.T) {
 			assert.Equal(t, mode, errPINF.NetworkMode)
 			// doing contains on error message is not good, but this line increase test coverage from 93% to 98%
 			// not sure how the average coverage is calculated ...
-			assert.Contains(t, err.Error(), mode)
+			assert.ErrorContains(t, err, mode)
 		}
 	})
 }
@@ -185,7 +185,7 @@ func TestTask_MappedPort(t *testing.T) {
 			errMPNF := &errMappedPortNotFound{}
 			require.ErrorAs(t, err, &errMPNF)
 			assert.Equal(t, mode, errMPNF.NetworkMode)
-			assert.Contains(t, err.Error(), mode) // for coverage
+			assert.ErrorContains(t, err, mode) // for coverage
 		}
 	})
 }

--- a/internal/aws/proxy/conn_test.go
+++ b/internal/aws/proxy/conn_test.go
@@ -255,8 +255,7 @@ func TestLoadEnvConfigCreds(t *testing.T) {
 	assert.Equal(t, cases.Val, value, "Expect the credentials value to match")
 
 	_, err = newAWSSession("ROLEARN", "TEST", zap.NewNop())
-	assert.Error(t, err, "expected error")
-	assert.Contains(t, err.Error(), "unable to handle AWS error", "expected error message")
+	assert.ErrorContains(t, err, "unable to handle AWS error", "expected error message")
 }
 
 func TestGetProxyUrlProxyAddressNotValid(t *testing.T) {
@@ -339,8 +338,7 @@ func TestProxyServerTransportInvalidProxyAddr(t *testing.T) {
 	_, err := proxyServerTransport(&Config{
 		ProxyAddress: "invalid\n",
 	})
-	assert.Error(t, err, "expected error")
-	assert.Contains(t, err.Error(), "invalid control character in URL")
+	assert.ErrorContains(t, err, "invalid control character in URL")
 }
 
 func TestProxyServerTransportHappyCase(t *testing.T) {

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -207,7 +207,7 @@ func TestCantGetServiceEndpoint(t *testing.T) {
 
 	_, err := NewServer(cfg, logger)
 	assert.Error(t, err, "NewServer should fail")
-	assert.Contains(t, err.Error(), "invalid region")
+	assert.ErrorContains(t, err, "invalid region")
 }
 
 func TestAWSEndpointInvalid(t *testing.T) {
@@ -222,7 +222,7 @@ func TestAWSEndpointInvalid(t *testing.T) {
 
 	_, err := NewServer(cfg, logger)
 	assert.Error(t, err, "NewServer should fail")
-	assert.Contains(t, err.Error(), "unable to parse AWS service endpoint")
+	assert.ErrorContains(t, err, "unable to parse AWS service endpoint")
 }
 
 func TestCanCreateTransport(t *testing.T) {
@@ -237,7 +237,7 @@ func TestCanCreateTransport(t *testing.T) {
 
 	_, err := NewServer(cfg, logger)
 	assert.Error(t, err, "NewServer should fail")
-	assert.Contains(t, err.Error(), "failed to parse proxy URL")
+	assert.ErrorContains(t, err, "failed to parse proxy URL")
 }
 
 func TestGetServiceEndpointInvalidAWSConfig(t *testing.T) {

--- a/internal/coreinternal/consumerretry/logs_test.go
+++ b/internal/coreinternal/consumerretry/logs_test.go
@@ -88,8 +88,7 @@ func TestConsumeLogs_ContextDeadline(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
 	defer cancel()
 	err := consumer.ConsumeLogs(ctx, testdata.GenerateLogsTwoLogRecordsSameResource())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "context is cancelled or timed out retry later")
+	assert.ErrorContains(t, err, "context is cancelled or timed out retry later")
 }
 
 func TestConsumeLogs_PartialRetry(t *testing.T) {

--- a/internal/coreinternal/timeutils/parser_test.go
+++ b/internal/coreinternal/timeutils/parser_test.go
@@ -13,8 +13,7 @@ import (
 
 func TestParseGoTimeBadLocation(t *testing.T) {
 	_, err := ParseGotime(time.RFC822, "02 Jan 06 15:04 BST", time.UTC)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to load location BST")
+	require.ErrorContains(t, err, "failed to load location BST")
 }
 
 func Test_setTimestampYear(t *testing.T) {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -62,8 +62,7 @@ func TestWatchingTimeouts(t *testing.T) {
 	shouldHaveTaken := time.Now().Add(100 * time.Millisecond).UnixNano()
 
 	err = cli.LoadContainerList(context.Background())
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), expectedError)
+	assert.ErrorContains(t, err, expectedError)
 	observed, logs := observer.New(zapcore.WarnLevel)
 	cli, err = NewDockerClient(config, zap.New(observed))
 	assert.NotNil(t, cli)
@@ -120,9 +119,8 @@ func TestFetchingTimeouts(t *testing.T) {
 	)
 
 	assert.Nil(t, statsJSON)
-	require.Error(t, err)
 
-	assert.Contains(t, err.Error(), expectedError)
+	assert.ErrorContains(t, err, expectedError)
 
 	assert.Len(t, logs.All(), 1)
 	for _, l := range logs.All() {

--- a/internal/kafka/authentication_test.go
+++ b/internal/kafka/authentication_test.go
@@ -155,8 +155,7 @@ func TestAuthentication(t *testing.T) {
 			config := &sarama.Config{}
 			err := ConfigureAuthentication(test.auth, config)
 			if test.err != "" {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), test.err)
+				assert.ErrorContains(t, err, test.err)
 			} else {
 				// equalizes SCRAMClientGeneratorFunc to do assertion with the same reference.
 				config.Net.SASL.SCRAMClientGeneratorFunc = test.saramaConfig.Net.SASL.SCRAMClientGeneratorFunc

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -627,5 +627,5 @@ func Test_replaceAllPatterns_invalid_model(t *testing.T) {
 	invalidMode := "invalid"
 	exprFunc, err := replaceAllPatterns[any](target, invalidMode, "regex", replacement, function, replacementFormat)
 	assert.Nil(t, exprFunc)
-	assert.Contains(t, err.Error(), "invalid mode")
+	assert.ErrorContains(t, err, "invalid mode")
 }

--- a/pkg/sampling/oteltracestate_test.go
+++ b/pkg/sampling/oteltracestate_test.go
@@ -87,7 +87,7 @@ func TestOpenTelemetryTraceStateRValuePValue(t *testing.T) {
 	require.Equal(t, "", otts.RValue())
 
 	// The error is oblivious to the old r-value, but that's ok.
-	require.Contains(t, err.Error(), "14 hex digits")
+	require.ErrorContains(t, err, "14 hex digits")
 
 	require.Equal(t, []KV{{"p", "2"}}, otts.ExtraValues())
 

--- a/pkg/stanza/entry/attribute_field_test.go
+++ b/pkg/stanza/entry/attribute_field_test.go
@@ -460,13 +460,11 @@ func TestAttributeFieldUnmarshalFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var fy AttributeField
 			err := yaml.UnmarshalStrict(tc.invalid, &fy)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 
 			var fj AttributeField
 			err = json.Unmarshal(tc.invalid, &fj)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
 }

--- a/pkg/stanza/entry/body_field_test.go
+++ b/pkg/stanza/entry/body_field_test.go
@@ -386,13 +386,11 @@ func TestBodyFieldUnmarshalFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var fy BodyField
 			err := yaml.UnmarshalStrict(tc.invalid, &fy)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 
 			var fj BodyField
 			err = json.Unmarshal(tc.invalid, &fj)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
 }

--- a/pkg/stanza/entry/entry_test.go
+++ b/pkg/stanza/entry/entry_test.go
@@ -275,8 +275,7 @@ func TestReadToInterfaceMapWithMissingField(t *testing.T) {
 	field := NewAttributeField("label")
 	dest := map[string]any{}
 	err := entry.readToInterfaceMap(field, &dest)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "can not be read as a map[string]any")
+	require.ErrorContains(t, err, "can not be read as a map[string]any")
 }
 
 func TestReadToStringMapWithMissingField(t *testing.T) {
@@ -284,8 +283,7 @@ func TestReadToStringMapWithMissingField(t *testing.T) {
 	field := NewAttributeField("label")
 	dest := map[string]string{}
 	err := entry.readToStringMap(field, &dest)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "can not be read as a map[string]string")
+	require.ErrorContains(t, err, "can not be read as a map[string]string")
 }
 
 func TestReadToInterfaceMissingField(t *testing.T) {
@@ -293,8 +291,7 @@ func TestReadToInterfaceMissingField(t *testing.T) {
 	field := NewAttributeField("label")
 	var dest any
 	err := entry.readToInterface(field, &dest)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "can not be read as a any")
+	require.ErrorContains(t, err, "can not be read as a any")
 }
 
 func TestDefaultTimestamps(t *testing.T) {

--- a/pkg/stanza/entry/field_test.go
+++ b/pkg/stanza/entry/field_test.go
@@ -143,13 +143,11 @@ func TestFieldUnmarshalJSON(t *testing.T) {
 
 			switch {
 			case tc.expectedErrRootable != "":
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 				require.Error(t, errRootable)
 				require.Contains(t, errRootable.Error(), tc.expectedErrRootable)
 			case tc.expectedErr != "":
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 				require.NoError(t, errRootable)
 				require.Equal(t, tc.expected, rootableField.Field)
 			default:
@@ -233,8 +231,7 @@ func TestFieldUnmarshalYAMLFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var f Field
 			err := yaml.UnmarshalStrict(tc.input, &f)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expected)
+			require.ErrorContains(t, err, tc.expected)
 		})
 	}
 }
@@ -284,8 +281,7 @@ func TestFromJSONDot(t *testing.T) {
 
 func TestFieldFromStringInvalidSplit(t *testing.T) {
 	_, err := NewField("resource[test]")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "splitting field")
+	require.ErrorContains(t, err, "splitting field")
 }
 
 func TestFieldFromStringWithResource(t *testing.T) {

--- a/pkg/stanza/entry/resource_field_test.go
+++ b/pkg/stanza/entry/resource_field_test.go
@@ -460,13 +460,11 @@ func TestResourceFieldUnmarshalFailure(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var fy ResourceField
 			err := yaml.UnmarshalStrict(tc.invalid, &fy)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 
 			var fj ResourceField
 			err = json.Unmarshal(tc.invalid, &fj)
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.expectedErr)
+			require.ErrorContains(t, err, tc.expectedErr)
 		})
 	}
 }

--- a/pkg/stanza/operator/config_test.go
+++ b/pkg/stanza/operator/config_test.go
@@ -43,24 +43,21 @@ func TestUnmarshalJSONErrors(t *testing.T) {
 		raw := `{}}`
 		cfg := &Config{}
 		err := cfg.UnmarshalJSON([]byte(raw))
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid")
+		require.ErrorContains(t, err, "invalid")
 	})
 
 	t.Run("MissingType", func(t *testing.T) {
 		raw := `{"id":"stdout"}`
 		var cfg Config
 		err := json.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "missing required field")
+		require.ErrorContains(t, err, "missing required field")
 	})
 
 	t.Run("UnknownType", func(t *testing.T) {
 		raw := `{"id":"stdout","type":"nonexist"}`
 		var cfg Config
 		err := json.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "unsupported type")
+		require.ErrorContains(t, err, "unsupported type")
 	})
 
 	t.Run("TypeSpecificUnmarshal", func(t *testing.T) {
@@ -68,8 +65,7 @@ func TestUnmarshalJSONErrors(t *testing.T) {
 		Register("operator", func() Builder { return &FakeBuilder{} })
 		var cfg Config
 		err := json.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "cannot unmarshal string into")
+		require.ErrorContains(t, err, "cannot unmarshal string into")
 	})
 }
 
@@ -87,32 +83,28 @@ func TestUnmarshalYAMLErrors(t *testing.T) {
 		raw := `-- - \n||\\`
 		var cfg Config
 		err := yaml.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed ")
+		require.ErrorContains(t, err, "failed ")
 	})
 
 	t.Run("MissingType", func(t *testing.T) {
 		raw := "id: operator\n"
 		var cfg Config
 		err := yaml.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "missing required field")
+		require.ErrorContains(t, err, "missing required field")
 	})
 
 	t.Run("NonStringType", func(t *testing.T) {
 		raw := "id: operator\ntype: 123"
 		var cfg Config
 		err := yaml.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "non-string type")
+		require.ErrorContains(t, err, "non-string type")
 	})
 
 	t.Run("UnknownType", func(t *testing.T) {
 		raw := "id: operator\ntype: unknown\n"
 		var cfg Config
 		err := yaml.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "unsupported type")
+		require.ErrorContains(t, err, "unsupported type")
 	})
 
 	t.Run("TypeSpecificUnmarshal", func(t *testing.T) {
@@ -120,7 +112,6 @@ func TestUnmarshalYAMLErrors(t *testing.T) {
 		Register("operator", func() Builder { return &FakeBuilder{} })
 		var cfg Config
 		err := yaml.Unmarshal([]byte(raw), &cfg)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "cannot unmarshal !!str")
+		require.ErrorContains(t, err, "cannot unmarshal !!str")
 	})
 }

--- a/pkg/stanza/operator/helper/input_test.go
+++ b/pkg/stanza/operator/helper/input_test.go
@@ -23,8 +23,7 @@ func TestInputConfigMissingBase(t *testing.T) {
 
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required `type` field.")
+	require.ErrorContains(t, err, "missing required `type` field.")
 }
 
 func TestInputConfigMissingOutput(t *testing.T) {

--- a/pkg/stanza/operator/helper/operator_test.go
+++ b/pkg/stanza/operator/helper/operator_test.go
@@ -46,8 +46,7 @@ func TestBasicConfigBuildWithoutType(t *testing.T) {
 
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required `type` field.")
+	require.ErrorContains(t, err, "missing required `type` field.")
 }
 
 func TestBasicConfigBuildMissingLogger(t *testing.T) {
@@ -59,8 +58,7 @@ func TestBasicConfigBuildMissingLogger(t *testing.T) {
 	set := componenttest.NewNopTelemetrySettings()
 	set.Logger = nil
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "operator build context is missing a logger.")
+	require.ErrorContains(t, err, "operator build context is missing a logger.")
 }
 
 func TestBasicConfigBuildValid(t *testing.T) {

--- a/pkg/stanza/operator/helper/output_test.go
+++ b/pkg/stanza/operator/helper/output_test.go
@@ -17,8 +17,7 @@ func TestOutputConfigMissingBase(t *testing.T) {
 	config := OutputConfig{}
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required `type` field.")
+	require.ErrorContains(t, err, "missing required `type` field.")
 }
 
 func TestOutputConfigBuildValid(t *testing.T) {
@@ -84,6 +83,5 @@ func TestOutputOperatorSetOutputs(t *testing.T) {
 	}
 
 	err := output.SetOutputs([]operator.Operator{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Operator can not output")
+	require.ErrorContains(t, err, "Operator can not output")
 }

--- a/pkg/stanza/operator/helper/parser_test.go
+++ b/pkg/stanza/operator/helper/parser_test.go
@@ -24,8 +24,7 @@ func TestParserConfigMissingBase(t *testing.T) {
 	config := ParserConfig{}
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required `type` field.")
+	require.ErrorContains(t, err, "missing required `type` field.")
 }
 
 func TestParserConfigInvalidTimeParser(t *testing.T) {
@@ -39,8 +38,7 @@ func TestParserConfigInvalidTimeParser(t *testing.T) {
 
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required configuration parameter `layout`")
+	require.ErrorContains(t, err, "missing required configuration parameter `layout`")
 }
 
 func TestParserConfigBodyCollision(t *testing.T) {
@@ -52,8 +50,7 @@ func TestParserConfigBodyCollision(t *testing.T) {
 
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "`parse_to: body` not allowed when `body` is configured")
+	require.ErrorContains(t, err, "`parse_to: body` not allowed when `body` is configured")
 }
 
 func TestParserConfigBuildValid(t *testing.T) {
@@ -123,8 +120,7 @@ func TestParserMissingField(t *testing.T) {
 	ctx := context.Background()
 	testEntry := entry.New()
 	err := parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Entry is missing the expected parse_from field.")
+	require.ErrorContains(t, err, "Entry is missing the expected parse_from field.")
 }
 
 func TestParserInvalidParseDrop(t *testing.T) {
@@ -142,8 +138,7 @@ func TestParserInvalidParseDrop(t *testing.T) {
 	ctx := context.Background()
 	testEntry := entry.New()
 	err := parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "parse failure")
+	require.ErrorContains(t, err, "parse failure")
 	fakeOut.ExpectNoEntry(t, 100*time.Millisecond)
 }
 
@@ -162,8 +157,7 @@ func TestParserInvalidParseSend(t *testing.T) {
 	ctx := context.Background()
 	testEntry := entry.New()
 	err := parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "parse failure")
+	require.ErrorContains(t, err, "parse failure")
 	fakeOut.ExpectEntry(t, testEntry)
 	fakeOut.ExpectNoEntry(t, 100*time.Millisecond)
 }
@@ -190,8 +184,7 @@ func TestParserInvalidTimeParseDrop(t *testing.T) {
 	ctx := context.Background()
 	testEntry := entry.New()
 	err := parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "time parser: log entry does not have the expected parse_from field")
+	require.ErrorContains(t, err, "time parser: log entry does not have the expected parse_from field")
 	fakeOut.ExpectNoEntry(t, 100*time.Millisecond)
 }
 
@@ -217,8 +210,7 @@ func TestParserInvalidTimeParseSend(t *testing.T) {
 	ctx := context.Background()
 	testEntry := entry.New()
 	err := parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "time parser: log entry does not have the expected parse_from field")
+	require.ErrorContains(t, err, "time parser: log entry does not have the expected parse_from field")
 	fakeOut.ExpectEntry(t, testEntry)
 	fakeOut.ExpectNoEntry(t, 100*time.Millisecond)
 }
@@ -241,8 +233,7 @@ func TestParserInvalidSeverityParseDrop(t *testing.T) {
 	ctx := context.Background()
 	testEntry := entry.New()
 	err := parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "severity parser: log entry does not have the expected parse_from field")
+	require.ErrorContains(t, err, "severity parser: log entry does not have the expected parse_from field")
 	fakeOut.ExpectNoEntry(t, 100*time.Millisecond)
 }
 
@@ -284,8 +275,7 @@ func TestParserInvalidTimeValidSeverityParse(t *testing.T) {
 	require.NoError(t, err)
 
 	err = parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "time parser: log entry does not have the expected parse_from field")
+	require.ErrorContains(t, err, "time parser: log entry does not have the expected parse_from field")
 
 	// But, this should have been set anyways
 	require.Equal(t, entry.Info, testEntry.Severity)
@@ -339,8 +329,7 @@ func TestParserValidTimeInvalidSeverityParse(t *testing.T) {
 	require.NoError(t, err)
 
 	err = parser.ProcessWith(ctx, testEntry, parse)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "severity parser: log entry does not have the expected parse_from field")
+	require.ErrorContains(t, err, "severity parser: log entry does not have the expected parse_from field")
 
 	require.Equal(t, expected, testEntry.Timestamp)
 }

--- a/pkg/stanza/operator/helper/time_test.go
+++ b/pkg/stanza/operator/helper/time_test.go
@@ -571,8 +571,7 @@ func TestSetInvalidLocation(t *testing.T) {
 	tp := NewTimeParser()
 	tp.Location = "not_a_location"
 	err := tp.setLocation()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to load location "+"not_a_location")
+	require.ErrorContains(t, err, "failed to load location "+"not_a_location")
 }
 
 func TestUnmarshal(t *testing.T) {

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -26,8 +26,7 @@ func TestTransformerConfigMissingBase(t *testing.T) {
 	cfg.OutputIDs = []string{"test-output"}
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing required `type` field.")
+	require.ErrorContains(t, err, "missing required `type` field.")
 }
 
 func TestTransformerConfigMissingOutput(t *testing.T) {
@@ -58,8 +57,7 @@ func TestTransformerOnErrorInvalid(t *testing.T) {
 	cfg.OnError = "invalid"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "operator config has an invalid `on_error` field.")
+	require.ErrorContains(t, err, "operator config has an invalid `on_error` field.")
 }
 
 func TestTransformerOperatorCanProcess(t *testing.T) {

--- a/pkg/stanza/operator/helper/writer_test.go
+++ b/pkg/stanza/operator/helper/writer_test.go
@@ -119,8 +119,7 @@ func TestWriterSetOutputsMissing(t *testing.T) {
 	}
 
 	err := writer.SetOutputs([]operator.Operator{output1})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "does not exist")
+	require.ErrorContains(t, err, "does not exist")
 }
 
 func TestWriterSetOutputsInvalid(t *testing.T) {
@@ -132,8 +131,7 @@ func TestWriterSetOutputsInvalid(t *testing.T) {
 	}
 
 	err := writer.SetOutputs([]operator.Operator{output1})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "can not process entries")
+	require.ErrorContains(t, err, "can not process entries")
 }
 
 func TestWriterSetOutputsValid(t *testing.T) {

--- a/pkg/stanza/operator/input/windows/bookmark_test.go
+++ b/pkg/stanza/operator/input/windows/bookmark_test.go
@@ -14,16 +14,14 @@ import (
 func TestBookmarkOpenPreexisting(t *testing.T) {
 	bookmark := Bookmark{handle: 5}
 	err := bookmark.Open("")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "bookmark handle is already open")
+	require.ErrorContains(t, err, "bookmark handle is already open")
 }
 
 func TestBookmarkOpenInvalidUTF8(t *testing.T) {
 	bookmark := NewBookmark()
 	invalidUTF8 := "\u0000"
 	err := bookmark.Open(invalidUTF8)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to convert bookmark xml to utf16")
+	require.ErrorContains(t, err, "failed to convert bookmark xml to utf16")
 }
 
 func TestBookmarkOpenSyscallFailure(t *testing.T) {
@@ -31,8 +29,7 @@ func TestBookmarkOpenSyscallFailure(t *testing.T) {
 	xml := "<bookmark><\\bookmark>"
 	createBookmarkProc = SimpleMockProc(0, 0, ErrorNotSupported)
 	err := bookmark.Open(xml)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to create bookmark handle from xml")
+	require.ErrorContains(t, err, "failed to create bookmark handle from xml")
 }
 
 func TestBookmarkOpenSuccess(t *testing.T) {
@@ -49,8 +46,7 @@ func TestBookmarkUpdateFailureOnCreateSyscall(t *testing.T) {
 	bookmark := NewBookmark()
 	createBookmarkProc = SimpleMockProc(0, 0, ErrorNotSupported)
 	err := bookmark.Update(event)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "syscall to `EvtCreateBookmark` failed")
+	require.ErrorContains(t, err, "syscall to `EvtCreateBookmark` failed")
 }
 
 func TestBookmarkUpdateFailureOnUpdateSyscall(t *testing.T) {
@@ -59,8 +55,7 @@ func TestBookmarkUpdateFailureOnUpdateSyscall(t *testing.T) {
 	createBookmarkProc = SimpleMockProc(1, 0, ErrorSuccess)
 	updateBookmarkProc = SimpleMockProc(0, 0, ErrorNotSupported)
 	err := bookmark.Update(event)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "syscall to `EvtUpdateBookmark` failed")
+	require.ErrorContains(t, err, "syscall to `EvtUpdateBookmark` failed")
 }
 
 func TestBookmarkUpdateSuccess(t *testing.T) {
@@ -83,8 +78,7 @@ func TestBookmarkCloseSyscallFailure(t *testing.T) {
 	bookmark := Bookmark{handle: 5}
 	closeProc = SimpleMockProc(0, 0, ErrorNotSupported)
 	err := bookmark.Close()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to close bookmark handle")
+	require.ErrorContains(t, err, "failed to close bookmark handle")
 }
 
 func TestBookmarkCloseSuccess(t *testing.T) {
@@ -99,8 +93,7 @@ func TestBookmarkRenderWhenClosed(t *testing.T) {
 	bookmark := NewBookmark()
 	buffer := NewBuffer()
 	_, err := bookmark.Render(buffer)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "bookmark handle is not open")
+	require.ErrorContains(t, err, "bookmark handle is not open")
 }
 
 func TestBookmarkRenderInvalidSyscall(t *testing.T) {
@@ -108,6 +101,5 @@ func TestBookmarkRenderInvalidSyscall(t *testing.T) {
 	buffer := NewBuffer()
 	renderProc = SimpleMockProc(0, 0, ErrorNotSupported)
 	_, err := bookmark.Render(buffer)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "syscall to 'EvtRender' failed")
+	require.ErrorContains(t, err, "syscall to 'EvtRender' failed")
 }

--- a/pkg/stanza/operator/input/windows/event_test.go
+++ b/pkg/stanza/operator/input/windows/event_test.go
@@ -21,8 +21,7 @@ func TestEventCloseSyscallFailure(t *testing.T) {
 	event := NewEvent(5)
 	closeProc = SimpleMockProc(0, 0, ErrorNotSupported)
 	err := event.Close()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to close event handle")
+	require.ErrorContains(t, err, "failed to close event handle")
 }
 
 func TestEventCloseSuccess(t *testing.T) {

--- a/pkg/stanza/operator/input/windows/input_test.go
+++ b/pkg/stanza/operator/input/windows/input_test.go
@@ -34,8 +34,7 @@ func TestInputStart_LocalSubscriptionError(t *testing.T) {
 	input.pollInterval = 1 * time.Second
 
 	err := input.Start(persister)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "The specified channel could not be found")
+	assert.ErrorContains(t, err, "The specified channel could not be found")
 }
 
 // TestInputStart_RemoteSubscriptionError ensures the input correctly handles remote subscription errors.
@@ -52,8 +51,7 @@ func TestInputStart_RemoteSubscriptionError(t *testing.T) {
 	}
 
 	err := input.Start(persister)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "The specified channel could not be found")
+	assert.ErrorContains(t, err, "The specified channel could not be found")
 }
 
 // TestInputStart_RemoteSessionError ensures the input correctly handles remote session errors.
@@ -72,8 +70,7 @@ func TestInputStart_RemoteSessionError(t *testing.T) {
 	}
 
 	err := input.Start(persister)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to start remote session for server remote-server: remote session error")
+	assert.ErrorContains(t, err, "failed to start remote session for server remote-server: remote session error")
 }
 
 // TestInputStart_RemoteAccessDeniedError ensures the input correctly handles remote access denied errors.
@@ -97,9 +94,8 @@ func TestInputStart_RemoteAccessDeniedError(t *testing.T) {
 	}
 
 	err := input.Start(persister)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to open subscription for remote server")
-	assert.Contains(t, err.Error(), "Access is denied")
+	assert.ErrorContains(t, err, "failed to open subscription for remote server")
+	assert.ErrorContains(t, err, "Access is denied")
 }
 
 // TestInputStart_BadChannelName ensures the input correctly handles bad channel names.
@@ -123,7 +119,6 @@ func TestInputStart_BadChannelName(t *testing.T) {
 	}
 
 	err := input.Start(persister)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to open subscription for remote server")
-	assert.Contains(t, err.Error(), "The specified channel could not be found")
+	assert.ErrorContains(t, err, "failed to open subscription for remote server")
+	assert.ErrorContains(t, err, "The specified channel could not be found")
 }

--- a/pkg/stanza/operator/input/windows/publisher_test.go
+++ b/pkg/stanza/operator/input/windows/publisher_test.go
@@ -14,8 +14,7 @@ import (
 func TestPublisherOpenPreexisting(t *testing.T) {
 	publisher := Publisher{handle: 5}
 	err := publisher.Open("provider_name_does_not_matter_for_this_test")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "publisher handle is already open")
+	require.ErrorContains(t, err, "publisher handle is already open")
 	require.True(t, publisher.Valid())
 }
 
@@ -23,8 +22,7 @@ func TestPublisherOpenInvalidUTF8(t *testing.T) {
 	publisher := NewPublisher()
 	invalidUTF8 := "\u0000"
 	err := publisher.Open(invalidUTF8)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to convert the provider name \"\\x00\" to utf16: invalid argument")
+	require.ErrorContains(t, err, "failed to convert the provider name \"\\x00\" to utf16: invalid argument")
 	require.False(t, publisher.Valid())
 }
 
@@ -33,8 +31,7 @@ func TestPublisherOpenSyscallFailure(t *testing.T) {
 	provider := "provider"
 	defer mockWithDeferredRestore(&openPublisherMetadataProc, SimpleMockProc(0, 0, ErrorNotSupported))()
 	err := publisher.Open(provider)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to open the metadata for the \"provider\" provider: The request is not supported.")
+	require.ErrorContains(t, err, "failed to open the metadata for the \"provider\" provider: The request is not supported.")
 	require.False(t, publisher.Valid())
 }
 
@@ -59,8 +56,7 @@ func TestPublisherCloseSyscallFailure(t *testing.T) {
 	publisher := Publisher{handle: 5}
 	defer mockWithDeferredRestore(&closeProc, SimpleMockProc(0, 0, ErrorNotSupported))()
 	err := publisher.Close()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to close publisher")
+	require.ErrorContains(t, err, "failed to close publisher")
 	require.True(t, publisher.Valid())
 }
 

--- a/pkg/stanza/operator/output/drop/output_test.go
+++ b/pkg/stanza/operator/output/drop/output_test.go
@@ -26,8 +26,7 @@ func TestBuildIvalid(t *testing.T) {
 	set := componenttest.NewNopTelemetrySettings()
 	set.Logger = nil
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "build context is missing a logger")
+	require.ErrorContains(t, err, "build context is missing a logger")
 }
 
 func TestProcess(t *testing.T) {

--- a/pkg/stanza/operator/parser/container/parser_test.go
+++ b/pkg/stanza/operator/parser/container/parser_test.go
@@ -39,8 +39,7 @@ func TestConfigBuildFailure(t *testing.T) {
 	config.OnError = "invalid_on_error"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `on_error` field")
+	require.ErrorContains(t, err, "invalid `on_error` field")
 }
 
 func TestConfigBuildFormatError(t *testing.T) {
@@ -48,29 +47,25 @@ func TestConfigBuildFormatError(t *testing.T) {
 	config.Format = "invalid_runtime"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `format` field")
+	require.ErrorContains(t, err, "invalid `format` field")
 }
 
 func TestDockerParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parseDocker([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as docker container logs")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as docker container logs")
 }
 
 func TestCrioParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parseCRIO([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as cri-o container logs")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as cri-o container logs")
 }
 
 func TestContainerdParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parseContainerd([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as containerd logs")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as containerd logs")
 }
 
 func TestFormatDetectionFailure(t *testing.T) {
@@ -79,8 +74,7 @@ func TestFormatDetectionFailure(t *testing.T) {
 		Body: `invalid container format`,
 	}
 	_, err := parser.detectFormat(e)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "entry cannot be parsed as container logs")
+	require.ErrorContains(t, err, "entry cannot be parsed as container logs")
 }
 
 func TestInternalRecombineCfg(t *testing.T) {

--- a/pkg/stanza/operator/parser/csv/parser_test.go
+++ b/pkg/stanza/operator/parser/csv/parser_test.go
@@ -41,8 +41,7 @@ func TestParserBuildFailure(t *testing.T) {
 	cfg.OnError = "invalid_on_error"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `on_error` field")
+	require.ErrorContains(t, err, "invalid `on_error` field")
 }
 
 func TestParserBuildFailureLazyIgnoreQuotes(t *testing.T) {
@@ -62,8 +61,7 @@ func TestParserBuildFailureInvalidDelimiter(t *testing.T) {
 	cfg.FieldDelimiter = ";;"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid 'delimiter': ';;'")
+	require.ErrorContains(t, err, "invalid 'delimiter': ';;'")
 }
 
 func TestParserBuildFailureBadHeaderConfig(t *testing.T) {
@@ -72,36 +70,31 @@ func TestParserBuildFailureBadHeaderConfig(t *testing.T) {
 	cfg.HeaderAttribute = "testheader"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "only one header parameter can be set: 'header' or 'header_attribute'")
+	require.ErrorContains(t, err, "only one header parameter can be set: 'header' or 'header_attribute'")
 }
 
 func TestParserByteFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "wrong number of fields: expected 3, found 1")
+	require.ErrorContains(t, err, "wrong number of fields: expected 3, found 1")
 }
 
 func TestParserStringFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse("invalid")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "wrong number of fields: expected 3, found 1")
+	require.ErrorContains(t, err, "wrong number of fields: expected 3, found 1")
 }
 
 func TestParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as csv")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as csv")
 }
 
 func TestParserInvalidTypeIgnoreQuotes(t *testing.T) {
 	parser := newTestParserIgnoreQuotes(t)
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as csv")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as csv")
 }
 
 func TestParserCSV(t *testing.T) {
@@ -1112,8 +1105,7 @@ func TestBuildParserCSV(t *testing.T) {
 		c.Header = "name"
 		set := componenttest.NewNopTelemetrySettings()
 		_, err := c.Build(set)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "missing field delimiter in header")
+		require.ErrorContains(t, err, "missing field delimiter in header")
 	})
 
 	t.Run("InvalidHeaderFieldWrongDelimiter", func(t *testing.T) {
@@ -1130,7 +1122,6 @@ func TestBuildParserCSV(t *testing.T) {
 		c.FieldDelimiter = ":"
 		set := componenttest.NewNopTelemetrySettings()
 		_, err := c.Build(set)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "missing field delimiter in header")
+		require.ErrorContains(t, err, "missing field delimiter in header")
 	})
 }

--- a/pkg/stanza/operator/parser/json/parser_test.go
+++ b/pkg/stanza/operator/parser/json/parser_test.go
@@ -40,29 +40,25 @@ func TestConfigBuildFailure(t *testing.T) {
 	config.OnError = "invalid_on_error"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `on_error` field")
+	require.ErrorContains(t, err, "invalid `on_error` field")
 }
 
 func TestParserStringFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse("invalid")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "expected { character for map value")
+	require.ErrorContains(t, err, "expected { character for map value")
 }
 
 func TestParserByteFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type []uint8 cannot be parsed as JSON")
+	require.ErrorContains(t, err, "type []uint8 cannot be parsed as JSON")
 }
 
 func TestParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type []int cannot be parsed as JSON")
+	require.ErrorContains(t, err, "type []int cannot be parsed as JSON")
 }
 
 func TestJSONImplementations(t *testing.T) {

--- a/pkg/stanza/operator/parser/jsonarray/config_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/config_test.go
@@ -92,7 +92,7 @@ func TestBuildWithFeatureGate(t *testing.T) {
 			set := componenttest.NewNopTelemetrySettings()
 			_, err := buildFunc().Build(set)
 			if err != nil {
-				require.Contains(t, err.Error(), c.onErr)
+				require.ErrorContains(t, err, c.onErr)
 			}
 		})
 	}

--- a/pkg/stanza/operator/parser/jsonarray/parser_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/parser_test.go
@@ -33,15 +33,13 @@ func TestParserBuildFailure(t *testing.T) {
 	cfg.OnError = "invalid_on_error"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `on_error` field")
+	require.ErrorContains(t, err, "invalid `on_error` field")
 }
 
 func TestParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as json array")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as json array")
 }
 
 func TestParserByteFailureHeadersMismatch(t *testing.T) {
@@ -54,8 +52,7 @@ func TestParserByteFailureHeadersMismatch(t *testing.T) {
 	require.NoError(t, err)
 	parser := op.(*Parser)
 	_, err = parser.parse("[\"stanza\",\"INFO\",\"started agent\", 42, true]")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "wrong number of fields: expected 3, found 5")
+	require.ErrorContains(t, err, "wrong number of fields: expected 3, found 5")
 }
 
 func TestParserJarray(t *testing.T) {

--- a/pkg/stanza/operator/parser/keyvalue/parser_test.go
+++ b/pkg/stanza/operator/parser/keyvalue/parser_test.go
@@ -44,8 +44,7 @@ func TestConfigBuildFailure(t *testing.T) {
 	config.OnError = "invalid_on_error"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `on_error` field")
+	require.ErrorContains(t, err, "invalid `on_error` field")
 }
 
 func TestBuild(t *testing.T) {
@@ -151,22 +150,19 @@ func TestBuild(t *testing.T) {
 func TestParserStringFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse("invalid")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("cannot split %q into 2 items, got 1 item(s)", "invalid"))
+	require.ErrorContains(t, err, fmt.Sprintf("cannot split %q into 2 items, got 1 item(s)", "invalid"))
 }
 
 func TestParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type []int cannot be parsed as key value pairs")
+	require.ErrorContains(t, err, "type []int cannot be parsed as key value pairs")
 }
 
 func TestParserEmptyInput(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse("")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "parse from field body is empty")
+	require.ErrorContains(t, err, "parse from field body is empty")
 }
 
 func TestKVImplementations(t *testing.T) {

--- a/pkg/stanza/operator/parser/regex/parser_test.go
+++ b/pkg/stanza/operator/parser/regex/parser_test.go
@@ -36,29 +36,25 @@ func TestParserBuildFailure(t *testing.T) {
 	cfg.OnError = "invalid_on_error"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `on_error` field")
+	require.ErrorContains(t, err, "invalid `on_error` field")
 }
 
 func TestParserByteFailure(t *testing.T) {
 	parser := newTestParser(t, "^(?P<key>test)", 0)
 	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]uint8' cannot be parsed as regex")
+	require.ErrorContains(t, err, "type '[]uint8' cannot be parsed as regex")
 }
 
 func TestParserStringFailure(t *testing.T) {
 	parser := newTestParser(t, "^(?P<key>test)", 0)
 	_, err := parser.parse("invalid")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "regex pattern does not match")
+	require.ErrorContains(t, err, "regex pattern does not match")
 }
 
 func TestParserInvalidType(t *testing.T) {
 	parser := newTestParser(t, "^(?P<key>test)", 0)
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as regex")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as regex")
 }
 
 func TestParserCache(t *testing.T) {
@@ -67,8 +63,7 @@ func TestParserCache(t *testing.T) {
 		require.NoError(t, parser.Stop())
 	}()
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as regex")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as regex")
 	require.NotNil(t, parser.cache, "expected cache to be configured")
 	require.Equal(t, uint16(200), parser.cache.maxSize())
 }
@@ -197,8 +192,7 @@ func TestBuildParserRegex(t *testing.T) {
 		c.Regex = ".*"
 		set := componenttest.NewNopTelemetrySettings()
 		_, err := c.Build(set)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "no named capture groups")
+		require.ErrorContains(t, err, "no named capture groups")
 	})
 
 	t.Run("NoNamedGroups", func(t *testing.T) {
@@ -206,8 +200,7 @@ func TestBuildParserRegex(t *testing.T) {
 		c.Regex = "(.*)"
 		set := componenttest.NewNopTelemetrySettings()
 		_, err := c.Build(set)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "no named capture groups")
+		require.ErrorContains(t, err, "no named capture groups")
 	})
 }
 

--- a/pkg/stanza/operator/parser/syslog/config_test.go
+++ b/pkg/stanza/operator/parser/syslog/config_test.go
@@ -128,8 +128,7 @@ func TestUnmarshal(t *testing.T) {
 func TestParserMissingProtocol(t *testing.T) {
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := NewConfig().Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "missing field 'protocol'")
+	require.ErrorContains(t, err, "missing field 'protocol'")
 }
 
 func TestRFC6587ConfigOptions(t *testing.T) {
@@ -232,6 +231,5 @@ func TestParserInvalidLocation(t *testing.T) {
 
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := config.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "failed to load location "+config.Location)
+	require.ErrorContains(t, err, "failed to load location "+config.Location)
 }

--- a/pkg/stanza/operator/parser/syslog/parser_test.go
+++ b/pkg/stanza/operator/parser/syslog/parser_test.go
@@ -70,8 +70,7 @@ func TestSyslogParseRFC5424_SDNameTooLong(t *testing.T) {
 	newEntry := entry.New()
 	newEntry.Body = body
 	err = op.Process(context.Background(), newEntry)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "expecting a structured data element id (from 1 to max 32 US-ASCII characters")
+	require.ErrorContains(t, err, "expecting a structured data element id (from 1 to max 32 US-ASCII characters")
 
 	select {
 	case e := <-fake.Received:
@@ -100,8 +99,7 @@ func TestSyslogParseRFC5424_Octet_Counting_MessageTooLong(t *testing.T) {
 	newEntry := entry.New()
 	newEntry.Body = body
 	err = op.Process(context.Background(), newEntry)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "message too long to parse. was size 215, max length 214")
+	require.ErrorContains(t, err, "message too long to parse. was size 215, max length 214")
 
 	select {
 	case e := <-fake.Received:

--- a/pkg/stanza/operator/parser/uri/parser_test.go
+++ b/pkg/stanza/operator/parser/uri/parser_test.go
@@ -33,29 +33,25 @@ func TestParserBuildFailure(t *testing.T) {
 	cfg.OnError = "invalid_on_error"
 	set := componenttest.NewNopTelemetrySettings()
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "invalid `on_error` field")
+	require.ErrorContains(t, err, "invalid `on_error` field")
 }
 
 func TestParserByteFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]byte("invalid"))
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]uint8' cannot be parsed as URI")
+	require.ErrorContains(t, err, "type '[]uint8' cannot be parsed as URI")
 }
 
 func TestParserStringFailure(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse("invalid")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "parse \"invalid\": invalid URI for request")
+	require.ErrorContains(t, err, "parse \"invalid\": invalid URI for request")
 }
 
 func TestParserInvalidType(t *testing.T) {
 	parser := newTestParser(t)
 	_, err := parser.parse([]int{})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "type '[]int' cannot be parsed as URI")
+	require.ErrorContains(t, err, "type '[]int' cannot be parsed as URI")
 }
 
 func TestProcess(t *testing.T) {

--- a/pkg/stanza/operator/transformer/noop/config_test.go
+++ b/pkg/stanza/operator/transformer/noop/config_test.go
@@ -23,6 +23,5 @@ func TestBuildInvalid(t *testing.T) {
 	set := componenttest.NewNopTelemetrySettings()
 	set.Logger = nil
 	_, err := cfg.Build(set)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "build context is missing a logger")
+	require.ErrorContains(t, err, "build context is missing a logger")
 }

--- a/pkg/stanza/pipeline/directed_test.go
+++ b/pkg/stanza/pipeline/directed_test.go
@@ -101,8 +101,7 @@ func TestPipeline(t *testing.T) {
 		operator2.On("Outputs").Return(nil)
 
 		_, err := NewDirectedPipeline([]operator.Operator{operator1, operator2})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "already exists")
+		require.ErrorContains(t, err, "already exists")
 	})
 
 	t.Run("OutputNotExist", func(t *testing.T) {
@@ -115,8 +114,7 @@ func TestPipeline(t *testing.T) {
 		operator2.On("Outputs").Return([]operator.Operator{operator1})
 
 		_, err := NewDirectedPipeline([]operator.Operator{operator2})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "does not exist")
+		require.ErrorContains(t, err, "does not exist")
 	})
 
 	t.Run("OutputNotProcessor", func(t *testing.T) {
@@ -132,8 +130,7 @@ func TestPipeline(t *testing.T) {
 		operator2.On("Outputs").Return([]operator.Operator{operator1})
 
 		_, err := NewDirectedPipeline([]operator.Operator{operator1, operator2})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "can not process")
+		require.ErrorContains(t, err, "can not process")
 	})
 
 	t.Run("DuplicateEdges", func(t *testing.T) {
@@ -155,8 +152,7 @@ func TestPipeline(t *testing.T) {
 		graph.SetEdge(edge)
 
 		err := connectNode(graph, node2)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "connection already exists")
+		require.ErrorContains(t, err, "connection already exists")
 	})
 
 	t.Run("Cyclical", func(t *testing.T) {
@@ -171,8 +167,7 @@ func TestPipeline(t *testing.T) {
 		mockOperator3.On("SetOutputs", mock.Anything).Return(nil)
 
 		_, err := NewDirectedPipeline([]operator.Operator{mockOperator1, mockOperator2, mockOperator3})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "circular dependency")
+		require.ErrorContains(t, err, "circular dependency")
 	})
 }
 
@@ -205,8 +200,7 @@ func TestPipelineStartOrder(t *testing.T) {
 	require.NoError(t, err)
 
 	err = pipeline.Start(mockPersister)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "operator 1 failed to start")
+	require.ErrorContains(t, err, "operator 1 failed to start")
 	require.True(t, mock2Started)
 	require.True(t, mock3Started)
 }

--- a/processor/geoipprocessor/config_test.go
+++ b/processor/geoipprocessor/config_test.go
@@ -96,7 +96,7 @@ func TestLoadConfig_InvalidProviderKey(t *testing.T) {
 	factories.Processors[metadata.Type] = factory
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-invalidProviderKey.yaml"), factories)
 
-	require.Contains(t, err.Error(), "error reading configuration for \"geoip\": invalid provider key: invalidProviderKey")
+	require.ErrorContains(t, err, "error reading configuration for \"geoip\": invalid provider key: invalidProviderKey")
 }
 
 func TestLoadConfig_ValidProviderKey(t *testing.T) {
@@ -152,5 +152,5 @@ func TestLoadConfig_ProviderValidateError(t *testing.T) {
 	factories.Processors[metadata.Type] = factory
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-mockProvider.yaml"), factories)
 
-	require.Contains(t, err.Error(), "error validating provider mock")
+	require.ErrorContains(t, err, "error validating provider mock")
 }

--- a/processor/geoipprocessor/internal/provider/maxmindprovider/factory_test.go
+++ b/processor/geoipprocessor/internal/provider/maxmindprovider/factory_test.go
@@ -25,6 +25,6 @@ func TestCreateProvider(t *testing.T) {
 
 	provider, err := factory.CreateGeoIPProvider(context.Background(), processortest.NewNopSettings(), cfg)
 
-	assert.Contains(t, err.Error(), "could not open geoip database")
+	assert.ErrorContains(t, err, "could not open geoip database")
 	assert.Nil(t, provider)
 }

--- a/receiver/activedirectorydsreceiver/scraper_test.go
+++ b/receiver/activedirectorydsreceiver/scraper_test.go
@@ -73,8 +73,8 @@ func TestScrape(t *testing.T) {
 		scrapeData, err := scraper.scrape(context.Background())
 		require.Error(t, err)
 		require.True(t, scrapererror.IsPartialScrapeError(err))
-		require.Contains(t, err.Error(), fullSyncObjectsRemainingErr.Error())
-		require.Contains(t, err.Error(), draInboundValuesDNErr.Error())
+		require.ErrorContains(t, err, fullSyncObjectsRemainingErr.Error())
+		require.ErrorContains(t, err, draInboundValuesDNErr.Error())
 
 		expectedMetrics, err := golden.ReadMetrics(partialScrapePath)
 		require.NoError(t, err)
@@ -106,9 +106,8 @@ func TestScrape(t *testing.T) {
 		}
 
 		err = scraper.shutdown(context.Background())
-		require.Error(t, err)
-		require.Contains(t, err.Error(), fullSyncObjectsRemainingErr.Error())
-		require.Contains(t, err.Error(), draInboundValuesDNErr.Error())
+		require.ErrorContains(t, err, fullSyncObjectsRemainingErr.Error())
+		require.ErrorContains(t, err, draInboundValuesDNErr.Error())
 	})
 
 	t.Run("Double shutdown does not error", func(t *testing.T) {

--- a/receiver/apachesparkreceiver/client_test.go
+++ b/receiver/apachesparkreceiver/client_test.go
@@ -55,7 +55,7 @@ func TestNewApacheSparkClient(t *testing.T) {
 			ac, err := newApacheSparkClient(context.Background(), tc.cfg, tc.host, tc.settings)
 			if tc.expectError != nil {
 				require.Nil(t, ac)
-				require.Contains(t, err.Error(), tc.expectError.Error())
+				require.ErrorContains(t, err, tc.expectError.Error())
 			} else {
 				require.NoError(t, err)
 

--- a/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
+++ b/receiver/awsxrayreceiver/internal/tracesegment/util_test.go
@@ -52,7 +52,7 @@ func TestSplitHeaderBodyNonJsonHeader(t *testing.T) {
 
 	var errRecv *recvErr.ErrRecoverable
 	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
-	assert.Contains(t, err.Error(), "invalid character 'o'")
+	assert.ErrorContains(t, err, "invalid character 'o'")
 }
 
 func TestSplitHeaderBodyEmptyBody(t *testing.T) {
@@ -76,7 +76,7 @@ func TestSplitHeaderBodyInvalidJsonHeader(t *testing.T) {
 
 	var errRecv *recvErr.ErrRecoverable
 	assert.ErrorAs(t, err, &errRecv, "should return recoverable error")
-	assert.Contains(t, err.Error(),
+	assert.ErrorContains(t, err,
 		fmt.Sprintf("invalid header %+v", Header{
 			Format:  "json",
 			Version: 20,

--- a/receiver/bigipreceiver/client_test.go
+++ b/receiver/bigipreceiver/client_test.go
@@ -83,7 +83,7 @@ func TestNewClient(t *testing.T) {
 			ac, err := newClient(context.Background(), tc.cfg, tc.host, tc.settings, tc.logger)
 			if tc.expectError != nil {
 				require.Nil(t, ac)
-				require.Contains(t, err.Error(), tc.expectError.Error())
+				require.ErrorContains(t, err, tc.expectError.Error())
 			} else {
 				require.NoError(t, err)
 
@@ -135,7 +135,7 @@ func TestGetNewToken(t *testing.T) {
 				tc := createTestClient(t, ts.URL)
 
 				err := tc.GetNewToken(context.Background())
-				require.Contains(t, err.Error(), "failed to decode response payload")
+				require.ErrorContains(t, err, "failed to decode response payload")
 				hasToken := tc.HasToken()
 				require.False(t, hasToken)
 			},
@@ -215,7 +215,7 @@ func TestGetVirtualServers(t *testing.T) {
 
 				pools, err := tc.GetPools(context.Background())
 				require.Nil(t, pools)
-				require.Contains(t, err.Error(), "failed to decode response payload")
+				require.ErrorContains(t, err, "failed to decode response payload")
 			},
 		},
 		{
@@ -413,7 +413,7 @@ func TestGetPools(t *testing.T) {
 
 				pools, err := tc.GetPools(context.Background())
 				require.Nil(t, pools)
-				require.Contains(t, err.Error(), "failed to decode response payload")
+				require.ErrorContains(t, err, "failed to decode response payload")
 			},
 		},
 		{
@@ -666,7 +666,7 @@ func TestGetNodes(t *testing.T) {
 
 				nodes, err := tc.GetNodes(context.Background())
 				require.Nil(t, nodes)
-				require.Contains(t, err.Error(), "failed to decode response payload")
+				require.ErrorContains(t, err, "failed to decode response payload")
 			},
 		},
 		{

--- a/receiver/cloudflarereceiver/logs_test.go
+++ b/receiver/cloudflarereceiver/logs_test.go
@@ -132,7 +132,7 @@ func TestPayloadToLogRecord(t *testing.T) {
 			if tc.expectedErr != "" {
 				require.Error(t, err)
 				require.Nil(t, logs)
-				require.Contains(t, err.Error(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, logs)

--- a/receiver/couchdbreceiver/client_test.go
+++ b/receiver/couchdbreceiver/client_test.go
@@ -48,8 +48,7 @@ func TestNewCouchDBClient(t *testing.T) {
 			componenttest.NewNopHost(),
 			componenttest.NewNopTelemetrySettings())
 
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "failed to create HTTP Client: ")
+		require.ErrorContains(t, err, "failed to create HTTP Client: ")
 		require.Nil(t, couchdbClient)
 	})
 	t.Run("no error", func(t *testing.T) {
@@ -87,27 +86,24 @@ func TestGet(t *testing.T) {
 		couchdbClient := defaultClient(t, url)
 
 		result, err := couchdbClient.Get(url)
-		require.Error(t, err)
 		require.Nil(t, result)
-		require.Contains(t, err.Error(), "invalid port ")
+		require.ErrorContains(t, err, "invalid port ")
 	})
 	t.Run("invalid endpoint", func(t *testing.T) {
 		url := ts.URL + "/invalid_endpoint"
 		couchdbClient := defaultClient(t, url)
 
 		result, err := couchdbClient.Get(url)
-		require.Error(t, err)
 		require.Nil(t, result)
-		require.Contains(t, err.Error(), "404 Not Found")
+		require.ErrorContains(t, err, "404 Not Found")
 	})
 	t.Run("invalid body", func(t *testing.T) {
 		url := ts.URL + "/invalid_body"
 		couchdbClient := defaultClient(t, url)
 
 		result, err := couchdbClient.Get(url)
-		require.Error(t, err)
 		require.Nil(t, result)
-		require.Contains(t, err.Error(), "failed to read response body ")
+		require.ErrorContains(t, err, "failed to read response body ")
 	})
 	t.Run("401 Unauthorized", func(t *testing.T) {
 		url := ts.URL + "/_node/_local/_stats/couchdb"
@@ -127,8 +123,7 @@ func TestGet(t *testing.T) {
 
 		result, err := couchdbClient.Get(url)
 		require.Nil(t, result)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "401 Unauthorized")
+		require.ErrorContains(t, err, "401 Unauthorized")
 	})
 	t.Run("no error", func(t *testing.T) {
 		url := ts.URL + "/_node/_local/_stats/couchdb"

--- a/receiver/dockerstatsreceiver/config_test.go
+++ b/receiver/dockerstatsreceiver/config_test.go
@@ -127,8 +127,7 @@ func TestApiVersionCustomError(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	err := sub.Unmarshal(cfg)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(),
+	assert.ErrorContains(t, err,
 		`Hint: You may want to wrap the 'api_version' value in quotes (api_version: "1.40")`,
 	)
 

--- a/receiver/dockerstatsreceiver/receiver_test.go
+++ b/receiver/dockerstatsreceiver/receiver_test.go
@@ -150,13 +150,11 @@ func TestErrorsInStart(t *testing.T) {
 
 	cfg.Endpoint = "..not/a/valid/endpoint"
 	err := recv.start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "unable to parse docker host")
+	assert.ErrorContains(t, err, "unable to parse docker host")
 
 	cfg.Endpoint = unreachable
 	err = recv.start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "context deadline exceeded")
+	assert.ErrorContains(t, err, "context deadline exceeded")
 }
 
 func TestScrapeV2(t *testing.T) {

--- a/receiver/elasticsearchreceiver/client_test.go
+++ b/receiver/elasticsearchreceiver/client_test.go
@@ -370,8 +370,7 @@ func TestDoRequest404(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = client.doRequest(context.Background(), "invalid_path")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "404")
+	require.ErrorContains(t, err, "404")
 }
 
 func TestIndexStatsNoPassword(t *testing.T) {

--- a/receiver/elasticsearchreceiver/config_test.go
+++ b/receiver/elasticsearchreceiver/config_test.go
@@ -129,8 +129,7 @@ func TestValidateEndpoint(t *testing.T) {
 			case testCase.expectedErr != nil:
 				require.ErrorIs(t, err, testCase.expectedErr)
 			case testCase.expectedErrStr != "":
-				require.Error(t, err)
-				require.Contains(t, err.Error(), testCase.expectedErrStr)
+				require.ErrorContains(t, err, testCase.expectedErrStr)
 			default:
 				require.NoError(t, err)
 			}

--- a/receiver/elasticsearchreceiver/scraper_test.go
+++ b/receiver/elasticsearchreceiver/scraper_test.go
@@ -257,7 +257,7 @@ func TestScrapingError(t *testing.T) {
 
 				_, err = sc.scrape(context.Background())
 				require.True(t, scrapererror.IsPartialScrapeError(err))
-				require.Equal(t, err.Error(), err404.Error())
+				require.EqualError(t, err, err404.Error())
 
 			},
 		},
@@ -284,7 +284,7 @@ func TestScrapingError(t *testing.T) {
 
 				_, err = sc.scrape(context.Background())
 				require.True(t, scrapererror.IsPartialScrapeError(err))
-				require.Equal(t, err.Error(), err404.Error())
+				require.EqualError(t, err, err404.Error())
 
 			},
 		},
@@ -311,8 +311,8 @@ func TestScrapingError(t *testing.T) {
 				sc.client = &mockClient
 
 				m, err := sc.scrape(context.Background())
-				require.Contains(t, err.Error(), err404.Error())
-				require.Contains(t, err.Error(), err500.Error())
+				require.ErrorContains(t, err, err404.Error())
+				require.ErrorContains(t, err, err500.Error())
 
 				require.Equal(t, 0, m.DataPointCount())
 			},
@@ -340,7 +340,7 @@ func TestScrapingError(t *testing.T) {
 
 				_, err = sc.scrape(context.Background())
 				require.True(t, scrapererror.IsPartialScrapeError(err))
-				require.Contains(t, err.Error(), err404.Error())
+				require.ErrorContains(t, err, err404.Error())
 			},
 		},
 		{
@@ -366,8 +366,8 @@ func TestScrapingError(t *testing.T) {
 				sc.client = &mockClient
 
 				m, err := sc.scrape(context.Background())
-				require.Contains(t, err.Error(), err404.Error())
-				require.Contains(t, err.Error(), err500.Error())
+				require.ErrorContains(t, err, err404.Error())
+				require.ErrorContains(t, err, err500.Error())
 
 				require.Equal(t, 0, m.DataPointCount())
 			},
@@ -396,7 +396,7 @@ func TestScrapingError(t *testing.T) {
 
 				_, err = sc.scrape(context.Background())
 				require.True(t, scrapererror.IsPartialScrapeError(err))
-				require.Contains(t, err.Error(), errUnknownClusterStatus.Error())
+				require.ErrorContains(t, err, errUnknownClusterStatus.Error())
 			},
 		},
 	}

--- a/receiver/flinkmetricsreceiver/client_test.go
+++ b/receiver/flinkmetricsreceiver/client_test.go
@@ -93,7 +93,7 @@ func TestNewClient(t *testing.T) {
 			ac, err := newClient(context.Background(), tc.cfg, tc.host, tc.settings, tc.logger)
 			if tc.expectError != nil {
 				require.Nil(t, ac)
-				require.Contains(t, err.Error(), tc.expectError.Error())
+				require.ErrorContains(t, err, tc.expectError.Error())
 			} else {
 				require.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestGetJobmanagerMetrics(t *testing.T) {
 
 				metrics, err := tc.GetJobmanagerMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body")
+				require.ErrorContains(t, err, "failed to unmarshal response body")
 			},
 		},
 		{
@@ -220,7 +220,7 @@ func TestGetTaskmanagersMetrics(t *testing.T) {
 
 				metrics, err := tc.GetTaskmanagersMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body:")
+				require.ErrorContains(t, err, "failed to unmarshal response body:")
 			},
 		},
 		{
@@ -243,7 +243,7 @@ func TestGetTaskmanagersMetrics(t *testing.T) {
 
 				metrics, err := tc.GetTaskmanagersMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body:")
+				require.ErrorContains(t, err, "failed to unmarshal response body:")
 			},
 		},
 		{
@@ -321,7 +321,7 @@ func TestGetJobsMetrics(t *testing.T) {
 
 				metrics, err := tc.GetJobsMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body")
+				require.ErrorContains(t, err, "failed to unmarshal response body")
 			},
 		},
 		{
@@ -343,7 +343,7 @@ func TestGetJobsMetrics(t *testing.T) {
 
 				metrics, err := tc.GetJobsMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body")
+				require.ErrorContains(t, err, "failed to unmarshal response body")
 			},
 		},
 		{
@@ -423,7 +423,7 @@ func TestGetSubtasksMetrics(t *testing.T) {
 
 				metrics, err := tc.GetSubtasksMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body")
+				require.ErrorContains(t, err, "failed to unmarshal response body")
 			},
 		},
 		{
@@ -445,7 +445,7 @@ func TestGetSubtasksMetrics(t *testing.T) {
 
 				metrics, err := tc.GetSubtasksMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body")
+				require.ErrorContains(t, err, "failed to unmarshal response body")
 			},
 		},
 		{
@@ -473,7 +473,7 @@ func TestGetSubtasksMetrics(t *testing.T) {
 
 				metrics, err := tc.GetSubtasksMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body")
+				require.ErrorContains(t, err, "failed to unmarshal response body")
 			},
 		},
 		{
@@ -507,7 +507,7 @@ func TestGetSubtasksMetrics(t *testing.T) {
 
 				metrics, err := tc.GetSubtasksMetrics(context.Background())
 				require.Nil(t, metrics)
-				require.Contains(t, err.Error(), "failed to unmarshal response body")
+				require.ErrorContains(t, err, "failed to unmarshal response body")
 			},
 		},
 		{

--- a/receiver/fluentforwardreceiver/conversion_test.go
+++ b/receiver/fluentforwardreceiver/conversion_test.go
@@ -188,8 +188,7 @@ func TestPackedForwardEventConversionWithErrors(t *testing.T) {
 
 		var event PackedForwardEventLogRecords
 		err := event.DecodeMsg(reader)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "gzip")
+		require.ErrorContains(t, err, "gzip")
 		fmt.Println(err.Error())
 	})
 }

--- a/receiver/githubreceiver/config_test.go
+++ b/receiver/githubreceiver/config_test.go
@@ -67,7 +67,7 @@ func TestLoadInvalidConfig_NoScrapers(t *testing.T) {
 	// nolint:staticcheck
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-noscrapers.yaml"), factories)
 
-	require.Contains(t, err.Error(), "must specify at least one scraper")
+	require.ErrorContains(t, err, "must specify at least one scraper")
 }
 
 func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {
@@ -80,7 +80,7 @@ func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {
 	// nolint:staticcheck
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-invalidscraperkey.yaml"), factories)
 
-	require.Contains(t, err.Error(), "error reading configuration for \"github\": invalid scraper key: \"invalidscraperkey\"")
+	require.ErrorContains(t, err, "error reading configuration for \"github\": invalid scraper key: \"invalidscraperkey\"")
 }
 
 func TestConfig_Unmarshal(t *testing.T) {

--- a/receiver/hostmetricsreceiver/config_test.go
+++ b/receiver/hostmetricsreceiver/config_test.go
@@ -134,7 +134,7 @@ func TestLoadInvalidConfig_NoScrapers(t *testing.T) {
 	// nolint:staticcheck
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-noscrapers.yaml"), factories)
 
-	require.Contains(t, err.Error(), "must specify at least one scraper when using hostmetrics receiver")
+	require.ErrorContains(t, err, "must specify at least one scraper when using hostmetrics receiver")
 }
 
 func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {
@@ -147,5 +147,5 @@ func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {
 	// nolint:staticcheck
 	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-invalidscraperkey.yaml"), factories)
 
-	require.Contains(t, err.Error(), "error reading configuration for \"hostmetrics\": invalid scraper key: invalidscraperkey")
+	require.ErrorContains(t, err, "error reading configuration for \"hostmetrics\": invalid scraper key: invalidscraperkey")
 }

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -383,7 +383,7 @@ func TestScrape(t *testing.T) {
 
 			md, err := scraper.scrape(context.Background())
 			if test.expectedErr != "" {
-				assert.Contains(t, err.Error(), test.expectedErr)
+				assert.ErrorContains(t, err, test.expectedErr)
 
 				isPartial := scrapererror.IsPartialScrapeError(err)
 				assert.True(t, isPartial)

--- a/receiver/jmxreceiver/integration_test.go
+++ b/receiver/jmxreceiver/integration_test.go
@@ -157,5 +157,5 @@ func TestJMXReceiverInvalidOTLPEndpointIntegration(t *testing.T) {
 	}()
 
 	err := receiver.Start(context.Background(), componenttest.NewNopHost())
-	require.Contains(t, err.Error(), "listen tcp: lookup <invalid>:")
+	require.ErrorContains(t, err, "listen tcp: lookup <invalid>:")
 }

--- a/receiver/jmxreceiver/receiver_test.go
+++ b/receiver/jmxreceiver/receiver_test.go
@@ -181,8 +181,7 @@ func TestBuildOTLPReceiverInvalidEndpoints(t *testing.T) {
 			params := receivertest.NewNopSettings()
 			jmxReceiver := newJMXMetricReceiver(params, test.config, consumertest.NewNop())
 			otlpReceiver, err := jmxReceiver.buildOTLPReceiver()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), test.expectedErr)
+			require.ErrorContains(t, err, test.expectedErr)
 			require.Nil(t, otlpReceiver)
 		})
 	}

--- a/receiver/kafkametricsreceiver/receiver_test.go
+++ b/receiver/kafkametricsreceiver/receiver_test.go
@@ -53,8 +53,7 @@ func TestNewReceiver_invalid_auth_error(t *testing.T) {
 		},
 	}
 	r, err := newMetricsReceiver(context.Background(), *c, receivertest.NewNopSettings(), nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 	assert.Nil(t, r)
 }
 

--- a/receiver/kafkareceiver/kafka_receiver_test.go
+++ b/receiver/kafkareceiver/kafka_receiver_test.go
@@ -76,7 +76,7 @@ func TestNewTracesReceiver_err_auth_type(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 }
 
 func TestNewTracesReceiver_initial_offset_err(t *testing.T) {
@@ -428,8 +428,7 @@ func TestNewMetricsExporter_err_auth_type(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 }
 
 func TestNewMetricsReceiver_initial_offset_err(t *testing.T) {
@@ -768,8 +767,7 @@ func TestNewLogsExporter_err_auth_type(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, r)
 	err = r.Start(context.Background(), componenttest.NewNopHost())
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 }
 
 func TestNewLogsReceiver_initial_offset_err(t *testing.T) {

--- a/receiver/mongodbatlasreceiver/alerts_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_test.go
@@ -163,9 +163,8 @@ func TestPayloadToLogRecord(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			logs, err := payloadToLogs(now, []byte(tc.payload))
 			if tc.expectedErr != "" {
-				require.Error(t, err)
 				require.Nil(t, logs)
-				require.Contains(t, err.Error(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 				require.NotNil(t, logs)
@@ -240,8 +239,7 @@ func TestVerifyHMACSignature(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := verifyHMACSignature(tc.secret, tc.payload, tc.signatureHeader)
 			if tc.expectedErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/receiver/mongodbatlasreceiver/config_test.go
+++ b/receiver/mongodbatlasreceiver/config_test.go
@@ -340,8 +340,7 @@ func TestValidate(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.input.Validate()
 			if tc.expectedErr != "" {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tc.expectedErr)
+				require.ErrorContains(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}

--- a/receiver/mongodbreceiver/client_test.go
+++ b/receiver/mongodbreceiver/client_test.go
@@ -229,8 +229,7 @@ func TestGetVersionFailures(t *testing.T) {
 			}
 
 			_, err := client.GetVersion(context.TODO())
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tc.partialError)
+			require.ErrorContains(t, err, tc.partialError)
 		})
 	}
 

--- a/receiver/mongodbreceiver/config_test.go
+++ b/receiver/mongodbreceiver/config_test.go
@@ -94,7 +94,7 @@ func TestValidate(t *testing.T) {
 			if tc.expected == nil {
 				require.NoError(t, err)
 			} else {
-				require.Contains(t, err.Error(), tc.expected.Error())
+				require.ErrorContains(t, err, tc.expected.Error())
 			}
 		})
 	}

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -591,8 +591,7 @@ func TestReceiverRecvError(t *testing.T) {
 	ctc.putBatch(nil, fmt.Errorf("test recv error"))
 
 	err := ctc.wait()
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "test recv error")
+	require.ErrorContains(t, err, "test recv error")
 }
 
 func TestReceiverSendError(t *testing.T) {

--- a/receiver/podmanreceiver/podman_test.go
+++ b/receiver/podmanreceiver/podman_test.go
@@ -92,8 +92,7 @@ func TestWatchingTimeouts(t *testing.T) {
 	defer fetchCancel()
 
 	container, err := cli.fetchContainerStats(ctx, container{})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), expectedError)
+	assert.ErrorContains(t, err, expectedError)
 	assert.Empty(t, container)
 
 	assert.GreaterOrEqual(

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -305,8 +305,7 @@ func testTransactionAppendDuplicateLabels(t *testing.T, enableNativeHistograms b
 	)
 
 	_, err := tr.Append(0, dupLabels, 1917, 1.0)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid sample: non-unique label names: "a"`)
+	assert.ErrorContains(t, err, `invalid sample: non-unique label names: "a"`)
 }
 
 func TestTransactionAppendHistogramNoLe(t *testing.T) {
@@ -539,8 +538,7 @@ func testAppendExemplarWithDuplicateLabels(t *testing.T, enableNativeHistograms 
 		"a", "c",
 	)
 	_, err := tr.AppendExemplar(0, labels, exemplar.Exemplar{Value: 0})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), `invalid sample: non-unique label names: "a"`)
+	assert.ErrorContains(t, err, `invalid sample: non-unique label names: "a"`)
 }
 
 func TestAppendExemplarWithoutAddingMetric(t *testing.T) {

--- a/receiver/rabbitmqreceiver/client_test.go
+++ b/receiver/rabbitmqreceiver/client_test.go
@@ -74,7 +74,7 @@ func TestNewClient(t *testing.T) {
 			ac, err := newClient(context.Background(), tc.cfg, tc.host, tc.settings, tc.logger)
 			if tc.expectError != nil {
 				require.Nil(t, ac)
-				require.Contains(t, err.Error(), tc.expectError.Error())
+				require.ErrorContains(t, err, tc.expectError.Error())
 			} else {
 				require.NoError(t, err)
 
@@ -126,7 +126,7 @@ func TestGetQueuesDetails(t *testing.T) {
 
 				clusters, err := tc.GetQueues(context.Background())
 				require.Nil(t, clusters)
-				require.Contains(t, err.Error(), "failed to decode response payload")
+				require.ErrorContains(t, err, "failed to decode response payload")
 			},
 		},
 		{

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -147,7 +147,7 @@ func TestInvalidResourceAttributeEndpointType(t *testing.T) {
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
 	// nolint:staticcheck
 	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "invalid-resource-attributes.yaml"), factories)
-	require.Contains(t, err.Error(), "error reading configuration for \"receiver_creator\": resource attributes for unsupported endpoint type \"not.a.real.type\"")
+	require.ErrorContains(t, err, "error reading configuration for \"receiver_creator\": resource attributes for unsupported endpoint type \"not.a.real.type\"")
 	require.Nil(t, cfg)
 }
 
@@ -162,7 +162,7 @@ func TestInvalidReceiverResourceAttributeValueType(t *testing.T) {
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
 	// nolint:staticcheck
 	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "invalid-receiver-resource-attributes.yaml"), factories)
-	require.Contains(t, err.Error(), "error reading configuration for \"receiver_creator\": unsupported `resource_attributes` \"one\" value <nil> in examplereceiver/1")
+	require.ErrorContains(t, err, "error reading configuration for \"receiver_creator\": unsupported `resource_attributes` \"one\" value <nil> in examplereceiver/1")
 	require.Nil(t, cfg)
 }
 

--- a/receiver/redisreceiver/redis_scraper_test.go
+++ b/receiver/redisreceiver/redis_scraper_test.go
@@ -39,8 +39,7 @@ func TestRedisRunnable(t *testing.T) {
 func TestNewReceiver_invalid_endpoint(t *testing.T) {
 	c := createDefaultConfig().(*Config)
 	_, err := createMetricsReceiver(context.Background(), receivertest.NewNopSettings(), c, nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "invalid endpoint")
+	assert.ErrorContains(t, err, "invalid endpoint")
 }
 
 func TestNewReceiver_invalid_auth_error(t *testing.T) {
@@ -51,7 +50,6 @@ func TestNewReceiver_invalid_auth_error(t *testing.T) {
 		},
 	}
 	r, err := createMetricsReceiver(context.Background(), receivertest.NewNopSettings(), c, nil)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed to load TLS config")
+	assert.ErrorContains(t, err, "failed to load TLS config")
 	assert.Nil(t, r)
 }

--- a/receiver/riakreceiver/client_test.go
+++ b/receiver/riakreceiver/client_test.go
@@ -64,7 +64,7 @@ func TestNewClient(t *testing.T) {
 			ac, err := newClient(context.Background(), tc.cfg, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings(), zap.NewNop())
 			if tc.expectError != nil {
 				require.Nil(t, ac)
-				require.Contains(t, err.Error(), tc.expectError.Error())
+				require.ErrorContains(t, err, tc.expectError.Error())
 			} else {
 				require.NoError(t, err)
 

--- a/receiver/saphanareceiver/client_test.go
+++ b/receiver/saphanareceiver/client_test.go
@@ -211,7 +211,7 @@ func TestNullOutput(t *testing.T) {
 
 	results, err := client.collectDataFromQuery(context.TODO(), query)
 	// Error expected for second row, but data is also returned
-	require.Contains(t, err.Error(), "database row NULL value for required metric label id")
+	require.ErrorContains(t, err, "database row NULL value for required metric label id")
 	require.Equal(t, []map[string]string{
 		{
 			"id":    "my_id",

--- a/receiver/snmpreceiver/client_test.go
+++ b/receiver/snmpreceiver/client_test.go
@@ -67,7 +67,7 @@ func TestNewClient(t *testing.T) {
 			ac, err := newClient(tc.cfg, tc.logger)
 			if tc.expectError != nil {
 				require.Nil(t, ac)
-				require.Contains(t, err.Error(), tc.expectError.Error())
+				require.ErrorContains(t, err, tc.expectError.Error())
 			} else {
 				require.NoError(t, err)
 

--- a/receiver/snowflakereceiver/config_test.go
+++ b/receiver/snowflakereceiver/config_test.go
@@ -97,8 +97,7 @@ func TestValidateConfig(t *testing.T) {
 			t.Parallel()
 
 			err := test.conf.Validate()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), test.expect.Error())
+			require.ErrorContains(t, err, test.expect.Error())
 		})
 	}
 }

--- a/receiver/solacereceiver/unmarshaller_test.go
+++ b/receiver/solacereceiver/unmarshaller_test.go
@@ -327,8 +327,7 @@ func TestSolaceMessageUnmarshallerUnmarshal(t *testing.T) {
 			u := newTracesUnmarshaller(zap.NewNop(), telemetryBuilder, metricAttr)
 			traces, err := u.unmarshal(tt.message)
 			if tt.err != nil {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), tt.err.Error())
+				assert.ErrorContains(t, err, tt.err.Error())
 			} else {
 				assert.NoError(t, err)
 			}

--- a/receiver/statsdreceiver/config_test.go
+++ b/receiver/statsdreceiver/config_test.go
@@ -213,8 +213,7 @@ func TestConfig_Validate_MaxSize(t *testing.T) {
 			},
 		}
 		err := cfg.Validate()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "histogram max_size out of range")
+		assert.ErrorContains(t, err, "histogram max_size out of range")
 	}
 }
 func TestConfig_Validate_HistogramGoodConfig(t *testing.T) {

--- a/receiver/webhookeventreceiver/config_test.go
+++ b/receiver/webhookeventreceiver/config_test.go
@@ -106,8 +106,7 @@ func TestValidateConfig(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			err := test.conf.Validate()
-			require.Error(t, err)
-			require.Contains(t, err.Error(), test.expect.Error())
+			require.ErrorContains(t, err, test.expect.Error())
 		})
 	}
 }


### PR DESCRIPTION
#### Description

Testifylint doesn't support it yet. 
This replaces `Contains(t, err.Error()` by `ErrorContains(t, err` and `Equal(t, err.Error()` by `EqualError(t, err`
As they both check for nil error it becomes useless to check it yourself without having defined a custom message

<!-- Signed-off-by: Matthieu MOREL <matthieu.morel35@gmail.com> -->
