### PR TITLE
[exporter/datadogexporter, pkg/datadog, testbed] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/datadogexporter/factory.go
+++ b/exporter/datadogexporter/factory.go
@@ -190,10 +190,9 @@ func NewFactory() exporter.Factory {
 }
 
 func defaultClientConfig() confighttp.ClientConfig {
-	// do not use NewDefaultClientConfig for backwards-compatibility
-	return confighttp.ClientConfig{
-		Timeout: 15 * time.Second,
-	}
+	client := confighttp.NewDefaultClientConfig()
+	client.Timeout = 15 * time.Second
+	return client
 }
 
 // createDefaultConfig creates the default exporter configuration

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -281,10 +281,9 @@ func (c *Config) Unmarshal(configMap *confmap.Conf) error {
 }
 
 func defaultClientConfig() confighttp.ClientConfig {
-	// do not use NewDefaultClientConfig for backwards-compatibility
-	return confighttp.ClientConfig{
-		Timeout: 15 * time.Second,
-	}
+	client := confighttp.NewDefaultClientConfig()
+	client.Timeout = 15 * time.Second
+	return client
 }
 
 // CreateDefaultConfig creates the default exporter configuration

--- a/pkg/datadog/config/config.go
+++ b/pkg/datadog/config/config.go
@@ -147,7 +147,7 @@ func validateClientConfig(cfg confighttp.ClientConfig) error {
 	if cfg.Compression != "" {
 		unsupported = append(unsupported, "compression")
 	}
-	if cfg.Headers != nil {
+	if len(cfg.Headers) > 0 {
 		unsupported = append(unsupported, "headers")
 	}
 	if cfg.HTTP2ReadIdleTimeout != 0 {

--- a/testbed/mockdatasenders/mockdatadogagentexporter/factory.go
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/factory.go
@@ -33,10 +33,6 @@ func createDefaultConfig() component.Config {
 	client := confighttp.NewDefaultClientConfig()
 	client.Endpoint = "localhost:8126"
 	return client
-
-	return &Config{
-		ClientConfig: client,
-	}
 }
 
 func CreateTracesExporter(

--- a/testbed/mockdatasenders/mockdatadogagentexporter/factory.go
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/factory.go
@@ -30,8 +30,12 @@ func NewFactory() exporter.Factory {
 
 // CreateDefaultConfig creates the default configuration for DDAPM Exporter
 func createDefaultConfig() component.Config {
+	client := confighttp.NewDefaultClientConfig()
+	client.Endpoint = "localhost:8126"
+	return client
+
 	return &Config{
-		ClientConfig: confighttp.ClientConfig{Endpoint: "localhost:8126"},
+		ClientConfig: client,
 	}
 }
 


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457