### PR TITLE
[chore] [exporter/signalfx] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/signalfxexporter/config_test.go
+++ b/exporter/signalfxexporter/config_test.go
@@ -4,6 +4,7 @@
 package signalfxexporter
 
 import (
+	"net/http"
 	"net/url"
 	"path/filepath"
 	"testing"
@@ -38,6 +39,10 @@ func TestLoadConfig(t *testing.T) {
 	seventy := 70
 	hundred := 100
 	idleConnTimeout := 30 * time.Second
+	defaultMaxIdleConns := http.DefaultTransport.(*http.Transport).MaxIdleConns
+	defaultMaxIdleConnsPerHost := http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
+	defaultMaxConnsPerHost := http.DefaultTransport.(*http.Transport).MaxConnsPerHost
+	defaultIdleConnTimeout := http.DefaultTransport.(*http.Transport).IdleConnTimeout
 
 	tests := []struct {
 		id       component.ID
@@ -50,9 +55,10 @@ func TestLoadConfig(t *testing.T) {
 				Realm:       "ap0",
 				ClientConfig: confighttp.ClientConfig{
 					Timeout:              10 * time.Second,
-					Headers:              nil,
+					Headers:              map[string]configopaque.String{},
 					MaxIdleConns:         &hundred,
 					MaxIdleConnsPerHost:  &hundred,
+					MaxConnsPerHost:      &defaultMaxConnsPerHost,
 					IdleConnTimeout:      &idleConnTimeout,
 					HTTP2ReadIdleTimeout: 10 * time.Second,
 					HTTP2PingTimeout:     10 * time.Second,
@@ -86,8 +92,13 @@ func TestLoadConfig(t *testing.T) {
 				ExcludeProperties:   nil,
 				Correlation: &correlation.Config{
 					ClientConfig: confighttp.ClientConfig{
-						Endpoint: "",
-						Timeout:  5 * time.Second,
+						Endpoint:            "",
+						Timeout:             5 * time.Second,
+						Headers:             map[string]configopaque.String{},
+						MaxIdleConns:        &defaultMaxIdleConns,
+						MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+						MaxConnsPerHost:     &defaultMaxConnsPerHost,
+						IdleConnTimeout:     &defaultIdleConnTimeout,
 					},
 					StaleServiceTimeout: 5 * time.Minute,
 					SyncAttributes: map[string]string{
@@ -120,6 +131,7 @@ func TestLoadConfig(t *testing.T) {
 					},
 					MaxIdleConns:         &seventy,
 					MaxIdleConnsPerHost:  &seventy,
+					MaxConnsPerHost:      &defaultMaxConnsPerHost,
 					IdleConnTimeout:      &idleConnTimeout,
 					HTTP2ReadIdleTimeout: 10 * time.Second,
 					HTTP2PingTimeout:     10 * time.Second,
@@ -246,8 +258,13 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Correlation: &correlation.Config{
 					ClientConfig: confighttp.ClientConfig{
-						Endpoint: "",
-						Timeout:  5 * time.Second,
+						Endpoint:            "",
+						Timeout:             5 * time.Second,
+						Headers:             map[string]configopaque.String{},
+						MaxIdleConns:        &defaultMaxIdleConns,
+						MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+						MaxConnsPerHost:     &defaultMaxConnsPerHost,
+						IdleConnTimeout:     &defaultIdleConnTimeout,
 					},
 					StaleServiceTimeout: 5 * time.Minute,
 					SyncAttributes: map[string]string{

--- a/exporter/signalfxexporter/factory.go
+++ b/exporter/signalfxexporter/factory.go
@@ -50,18 +50,18 @@ func createDefaultConfig() component.Config {
 	maxConnCount := defaultMaxConns
 	idleConnTimeout := 30 * time.Second
 	timeout := 10 * time.Second
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = defaultHTTPTimeout
+	clientConfig.MaxIdleConns = &maxConnCount
+	clientConfig.MaxIdleConnsPerHost = &maxConnCount
+	clientConfig.IdleConnTimeout = &idleConnTimeout
+	clientConfig.HTTP2ReadIdleTimeout = defaultHTTP2ReadIdleTimeout
+	clientConfig.HTTP2PingTimeout = defaultHTTP2PingTimeout
 
 	return &Config{
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),
 		QueueSettings: exporterhelper.NewDefaultQueueConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			Timeout:              defaultHTTPTimeout,
-			MaxIdleConns:         &maxConnCount,
-			MaxIdleConnsPerHost:  &maxConnCount,
-			IdleConnTimeout:      &idleConnTimeout,
-			HTTP2ReadIdleTimeout: defaultHTTP2ReadIdleTimeout,
-			HTTP2PingTimeout:     defaultHTTP2PingTimeout,
-		},
+		ClientConfig:  clientConfig,
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
 			AccessTokenPassthrough: true,
 		},

--- a/exporter/signalfxexporter/internal/correlation/config.go
+++ b/exporter/signalfxexporter/internal/correlation/config.go
@@ -16,8 +16,10 @@ import (
 
 // DefaultConfig returns default configuration correlation values.
 func DefaultConfig() *Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 5 * time.Second
 	return &Config{
-		ClientConfig:        confighttp.ClientConfig{Timeout: 5 * time.Second},
+		ClientConfig:        clientConfig,
 		StaleServiceTimeout: 5 * time.Minute,
 		SyncAttributes: map[string]string{
 			conventions.AttributeK8SPodUID:   conventions.AttributeK8SPodUID,


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457