### PR TITLE
docs(attributesprocessor): Mention include_metadata is needed to get HTTP/gRPC headers

### DIFF
--- a/processor/attributesprocessor/README.md
+++ b/processor/attributesprocessor/README.md
@@ -59,7 +59,8 @@ For the actions `insert`, `update` and `upsert`,
   action: {insert, update, upsert}
   # FromContext specifies the context value to use to populate the attribute value. 
   # If the key is prefixed with `metadata.`, the values are searched
-  # in the receiver's transport protocol additional information like gRPC Metadata or HTTP Headers. 
+  # in the receiver's transport protocol additional information like gRPC Metadata or HTTP Headers
+  # (be sure to set `include_metadata: true` on the receiver).
   # If the key is prefixed with `auth.`, the values are searched
   # in the authentication information set by the server authenticator.
   # Refer to the server authenticator's documentation part of your pipeline for more information about which attributes are available.


### PR DESCRIPTION
**Description:** 
In the README of attributesprocessor, where it is explain that the user can use `from_context: metadata.my-header` to get the value of the HTTP/gRPC header `my-header`, mention that the user should also set `include_metadata: true` in the receiver configuration, otherwise the headers are not added to the metadata (and therefore cannot be read by attributesprocessor).
