### PR TITLE
[chore] [exporter/prometheusremotewrite] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -4,6 +4,7 @@
 package prometheusremotewriteexporter
 
 import (
+	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -24,6 +25,11 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
+	defaultMaxIdleConns := http.DefaultTransport.(*http.Transport).MaxIdleConns
+	defaultMaxIdleConnsPerHost := http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
+	defaultMaxConnsPerHost := http.DefaultTransport.(*http.Transport).MaxConnsPerHost
+	defaultIdleConnTimeout := http.DefaultTransport.(*http.Transport).IdleConnTimeout
+
 	t.Parallel()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
@@ -73,6 +79,10 @@ func TestLoadConfig(t *testing.T) {
 					Headers: map[string]configopaque.String{
 						"Prometheus-Remote-Write-Version": "0.1.0",
 						"X-Scope-OrgID":                   "234"},
+					MaxIdleConns:        &defaultMaxIdleConns,
+					MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+					MaxConnsPerHost:     &defaultMaxConnsPerHost,
+					IdleConnTimeout:     &defaultIdleConnTimeout,
 				},
 				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
 				TargetInfo: &TargetInfo{

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -4,7 +4,6 @@
 package prometheusremotewriteexporter
 
 import (
-	"net/http"
 	"path/filepath"
 	"testing"
 	"time"
@@ -25,16 +24,26 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	defaultMaxIdleConns := http.DefaultTransport.(*http.Transport).MaxIdleConns
-	defaultMaxIdleConnsPerHost := http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
-	defaultMaxConnsPerHost := http.DefaultTransport.(*http.Transport).MaxConnsPerHost
-	defaultIdleConnTimeout := http.DefaultTransport.(*http.Transport).IdleConnTimeout
-
 	t.Parallel()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "localhost:8888"
+	clientConfig.TLSSetting = configtls.ClientConfig{
+		Config: configtls.Config{
+			CAFile: "/var/lib/mycert.pem", // This is subject to change, but currently I have no idea what else to put here lol
+		},
+		Insecure: false,
+	}
+	clientConfig.ReadBufferSize = 0
+	clientConfig.WriteBufferSize = 512 * 1024
+	clientConfig.Timeout = 5 * time.Second
+	clientConfig.Headers = map[string]configopaque.String{
+		"Prometheus-Remote-Write-Version": "0.1.0",
+		"X-Scope-OrgID":                   "234",
+	}
 	tests := []struct {
 		id           component.ID
 		expected     component.Config
@@ -62,28 +71,10 @@ func TestLoadConfig(t *testing.T) {
 					QueueSize:    2000,
 					NumConsumers: 10,
 				},
-				AddMetricSuffixes: false,
-				Namespace:         "test-space",
-				ExternalLabels:    map[string]string{"key1": "value1", "key2": "value2"},
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: "localhost:8888",
-					TLSSetting: configtls.ClientConfig{
-						Config: configtls.Config{
-							CAFile: "/var/lib/mycert.pem", // This is subject to change, but currently I have no idea what else to put here lol
-						},
-						Insecure: false,
-					},
-					ReadBufferSize:  0,
-					WriteBufferSize: 512 * 1024,
-					Timeout:         5 * time.Second,
-					Headers: map[string]configopaque.String{
-						"Prometheus-Remote-Write-Version": "0.1.0",
-						"X-Scope-OrgID":                   "234"},
-					MaxIdleConns:        &defaultMaxIdleConns,
-					MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
-					MaxConnsPerHost:     &defaultMaxConnsPerHost,
-					IdleConnTimeout:     &defaultIdleConnTimeout,
-				},
+				AddMetricSuffixes:           false,
+				Namespace:                   "test-space",
+				ExternalLabels:              map[string]string{"key1": "value1", "key2": "value2"},
+				ClientConfig:                clientConfig,
 				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
 				TargetInfo: &TargetInfo{
 					Enabled: true,

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -45,7 +45,7 @@ func Test_NewPRWExporter(t *testing.T) {
 		BackOffConfig:   configretry.BackOffConfig{},
 		Namespace:       "",
 		ExternalLabels:  map[string]string{},
-		ClientConfig:    confighttp.ClientConfig{Endpoint: ""},
+		ClientConfig:    confighttp.NewDefaultClientConfig(),
 		TargetInfo: &TargetInfo{
 			Enabled: true,
 		},
@@ -155,6 +155,21 @@ func Test_Start(t *testing.T) {
 	}
 	set := exportertest.NewNopSettings()
 	set.BuildInfo = buildInfo
+
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "https://some.url:9411/api/prom/push"
+	clientConfigTLS := confighttp.NewDefaultClientConfig()
+	clientConfigTLS.Endpoint = "https://some.url:9411/api/prom/push"
+	clientConfigTLS.TLSSetting = configtls.ClientConfig{
+		Config: configtls.Config{
+			CAFile:   "non-existent file",
+			CertFile: "",
+			KeyFile:  "",
+		},
+		Insecure:   false,
+		ServerName: "",
+	}
+
 	tests := []struct {
 		name                 string
 		config               *Config
@@ -173,7 +188,7 @@ func Test_Start(t *testing.T) {
 			concurrency:    5,
 			externalLabels: map[string]string{"Key1": "Val1"},
 			set:            set,
-			clientSettings: confighttp.ClientConfig{Endpoint: "https://some.url:9411/api/prom/push"},
+			clientSettings: clientConfig,
 		},
 		{
 			name:                 "invalid_tls",
@@ -183,18 +198,7 @@ func Test_Start(t *testing.T) {
 			externalLabels:       map[string]string{"Key1": "Val1"},
 			set:                  set,
 			returnErrorOnStartUp: true,
-			clientSettings: confighttp.ClientConfig{
-				Endpoint: "https://some.url:9411/api/prom/push",
-				TLSSetting: configtls.ClientConfig{
-					Config: configtls.Config{
-						CAFile:   "non-existent file",
-						CertFile: "",
-						KeyFile:  "",
-					},
-					Insecure:   false,
-					ServerName: "",
-				},
-			},
+			clientSettings:       clientConfigTLS,
 		},
 	}
 
@@ -705,14 +709,13 @@ func Test_PushMetrics(t *testing.T) {
 						MaxInterval:     1 * time.Second,        // Shorter max interval
 						MaxElapsedTime:  2 * time.Second,        // Shorter max elapsed time
 					}
+					clientConfig := confighttp.NewDefaultClientConfig()
+					clientConfig.Endpoint = server.URL
+					clientConfig.ReadBufferSize = 0
+					clientConfig.WriteBufferSize = 512 * 1024
 					cfg := &Config{
-						Namespace: "",
-						ClientConfig: confighttp.ClientConfig{
-							Endpoint: server.URL,
-							// We almost read 0 bytes, so no need to tune ReadBufferSize.
-							ReadBufferSize:  0,
-							WriteBufferSize: 512 * 1024,
-						},
+						Namespace:         "",
+						ClientConfig:      clientConfig,
 						MaxBatchSizeBytes: 3000000,
 						RemoteWriteQueue:  RemoteWriteQueue{NumConsumers: 1},
 						TargetInfo: &TargetInfo{
@@ -938,11 +941,11 @@ func TestWALOnExporterRoundTrip(t *testing.T) {
 	// 2. Create the WAL configuration, create the
 	// exporter and export some time series!
 	tempDir := t.TempDir()
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = prweServer.URL
 	cfg := &Config{
-		Namespace: "test_ns",
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: prweServer.URL,
-		},
+		Namespace:        "test_ns",
+		ClientConfig:     clientConfig,
 		RemoteWriteQueue: RemoteWriteQueue{NumConsumers: 1},
 		WAL: &WALConfig{
 			Directory:  tempDir,

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -10,7 +10,6 @@ import (
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
-	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
@@ -81,6 +80,12 @@ func createMetricsExporter(ctx context.Context, set exporter.Settings,
 func createDefaultConfig() component.Config {
 	retrySettings := configretry.NewDefaultBackOffConfig()
 	retrySettings.InitialInterval = 50 * time.Millisecond
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "http://some.url:9411/api/prom/push"
+	// We almost read 0 bytes, so no need to tune ReadBufferSize.
+	clientConfig.ReadBufferSize = 0
+	clientConfig.WriteBufferSize = 512 * 1024
+	clientConfig.Timeout = exporterhelper.NewDefaultTimeoutConfig().Timeout
 
 	return &Config{
 		Namespace:         "",
@@ -90,14 +95,7 @@ func createDefaultConfig() component.Config {
 		BackOffConfig:     retrySettings,
 		AddMetricSuffixes: true,
 		SendMetadata:      false,
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: "http://some.url:9411/api/prom/push",
-			// We almost read 0 bytes, so no need to tune ReadBufferSize.
-			ReadBufferSize:  0,
-			WriteBufferSize: 512 * 1024,
-			Timeout:         exporterhelper.NewDefaultTimeoutConfig().Timeout,
-			Headers:         map[string]configopaque.String{},
-		},
+		ClientConfig:      clientConfig,
 		// TODO(jbd): Adjust the default queue size.
 		RemoteWriteQueue: RemoteWriteQueue{
 			Enabled:      true,

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -27,7 +27,7 @@ func Test_createDefaultConfig(t *testing.T) {
 func Test_createMetricsExporter(t *testing.T) {
 
 	invalidConfig := createDefaultConfig().(*Config)
-	invalidConfig.ClientConfig = confighttp.ClientConfig{}
+	invalidConfig.ClientConfig = confighttp.NewDefaultClientConfig()
 	invalidTLSConfig := createDefaultConfig().(*Config)
 	invalidTLSConfig.ClientConfig.TLSSetting = configtls.ClientConfig{
 		Config: configtls.Config{


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457