### PR TITLE
Add OTTL get editor function

### DIFF
--- a/pkg/ottl/ottlfuncs/func_get.go
+++ b/pkg/ottl/ottlfuncs/func_get.go
@@ -1,0 +1,35 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/ottlfuncs"
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+type GetArguments[K any] struct {
+	Value ottl.Getter[K]
+}
+
+func NewGetFactory[K any]() ottl.Factory[K] {
+	return ottl.NewFactory("get", &GetArguments[K]{}, createGetFunction[K])
+}
+
+func createGetFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ottl.ExprFunc[K], error) {
+	args, ok := oArgs.(*GetArguments[K])
+
+	if !ok {
+		return nil, fmt.Errorf("GetFactory args must be of type *GetArguments[K]")
+	}
+
+	return get(args.Value), nil
+}
+
+func get[K any](value ottl.Getter[K]) ottl.ExprFunc[K] {
+	return func(ctx context.Context, tCtx K) (any, error) {
+		return value.Get(ctx, tCtx)
+	}
+}

--- a/pkg/ottl/ottlfuncs/func_get_test.go
+++ b/pkg/ottl/ottlfuncs/func_get_test.go
@@ -1,0 +1,71 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottlfuncs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+)
+
+func Test_get(t *testing.T) {
+	tests := []struct {
+		name   string
+		getter ottl.Getter[any]
+		want   pcommon.Value
+	}{
+		{
+			name: "get string",
+			getter: ottl.StandardGetSetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return "a", nil
+				},
+			},
+			want: pcommon.NewValueStr("a"),
+		},
+		{
+			name: "get int",
+			getter: ottl.StandardGetSetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return 11, nil
+				},
+			},
+			want: pcommon.NewValueInt(11),
+		},
+		{
+			name: "get double",
+			getter: ottl.StandardGetSetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return 104.12, nil
+				},
+			},
+			want: pcommon.NewValueDouble(104.12),
+		},
+		{
+			name: "nil",
+			getter: ottl.StandardGetSetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return nil, nil
+				},
+			},
+			want: pcommon.NewValueEmpty(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			exprFunc := get(tt.getter)
+
+			result, err := exprFunc(context.Background(), nil)
+			assert.NoError(t, err)
+
+			actual := pcommon.NewValueEmpty()
+			assert.NoError(t, actual.FromRaw(result))
+			assert.Equal(t, tt.want, actual)
+		})
+	}
+}

--- a/pkg/ottl/ottlfuncs/functions.go
+++ b/pkg/ottl/ottlfuncs/functions.go
@@ -10,6 +10,7 @@ import (
 func StandardFuncs[K any]() map[string]ottl.Factory[K] {
 	f := []ottl.Factory[K]{
 		// Editors
+		NewGetFactory[K](),
 		NewDeleteKeyFactory[K](),
 		NewDeleteMatchingKeysFactory[K](),
 		NewKeepMatchingKeysFactory[K](),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Based on [OTTL grammar](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/ottl/LANGUAGE.md), any OTTL statement must have a single editor. A get OTTL editor function allows OTTL statements to retrieve data from underlying telemetry. This could be used in components to take OTTL statements as configuration to retrieve values from the underlying telemetry and build a more generic component. One example of this would be a generic connector that could produce metrics from any signals based on OTTL statements used to retrieve values from the underlying telemetry.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests are added to the PR.

<!--Describe the documentation added.-->
#### Documentation

WIP

<!--Please delete paragraphs that you did not use before submitting.-->
