### PR TITLE
azureeventhubreceiver: migrate to newer semconv version

### DIFF
--- a/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
+++ b/receiver/azureeventhubreceiver/azureresourcemetrics_unmarshaler.go
@@ -15,7 +15,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	conventions "go.opentelemetry.io/collector/semconv/v1.13.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azureeventhubreceiver/internal/metadata"


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.13.0 to v1.27.0

This is a trivial upgrade. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator). All attributes used by this component have the same value in both versions.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed