### PR TITLE
[chore] Ensure file is closed in Supervisor test

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1414,7 +1414,6 @@ func TestSupervisorInfoLoggingLevel(t *testing.T) {
 	// Read from log file checking for Info level logs
 	logFile, err := os.Open(supervisorLogFilePath)
 	require.NoError(t, err)
-	defer logFile.Close()
 
 	scanner := bufio.NewScanner(logFile)
 	check := false
@@ -1434,6 +1433,7 @@ func TestSupervisorInfoLoggingLevel(t *testing.T) {
 	}
 	// verify at least 1 log was read
 	require.True(t, check)
+	require.NoError(t, logFile.Close())
 }
 
 func findRandomPort() (int, error) {


### PR DESCRIPTION
**Description:**

Follow up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35468. This should fix issues like the following:

```
testing.go:1231: TempDir RemoveAll cleanup: remove C:\Users\RUNNER~1\AppData\Local\Temp\TestSupervisorInfoLoggingLevel3383092187\001\supervisor_log.log: The process cannot access the file because it is being used by another process.
```

I believe this error is caused by the temp directory doing a cleanup before all `defer` statements can run, but I'm not sure. This is how I've seen this error fixed in other tests.