### PR TITLE
[chore] [receiver/expvar] Use confighttp.NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/receiver/expvarreceiver/config_test.go
+++ b/receiver/expvarreceiver/config_test.go
@@ -27,7 +27,9 @@ func TestLoadConfig(t *testing.T) {
 	metricCfg := metadata.DefaultMetricsBuilderConfig()
 	metricCfg.Metrics.ProcessRuntimeMemstatsTotalAlloc.Enabled = true
 	metricCfg.Metrics.ProcessRuntimeMemstatsMallocs.Enabled = false
-
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = "http://localhost:8000/custom/path"
+	clientConfig.Timeout = time.Second * 5
 	tests := []struct {
 		id           component.ID
 		expected     component.Config
@@ -45,10 +47,7 @@ func TestLoadConfig(t *testing.T) {
 					InitialDelay:       time.Second,
 					Timeout:            time.Second * 5,
 				},
-				ClientConfig: confighttp.ClientConfig{
-					Endpoint: "http://localhost:8000/custom/path",
-					Timeout:  time.Second * 5,
-				},
+				ClientConfig:         clientConfig,
 				MetricsBuilderConfig: metricCfg,
 			},
 		},

--- a/receiver/expvarreceiver/factory.go
+++ b/receiver/expvarreceiver/factory.go
@@ -56,12 +56,12 @@ func newMetricsReceiver(
 }
 
 func newDefaultConfig() component.Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = defaultEndpoint
+	clientConfig.Timeout = defaultTimeout
 	return &Config{
-		ControllerConfig: scraperhelper.NewDefaultControllerConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			Endpoint: defaultEndpoint,
-			Timeout:  defaultTimeout,
-		},
+		ControllerConfig:     scraperhelper.NewDefaultControllerConfig(),
+		ClientConfig:         clientConfig,
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}
 }

--- a/receiver/expvarreceiver/factory_test.go
+++ b/receiver/expvarreceiver/factory_test.go
@@ -32,6 +32,8 @@ func TestValidConfig(t *testing.T) {
 
 func TestCreateMetrics(t *testing.T) {
 	factory := NewFactory()
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Endpoint = defaultEndpoint
 	metricsReceiver, err := factory.CreateMetrics(
 		context.Background(),
 		receivertest.NewNopSettings(),
@@ -39,9 +41,7 @@ func TestCreateMetrics(t *testing.T) {
 			ControllerConfig: scraperhelper.ControllerConfig{
 				CollectionInterval: 10 * time.Second,
 			},
-			ClientConfig: confighttp.ClientConfig{
-				Endpoint: defaultEndpoint,
-			},
+			ClientConfig:         clientConfig,
 			MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 		},
 		consumertest.NewNop(),


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457