### PR TITLE
[exporter/alertmanager] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/alertmanagerexporter/config_test.go
+++ b/exporter/alertmanagerexporter/config_test.go
@@ -4,6 +4,7 @@
 package alertmanagerexporter
 
 import (
+	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -23,6 +24,7 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
+	defaultTransport := http.DefaultTransport.(*http.Transport)
 	t.Parallel()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
@@ -74,9 +76,13 @@ func TestLoadConfig(t *testing.T) {
 							CAFile: "/var/lib/mycert.pem",
 						},
 					},
-					ReadBufferSize:  0,
-					WriteBufferSize: 524288,
-					Timeout:         time.Second * 10,
+					ReadBufferSize:      0,
+					WriteBufferSize:     524288,
+					Timeout:             time.Second * 10,
+					MaxIdleConns:        &defaultTransport.MaxIdleConns,
+					MaxIdleConnsPerHost: &defaultTransport.MaxIdleConnsPerHost,
+					MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
+					IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
 				},
 			},
 		},

--- a/exporter/alertmanagerexporter/factory.go
+++ b/exporter/alertmanagerexporter/factory.go
@@ -10,7 +10,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -27,18 +26,18 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "http://localhost:9093"
+	clientConfig.Timeout = 30 * time.Second
+	clientConfig.WriteBufferSize = 512 * 1024
+
 	return &Config{
 		GeneratorURL:    "opentelemetry-collector",
 		DefaultSeverity: "info",
 		TimeoutSettings: exporterhelper.NewDefaultTimeoutConfig(),
 		BackoffConfig:   configretry.NewDefaultBackOffConfig(),
 		QueueSettings:   exporterhelper.NewDefaultQueueConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint:        "http://localhost:9093",
-			Timeout:         30 * time.Second,
-			Headers:         map[string]configopaque.String{},
-			WriteBufferSize: 512 * 1024,
-		},
+		ClientConfig:    clientConfig,
 	}
 }
 


### PR DESCRIPTION
**Description:** 
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457