### PR TITLE
[chore] [receiver/purefb] Use confighttp.NewDefaultClientConfig instead of manually creating struct

### DIFF
--- a/receiver/purefbreceiver/config_test.go
+++ b/receiver/purefbreceiver/config_test.go
@@ -23,8 +23,6 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
-	clientConfig := confighttp.NewDefaultClientConfig()
-
 	tests := []struct {
 		id       component.ID
 		expected component.Config
@@ -32,7 +30,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewID(metadata.Type),
 			expected: &Config{
-				ClientConfig: clientConfig,
+				ClientConfig: confighttp.NewDefaultClientConfig(),
 				Settings: &Settings{
 					ReloadIntervals: &ReloadIntervals{
 						Array:   15 * time.Second,

--- a/receiver/purefbreceiver/config_test.go
+++ b/receiver/purefbreceiver/config_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/purefbreceiver/internal/metadata"
@@ -22,6 +23,8 @@ func TestLoadConfig(t *testing.T) {
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
+	clientConfig := confighttp.NewDefaultClientConfig()
+
 	tests := []struct {
 		id       component.ID
 		expected component.Config
@@ -29,6 +32,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewID(metadata.Type),
 			expected: &Config{
+				ClientConfig: clientConfig,
 				Settings: &Settings{
 					ReloadIntervals: &ReloadIntervals{
 						Array:   15 * time.Second,

--- a/receiver/purefbreceiver/factory.go
+++ b/receiver/purefbreceiver/factory.go
@@ -28,7 +28,7 @@ func NewFactory() receiver.Factory {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		ClientConfig: confighttp.ClientConfig{},
+		ClientConfig: confighttp.NewDefaultClientConfig(),
 		Settings: &Settings{
 			ReloadIntervals: &ReloadIntervals{
 				Array:   15 * time.Second,


### PR DESCRIPTION
**Description:**
This PR makes usage of `NewDefaultClientConfig` instead of manually creating the confighttp.ClientConfig struct.

**Link to tracking Issue:** #35457