### PR TITLE
[receiver/datadogreceiver] Return json for traces if the version is > 0.3

### DIFF
--- a/.chloggen/datadog-trace-receiver-return-body.yaml
+++ b/.chloggen/datadog-trace-receiver-return-body.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Return a json reponse instead of "OK" when a trace is received with a newer protocol version.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35705]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -245,13 +245,17 @@ func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Reques
 	}
 
 	urlSplit := strings.Split(req.RequestURI, "/")
-	switch version := urlSplit[1]; version {
-	case "v0.1", "v0.2", "v0.3":
+	if len(urlSplit) == 3 {
+		// Match the response logic from dd-agent https://github.com/DataDog/datadog-agent/blob/86b2ae24f93941447a5bf0a2b6419caed77e76dd/pkg/trace/api/api.go#L511-L519
+		switch version := urlSplit[1]; version {
+		case "v0.1", "v0.2", "v0.3":
+			_, _ = w.Write([]byte("OK"))
+		default:
+			_, _ = w.Write([]byte("{}"))
+		}
+	} else {
 		_, _ = w.Write([]byte("OK"))
-	default:
-		_, _ = w.Write([]byte("{}"))
 	}
-
 }
 
 // handleV1Series handles the v1 series endpoint https://docs.datadoghq.com/api/latest/metrics/#submit-metrics

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/DataDog/agent-payload/v5/gogen"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
@@ -243,8 +244,9 @@ func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Reques
 		}
 	}
 
-	switch version := req.Header.Get(header.TracerVersion); version {
-	case "0.1", "0.2", "0.3":
+	urlSplit := strings.Split(req.RequestURI, "/")
+	switch version := urlSplit[1]; version {
+	case "v0.1", "v0.2", "v0.3":
 		_, _ = w.Write([]byte("OK"))
 	default:
 		_, _ = w.Write([]byte("{}"))

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -244,18 +244,21 @@ func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Reques
 		}
 	}
 
+	responseBody := "OK"
+	contentType := "text/plain"
 	urlSplit := strings.Split(req.RequestURI, "/")
 	if len(urlSplit) == 3 {
 		// Match the response logic from dd-agent https://github.com/DataDog/datadog-agent/blob/86b2ae24f93941447a5bf0a2b6419caed77e76dd/pkg/trace/api/api.go#L511-L519
 		switch version := urlSplit[1]; version {
 		case "v0.1", "v0.2", "v0.3":
-			_, _ = w.Write([]byte("OK"))
+			// Keep the "OK" response for these versions
 		default:
-			_, _ = w.Write([]byte("{}"))
+			contentType = "application/json"
+			responseBody = "{}"
 		}
-	} else {
-		_, _ = w.Write([]byte("OK"))
 	}
+	w.Header().Set("Content-Type", contentType)
+	_, _ = w.Write([]byte(responseBody))
 }
 
 // handleV1Series handles the v1 series endpoint https://docs.datadoghq.com/api/latest/metrics/#submit-metrics

--- a/receiver/datadogreceiver/receiver.go
+++ b/receiver/datadogreceiver/receiver.go
@@ -243,7 +243,12 @@ func (ddr *datadogReceiver) handleTraces(w http.ResponseWriter, req *http.Reques
 		}
 	}
 
-	_, _ = w.Write([]byte("OK"))
+	switch version := req.Header.Get(header.TracerVersion); version {
+	case "0.1", "0.2", "0.3":
+		_, _ = w.Write([]byte("OK"))
+	default:
+		_, _ = w.Write([]byte("{}"))
+	}
 
 }
 


### PR DESCRIPTION

#### Description

Problem: 

* [The Datadog agent for versions > 0.3 returns Json instead of "Ok"](https://github.com/DataDog/datadog-agent/blob/86b2ae24f93941447a5bf0a2b6419caed77e76dd/pkg/trace/api/api.go#L511-L519)
* [dd-trace-js is using V0.4 for sending data to Datadog and that expects to get a JSON response back](https://github.com/DataDog/dd-trace-js/blob/2d175d30d5ad7291c238819116a07f003074316b/packages/dd-trace/src/exporters/agent/writer.js#L52)
* When sending traces from NodeJS with the dd-trace-js library it works, but throws a high volume of errors from the non-json response.

Fix: For trace submissions with a version > 0.3 return a valid, but empty Json response.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit test to ensure the expected responses to traces are returned.
