### PR TITLE
[chore] Skip Supervisor log file test on Windows

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1363,6 +1363,10 @@ type LogEntry struct {
 }
 
 func TestSupervisorInfoLoggingLevel(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Zap does not close the log file and Windows disallows removing files that are still opened.")
+	}
+
 	storageDir := t.TempDir()
 	remoteCfgFilePath := filepath.Join(storageDir, "last_recv_remote_config.dat")
 
@@ -1434,7 +1438,6 @@ func TestSupervisorInfoLoggingLevel(t *testing.T) {
 	// verify at least 1 log was read
 	require.True(t, check)
 	require.NoError(t, logFile.Close())
-	require.NoError(t, os.Remove(supervisorLogFilePath))
 }
 
 func findRandomPort() (int, error) {

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1434,6 +1434,7 @@ func TestSupervisorInfoLoggingLevel(t *testing.T) {
 	// verify at least 1 log was read
 	require.True(t, check)
 	require.NoError(t, logFile.Close())
+	require.NoError(t, os.Remove(supervisorLogFilePath))
 }
 
 func findRandomPort() (int, error) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Follow up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35588.

This skips the test on Windows. The logic should be similar on other operating systems, so it's not a significant loss to skip it. The issue arises because Zap does not close log files itself and provides no handles to close them, so we would need to find a clever way to close the file or would need to simply not clean it up after the test executes.