### PR TITLE
[chore] [internal/aws/ecsutil] Use confighttp.NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/internal/aws/ecsutil/client_test.go
+++ b/internal/aws/ecsutil/client_test.go
@@ -37,7 +37,7 @@ func TestClient(t *testing.T) {
 
 func TestNewClientProvider(t *testing.T) {
 	baseURL, _ := url.Parse("http://localhost:8080")
-	provider := NewClientProvider(*baseURL, confighttp.ClientConfig{}, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+	provider := NewClientProvider(*baseURL, confighttp.NewDefaultClientConfig(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	require.NotNil(t, provider)
 	_, ok := provider.(*defaultClientProvider)
 	require.True(t, ok)
@@ -49,7 +49,7 @@ func TestNewClientProvider(t *testing.T) {
 
 func TestDefaultClient(t *testing.T) {
 	endpoint, _ := url.Parse("http://localhost:8080")
-	client, err := defaultClient(context.Background(), *endpoint, confighttp.ClientConfig{}, componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
+	client, err := defaultClient(context.Background(), *endpoint, confighttp.NewDefaultClientConfig(), componenttest.NewNopHost(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.NotNil(t, client.httpClient.Transport)
 	require.Equal(t, "http://localhost:8080", client.baseURL.String())

--- a/internal/aws/ecsutil/metadata_provider.go
+++ b/internal/aws/ecsutil/metadata_provider.go
@@ -42,7 +42,7 @@ func NewDetectedTaskMetadataProvider(set component.TelemetrySettings) (MetadataP
 		return nil, fmt.Errorf("unable to detect task metadata endpoint")
 	}
 
-	clientSettings := confighttp.ClientConfig{}
+	clientSettings := confighttp.NewDefaultClientConfig()
 	client, err := NewRestClient(*endpoint, clientSettings, set)
 	if err != nil {
 		return nil, err

--- a/internal/aws/ecsutil/rest_client_test.go
+++ b/internal/aws/ecsutil/rest_client_test.go
@@ -23,7 +23,7 @@ func (f *fakeClient) Get(path string) ([]byte, error) {
 
 func TestRestClient(t *testing.T) {
 	u, _ := url.Parse("http://www.test.com")
-	rest, err := NewRestClient(*u, confighttp.ClientConfig{}, componenttest.NewNopTelemetrySettings())
+	rest, err := NewRestClient(*u, confighttp.NewDefaultClientConfig(), componenttest.NewNopTelemetrySettings())
 	require.NoError(t, err)
 	require.NotNil(t, rest)
 }


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457