### PR TITLE
Add the tidying back for otelcontribcol but only on the release thingie

### DIFF
--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -54,6 +54,10 @@ git commit -m "make multimod-sync changes ${CANDIDATE_BETA}" || (echo "no multim
 
 make gotidy
 
+pushd cmd/otelcontribcol
+go mod tidy
+popd
+
 git add .
 git commit -m "make gotidy changes ${CANDIDATE_BETA}" || (echo "no gotidy changes to commit")
 make otelcontribcol


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The change in #35608 was too aggressive, this reverts the changes in release-prepare-release.sh
