### PR TITLE
[chore] [exporter/sumologic] Use NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/exporter/sumologicexporter/config.go
+++ b/exporter/sumologicexporter/config.go
@@ -63,13 +63,13 @@ type Config struct {
 
 // createDefaultClientConfig returns default http client settings
 func createDefaultClientConfig() confighttp.ClientConfig {
-	return confighttp.ClientConfig{
-		Timeout:     defaultTimeout,
-		Compression: DefaultCompressEncoding,
-		Auth: &configauth.Authentication{
-			AuthenticatorID: component.NewID(sumologicextension.NewFactory().Type()),
-		},
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = defaultTimeout
+	clientConfig.Compression = DefaultCompressEncoding
+	clientConfig.Auth = &configauth.Authentication{
+		AuthenticatorID: component.NewID(sumologicextension.NewFactory().Type()),
 	}
+	return clientConfig
 }
 
 func (cfg *Config) Validate() error {

--- a/exporter/sumologicexporter/config_test.go
+++ b/exporter/sumologicexporter/config_test.go
@@ -14,6 +14,15 @@ import (
 )
 
 func TestInitExporterInvalidConfiguration(t *testing.T) {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "test_endpoint"
+	clientConfig.Timeout = defaultTimeout
+
+	clientConfigGzip := confighttp.NewDefaultClientConfig()
+	clientConfigGzip.Endpoint = "test_endpoint"
+	clientConfigGzip.Timeout = defaultTimeout
+	clientConfigGzip.Compression = "gzip"
+
 	testcases := []struct {
 		name          string
 		cfg           *Config
@@ -25,10 +34,7 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 			cfg: &Config{
 				LogFormat:    "test_format",
 				MetricFormat: "otlp",
-				ClientConfig: confighttp.ClientConfig{
-					Timeout:  defaultTimeout,
-					Endpoint: "test_endpoint",
-				},
+				ClientConfig: clientConfig,
 			},
 		},
 		{
@@ -37,11 +43,7 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 			cfg: &Config{
 				LogFormat:    "json",
 				MetricFormat: "test_format",
-				ClientConfig: confighttp.ClientConfig{
-					Timeout:     defaultTimeout,
-					Endpoint:    "test_endpoint",
-					Compression: "gzip",
-				},
+				ClientConfig: clientConfigGzip,
 			},
 		},
 		{
@@ -50,11 +52,7 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 			cfg: &Config{
 				LogFormat:    "json",
 				MetricFormat: "carbon2",
-				ClientConfig: confighttp.ClientConfig{
-					Timeout:     defaultTimeout,
-					Endpoint:    "test_endpoint",
-					Compression: "gzip",
-				},
+				ClientConfig: clientConfigGzip,
 			},
 		},
 		{
@@ -63,11 +61,7 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 			cfg: &Config{
 				LogFormat:    "json",
 				MetricFormat: "graphite",
-				ClientConfig: confighttp.ClientConfig{
-					Timeout:     defaultTimeout,
-					Endpoint:    "test_endpoint",
-					Compression: "gzip",
-				},
+				ClientConfig: clientConfigGzip,
 			},
 		},
 	}
@@ -87,6 +81,11 @@ func TestInitExporterInvalidConfiguration(t *testing.T) {
 }
 
 func TestConfigInvalidTimeout(t *testing.T) {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 56 * time.Second
+
+	clientConfigZeroTimeout := confighttp.NewDefaultClientConfig()
+	clientConfigZeroTimeout.Timeout = 0 * time.Second
 	testcases := []struct {
 		name          string
 		expectedError error
@@ -96,18 +95,14 @@ func TestConfigInvalidTimeout(t *testing.T) {
 			name:          "over the limit timeout",
 			expectedError: errors.New("timeout must be between 1 and 55 seconds, got 56s"),
 			cfg: &Config{
-				ClientConfig: confighttp.ClientConfig{
-					Timeout: 56 * time.Second,
-				},
+				ClientConfig: clientConfig,
 			},
 		},
 		{
 			name:          "less than 1 timeout",
 			expectedError: errors.New("timeout must be between 1 and 55 seconds, got 0s"),
 			cfg: &Config{
-				ClientConfig: confighttp.ClientConfig{
-					Timeout: 0 * time.Second,
-				},
+				ClientConfig: clientConfigZeroTimeout,
 			},
 		},
 	}

--- a/exporter/sumologicexporter/exporter_test.go
+++ b/exporter/sumologicexporter/exporter_test.go
@@ -235,15 +235,15 @@ func TestPartiallyFailed(t *testing.T) {
 }
 
 func TestInvalidHTTPCLient(t *testing.T) {
-	exp, err := initExporter(&Config{
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: "test_endpoint",
-			TLSSetting: configtls.ClientConfig{
-				Config: configtls.Config{
-					MinVersion: "invalid",
-				},
-			},
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "test_endpoint"
+	clientConfig.TLSSetting = configtls.ClientConfig{
+		Config: configtls.Config{
+			MinVersion: "invalid",
 		},
+	}
+	exp, err := initExporter(&Config{
+		ClientConfig: clientConfig,
 	}, exportertest.NewNopSettings())
 	require.NoError(t, err)
 

--- a/exporter/sumologicexporter/factory_test.go
+++ b/exporter/sumologicexporter/factory_test.go
@@ -4,6 +4,7 @@
 package sumologicexporter
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/configauth"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/config/configopaque"
 	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
 
@@ -28,6 +30,10 @@ func TestCreateDefaultConfig(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	qs := exporterhelper.NewDefaultQueueConfig()
 	qs.Enabled = false
+	defaultMaxIdleConns := http.DefaultTransport.(*http.Transport).MaxIdleConns
+	defaultMaxIdleConnsPerHost := http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
+	defaultMaxConnsPerHost := http.DefaultTransport.(*http.Transport).MaxConnsPerHost
+	defaultIdleConnTimeout := http.DefaultTransport.(*http.Transport).IdleConnTimeout
 
 	assert.Equal(t, &Config{
 		MaxRequestBodySize: 1_048_576,
@@ -41,6 +47,11 @@ func TestCreateDefaultConfig(t *testing.T) {
 			Auth: &configauth.Authentication{
 				AuthenticatorID: component.NewID(metadata.Type),
 			},
+			Headers:             map[string]configopaque.String{},
+			MaxIdleConns:        &defaultMaxIdleConns,
+			MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+			MaxConnsPerHost:     &defaultMaxConnsPerHost,
+			IdleConnTimeout:     &defaultIdleConnTimeout,
 		},
 		BackOffConfig: configretry.NewDefaultBackOffConfig(),
 		QueueSettings: qs,


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457