### PR TITLE
[chore] [exporter/alertmanager] fix test

### DIFF
--- a/exporter/alertmanagerexporter/config_test.go
+++ b/exporter/alertmanagerexporter/config_test.go
@@ -24,7 +24,10 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
-	defaultTransport := http.DefaultTransport.(*http.Transport)
+	defaultMaxIdleConns := http.DefaultTransport.(*http.Transport).MaxIdleConns
+	defaultMaxIdleConnsPerHost := http.DefaultTransport.(*http.Transport).MaxIdleConnsPerHost
+	defaultMaxConnsPerHost := http.DefaultTransport.(*http.Transport).MaxConnsPerHost
+	defaultIdleConnTimeout := http.DefaultTransport.(*http.Transport).IdleConnTimeout
 	t.Parallel()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
@@ -79,10 +82,10 @@ func TestLoadConfig(t *testing.T) {
 					ReadBufferSize:      0,
 					WriteBufferSize:     524288,
 					Timeout:             time.Second * 10,
-					MaxIdleConns:        &defaultTransport.MaxIdleConns,
-					MaxIdleConnsPerHost: &defaultTransport.MaxIdleConnsPerHost,
-					MaxConnsPerHost:     &defaultTransport.MaxConnsPerHost,
-					IdleConnTimeout:     &defaultTransport.IdleConnTimeout,
+					MaxIdleConns:        &defaultMaxIdleConns,
+					MaxIdleConnsPerHost: &defaultMaxIdleConnsPerHost,
+					MaxConnsPerHost:     &defaultMaxConnsPerHost,
+					IdleConnTimeout:     &defaultIdleConnTimeout,
 				},
 			},
 		},


### PR DESCRIPTION
**Description:** This is a follow up to: #35518. Don't rely on global DefaultTransport, instead create own variables. This is based on feedback from: https://github.com/open-telemetry/opentelemetry-collector/pull/11299#discussion_r1783093442.
