### PR TITLE
[chore] [receiver/cloudfoundry] Use confighttp.NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/receiver/cloudfoundryreceiver/config_test.go
+++ b/receiver/cloudfoundryreceiver/config_test.go
@@ -25,6 +25,13 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "https://log-stream.sys.example.internal"
+	clientConfig.TLSSetting = configtls.ClientConfig{
+		InsecureSkipVerify: true,
+	}
+	clientConfig.Timeout = time.Second * 20
+
 	tests := []struct {
 		id           component.ID
 		expected     component.Config
@@ -34,14 +41,8 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "one"),
 			expected: &Config{
 				RLPGateway: RLPGatewayConfig{
-					ClientConfig: confighttp.ClientConfig{
-						Endpoint: "https://log-stream.sys.example.internal",
-						TLSSetting: configtls.ClientConfig{
-							InsecureSkipVerify: true,
-						},
-						Timeout: time.Second * 20,
-					},
-					ShardID: "otel-test",
+					ClientConfig: clientConfig,
+					ShardID:      "otel-test",
 				},
 				UAA: UAAConfig{
 					LimitedClientConfig: LimitedClientConfig{
@@ -67,14 +68,8 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "shardidnotdefined"),
 			expected: &Config{
 				RLPGateway: RLPGatewayConfig{
-					ClientConfig: confighttp.ClientConfig{
-						Endpoint: "https://log-stream.sys.example.internal",
-						TLSSetting: configtls.ClientConfig{
-							InsecureSkipVerify: true,
-						},
-						Timeout: time.Second * 20,
-					},
-					ShardID: "opentelemetry",
+					ClientConfig: clientConfig,
+					ShardID:      "opentelemetry",
 				},
 				UAA: UAAConfig{
 					LimitedClientConfig: LimitedClientConfig{
@@ -133,22 +128,22 @@ func TestInvalidConfigValidation(t *testing.T) {
 func TestHTTPConfigurationStructConsistency(t *testing.T) {
 	// LimitedClientConfig must have the same structure as ClientConfig, but without the fields that the UAA
 	// library does not support.
-	checkTypeFieldMatch(t, "Endpoint", reflect.TypeOf(LimitedClientConfig{}), reflect.TypeOf(confighttp.ClientConfig{}))
-	checkTypeFieldMatch(t, "TLSSetting", reflect.TypeOf(LimitedClientConfig{}), reflect.TypeOf(confighttp.ClientConfig{}))
+	checkTypeFieldMatch(t, "Endpoint", reflect.TypeOf(LimitedClientConfig{}), reflect.TypeOf(confighttp.NewDefaultClientConfig()))
+	checkTypeFieldMatch(t, "TLSSetting", reflect.TypeOf(LimitedClientConfig{}), reflect.TypeOf(confighttp.NewDefaultClientConfig()))
 	checkTypeFieldMatch(t, "InsecureSkipVerify", reflect.TypeOf(LimitedTLSClientSetting{}), reflect.TypeOf(configtls.ClientConfig{}))
 }
 
 func loadSuccessfulConfig(t *testing.T) *Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "https://log-stream.sys.example.internal"
+	clientConfig.Timeout = time.Second * 20
+	clientConfig.TLSSetting = configtls.ClientConfig{
+		InsecureSkipVerify: true,
+	}
 	configuration := &Config{
 		RLPGateway: RLPGatewayConfig{
-			ClientConfig: confighttp.ClientConfig{
-				Endpoint: "https://log-stream.sys.example.internal",
-				Timeout:  time.Second * 20,
-				TLSSetting: configtls.ClientConfig{
-					InsecureSkipVerify: true,
-				},
-			},
-			ShardID: "otel-test",
+			ClientConfig: clientConfig,
+			ShardID:      "otel-test",
 		},
 		UAA: UAAConfig{
 			LimitedClientConfig: LimitedClientConfig{

--- a/receiver/cloudfoundryreceiver/factory.go
+++ b/receiver/cloudfoundryreceiver/factory.go
@@ -33,15 +33,15 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = defaultURL
+	clientConfig.TLSSetting = configtls.ClientConfig{
+		InsecureSkipVerify: false,
+	}
 	return &Config{
 		RLPGateway: RLPGatewayConfig{
-			ClientConfig: confighttp.ClientConfig{
-				Endpoint: defaultURL,
-				TLSSetting: configtls.ClientConfig{
-					InsecureSkipVerify: false,
-				},
-			},
-			ShardID: defaultRLPGatewayShardID,
+			ClientConfig: clientConfig,
+			ShardID:      defaultRLPGatewayShardID,
 		},
 		UAA: UAAConfig{
 			LimitedClientConfig: LimitedClientConfig{


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457