### PR TITLE
[chore] [exporter/mezmo] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/mezmoexporter/config.go
+++ b/exporter/mezmoexporter/config.go
@@ -46,9 +46,9 @@ type Config struct {
 
 // returns default http client settings
 func createDefaultClientConfig() confighttp.ClientConfig {
-	return confighttp.ClientConfig{
-		Timeout: defaultTimeout,
-	}
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = defaultTimeout
+	return clientConfig
 }
 
 func (c *Config) Validate() error {

--- a/exporter/mezmoexporter/config_test.go
+++ b/exporter/mezmoexporter/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -42,7 +43,12 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "allsettings"),
 			expected: &Config{
 				ClientConfig: confighttp.ClientConfig{
-					Timeout: 5 * time.Second,
+					Timeout:             5 * time.Second,
+					MaxIdleConns:        &defaultMaxIdleConns,
+					MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+					MaxConnsPerHost:     &defaultMaxConnsPerHost,
+					IdleConnTimeout:     &defaultIdleConnTimeout,
+					Headers:             map[string]configopaque.String{},
 				},
 				BackOffConfig: configretry.BackOffConfig{
 					Enabled:             false,

--- a/exporter/mezmoexporter/factory_test.go
+++ b/exporter/mezmoexporter/factory_test.go
@@ -5,12 +5,14 @@ package mezmoexporter
 
 import (
 	"context"
+	"net/http"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/exportertest"
@@ -25,6 +27,11 @@ func TestType(t *testing.T) {
 }
 
 func TestCreateDefaultConfig(t *testing.T) {
+	defaultMaxIdleConns := http.DefaultTransport.(*http.Transport).MaxIdleConns
+	defaultMaxIdleConnsPerHost := http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
+	defaultMaxConnsPerHost := http.DefaultTransport.(*http.Transport).MaxConnsPerHost
+	defaultIdleConnTimeout := http.DefaultTransport.(*http.Transport).IdleConnTimeout
+
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 
@@ -33,7 +40,12 @@ func TestCreateDefaultConfig(t *testing.T) {
 		IngestKey: "",
 
 		ClientConfig: confighttp.ClientConfig{
-			Timeout: 5 * time.Second,
+			Timeout:             5 * time.Second,
+			MaxIdleConns:        &defaultMaxIdleConns,
+			MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+			MaxConnsPerHost:     &defaultMaxConnsPerHost,
+			IdleConnTimeout:     &defaultIdleConnTimeout,
+			Headers:             map[string]configopaque.String{},
 		},
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),
 		QueueSettings: exporterhelper.NewDefaultQueueConfig(),

--- a/exporter/mezmoexporter/factory_test.go
+++ b/exporter/mezmoexporter/factory_test.go
@@ -26,12 +26,12 @@ func TestType(t *testing.T) {
 	assert.Equal(t, pType, metadata.Type)
 }
 
-func TestCreateDefaultConfig(t *testing.T) {
-	defaultMaxIdleConns := http.DefaultTransport.(*http.Transport).MaxIdleConns
-	defaultMaxIdleConnsPerHost := http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
-	defaultMaxConnsPerHost := http.DefaultTransport.(*http.Transport).MaxConnsPerHost
-	defaultIdleConnTimeout := http.DefaultTransport.(*http.Transport).IdleConnTimeout
+var defaultMaxIdleConns = http.DefaultTransport.(*http.Transport).MaxIdleConns
+var defaultMaxIdleConnsPerHost = http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
+var defaultMaxConnsPerHost = http.DefaultTransport.(*http.Transport).MaxConnsPerHost
+var defaultIdleConnTimeout = http.DefaultTransport.(*http.Transport).IdleConnTimeout
 
+func TestCreateDefaultConfig(t *testing.T) {
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457