### PR TITLE
[chore] [receiver/awsecscontainermetrics] Use confighttp.NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/factory.go
+++ b/receiver/awsecscontainermetricsreceiver/factory.go
@@ -50,7 +50,7 @@ func createMetricsReceiver(
 	if err != nil || endpoint == nil {
 		return nil, fmt.Errorf("unable to detect task metadata endpoint: %w", err)
 	}
-	clientSettings := confighttp.ClientConfig{}
+	clientSettings := confighttp.NewDefaultClientConfig()
 	rest, err := ecsutil.NewRestClient(*endpoint, clientSettings, params.TelemetrySettings)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457