### PR TITLE
[receiver/k8seventsreceiver] adding namespace to k8sEventsReceiver's resource attributes

### DIFF
--- a/.chloggen/enable_ingesting_k8s_event_receiver_into_index_from_namespace_annotation.yaml
+++ b/.chloggen/enable_ingesting_k8s_event_receiver_into_index_from_namespace_annotation.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8seventsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: adding namespace to k8s events receiver resource attributes to enable matching for k8sattributes processor, which will then allow to ingest events into index defined in namespace annotation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [17]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/enable_ingesting_k8s_event_receiver_into_index_from_namespace_annotation.yaml
+++ b/.chloggen/enable_ingesting_k8s_event_receiver_into_index_from_namespace_annotation.yaml
@@ -10,7 +10,7 @@ component: k8seventsreceiver
 note: adding namespace to k8s events receiver resource attributes to enable matching for k8sattributes processor, which will then allow to ingest events into index defined in namespace annotation
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [17]
+issues: [35528]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/receiver/k8seventsreceiver/k8s_event_to_logdata.go
+++ b/receiver/k8seventsreceiver/k8s_event_to_logdata.go
@@ -18,7 +18,7 @@ const (
 	totalLogAttributes = 7
 
 	// Number of resource attributes to add to the plog.ResourceLogs.
-	totalResourceAttributes = 6
+	totalResourceAttributes = 8
 )
 
 // Only two types of events are created as of now.
@@ -39,6 +39,7 @@ func k8sEventToLogData(logger *zap.Logger, ev *corev1.Event) plog.Logs {
 	resourceAttrs.EnsureCapacity(totalResourceAttributes)
 
 	resourceAttrs.PutStr(semconv.AttributeK8SNodeName, ev.Source.Host)
+	resourceAttrs.PutStr(semconv.AttributeK8SNamespaceName, ev.Namespace)
 
 	// Attributes related to the object causing the event.
 	resourceAttrs.PutStr("k8s.object.kind", ev.InvolvedObject.Kind)

--- a/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
+++ b/receiver/k8seventsreceiver/k8s_event_to_logdata_test.go
@@ -20,7 +20,7 @@ func TestK8sEventToLogData(t *testing.T) {
 	lr := rl.ScopeLogs().At(0)
 	attrs := lr.LogRecords().At(0).Attributes()
 	assert.Equal(t, 1, ld.ResourceLogs().Len())
-	assert.Equal(t, 7, resourceAttrs.Len())
+	assert.Equal(t, 8, resourceAttrs.Len())
 	assert.Equal(t, 7, attrs.Len())
 
 	// Count attribute will not be present in the LogData


### PR DESCRIPTION
Description: adding namespace to k8sEventsReceiver's resource attributes to enable matching for k8sattributes processor, which will then allow to ingest events into index defined in namespace annotation

Link to tracking Issue: N/A

Testing: Manually tested

Documentation: N/A