### PR TITLE
[chore] [receiver/github] Use confighttp.NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/receiver/githubreceiver/internal/scraper/githubscraper/config_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/config_test.go
@@ -19,11 +19,12 @@ func TestConfig(t *testing.T) {
 	factory := Factory{}
 	defaultConfig := factory.CreateDefaultConfig()
 
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = 15 * time.Second
+
 	expectedConfig := &Config{
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			Timeout: 15 * time.Second,
-		},
+		ClientConfig:         clientConfig,
 	}
 
 	assert.Equal(t, expectedConfig, defaultConfig)

--- a/receiver/githubreceiver/internal/scraper/githubscraper/factory.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/factory.go
@@ -24,11 +24,11 @@ const (
 type Factory struct{}
 
 func (f *Factory) CreateDefaultConfig() internal.Config {
+	clientConfig := confighttp.NewDefaultClientConfig()
+	clientConfig.Timeout = defaultHTTPTimeout
 	return &Config{
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
-		ClientConfig: confighttp.ClientConfig{
-			Timeout: defaultHTTPTimeout,
-		},
+		ClientConfig:         clientConfig,
 	}
 }
 


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457