### PR TITLE
[chore] [receiver/couchdb] Use confighttp.NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/receiver/couchdbreceiver/client_test.go
+++ b/receiver/couchdbreceiver/client_test.go
@@ -33,18 +33,19 @@ func defaultClient(t *testing.T, endpoint string) client {
 }
 
 func TestNewCouchDBClient(t *testing.T) {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = defaultEndpoint
+	clientConfig.TLSSetting = configtls.ClientConfig{
+		Config: configtls.Config{
+			CAFile: "/non/existent",
+		},
+	}
 	t.Run("Invalid config", func(t *testing.T) {
 		couchdbClient, err := newCouchDBClient(
 			context.Background(),
 			&Config{
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: defaultEndpoint,
-					TLSSetting: configtls.ClientConfig{
-						Config: configtls.Config{
-							CAFile: "/non/existent",
-						},
-					},
-				}},
+				ClientConfig: clientConfig,
+			},
 			componenttest.NewNopHost(),
 			componenttest.NewNopTelemetrySettings())
 
@@ -107,14 +108,15 @@ func TestGet(t *testing.T) {
 	})
 	t.Run("401 Unauthorized", func(t *testing.T) {
 		url := ts.URL + "/_node/_local/_stats/couchdb"
+		clientConfig := confighttp.NewDefaultClientConfig()
+		clientConfig.Endpoint = url
+
 		couchdbClient, err := newCouchDBClient(
 			context.Background(),
 			&Config{
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: url,
-				},
-				Username: "unauthorized",
-				Password: "unauthorized",
+				ClientConfig: clientConfig,
+				Username:     "unauthorized",
+				Password:     "unauthorized",
 			},
 			componenttest.NewNopHost(),
 			componenttest.NewNopTelemetrySettings())
@@ -179,14 +181,15 @@ func TestGetNodeStats(t *testing.T) {
 }
 
 func TestBuildReq(t *testing.T) {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = defaultEndpoint
+
 	couchdbClient := couchDBClient{
 		client: &http.Client{},
 		cfg: &Config{
-			ClientConfig: confighttp.ClientConfig{
-				Endpoint: defaultEndpoint,
-			},
-			Username: "otelu",
-			Password: "otelp",
+			ClientConfig: clientConfig,
+			Username:     "otelu",
+			Password:     "otelp",
 		},
 		logger: zap.NewNop(),
 	}
@@ -201,12 +204,13 @@ func TestBuildReq(t *testing.T) {
 }
 
 func TestBuildBadReq(t *testing.T) {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = defaultEndpoint
+
 	couchdbClient := couchDBClient{
 		client: &http.Client{},
 		cfg: &Config{
-			ClientConfig: confighttp.ClientConfig{
-				Endpoint: defaultEndpoint,
-			},
+			ClientConfig: clientConfig,
 		},
 		logger: zap.NewNop(),
 	}

--- a/receiver/couchdbreceiver/config_test.go
+++ b/receiver/couchdbreceiver/config_test.go
@@ -20,6 +20,12 @@ import (
 )
 
 func TestValidate(t *testing.T) {
+	clientConfigInvalid := confighttp.NewDefaultClientConfig()
+	clientConfigInvalid.Endpoint = "http://localhost :5984"
+
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "http://localhost:5984"
+
 	testCases := []struct {
 		desc        string
 		cfg         *Config
@@ -28,9 +34,7 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "missing username, password and invalid endpoint",
 			cfg: &Config{
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: "http://localhost :5984",
-				},
+				ClientConfig:     clientConfigInvalid,
 				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
 			},
 			expectedErr: multierr.Combine(
@@ -42,9 +46,7 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "missing password and invalid endpoint",
 			cfg: &Config{
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: "http://localhost :5984",
-				},
+				ClientConfig:     clientConfigInvalid,
 				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
 				Username:         "otelu",
 			},
@@ -56,9 +58,7 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "missing username and invalid endpoint",
 			cfg: &Config{
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: "http://localhost :5984",
-				},
+				ClientConfig:     clientConfigInvalid,
 				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
 				Password:         "otelp",
 			},
@@ -70,11 +70,9 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "invalid endpoint",
 			cfg: &Config{
-				Username: "otel",
-				Password: "otel",
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: "http://localhost :5984",
-				},
+				Username:         "otel",
+				Password:         "otel",
+				ClientConfig:     clientConfigInvalid,
 				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
 			},
 			expectedErr: fmt.Errorf(errInvalidEndpoint.Error(), "parse \"http://localhost :5984\": invalid character \" \" in host name"),
@@ -82,11 +80,9 @@ func TestValidate(t *testing.T) {
 		{
 			desc: "no error",
 			cfg: &Config{
-				Username: "otel",
-				Password: "otel",
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: "http://localhost:5984",
-				},
+				Username:         "otel",
+				Password:         "otel",
+				ClientConfig:     clientConfig,
 				ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
 			},
 			expectedErr: nil,

--- a/receiver/couchdbreceiver/factory.go
+++ b/receiver/couchdbreceiver/factory.go
@@ -26,14 +26,14 @@ func NewFactory() receiver.Factory {
 }
 
 func createDefaultConfig() component.Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.TLSSetting = configtls.ClientConfig{}
+	clientConfig.Endpoint = defaultEndpoint
+	clientConfig.Timeout = 1 * time.Minute
 	return &Config{
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 		ControllerConfig:     scraperhelper.NewDefaultControllerConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			TLSSetting: configtls.ClientConfig{},
-			Endpoint:   defaultEndpoint,
-			Timeout:    1 * time.Minute,
-		},
+		ClientConfig:         clientConfig,
 	}
 }
 

--- a/receiver/couchdbreceiver/scraper_test.go
+++ b/receiver/couchdbreceiver/scraper_test.go
@@ -158,7 +158,7 @@ func TestMetricSettings(t *testing.T) {
 		CouchdbHttpdViews:         metadata.MetricConfig{Enabled: false},
 	}
 	cfg := &Config{
-		ClientConfig:         confighttp.ClientConfig{},
+		ClientConfig:         confighttp.NewDefaultClientConfig(),
 		MetricsBuilderConfig: mbc,
 	}
 	scraper := newCouchdbScraper(receivertest.NewNopSettings(), cfg)


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457