### PR TITLE
[chore][fileconsumer/tracker] cleanup tracker and use options

### DIFF
--- a/pkg/stanza/fileconsumer/config.go
+++ b/pkg/stanza/fileconsumer/config.go
@@ -25,7 +25,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/scanner"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/tracker"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/matcher"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/helper"
@@ -174,13 +173,6 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 		AcquireFSLock:           c.AcquireFSLock,
 	}
 
-	var t tracker.Tracker
-	if o.noTracking {
-		t = tracker.NewNoStateTracker(set, c.MaxConcurrentFiles/2)
-	} else {
-		t = tracker.NewFileTracker(set, c.MaxConcurrentFiles/2)
-	}
-
 	telemetryBuilder, err := metadata.NewTelemetryBuilder(set)
 	if err != nil {
 		return nil, err
@@ -192,8 +184,8 @@ func (c Config) Build(set component.TelemetrySettings, emit emit.Callback, opts 
 		pollInterval:     c.PollInterval,
 		maxBatchFiles:    c.MaxConcurrentFiles / 2,
 		maxBatches:       c.MaxBatches,
-		tracker:          t,
 		telemetryBuilder: telemetryBuilder,
+		noTracking:       o.noTracking,
 	}, nil
 }
 

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -77,7 +77,9 @@ func (m *Manager) Stop() error {
 		m.cancel = nil
 	}
 	m.wg.Wait()
-	m.telemetryBuilder.FileconsumerOpenFiles.Add(context.TODO(), int64(0-m.tracker.ClosePreviousFiles()))
+	if m.tracker != nil {
+		m.telemetryBuilder.FileconsumerOpenFiles.Add(context.TODO(), int64(0-m.tracker.ClosePreviousFiles()))
+	}
 	if m.persister != nil {
 		if err := checkpoint.Save(context.Background(), m.persister, m.tracker.GetMetadata()); err != nil {
 			m.set.Logger.Error("save offsets", zap.Error(err))

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -269,5 +269,9 @@ func (m *Manager) newReader(ctx context.Context, file *os.File, fp *fingerprint.
 }
 
 func (m *Manager) instantiateTracker() {
-	m.tracker = tracker.NewFileTracker(m.set, tracker.WithMaxBatchFiles(m.maxBatchFiles), tracker.WithNoTracking(m.noTracking))
+	opts := []tracker.OptionFunc{tracker.WithMaxBatchFiles(m.maxBatchFiles)}
+	if m.noTracking {
+		opts = append(opts, tracker.WithNoTracking())
+	}
+	m.tracker = tracker.NewFileTracker(m.set, opts...)
 }

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -48,6 +48,9 @@ func (m *Manager) Start(persister operator.Persister) error {
 		m.set.Logger.Warn("finding files", zap.Error(err))
 	}
 
+	// instantiate the tracker
+	m.instantiateTracker()
+
 	if persister != nil {
 		m.persister = persister
 		offsets, err := checkpoint.Load(ctx, m.persister)
@@ -60,9 +63,6 @@ func (m *Manager) Start(persister operator.Persister) error {
 			m.tracker.LoadMetadata(offsets)
 		}
 	}
-
-	// instantiate the tracker
-	m.instantiateTracker()
 
 	// Start polling goroutine
 	m.startPoller(ctx)

--- a/pkg/stanza/fileconsumer/file.go
+++ b/pkg/stanza/fileconsumer/file.go
@@ -30,6 +30,7 @@ type Manager struct {
 	readerFactory reader.Factory
 	fileMatcher   *matcher.Matcher
 	tracker       tracker.Tracker
+	noTracking    bool
 
 	pollInterval  time.Duration
 	persister     operator.Persister
@@ -59,6 +60,9 @@ func (m *Manager) Start(persister operator.Persister) error {
 			m.tracker.LoadMetadata(offsets)
 		}
 	}
+
+	// instantiate the tracker
+	m.instantiateTracker()
 
 	// Start polling goroutine
 	m.startPoller(ctx)
@@ -260,4 +264,8 @@ func (m *Manager) newReader(ctx context.Context, file *os.File, fp *fingerprint.
 	}
 	m.telemetryBuilder.FileconsumerOpenFiles.Add(ctx, 1)
 	return r, nil
+}
+
+func (m *Manager) instantiateTracker() {
+	m.tracker = tracker.NewFileTracker(m.set, tracker.WithMaxBatchFiles(m.maxBatchFiles), tracker.WithNoTracking(m.noTracking))
 }

--- a/pkg/stanza/fileconsumer/internal/tracker/tracker.go
+++ b/pkg/stanza/fileconsumer/internal/tracker/tracker.go
@@ -52,9 +52,9 @@ func WithMaxBatchFiles(maxBatchFiles int) OptionFunc {
 	}
 }
 
-func WithNoTracking(noTracking bool) OptionFunc {
+func WithNoTracking() OptionFunc {
 	return func(fto *option) {
-		fto.noTracking = noTracking
+		fto.noTracking = true
 	}
 }
 

--- a/pkg/stanza/fileconsumer/internal/tracker/tracker.go
+++ b/pkg/stanza/fileconsumer/internal/tracker/tracker.go
@@ -40,9 +40,8 @@ type fileTracker struct {
 }
 
 type option struct {
-	maxBatchFiles  int
-	pollsToArchive int
-	noTracking     bool
+	maxBatchFiles int
+	noTracking    bool
 }
 
 type OptionFunc func(*option)

--- a/pkg/stanza/fileconsumer/util_test.go
+++ b/pkg/stanza/fileconsumer/util_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/emittest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/tracker"
 )
 
 func testManager(t *testing.T, cfg *Config, opts ...Option) (*Manager, *emittest.Sink) {
@@ -20,6 +21,7 @@ func testManager(t *testing.T, cfg *Config, opts ...Option) (*Manager, *emittest
 func testManagerWithSink(t *testing.T, cfg *Config, sink *emittest.Sink, opts ...Option) *Manager {
 	set := componenttest.NewNopTelemetrySettings()
 	input, err := cfg.Build(set, sink.Callback, opts...)
+	input.tracker = tracker.NewFileTracker(set)
 	require.NoError(t, err)
 	t.Cleanup(func() { input.tracker.ClosePreviousFiles() })
 	return input


### PR DESCRIPTION
**Description:** @djaglowski this follows our [discussion](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35098/files#r1781180902).

I've introduced options and moved tracker into `Start`. Looks much neater and configurable.
