### PR TITLE
awss3receiver: Fix notifications test which fail when run on Windows

### DIFF
--- a/receiver/awss3receiver/notifications_test.go
+++ b/receiver/awss3receiver/notifications_test.go
@@ -6,7 +6,6 @@ package awss3receiver // import "github.com/open-telemetry/opentelemetry-collect
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -212,7 +211,7 @@ func Test_opampNotifier_SendStatus_MessagePending(t *testing.T) {
 			tryCount++
 			return pending
 		},
-		pendingChannel: make(chan struct{}),
+		pendingChannel: make(chan struct{}, 1),
 	}
 	notifier := &opampNotifier{handler: &registry, logger: zap.NewNop()}
 	toSend := statusNotification{
@@ -221,20 +220,16 @@ func Test_opampNotifier_SendStatus_MessagePending(t *testing.T) {
 		IngestTime:    time.Time{},
 	}
 
-	var completionTime time.Time
-
-	now := time.Now()
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
+	doneChan := make(chan struct{}, 1)
 	go func() {
 		notifier.SendStatus(context.Background(), toSend)
-		completionTime = time.Now()
-		wg.Done()
+		doneChan <- struct{}{}
 	}()
 	require.Empty(t, registry.sentMessages)
+	require.Empty(t, doneChan)
 	registry.pendingChannel <- struct{}{}
-	wg.Wait()
-	require.True(t, completionTime.After(now))
+	<-doneChan
+	require.Empty(t, registry.pendingChannel)
 	require.Len(t, registry.sentMessages, 1)
 	require.Equal(t, "TimeBasedIngestStatus", registry.sentMessages[0].messageType)
 }
@@ -258,7 +253,7 @@ func Test_opampNotifier_SendStatus_Error(t *testing.T) {
 func Test_opampNotifier_SendStatus_MaxRetries(t *testing.T) {
 	registry := mockCustomCapabilityRegistry{
 		shouldReturnPending: func() bool { return true },
-		pendingChannel:      make(chan struct{}),
+		pendingChannel:      make(chan struct{}, 1),
 	}
 	notifier := &opampNotifier{handler: &registry, logger: zap.NewNop()}
 	toSend := statusNotification{
@@ -266,23 +261,18 @@ func Test_opampNotifier_SendStatus_MaxRetries(t *testing.T) {
 		IngestStatus:  IngestStatusIngesting,
 		IngestTime:    time.Time{},
 	}
-	var completionTime time.Time
-	now := time.Now()
-	wg := &sync.WaitGroup{}
-	wg.Add(1)
-
+	doneChan := make(chan struct{}, 1)
 	go func() {
 		notifier.SendStatus(context.Background(), toSend)
-		completionTime = time.Now()
-		wg.Done()
+		doneChan <- struct{}{}
 	}()
+	require.Empty(t, doneChan)
 
 	for attempt := 0; attempt < maxNotificationAttempts; attempt++ {
 		registry.pendingChannel <- struct{}{}
 	}
-	wg.Wait()
-
-	require.True(t, completionTime.After(now))
+	<-doneChan
+	require.Empty(t, registry.pendingChannel)
 	require.Empty(t, registry.sentMessages)
 	require.Equal(t, maxNotificationAttempts, registry.sendMessageCalls)
 }


### PR DESCRIPTION
#### Description
Remove the use of time to detect the order of completion and replace with channels.

#### Link to tracking issue
Fixes #35704

#### Testing
Tested that the new method detects failure to wait on the pending channel by removing the code in SendStatus() that receives from the channel and confirming that the test fails. 

