### PR TITLE
feat: [receiver/httpcheck] Adding dnslookup duration metric

### DIFF
--- a/.chloggen/main.yaml
+++ b/.chloggen/main.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: httpcheckreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add DNS Duration Metric to httpcheckreceiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34987]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Add a DNS Duration Timing Metric to ensure that the DNS Timing is measured if the "endpoint" configuration variable is a FQDN/Host. | This allows for more detailed measurements within the total http Layer-7 call flow. | This also helps developers understand the latency distribution between the DNS Portion of Layer7, and all the other components.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/httpcheckreceiver/documentation.md
+++ b/receiver/httpcheckreceiver/documentation.md
@@ -12,6 +12,20 @@ metrics:
     enabled: false
 ```
 
+### httpcheck.dnslookup_duration
+
+Measures the duration of the DNS Component of the HTTP check.
+
+| Unit | Metric Type | Value Type |
+| ---- | ----------- | ---------- |
+| ms | Gauge | Int |
+
+#### Attributes
+
+| Name | Description | Values |
+| ---- | ----------- | ------ |
+| http.url | Full HTTP request URL. | Any Str |
+
 ### httpcheck.duration
 
 Measures the duration of the HTTP check.

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config.go
@@ -27,13 +27,17 @@ func (ms *MetricConfig) Unmarshal(parser *confmap.Conf) error {
 
 // MetricsConfig provides config for httpcheck metrics.
 type MetricsConfig struct {
-	HttpcheckDuration MetricConfig `mapstructure:"httpcheck.duration"`
-	HttpcheckError    MetricConfig `mapstructure:"httpcheck.error"`
-	HttpcheckStatus   MetricConfig `mapstructure:"httpcheck.status"`
+	HttpcheckDnslookupDuration MetricConfig `mapstructure:"httpcheck.dnslookup_duration"`
+	HttpcheckDuration          MetricConfig `mapstructure:"httpcheck.duration"`
+	HttpcheckError             MetricConfig `mapstructure:"httpcheck.error"`
+	HttpcheckStatus            MetricConfig `mapstructure:"httpcheck.status"`
 }
 
 func DefaultMetricsConfig() MetricsConfig {
 	return MetricsConfig{
+		HttpcheckDnslookupDuration: MetricConfig{
+			Enabled: true,
+		},
 		HttpcheckDuration: MetricConfig{
 			Enabled: true,
 		},

--- a/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
+++ b/receiver/httpcheckreceiver/internal/metadata/generated_config_test.go
@@ -25,9 +25,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "all_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					HttpcheckDuration: MetricConfig{Enabled: true},
-					HttpcheckError:    MetricConfig{Enabled: true},
-					HttpcheckStatus:   MetricConfig{Enabled: true},
+					HttpcheckDnslookupDuration: MetricConfig{Enabled: true},
+					HttpcheckDuration:          MetricConfig{Enabled: true},
+					HttpcheckError:             MetricConfig{Enabled: true},
+					HttpcheckStatus:            MetricConfig{Enabled: true},
 				},
 			},
 		},
@@ -35,9 +36,10 @@ func TestMetricsBuilderConfig(t *testing.T) {
 			name: "none_set",
 			want: MetricsBuilderConfig{
 				Metrics: MetricsConfig{
-					HttpcheckDuration: MetricConfig{Enabled: false},
-					HttpcheckError:    MetricConfig{Enabled: false},
-					HttpcheckStatus:   MetricConfig{Enabled: false},
+					HttpcheckDnslookupDuration: MetricConfig{Enabled: false},
+					HttpcheckDuration:          MetricConfig{Enabled: false},
+					HttpcheckError:             MetricConfig{Enabled: false},
+					HttpcheckStatus:            MetricConfig{Enabled: false},
 				},
 			},
 		},

--- a/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
+++ b/receiver/httpcheckreceiver/internal/metadata/testdata/config.yaml
@@ -1,6 +1,8 @@
 default:
 all_set:
   metrics:
+    httpcheck.dnslookup_duration:
+      enabled: true
     httpcheck.duration:
       enabled: true
     httpcheck.error:
@@ -9,6 +11,8 @@ all_set:
       enabled: true
 none_set:
   metrics:
+    httpcheck.dnslookup_duration:
+      enabled: false
     httpcheck.duration:
       enabled: false
     httpcheck.error:

--- a/receiver/httpcheckreceiver/metadata.yaml
+++ b/receiver/httpcheckreceiver/metadata.yaml
@@ -45,6 +45,13 @@ metrics:
       value_type: int
     unit: ms
     attributes: [http.url]
+  httpcheck.dnslookup_duration:
+    description: Measures the duration of the DNS Component of the HTTP check.
+    enabled: true
+    gauge:
+      value_type: int
+    unit: ms
+    attributes: [http.url]
   httpcheck.error:
     description: Records errors occurring during HTTP check.
     enabled: true


### PR DESCRIPTION
**Description:** Add a DNS Duration Timing Metric to ensure that the DNS Timing is measured if the "endpoint" configuration variable is a FQDN/Host. This allows for more detailed measurements within the total http Layer-7 call flow. This also helps useres understand the latency distribution between the DNS Portion of Layer7, and all the other components.

**Link to tracking Issue:** #34987 

**Testing:** Looking for feedback here... unsure what tests (if any) should be added. I have built the project and tested that it works as expected in the following cases:

1. Using FQDN Endpoint
2. Using IPV4 Endpoint
3. A DNS & IP Endpoint that does not resolve and results in a timeout.

**Documentation:** Documentation is auto-generated for the new httpcheck.dnslookup_duration metric.