### PR TITLE
dockerstatsreceiver: migrate to newer semconv version

### DIFF
--- a/receiver/dockerstatsreceiver/integration_test.go
+++ b/receiver/dockerstatsreceiver/integration_test.go
@@ -21,7 +21,7 @@ import (
 	"go.opentelemetry.io/collector/pipeline"
 	rcvr "go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )

--- a/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
+++ b/receiver/dockerstatsreceiver/internal/metadata/generated_metrics.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 type metricContainerBlockioIoMergedRecursive struct {

--- a/receiver/dockerstatsreceiver/metadata.yaml
+++ b/receiver/dockerstatsreceiver/metadata.yaml
@@ -9,7 +9,7 @@ status:
     active: [rmfitzpatrick, jamesmoessis]
   unsupported_platforms: [darwin, windows]
 
-sem_conv_version: 1.6.1
+sem_conv_version: 1.27.0
 
 # Note: there are other, additional resource attributes that the user can configure through the yaml
 resource_attributes:

--- a/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cgroups_v2/expected_metrics.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
         - key: container.runtime
           value:
             stringValue: docker
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/cpu_limit/expected_metrics.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
         - key: container.runtime
           value:
             stringValue: docker
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/no_pids_stats/expected_metrics.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/pids_stats_max/expected_metrics.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
         - key: container.runtime
           value:
             stringValue: docker
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container/expected_metrics.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
         - key: env-var-metric-label-2
           value:
             stringValue: env-var-2
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/single_container_with_optional_resource_attributes/expected_metrics.yaml
@@ -28,7 +28,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.

--- a/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
+++ b/receiver/dockerstatsreceiver/testdata/mock/two_containers/expected_metrics.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.
@@ -807,7 +807,7 @@ resourceMetrics:
         - key: env-var-metric-label
           value:
             stringValue: env-var2
-    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Number of bytes transferred to/from the disk by the group and descendant groups.


### PR DESCRIPTION
Description: The version of semconv is upgraded from v1.6.1 to v1.27.0

This is a trivial upgrade. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator). All attributes used by this component have the same value in both versions.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed