### PR TITLE
hostmetricsreceiver: migrate to newer semconv version

### DIFF
--- a/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_receiver_test.go
@@ -22,7 +22,7 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/scraperhelper"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/cpuscraper"

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeState specifies the a value state attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/cpuscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/cpu
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   cpu:

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeDirection specifies the a value direction attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/diskscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/disk
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeState specifies the a value state attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/filesystem
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 type metricSystemCPULoadAverage15m struct {

--- a/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/loadscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/load
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 metrics:
   system.cpu.load_average.1m:

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeState specifies the a value state attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/memoryscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/memory
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   state:

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeDirection specifies the a value direction attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/networkscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/network
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeDirection specifies the a value direction attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/pagingscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/paging
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   device:

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/internal/metadata/generated_metrics.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeStatus specifies the a value status attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processesscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/processes
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 attributes:
   status:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata/generated_metrics.go
@@ -10,7 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver"
-	conventions "go.opentelemetry.io/collector/semconv/v1.9.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 // AttributeContextSwitchType specifies the a value context_switch_type attribute.

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/metadata.yaml
@@ -2,7 +2,7 @@ type: hostmetricsreceiver/process
 
 parent: hostmetrics
 
-sem_conv_version: 1.9.0
+sem_conv_version: 1.27.0
 
 resource_attributes:
   process.pid:

--- a/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/processscraper/process_scraper_test.go
@@ -21,9 +21,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	"go.opentelemetry.io/collector/receiver/scrapererror"
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterset"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/internal/scraper/processscraper/internal/metadata"
 )

--- a/receiver/hostmetricsreceiver/testdata/e2e/expected_process.yaml
+++ b/receiver/hostmetricsreceiver/testdata/e2e/expected_process.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: process.pid
           value:
             intValue: "95041"
-    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Total CPU seconds broken down by different states.
@@ -97,7 +97,7 @@ resourceMetrics:
         - key: process.pid
           value:
             intValue: "4668"
-    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Total CPU seconds broken down by different states.

--- a/receiver/hostmetricsreceiver/testdata/e2e/expected_process_separate_proc.yaml
+++ b/receiver/hostmetricsreceiver/testdata/e2e/expected_process_separate_proc.yaml
@@ -22,7 +22,7 @@ resourceMetrics:
         - key: process.pid
           value:
             intValue: "4668"
-    schemaUrl: https://opentelemetry.io/schemas/1.9.0
+    schemaUrl: https://opentelemetry.io/schemas/1.27.0
     scopeMetrics:
       - metrics:
           - description: Total CPU seconds broken down by different states.


### PR DESCRIPTION
Description: The version of semconv is upgraded to v1.27.0

This is a trivial upgrade. The semconv attributes' value have been compared using [go-otel-semconv-comparator](https://github.com/narcis96/go-otel-semconv-comparator). All attributes used by this component have the same value in both versions.

Link to tracking Issue: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/22095

Testing: Tests passed