### PR TITLE
[chore] Fix `make update-otel` on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,7 +383,7 @@ define updatehelper
 			echo "Usage: updatehelper <versions.yaml> <go.mod> <builder-config.yaml>"; \
 			exit 1; \
 	fi
-	grep "go\.opentelemetry\.io" $(1) | sed 's/^\s*-\s*//' | while IFS= read -r line; do \
+	grep "go\.opentelemetry\.io" $(1) | sed 's/^[[:space:]]*-[[:space:]]*//' | while IFS= read -r line; do \
 			if grep -qF "$$line" $(2); then \
 					package=$$(grep -F "$$line" $(2) | head -n 1 | awk '{print $$1}'); \
 					version=$$(grep -F "$$line" $(2) | head -n 1 | awk '{print $$2}'); \
@@ -391,7 +391,7 @@ define updatehelper
 					builder_version=$$(grep -F "$$package" $(3) | awk '{print $$4}'); \
 					if [ "$$builder_package" == "$$package" ]; then \
 						echo "$$builder_version";\
-						sed -i -e "s|$$builder_package.*$$builder_version|$$builder_package $$version|" $(3); \
+						sed -i '' -e "s|$$builder_package.*$$builder_version|$$builder_package $$version|" $(3); \
 						echo "[$(3)]: $$package updated to $$version"; \
 					fi; \
 			fi; \

--- a/Makefile
+++ b/Makefile
@@ -391,7 +391,8 @@ define updatehelper
 					builder_version=$$(grep -F "$$package" $(3) | awk '{print $$4}'); \
 					if [ "$$builder_package" == "$$package" ]; then \
 						echo "$$builder_version";\
-						sed -i '' -e "s|$$builder_package.*$$builder_version|$$builder_package $$version|" $(3); \
+						sed -i.bak -e "s|$$builder_package.*$$builder_version|$$builder_package $$version|" $(3); \
+						rm $(3).bak; \
 						echo "[$(3)]: $$package updated to $$version"; \
 					fi; \
 			fi; \

--- a/Makefile
+++ b/Makefile
@@ -390,10 +390,9 @@ define updatehelper
 					builder_package=$$(grep -F "$$package" $(3) | awk '{print $$3}'); \
 					builder_version=$$(grep -F "$$package" $(3) | awk '{print $$4}'); \
 					if [ "$$builder_package" == "$$package" ]; then \
-						echo "$$builder_version";\
 						sed -i.bak -e "s|$$builder_package.*$$builder_version|$$builder_package $$version|" $(3); \
 						rm $(3).bak; \
-						echo "[$(3)]: $$package updated to $$version"; \
+						echo "[$(3)]: $$package updated from $$builder_version to $$version"; \
 					fi; \
 			fi; \
 	done


### PR DESCRIPTION
**Description:**

When working on #35580, it seemed that `make update-otel` was not properly updating the `builder-config.yaml` files. I traced this down to the `updatehelper` script not working as intended. This turned out to be because it uses some features of the `sed` utility which do not exist on macOS, causing no updates to be made.

The `\s` (whitespace) regex class is a GNU extension for `sed`; the POSIX-compatible equivalent is `[[:space:]]` ([related SO question](https://stackoverflow.com/questions/18840175/find-and-replace-with-spaces-using-sed-mac-terminal)).

Moreover, on macOS, the `-i` (in-place) option requires an argument, even if empty; otherwise the `-e` following it is parsed as that argument, creating an unnecessary backup file ([related SO question](https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux)).

**Testing:**

I manually tested this change as part of developing the aforementioned PR; the script seems to work on macOS now. It would be good for someone to test this change on Linux to make sure nothing has broken there.
