### PR TITLE
[receiver/vcenter] Track collection times for vCenter Performance Metric API

### DIFF
--- a/receiver/vcenterreceiver/internal/mockserver/responses/host-performance-counters.xml
+++ b/receiver/vcenterreceiver/internal/mockserver/responses/host-performance-counters.xml
@@ -8,9 +8,17 @@
         <QueryPerfResponse
             xmlns="urn:vim25">
             <returnval xsi:type="PerfEntityMetric">
-                <entity type="HostSystem">host-1002</entity>
+            <entity type="HostSystem">host-1002</entity>
                 <sampleInfo>
                     <timestamp>2022-05-17T17:26:00Z</timestamp>
+                    <interval>20</interval>
+                </sampleInfo>
+                <sampleInfo>
+                    <timestamp>2022-05-17T17:26:20Z</timestamp>
+                    <interval>20</interval>
+                </sampleInfo>
+                <sampleInfo>
+                    <timestamp>2022-05-17T17:26:40Z</timestamp>
                     <interval>20</interval>
                 </sampleInfo>
                 <value xsi:type="PerfMetricIntSeries">
@@ -19,12 +27,16 @@
                         <instance>vmnic3</instance>
                     </id>
                     <value>864</value>
+                    <value>864</value>
+                    <value>866</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>532</counterId>
                         <instance>vmnic3</instance>
                     </id>
+                    <value>488</value>
+                    <value>488</value>
                     <value>488</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -33,12 +45,16 @@
                         <instance>vmnic3</instance>
                     </id>
                     <value>41480</value>
+                    <value>41480</value>
+                    <value>41480</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance>vmnic3</instance>
                     </id>
+                    <value>42703</value>
+                    <value>42703</value>
                     <value>42703</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -47,6 +63,8 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -54,12 +72,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -68,6 +90,8 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -75,12 +99,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -89,6 +117,8 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -96,12 +126,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -110,6 +144,8 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -117,6 +153,8 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -124,12 +162,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -138,12 +180,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -152,12 +198,16 @@
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -166,12 +216,16 @@
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -180,12 +234,16 @@
                         <instance>vmnic3</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic1</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -194,12 +252,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
+                    <value>1</value>
+                    <value>1</value>
                     <value>1</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -208,12 +270,16 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>517</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -222,12 +288,16 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
+                    <value>2</value>
+                    <value>2</value>
                     <value>2</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -236,12 +306,16 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance></instance>
                     </id>
+                    <value>1058</value>
+                    <value>1058</value>
                     <value>1058</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -250,12 +324,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -264,12 +342,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>2569</value>
+                    <value>2569</value>
+                    <value>2569</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>532</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -278,12 +360,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>12984</value>
+                    <value>12984</value>
+                    <value>12984</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>501</counterId>
                         <instance>vmnic0</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -292,6 +378,8 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -299,12 +387,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>530</counterId>
                         <instance>vmnic0</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>  
                 <value xsi:type="PerfMetricIntSeries">
@@ -313,12 +405,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>14458</value>
+                    <value>14458</value>
+                    <value>14458</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance></instance>
                     </id>
+                    <value>31</value>
+                    <value>31</value>
                     <value>31</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -327,614 +423,7 @@
                         <instance></instance>
                     </id>
                     <value>1840</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>501</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>502</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>9</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>463</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>4000</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>146</counterId>
-                        <instance>vmnic1</instance>
-                    </id>
-                    <value>120</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>537</counterId>
-                        <instance>vmnic1</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>531</counterId>
-                        <instance>vmnic0</instance>
-                    </id>
-                    <value>681</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
-                    </id>
-                    <value>19</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>531</counterId>
-                        <instance>vmnic3</instance>
-                    </id>
-                    <value>376</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>532</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>3058</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>532</counterId>
-                        <instance>vmnic1</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>146</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>57390</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>538</counterId>
-                        <instance>vmnic2</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>147</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>54464</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>147</counterId>
-                        <instance>vmnic1</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>146</counterId>
-                        <instance>vmnic2</instance>
-                    </id>
-                    <value>109</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>531</counterId>
-                        <instance>vmnic2</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>537</counterId>
-                        <instance>vmnic3</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>147</counterId>
-                        <instance>vmnic2</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>143</counterId>
-                        <instance>vmnic2</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>143</counterId>
-                        <instance>vmnic0</instance>
-                    </id>
-                    <value>3251</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>143</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>4117</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>537</counterId>
-                        <instance>vmnic0</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>537</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
-                    </id>
-                    <value>6</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>538</counterId>
-                        <instance>vmnic0</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>133</counterId>
-                        <instance>4000</instance>
-                    </id>
-                    <value>1002</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>124</counterId>
-                        <instance>4000</instance>
-                    </id>
-                    <value>977</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>518</counterId>
-                        <instance>4000</instance>
-                    </id>
-                    <value>782</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>522</counterId>
-                        <instance>4000</instance>
-                    </id>
-                    <value>782</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>131</counterId>
-                        <instance>4000</instance>
-                    </id>
-                    <value>782</value>
-                </value>
-            </returnval>
-            <returnval xsi:type="PerfEntityMetric">
-                <entity type="HostSystem">host-1003</entity>
-                <sampleInfo>
-                    <timestamp>2022-05-17T17:26:00Z</timestamp>
-                    <interval>20</interval>
-                </sampleInfo>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>143</counterId>
-                        <instance>vmnic3</instance>
-                    </id>
-                    <value>864</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>532</counterId>
-                        <instance>vmnic3</instance>
-                    </id>
-                    <value>488</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>147</counterId>
-                        <instance>vmnic3</instance>
-                    </id>
-                    <value>41480</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>146</counterId>
-                        <instance>vmnic3</instance>
-                    </id>
-                    <value>42703</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>520</counterId>
-                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>521</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>538</counterId>
-                        <instance>vmnic3</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>531</counterId>
-                        <instance>vmnic1</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>501</counterId>
-                        <instance>vmnic0</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>502</counterId>
-                        <instance>vmnic0</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>516</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
-                    </id>
-                    <value>1</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>538</counterId>
-                        <instance>vmnic1</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>517</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>143</counterId>
-                        <instance>vmnic1</instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>130</counterId>
-                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
-                    </id>
-                    <value>2</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>538</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>0</value>
-                </value>
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>531</counterId>
-                        <instance></instance>
-                    </id>
-                    <value>1058</value>
-                </value>  
-                <value xsi:type="PerfMetricIntSeries">
-                    <id>
-                        <counterId>435</counterId>
-                        <instance></instance>
-                    </id>
+                    <value>1840</value>
                     <value>1840</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -943,12 +432,16 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>502</counterId>
                         <instance></instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -957,12 +450,808 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>463</counterId>
                         <instance></instance>
                     </id>
+                    <value>4000</value>
+                    <value>4000</value>
+                    <value>4000</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>146</counterId>
+                        <instance>vmnic1</instance>
+                    </id>
+                    <value>120</value>
+                    <value>120</value>
+                    <value>120</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>537</counterId>
+                        <instance>vmnic1</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>531</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>681</value>
+                    <value>681</value>
+                    <value>681</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
+                    </id>
+                    <value>19</value>
+                    <value>19</value>
+                    <value>19</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>531</counterId>
+                        <instance>vmnic3</instance>
+                    </id>
+                    <value>376</value>
+                    <value>376</value>
+                    <value>376</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>532</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>3058</value>
+                    <value>3058</value>
+                    <value>3058</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>532</counterId>
+                        <instance>vmnic1</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>146</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>57390</value>
+                    <value>57390</value>
+                    <value>57390</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>538</counterId>
+                        <instance>vmnic2</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>147</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>54464</value>
+                    <value>54464</value>
+                    <value>54464</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>147</counterId>
+                        <instance>vmnic1</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>146</counterId>
+                        <instance>vmnic2</instance>
+                    </id>
+                    <value>109</value>
+                    <value>109</value>
+                    <value>109</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>531</counterId>
+                        <instance>vmnic2</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>537</counterId>
+                        <instance>vmnic3</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>147</counterId>
+                        <instance>vmnic2</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>143</counterId>
+                        <instance>vmnic2</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>143</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>3251</value>
+                    <value>3251</value>
+                    <value>3251</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>143</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>4117</value>
+                    <value>4117</value>
+                    <value>4117</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>537</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>537</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
+                    </id>
+                    <value>6</value>
+                    <value>6</value>
+                    <value>6</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>538</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>133</counterId>
+                        <instance>4000</instance>
+                    </id>
+                    <value>1002</value>
+                    <value>1002</value>
+                    <value>1002</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>124</counterId>
+                        <instance>4000</instance>
+                    </id>
+                    <value>977</value>
+                    <value>977</value>
+                    <value>977</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>518</counterId>
+                        <instance>4000</instance>
+                    </id>
+                    <value>782</value>
+                    <value>782</value>
+                    <value>782</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>522</counterId>
+                        <instance>4000</instance>
+                    </id>
+                    <value>782</value>
+                    <value>782</value>
+                    <value>782</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>131</counterId>
+                        <instance>4000</instance>
+                    </id>
+                    <value>782</value>
+                    <value>782</value>
+                    <value>782</value>
+                </value>
+                <startTime>2022-05-17T17:26:00Z</startTime>
+                <endTime>2022-05-17T17:27:00Z</endTime>
+            </returnval>
+            <returnval xsi:type="PerfEntityMetric">
+                <entity type="HostSystem">host-1003</entity>
+                <sampleInfo>
+                    <timestamp>2022-05-17T17:26:00Z</timestamp>
+                    <interval>20</interval>
+                </sampleInfo>
+                <sampleInfo>
+                    <timestamp>2022-05-17T17:26:20Z</timestamp>
+                    <interval>20</interval>
+                </sampleInfo>
+                <sampleInfo>
+                    <timestamp>2022-05-17T17:26:40Z</timestamp>
+                    <interval>20</interval>
+                </sampleInfo>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>143</counterId>
+                        <instance>vmnic3</instance>
+                    </id>
+                    <value>864</value>
+                    <value>864</value>
+                    <value>864</value>
+
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>532</counterId>
+                        <instance>vmnic3</instance>
+                    </id>
+                    <value>488</value>
+                    <value>488</value>
+                    <value>488</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>147</counterId>
+                        <instance>vmnic3</instance>
+                    </id>
+                    <value>41480</value>
+                    <value>41480</value>
+                    <value>41480</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>146</counterId>
+                        <instance>vmnic3</instance>
+                    </id>
+                    <value>42703</value>
+                    <value>42703</value>
+                    <value>42703</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>520</counterId>
+                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>521</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>538</counterId>
+                        <instance>vmnic3</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>531</counterId>
+                        <instance>vmnic1</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>501</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>502</counterId>
+                        <instance>vmnic0</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>516</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
+                    </id>
+                    <value>1</value>
+                    <value>1</value>
+                    <value>1</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>538</counterId>
+                        <instance>vmnic1</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>517</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>143</counterId>
+                        <instance>vmnic1</instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>130</counterId>
+                        <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
+                    </id>
+                    <value>2</value>
+                    <value>2</value>
+                    <value>2</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>538</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>531</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>1058</value>
+                    <value>1058</value>
+                    <value>1058</value>
+                </value>  
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>435</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>1840</value>
+                    <value>1840</value>
+                    <value>1840</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>501</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>502</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>9</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
+                </value>
+                <value xsi:type="PerfMetricIntSeries">
+                    <id>
+                        <counterId>463</counterId>
+                        <instance></instance>
+                    </id>
+                    <value>4000</value>
+                    <value>4000</value>
                     <value>4000</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -971,12 +1260,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -985,12 +1278,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>2569</value>
+                    <value>2569</value>
+                    <value>2569</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>532</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -999,12 +1296,16 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>530</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value> 
                 <value xsi:type="PerfMetricIntSeries">
@@ -1013,12 +1314,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>12984</value>
+                    <value>12984</value>
+                    <value>12984</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance>vmnic0</instance>
                     </id>
+                    <value>14458</value>
+                    <value>14458</value>
                     <value>14458</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1027,12 +1332,16 @@
                         <instance></instance>
                     </id>
                     <value>31</value>
+                    <value>31</value>
+                    <value>31</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>146</counterId>
                         <instance>vmnic1</instance>
                     </id>
+                    <value>120</value>
+                    <value>120</value>
                     <value>120</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1041,12 +1350,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic1</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1055,12 +1368,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>681</value>
+                    <value>681</value>
+                    <value>681</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
+                    <value>19</value>
+                    <value>19</value>
                     <value>19</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1069,12 +1386,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic3</instance>
                     </id>
+                    <value>376</value>
+                    <value>376</value>
                     <value>376</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1083,12 +1404,16 @@
                         <instance></instance>
                     </id>
                     <value>3058</value>
+                    <value>3058</value>
+                    <value>3058</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>532</counterId>
                         <instance>vmnic1</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1097,12 +1422,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1111,12 +1440,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1125,12 +1458,16 @@
                         <instance></instance>
                     </id>
                     <value>57390</value>
+                    <value>57390</value>
+                    <value>57390</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>521</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1139,12 +1476,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>538</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1153,12 +1494,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>147</counterId>
                         <instance></instance>
                     </id>
+                    <value>54464</value>
+                    <value>54464</value>
                     <value>54464</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1167,12 +1512,16 @@
                         <instance>vmnic1</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>520</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1181,12 +1530,16 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>109</value>
+                    <value>109</value>
+                    <value>109</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>531</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1195,6 +1548,8 @@
                         <instance>vmnic3</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1202,12 +1557,16 @@
                         <instance>vmnic2</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>143</counterId>
                         <instance>vmnic2</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1216,12 +1575,16 @@
                         <instance>t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>143</counterId>
                         <instance>vmnic0</instance>
                     </id>
+                    <value>3251</value>
+                    <value>3251</value>
                     <value>3251</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1230,12 +1593,16 @@
                         <instance></instance>
                     </id>
                     <value>4117</value>
+                    <value>4117</value>
+                    <value>4117</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1244,12 +1611,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>537</counterId>
                         <instance>vmnic0</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1258,12 +1629,16 @@
                         <instance></instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>130</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
+                    <value>6</value>
+                    <value>6</value>
                     <value>6</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1272,12 +1647,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>520</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1286,12 +1665,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>516</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1300,12 +1683,16 @@
                         <instance>t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>516</counterId>
                         <instance>t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500</instance>
                     </id>
+                    <value>0</value>
+                    <value>0</value>
                     <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1314,12 +1701,16 @@
                         <instance>vmnic0</instance>
                     </id>
                     <value>0</value>
+                    <value>0</value>
+                    <value>0</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>133</counterId>
                         <instance>4000</instance>
                     </id>
+                    <value>1002</value>
+                    <value>1002</value>
                     <value>1002</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1328,12 +1719,16 @@
                         <instance>4000</instance>
                     </id>
                     <value>977</value>
+                    <value>977</value>
+                    <value>977</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
                         <counterId>518</counterId>
                         <instance>4000</instance>
                     </id>
+                    <value>782</value>
+                    <value>782</value>
                     <value>782</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
@@ -1342,6 +1737,8 @@
                         <instance>4000</instance>
                     </id>
                     <value>782</value>
+                    <value>782</value>
+                    <value>782</value>
                 </value>
                 <value xsi:type="PerfMetricIntSeries">
                     <id>
@@ -1349,7 +1746,11 @@
                         <instance>4000</instance>
                     </id>
                     <value>782</value>
+                    <value>782</value>
+                    <value>782</value>
                 </value>
+                <startTime>2022-05-17T17:26:00Z</startTime>
+                <endTime>2022-05-17T17:27:00Z</endTime>
             </returnval>
         </QueryPerfResponse>
     </soapenv:Body>

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -361,22 +361,22 @@ func (v *vcenterMetricScraper) recordHostPerformanceMetrics(entityMetric *perfor
 			case "net.bytesRx.average":
 				v.mb.RecordVcenterHostNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived, val.Instance)
 			case "net.packetsTx.summation":
-				txRate := float64(nestedValue) / 20
+				txRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterHostNetworkPacketRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), txRate, metadata.AttributeThroughputDirectionTransmitted, val.Instance)
 			case "net.packetsRx.summation":
-				rxRate := float64(nestedValue) / 20
+				rxRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterHostNetworkPacketRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), rxRate, metadata.AttributeThroughputDirectionReceived, val.Instance)
 			case "net.droppedTx.summation":
-				txRate := float64(nestedValue) / 20
+				txRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterHostNetworkPacketDropRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), txRate, metadata.AttributeThroughputDirectionTransmitted, val.Instance)
 			case "net.droppedRx.summation":
-				rxRate := float64(nestedValue) / 20
+				rxRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterHostNetworkPacketDropRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), rxRate, metadata.AttributeThroughputDirectionReceived, val.Instance)
 			case "net.errorsRx.summation":
-				rxRate := float64(nestedValue) / 20
+				rxRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterHostNetworkPacketErrorRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), rxRate, metadata.AttributeThroughputDirectionReceived, val.Instance)
 			case "net.errorsTx.summation":
-				txRate := float64(nestedValue) / 20
+				txRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterHostNetworkPacketErrorRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), txRate, metadata.AttributeThroughputDirectionTransmitted, val.Instance)
 			case "cpu.reservedCapacity.average":
 				v.mb.RecordVcenterHostCPUReservedDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeCPUReservationTypeUsed)
@@ -449,16 +449,16 @@ func (v *vcenterMetricScraper) recordVMPerformanceMetrics(entityMetric *performa
 			case "net.bytesRx.average":
 				v.mb.RecordVcenterVMNetworkThroughputDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), nestedValue, metadata.AttributeThroughputDirectionReceived, val.Instance)
 			case "net.packetsTx.summation":
-				txRate := float64(nestedValue) / 20
+				txRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterVMNetworkPacketRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), txRate, metadata.AttributeThroughputDirectionTransmitted, val.Instance)
 			case "net.packetsRx.summation":
-				rxRate := float64(nestedValue) / 20
+				rxRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterVMNetworkPacketRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), rxRate, metadata.AttributeThroughputDirectionReceived, val.Instance)
 			case "net.droppedTx.summation":
-				txRate := float64(nestedValue) / 20
+				txRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterVMNetworkPacketDropRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), txRate, metadata.AttributeThroughputDirectionTransmitted, val.Instance)
 			case "net.droppedRx.summation":
-				rxRate := float64(nestedValue) / 20
+				rxRate := float64(nestedValue) / float64(si.Interval)
 				v.mb.RecordVcenterVMNetworkPacketDropRateDataPoint(pcommon.NewTimestampFromTime(si.Timestamp), rxRate, metadata.AttributeThroughputDirectionReceived, val.Instance)
 			}
 		}

--- a/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected-all-enabled.yaml
@@ -417,15 +417,43 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -455,7 +483,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -465,8 +523,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
@@ -477,8 +545,22 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -494,7 +576,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -504,7 +616,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "19"
                   attributes:
@@ -514,7 +646,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "6"
                   attributes:
@@ -524,7 +676,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -534,7 +706,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2"
                   attributes:
@@ -544,7 +736,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -554,7 +766,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -564,7 +796,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -574,7 +826,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -584,7 +856,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -594,8 +886,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -625,7 +927,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -635,8 +967,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/s}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -650,7 +992,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -660,7 +1032,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -670,7 +1062,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -680,7 +1092,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -690,7 +1122,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -700,7 +1152,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -710,7 +1182,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -720,7 +1212,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -730,7 +1242,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -740,8 +1272,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/s}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
@@ -755,7 +1297,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 722.9
                   attributes:
@@ -765,7 +1337,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 6
                   attributes:
@@ -775,7 +1367,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 5.45
                   attributes:
@@ -785,7 +1397,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2135.15
                   attributes:
@@ -795,7 +1427,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2723.2
                   attributes:
@@ -805,7 +1457,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 649.2
                   attributes:
@@ -815,7 +1487,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -825,7 +1517,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -835,7 +1547,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2074
                   attributes:
@@ -845,8 +1577,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/s}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -862,7 +1604,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "681"
                   attributes:
@@ -872,7 +1644,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -882,7 +1674,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -892,7 +1704,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "376"
                   attributes:
@@ -902,7 +1734,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3058"
                   attributes:
@@ -912,7 +1764,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2569"
                   attributes:
@@ -922,7 +1794,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -932,7 +1824,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -942,7 +1854,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "488"
                   attributes:
@@ -952,8 +1884,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
@@ -965,36 +1907,106 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "864"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "864"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:
@@ -1152,15 +2164,43 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -1190,7 +2230,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -1200,8 +2270,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
@@ -1212,8 +2292,22 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -1229,7 +2323,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1239,7 +2363,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "19"
                   attributes:
@@ -1249,7 +2393,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "6"
                   attributes:
@@ -1259,7 +2423,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1269,7 +2453,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2"
                   attributes:
@@ -1279,7 +2483,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -1289,7 +2513,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1299,7 +2543,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1309,7 +2573,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1319,7 +2603,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -1329,8 +2633,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -1360,7 +2674,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1370,8 +2714,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/s}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -1385,7 +2739,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1395,7 +2779,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1405,7 +2809,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1415,7 +2839,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1425,7 +2869,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1435,7 +2899,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1445,7 +2929,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1455,7 +2959,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1465,7 +2989,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1475,8 +3019,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/s}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
@@ -1490,7 +3044,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 722.9
                   attributes:
@@ -1500,7 +3084,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 6
                   attributes:
@@ -1510,7 +3114,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 5.45
                   attributes:
@@ -1520,7 +3144,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2135.15
                   attributes:
@@ -1530,7 +3174,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2723.2
                   attributes:
@@ -1540,7 +3204,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 649.2
                   attributes:
@@ -1550,7 +3234,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1560,7 +3264,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1570,7 +3294,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2074
                   attributes:
@@ -1580,8 +3324,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/s}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -1597,7 +3351,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "681"
                   attributes:
@@ -1607,7 +3391,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1617,7 +3421,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1627,7 +3451,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "376"
                   attributes:
@@ -1637,7 +3481,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3058"
                   attributes:
@@ -1647,7 +3511,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2569"
                   attributes:
@@ -1657,7 +3541,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1667,7 +3571,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1677,7 +3601,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "488"
                   attributes:
@@ -1687,8 +3631,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
@@ -1700,36 +3654,106 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "864"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "866"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:

--- a/receiver/vcenterreceiver/testdata/metrics/expected.yaml
+++ b/receiver/vcenterreceiver/testdata/metrics/expected.yaml
@@ -417,15 +417,43 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -455,7 +483,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -465,8 +523,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
@@ -477,8 +545,22 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -494,7 +576,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -504,7 +616,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "19"
                   attributes:
@@ -514,7 +646,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "6"
                   attributes:
@@ -524,7 +676,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -534,7 +706,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2"
                   attributes:
@@ -544,7 +736,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -554,7 +766,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -564,7 +796,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -574,7 +826,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -584,7 +856,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -594,8 +886,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -625,7 +927,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -635,8 +967,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/s}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -650,7 +992,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -660,7 +1032,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -670,7 +1062,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -680,7 +1092,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -690,7 +1122,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -700,7 +1152,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -710,7 +1182,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -720,7 +1212,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -730,7 +1242,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -740,8 +1272,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/s}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
@@ -755,7 +1297,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 722.9
                   attributes:
@@ -765,7 +1337,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 6
                   attributes:
@@ -775,7 +1367,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 5.45
                   attributes:
@@ -785,7 +1397,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2135.15
                   attributes:
@@ -795,7 +1427,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2723.2
                   attributes:
@@ -805,7 +1457,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 649.2
                   attributes:
@@ -815,7 +1487,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -825,7 +1517,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -835,7 +1547,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2074
                   attributes:
@@ -845,8 +1577,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/s}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -862,7 +1604,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "681"
                   attributes:
@@ -872,7 +1644,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -882,7 +1674,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -892,7 +1704,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "376"
                   attributes:
@@ -902,7 +1734,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3058"
                   attributes:
@@ -912,7 +1764,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2569"
                   attributes:
@@ -922,7 +1794,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -932,7 +1824,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -942,7 +1854,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "488"
                   attributes:
@@ -952,8 +1884,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
@@ -965,36 +1907,106 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "864"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "864"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:
@@ -1152,15 +2164,43 @@ resourceMetrics:
                     - key: cpu_reservation_type
                       value:
                         stringValue: total
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4000"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: total
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: cpu_reservation_type
                       value:
                         stringValue: used
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: cpu_reservation_type
+                      value:
+                        stringValue: used
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: MHz
           - description: The amount of CPU used by the host.
             name: vcenter.host.cpu.usage
@@ -1190,7 +2230,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -1200,8 +2270,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.avg
             unit: ms
           - description: Highest latency value across all disks used by the host.
@@ -1212,8 +2292,22 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1002"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.disk.latency.max
             unit: ms
           - description: Average number of kilobytes read from or written to the disk each second.
@@ -1229,7 +2323,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "31"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1239,7 +2363,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.ATA_____DELLBOSS_VD_____________________________983baa25884a001000000000
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "19"
                   attributes:
@@ -1249,7 +2393,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "19"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E10E3E4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "6"
                   attributes:
@@ -1259,7 +2423,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "6"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_NVMe_P4610_1.6TB_SFF_00010E266CE4D25C
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1269,7 +2453,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____362E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2"
                   attributes:
@@ -1279,7 +2483,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3C2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "1"
                   attributes:
@@ -1289,7 +2513,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____3D2E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1299,7 +2543,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____482E000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1309,7 +2573,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____B32D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1319,7 +2603,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: read
+                    - key: object
+                      value:
+                        stringValue: t10.NVMe____Dell_Express_Flash_PM1725b_3.2TB_SFF____BD2D000121382500
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "782"
                   attributes:
@@ -1329,8 +2633,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: "4000"
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "782"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: write
+                    - key: object
+                      value:
+                        stringValue: "4000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The amount of memory the host system is using.
             name: vcenter.host.memory.usage
@@ -1360,7 +2674,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1370,8 +2714,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.drop.rate
             unit: '{packets/s}'
           - description: The rate of packet errors transmitted or received on the host network.
@@ -1385,7 +2739,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1395,7 +2779,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1405,7 +2809,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1415,7 +2839,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1425,7 +2869,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1435,7 +2899,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1445,7 +2929,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1455,7 +2959,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1465,7 +2989,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1475,8 +3019,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.error.rate
             unit: '{errors/s}'
           - description: The rate of packets transmitted or received across each physical NIC (network interface controller) instance on the host.
@@ -1490,7 +3044,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2869.5
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 722.9
                   attributes:
@@ -1500,7 +3084,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 722.9
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 6
                   attributes:
@@ -1510,7 +3114,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 6
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 5.45
                   attributes:
@@ -1520,7 +3144,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 5.45
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2135.15
                   attributes:
@@ -1530,7 +3174,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2135.15
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2723.2
                   attributes:
@@ -1540,7 +3204,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2723.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 649.2
                   attributes:
@@ -1550,7 +3234,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 649.2
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1560,7 +3264,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 0
                   attributes:
@@ -1570,7 +3294,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 0
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asDouble: 2074
                   attributes:
@@ -1580,8 +3324,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asDouble: 2074
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             name: vcenter.host.network.packet.rate
             unit: '{packets/s}'
           - description: The amount of data that was transmitted or received over the network by the host.
@@ -1597,7 +3351,37 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "1058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "681"
                   attributes:
@@ -1607,7 +3391,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "681"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1617,7 +3421,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1627,7 +3451,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "376"
                   attributes:
@@ -1637,7 +3481,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "376"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: received
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3058"
                   attributes:
@@ -1647,7 +3511,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3058"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "2569"
                   attributes:
@@ -1657,7 +3541,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "2569"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1667,7 +3571,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
@@ -1677,7 +3601,27 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "488"
                   attributes:
@@ -1687,8 +3631,18 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "488"
+                  attributes:
+                    - key: direction
+                      value:
+                        stringValue: transmitted
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The sum of the data transmitted and received for all the NIC instances of the host.
             name: vcenter.host.network.usage
@@ -1700,36 +3654,106 @@ resourceMetrics:
                     - key: object
                       value:
                         stringValue: ""
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "1000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "4117"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: ""
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "3251"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic0
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "3251"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic0
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic1
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic1
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "0"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic2
-                  startTimeUnixNano: "2000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "0"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic2
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
+                - asInt: "864"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
                   timeUnixNano: "1000000"
                 - asInt: "864"
                   attributes:
                     - key: object
                       value:
                         stringValue: vmnic3
-                  startTimeUnixNano: "2000000"
-                  timeUnixNano: "1000000"
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "2000000"
+                - asInt: "866"
+                  attributes:
+                    - key: object
+                      value:
+                        stringValue: vmnic3
+                  startTimeUnixNano: "4000000"
+                  timeUnixNano: "3000000"
             unit: '{KiBy/s}'
           - description: The host's read IOs which could be satisfied by the local client cache.
             gauge:


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
The following PR changes the way vCenter is collecting the performance metrics, by providing it a start and end time to the collection. The sampling interval is now defaulted to 20s when the collection interval is an hour and under, and defaulted to 300s when it is anything over an hour.

This change provide 3x datapoints per metric (ignoring attributes) with a 1m collector collection interval, 15x datapoints with a 5m collector collection interval, etc.

**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>