### PR TITLE
[chore] Fix Supervisor network tests on Windows

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -352,7 +352,12 @@ func TestSupervisorStartsWithNoOpAMPServer(t *testing.T) {
 	// Verify the collector is not running after 250 ms by checking the healthcheck endpoint
 	time.Sleep(250 * time.Millisecond)
 	_, err := http.DefaultClient.Get("http://localhost:12345")
-	require.ErrorContains(t, err, "connection refused")
+
+	if runtime.GOOS != "windows" {
+		require.ErrorContains(t, err, "connection refused")
+	} else {
+		require.ErrorContains(t, err, "No connection could be made")
+	}
 
 	// Start the server and wait for the supervisor to connect
 	server.start()
@@ -1341,7 +1346,11 @@ func TestSupervisorStopsAgentProcessWithEmptyConfigMap(t *testing.T) {
 	// Verify the collector is not running after 250 ms by checking the healthcheck endpoint
 	time.Sleep(250 * time.Millisecond)
 	_, err := http.DefaultClient.Get("http://localhost:12345")
-	require.ErrorContains(t, err, "connection refused")
+	if runtime.GOOS != "windows" {
+		require.ErrorContains(t, err, "connection refused")
+	} else {
+		require.ErrorContains(t, err, "No connection could be made")
+	}
 
 }
 


### PR DESCRIPTION
**Description:**

Follow-up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35430. It looks like connection failure messages are different on Windows, and this is causing the tests to fail.

I'd like to keep checking the message since HTTP requests can fail both when creating and when performing the test, but if someone has a different opinion, I'm fine just checking `require.Error(t, err)`.