### PR TITLE
[chore][exporter/elasticsearch] fix flaky assertion in TestExporterMetrics

### DIFF
--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -532,7 +532,6 @@ func TestExporterMetrics(t *testing.T) {
 			rec.Record(docs)
 			return itemsAllOK(docs)
 		})
-		defer server.Close()
 
 		exporter := newTestMetricsExporter(t, server.URL, func(cfg *Config) {
 			cfg.Mapping.Mode = "ecs"

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -532,6 +532,7 @@ func TestExporterMetrics(t *testing.T) {
 			rec.Record(docs)
 			return itemsAllOK(docs)
 		})
+		defer server.Close()
 
 		exporter := newTestMetricsExporter(t, server.URL, func(cfg *Config) {
 			cfg.Mapping.Mode = "ecs"

--- a/exporter/elasticsearchexporter/utils_test.go
+++ b/exporter/elasticsearchexporter/utils_test.go
@@ -48,7 +48,13 @@ func assertItemsEqual(t *testing.T, expected, actual []itemRequest, assertOrder 
 		copy(actualItems, actual)
 		slices.SortFunc(actualItems, itemRequestsSortFunc)
 	}
-	assert.Equal(t, expectedItems, actualItems)
+
+	assert.Equal(t, len(expectedItems), len(actualItems), "want %d items, got %d", len(expectedItems), len(actualItems))
+	for i, want := range expectedItems {
+		got := actualItems[i]
+		assert.JSONEq(t, string(want.Action), string(got.Action), "item %d action", i)
+		assert.JSONEq(t, string(want.Document), string(got.Document), "item %d document", i)
+	}
 }
 
 type itemResponse struct {


### PR DESCRIPTION
#### Description

Sometimes the order of fields in the json strings change which causes failures in the test.
