### PR TITLE
[receiver/azureblobreceiver] support for default auth

### DIFF
--- a/.chloggen/feature_azureblobreceiverDefaultAuth.yaml
+++ b/.chloggen/feature_azureblobreceiverDefaultAuth.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'azureblobreceiver'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "adds support for using azidentity default auth, enabling the use of Azure Managed Identities, e.g. Workload Identities on AKS"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/feature_azureblobreceiverDefaultAuth.yaml
+++ b/.chloggen/feature_azureblobreceiverDefaultAuth.yaml
@@ -10,12 +10,14 @@ component: 'azureblobreceiver'
 note: "adds support for using azidentity default auth, enabling the use of Azure Managed Identities, e.g. Workload Identities on AKS"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [35636]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  This change allows to use authentication type "default", which makes the receiver use azidentity default Credentials, 
+  which automatically picks up, identities assigned to e.g. a container or a VirtualMachine
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/azureblobreceiver/README.md
+++ b/receiver/azureblobreceiver/README.md
@@ -24,7 +24,7 @@ The following settings are required:
 
 The following settings can be optionally configured:
 
-- `auth` (default = connection_string): Specifies the used authentication method. Supported values are `connection_string`, `service_principal`.
+- `auth` (default = connection_string): Specifies the used authentication method. Supported values are `connection_string`, `service_principal`, `default`.
 - `cloud` (default = "AzureCloud"): Defines which Azure Cloud to use when using the `service_principal` authentication method. Value is either `AzureCloud` or `AzureUSGovernment`.
 - `logs:`
   `  container_name:` (default = "logs"): Name of the blob container with the logs

--- a/receiver/azureblobreceiver/config.go
+++ b/receiver/azureblobreceiver/config.go
@@ -69,16 +69,17 @@ type AuthType string
 const (
 	ServicePrincipalAuth AuthType = "service_principal"
 	ConnectionStringAuth AuthType = "connection_string"
+	DefaultAuth          AuthType = "default"
 )
 
 func (e *AuthType) UnmarshalText(text []byte) error {
 	str := AuthType(text)
 	switch str {
-	case ServicePrincipalAuth, ConnectionStringAuth:
+	case ServicePrincipalAuth, ConnectionStringAuth, DefaultAuth:
 		*e = str
 		return nil
 	default:
-		return fmt.Errorf("authentication %v is not supported. supported authentications include [%v,%v]", str, ServicePrincipalAuth, ConnectionStringAuth)
+		return fmt.Errorf("authentication %v is not supported. supported authentications include [%v,%v,%v]", str, ServicePrincipalAuth, ConnectionStringAuth, DefaultAuth)
 	}
 }
 

--- a/receiver/azureblobreceiver/factory.go
+++ b/receiver/azureblobreceiver/factory.go
@@ -141,6 +141,15 @@ func (f *blobReceiverFactory) getBlobEventHandler(cfg *Config, logger *zap.Logge
 		if err != nil {
 			return nil, err
 		}
+	case DefaultAuth:
+		cred, err := azidentity.NewDefaultAzureCredential(nil)
+		if err != nil {
+			return nil, err
+		}
+		bc, err = newBlobClientFromCredential(cfg.StorageAccountURL, cred, logger)
+		if err != nil {
+			return nil, err
+		}
 	default:
 		return nil, fmt.Errorf("unknown authentication %v", cfg.Authentication)
 	}


### PR DESCRIPTION
adds "default" auth, to make the azure go package, autodiscover credentials added by e.g. workload identities 