### PR TITLE
[processor/deltacumulative] fix meter panic

### DIFF
--- a/.chloggen/deltatocumulative-bug-meter.yaml
+++ b/.chloggen/deltatocumulative-bug-meter.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: deltatocumulative
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix meter panic on startup
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35685]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: properly constructs the TelemetryBuilder, so it does not panic on startup, rendering the entire component unusable
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/deltatocumulativeprocessor/factory.go
+++ b/processor/deltatocumulativeprocessor/factory.go
@@ -29,16 +29,12 @@ func createMetricsProcessor(_ context.Context, set processor.Settings, cfg compo
 		return nil, fmt.Errorf("configuration parsing error")
 	}
 
-	telb, err := metadata.NewTelemetryBuilder(set.TelemetrySettings)
-	if err != nil {
-		return nil, err
-	}
-	proc := newProcessor(pcfg, set.Logger, telb, next)
-
 	ltel, err := ltel.New(set.TelemetrySettings)
 	if err != nil {
 		return nil, err
 	}
+
+	proc := newProcessor(pcfg, set.Logger, &ltel.TelemetryBuilder, next)
 	linear := newLinear(pcfg, ltel, proc)
 
 	return Chain{linear, proc}, nil

--- a/processor/deltatocumulativeprocessor/processor_test.go
+++ b/processor/deltatocumulativeprocessor/processor_test.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-package deltatocumulativeprocessor_test
+package deltatocumulativeprocessor
 
 import (
 	"context"
@@ -19,10 +19,10 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics/identity"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
-	self "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/datatest/compare"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/metrics"
@@ -30,15 +30,15 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testdata/random"
 )
 
-func setup(t *testing.T, cfg *self.Config) (processor.Metrics, *consumertest.MetricsSink) {
+func setup(t *testing.T, cfg *Config) (processor.Metrics, *consumertest.MetricsSink) {
 	t.Helper()
 
 	next := &consumertest.MetricsSink{}
 	if cfg == nil {
-		cfg = &self.Config{MaxStale: 0, MaxStreams: math.MaxInt}
+		cfg = &Config{MaxStale: 0, MaxStreams: math.MaxInt}
 	}
 
-	proc, err := self.NewFactory().CreateMetrics(
+	proc, err := NewFactory().CreateMetrics(
 		context.Background(),
 		processortest.NewNopSettings(),
 		cfg,
@@ -173,7 +173,7 @@ func TestTimestamps(t *testing.T) {
 }
 
 func TestStreamLimit(t *testing.T) {
-	proc, sink := setup(t, &self.Config{MaxStale: 5 * time.Minute, MaxStreams: 10})
+	proc, sink := setup(t, &Config{MaxStale: 5 * time.Minute, MaxStreams: 10})
 
 	good := make([]SumBuilder, 10)
 	for i := range good {
@@ -306,5 +306,25 @@ func TestIgnore(t *testing.T) {
 
 	if diff := compare.Diff([]pmetric.Metrics{out}, sink.AllMetrics()); diff != "" {
 		t.Fatal(diff)
+	}
+}
+
+func TestTelemetry(t *testing.T) {
+	tt := setupTestTelemetry()
+
+	next := &consumertest.MetricsSink{}
+	cfg := createDefaultConfig()
+
+	_, err := NewFactory().CreateMetrics(
+		context.Background(),
+		tt.NewSettings(),
+		cfg,
+		next,
+	)
+	require.NoError(t, err)
+
+	var rm metricdata.ResourceMetrics
+	if err := tt.reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

As an oversight, https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35048 creates two `metadata.TelemetryBuilder` instances.
It also introduces an async metric, but one `TelemetryBuilder` sets no callback for that, leading to a panic on `Collect()`.
Fixes that by using the same `TelemetryBuilder` for both, properly setting the callback.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
n/a

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Test was added in first commit that passes after adding second commit

<!--Please delete paragraphs that you did not use before submitting.-->
