### PR TITLE
[chore] [exporter/logzio] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/logzioexporter/config_test.go
+++ b/exporter/logzioexporter/config_test.go
@@ -23,7 +23,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter/internal/metadata"
 )
 
-var defaultTransport = http.DefaultTransport.(*http.Transport)
+var defaultMaxIdleConns = http.DefaultTransport.(*http.Transport).MaxIdleConns
+var defaultMaxIdleConnsPerHost = http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
+var defaultMaxConnsPerHost = http.DefaultTransport.(*http.Transport).MaxConnsPerHost
+var defaultIdleConnTimeout = http.DefaultTransport.(*http.Transport).IdleConnTimeout
 
 func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
@@ -51,10 +54,10 @@ func TestLoadConfig(t *testing.T) {
 		Compression: configcompression.TypeGzip,
 		// We almost read 0 bytes, so no need to tune ReadBufferSize.
 		WriteBufferSize:     512 * 1024,
-		MaxIdleConns:        &defaultTransport.MaxIdleConns,
-		MaxIdleConnsPerHost: &defaultTransport.MaxIdleConnsPerHost,
-		MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
-		IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
+		MaxIdleConns:        &defaultMaxIdleConns,
+		MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+		MaxConnsPerHost:     &defaultMaxConnsPerHost,
+		IdleConnTimeout:     &defaultIdleConnTimeout,
 	}
 	assert.Equal(t, expected, cfg)
 }
@@ -82,10 +85,10 @@ func TestDefaultLoadConfig(t *testing.T) {
 		Compression: configcompression.TypeGzip,
 		// We almost read 0 bytes, so no need to tune ReadBufferSize.
 		WriteBufferSize:     512 * 1024,
-		MaxIdleConns:        &defaultTransport.MaxIdleConns,
-		MaxIdleConnsPerHost: &defaultTransport.MaxIdleConnsPerHost,
-		MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
-		IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
+		MaxIdleConns:        &defaultMaxIdleConns,
+		MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+		MaxConnsPerHost:     &defaultMaxConnsPerHost,
+		IdleConnTimeout:     &defaultIdleConnTimeout,
 	}
 	assert.Equal(t, expected, cfg)
 }

--- a/exporter/logzioexporter/config_test.go
+++ b/exporter/logzioexporter/config_test.go
@@ -4,7 +4,6 @@
 package logzioexporter
 
 import (
-	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -14,7 +13,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -22,11 +20,6 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter/internal/metadata"
 )
-
-var defaultMaxIdleConns = http.DefaultTransport.(*http.Transport).MaxIdleConns
-var defaultMaxIdleConnsPerHost = http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
-var defaultMaxConnsPerHost = http.DefaultTransport.(*http.Transport).MaxConnsPerHost
-var defaultIdleConnTimeout = http.DefaultTransport.(*http.Transport).IdleConnTimeout
 
 func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
@@ -46,19 +39,11 @@ func TestLoadConfig(t *testing.T) {
 	expected.BackOffConfig.MaxInterval = 5 * time.Second
 	expected.QueueSettings = exporterhelper.NewDefaultQueueConfig()
 	expected.QueueSettings.Enabled = false
-	expected.ClientConfig = confighttp.ClientConfig{
-		Endpoint: "",
-		Timeout:  30 * time.Second,
-		Headers:  map[string]configopaque.String{},
-		// Default to gzip compression
-		Compression: configcompression.TypeGzip,
-		// We almost read 0 bytes, so no need to tune ReadBufferSize.
-		WriteBufferSize:     512 * 1024,
-		MaxIdleConns:        &defaultMaxIdleConns,
-		MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
-		MaxConnsPerHost:     &defaultMaxConnsPerHost,
-		IdleConnTimeout:     &defaultIdleConnTimeout,
-	}
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 30 * time.Second
+	clientConfig.Compression = configcompression.TypeGzip
+	clientConfig.WriteBufferSize = 512 * 1024
+	expected.ClientConfig = clientConfig
 	assert.Equal(t, expected, cfg)
 }
 
@@ -77,23 +62,19 @@ func TestDefaultLoadConfig(t *testing.T) {
 	}
 	expected.BackOffConfig = configretry.NewDefaultBackOffConfig()
 	expected.QueueSettings = exporterhelper.NewDefaultQueueConfig()
-	expected.ClientConfig = confighttp.ClientConfig{
-		Endpoint: "",
-		Timeout:  30 * time.Second,
-		Headers:  map[string]configopaque.String{},
-		// Default to gzip compression
-		Compression: configcompression.TypeGzip,
-		// We almost read 0 bytes, so no need to tune ReadBufferSize.
-		WriteBufferSize:     512 * 1024,
-		MaxIdleConns:        &defaultMaxIdleConns,
-		MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
-		MaxConnsPerHost:     &defaultMaxConnsPerHost,
-		IdleConnTimeout:     &defaultIdleConnTimeout,
-	}
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 30 * time.Second
+	clientConfig.Compression = configcompression.TypeGzip
+	clientConfig.WriteBufferSize = 512 * 1024
+	expected.ClientConfig = clientConfig
 	assert.Equal(t, expected, cfg)
 }
 
 func TestCheckAndWarnDeprecatedOptions(t *testing.T) {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 10 * time.Second
+	clientConfig.Compression = configcompression.TypeGzip
+	clientConfig.WriteBufferSize = 512 * 1024
 	// Config with legacy options
 	actualCfg := &Config{
 		QueueSettings:  exporterhelper.NewDefaultQueueConfig(),
@@ -102,15 +83,7 @@ func TestCheckAndWarnDeprecatedOptions(t *testing.T) {
 		CustomEndpoint: "https://api.example.com",
 		QueueMaxLength: 10,
 		DrainInterval:  10,
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: "",
-			Timeout:  10 * time.Second,
-			Headers:  map[string]configopaque.String{},
-			// Default to gzip compression
-			Compression: configcompression.TypeGzip,
-			// We almost read 0 bytes, so no need to tune ReadBufferSize.
-			WriteBufferSize: 512 * 1024,
-		},
+		ClientConfig:   clientConfig,
 	}
 	params := exportertest.NewNopSettings()
 	logger := hclog2ZapLogger{
@@ -119,6 +92,12 @@ func TestCheckAndWarnDeprecatedOptions(t *testing.T) {
 	}
 	actualCfg.checkAndWarnDeprecatedOptions(&logger)
 
+	clientConfigEndpoint := confighttp.NewDefaultClientConfig()
+	clientConfigEndpoint.Timeout = 10 * time.Second
+	clientConfigEndpoint.Compression = configcompression.TypeGzip
+	clientConfigEndpoint.WriteBufferSize = 512 * 1024
+	clientConfigEndpoint.Endpoint = "https://api.example.com"
+
 	expected := &Config{
 		Token:          "logzioTESTtoken",
 		CustomEndpoint: "https://api.example.com",
@@ -126,15 +105,7 @@ func TestCheckAndWarnDeprecatedOptions(t *testing.T) {
 		DrainInterval:  10,
 		BackOffConfig:  configretry.NewDefaultBackOffConfig(),
 		QueueSettings:  exporterhelper.NewDefaultQueueConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: "https://api.example.com",
-			Timeout:  10 * time.Second,
-			Headers:  map[string]configopaque.String{},
-			// Default to gzip compression
-			Compression: configcompression.TypeGzip,
-			// We almost read 0 bytes, so no need to tune ReadBufferSize.
-			WriteBufferSize: 512 * 1024,
-		},
+		ClientConfig:   clientConfigEndpoint,
 	}
 	expected.QueueSettings.QueueSize = 10
 	assert.Equal(t, expected, actualCfg)

--- a/exporter/logzioexporter/config_test.go
+++ b/exporter/logzioexporter/config_test.go
@@ -4,6 +4,7 @@
 package logzioexporter
 
 import (
+	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -21,6 +22,8 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/logzioexporter/internal/metadata"
 )
+
+var defaultTransport = http.DefaultTransport.(*http.Transport)
 
 func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
@@ -47,7 +50,11 @@ func TestLoadConfig(t *testing.T) {
 		// Default to gzip compression
 		Compression: configcompression.TypeGzip,
 		// We almost read 0 bytes, so no need to tune ReadBufferSize.
-		WriteBufferSize: 512 * 1024,
+		WriteBufferSize:     512 * 1024,
+		MaxIdleConns:        &defaultTransport.MaxIdleConns,
+		MaxIdleConnsPerHost: &defaultTransport.MaxIdleConnsPerHost,
+		MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
+		IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
 	}
 	assert.Equal(t, expected, cfg)
 }
@@ -74,7 +81,11 @@ func TestDefaultLoadConfig(t *testing.T) {
 		// Default to gzip compression
 		Compression: configcompression.TypeGzip,
 		// We almost read 0 bytes, so no need to tune ReadBufferSize.
-		WriteBufferSize: 512 * 1024,
+		WriteBufferSize:     512 * 1024,
+		MaxIdleConns:        &defaultTransport.MaxIdleConns,
+		MaxIdleConnsPerHost: &defaultTransport.MaxIdleConnsPerHost,
+		MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
+		IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
 	}
 	assert.Equal(t, expected, cfg)
 }

--- a/exporter/logzioexporter/exporter_test.go
+++ b/exporter/logzioexporter/exporter_test.go
@@ -186,12 +186,13 @@ func TestExportErrors(tester *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			rw.WriteHeader(test.status)
 		}))
+		clientConfig := confighttp.NewDefaultClientConfig()
+		clientConfig.Endpoint = server.URL
+
 		cfg := &Config{
-			Region: "",
-			Token:  "token",
-			ClientConfig: confighttp.ClientConfig{
-				Endpoint: server.URL,
-			},
+			Region:       "",
+			Token:        "token",
+			ClientConfig: clientConfig,
 		}
 		td := newTestTracesWithAttributes()
 		ld := testdata.GenerateLogs(10)
@@ -240,13 +241,13 @@ func TestPushTraceData(tester *testing.T) {
 		recordedRequests, _ = io.ReadAll(req.Body)
 		rw.WriteHeader(http.StatusOK)
 	}))
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = server.URL
+	clientConfig.Compression = configcompression.TypeGzip
 	cfg := Config{
-		Token:  "token",
-		Region: "",
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint:    server.URL,
-			Compression: configcompression.TypeGzip,
-		},
+		Token:        "token",
+		Region:       "",
+		ClientConfig: clientConfig,
 	}
 	defer server.Close()
 	td := newTestTraces()
@@ -273,13 +274,13 @@ func TestPushLogsData(tester *testing.T) {
 		recordedRequests, _ = io.ReadAll(req.Body)
 		rw.WriteHeader(http.StatusOK)
 	}))
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = server.URL
+	clientConfig.Compression = configcompression.TypeGzip
 	cfg := Config{
-		Token:  "token",
-		Region: "",
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint:    server.URL,
-			Compression: configcompression.TypeGzip,
-		},
+		Token:        "token",
+		Region:       "",
+		ClientConfig: clientConfig,
 	}
 	defer server.Close()
 	ld := generateLogsOneEmptyTimestamp()

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -34,20 +34,19 @@ func NewFactory() exporter.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 30 * time.Second
+	clientConfig.Headers = map[string]configopaque.String{}
+	// Default to gzip compression
+	clientConfig.Compression = configcompression.TypeGzip
+	// We almost read 0 bytes, so no need to tune ReadBufferSize.
+	clientConfig.WriteBufferSize = 512 * 1024
 	return &Config{
 		Region:        "",
 		Token:         "",
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),
 		QueueSettings: exporterhelper.NewDefaultQueueConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: "",
-			Timeout:  30 * time.Second,
-			Headers:  map[string]configopaque.String{},
-			// Default to gzip compression
-			Compression: configcompression.TypeGzip,
-			// We almost read 0 bytes, so no need to tune ReadBufferSize.
-			WriteBufferSize: 512 * 1024,
-		},
+		ClientConfig:  clientConfig,
 	}
 }
 

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -36,7 +36,6 @@ func NewFactory() exporter.Factory {
 func createDefaultConfig() component.Config {
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.Timeout = 30 * time.Second
-	clientConfig.Headers = map[string]configopaque.String{}
 	// Default to gzip compression
 	clientConfig.Compression = configcompression.TypeGzip
 	// We almost read 0 bytes, so no need to tune ReadBufferSize.

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configcompression"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"

--- a/exporter/logzioexporter/factory_test.go
+++ b/exporter/logzioexporter/factory_test.go
@@ -60,12 +60,12 @@ func TestGenerateUrl(t *testing.T) {
 		{"", "EU", "https://listener-eu.logz.io:8071/?token=token"},
 	}
 	for _, test := range generateURLTests {
+		clientConfig := confighttp.NewDefaultClientConfig()
+		clientConfig.Endpoint = test.endpoint
 		cfg := &Config{
-			Region: test.region,
-			Token:  "token",
-			ClientConfig: confighttp.ClientConfig{
-				Endpoint: test.endpoint,
-			},
+			Region:       test.region,
+			Token:        "token",
+			ClientConfig: clientConfig,
 		}
 		output, _ := generateEndpoint(cfg)
 		require.Equal(t, test.expected, output)

--- a/exporter/logzioexporter/jsonlog_test.go
+++ b/exporter/logzioexporter/jsonlog_test.go
@@ -83,13 +83,13 @@ func TestSetTimeStamp(t *testing.T) {
 	}))
 	defer func() { server.Close() }()
 	ld := generateLogsOneEmptyTimestamp()
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = server.URL
+	clientConfig.Compression = configcompression.TypeGzip
 	cfg := &Config{
-		Region: "us",
-		Token:  "token",
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint:    server.URL,
-			Compression: configcompression.TypeGzip,
-		},
+		Region:       "us",
+		Token:        "token",
+		ClientConfig: clientConfig,
 	}
 	var err error
 	params := exportertest.NewNopSettings()


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457