### PR TITLE
[receiver/datadog] Fix service_check name conversion

### DIFF
--- a/.chloggen/alexg_fix-service-check-metric-name.yaml
+++ b/.chloggen/alexg_fix-service-check-metric-name.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: datadogreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Use `Check` name from Service Check structure as metric name rather than hardcoded string `service_check`"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35718]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/datadogreceiver/internal/translator/service_check_translator.go
+++ b/receiver/datadogreceiver/internal/translator/service_check_translator.go
@@ -27,7 +27,7 @@ func (mt *MetricsTranslator) TranslateServices(services []ServiceCheck) pmetric.
 	bt.Metrics = pmetric.NewMetrics()
 
 	for _, service := range services {
-		metricProperties := parseSeriesProperties("service_check", "service_check", service.Tags, service.HostName, mt.buildInfo.Version, mt.stringPool)
+		metricProperties := parseSeriesProperties(service.Check, "service_check", service.Tags, service.HostName, mt.buildInfo.Version, mt.stringPool)
 		metric, metricID := bt.Lookup(metricProperties) // TODO(alexg): proper name
 
 		dps := metric.Gauge().DataPoints()

--- a/receiver/datadogreceiver/internal/translator/service_check_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/service_check_translator_test.go
@@ -187,7 +187,7 @@ func TestTranslateCheckRun(t *testing.T) {
 				requireScope(t, result, expectedAttrs.scope, component.NewDefaultBuildInfo().Version)
 
 				metric := result.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-				requireGauge(t, metric, "service_check", 1)
+				requireGauge(t, metric, "app.working", 1)
 
 				dp := metric.Gauge().DataPoints().At(0)
 				requireDp(t, dp, expectedAttrs.dp, 1700000000, 0)
@@ -213,7 +213,7 @@ func TestTranslateCheckRun(t *testing.T) {
 				requireScope(t, result, expectedAttrs.scope, component.NewDefaultBuildInfo().Version)
 
 				metric := result.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0)
-				requireGauge(t, metric, "service_check", 1)
+				requireGauge(t, metric, "app.working", 1)
 
 				dp := metric.Gauge().DataPoints().At(0)
 				requireDp(t, dp, expectedAttrs.dp, 0, 0)

--- a/receiver/datadogreceiver/receiver_test.go
+++ b/receiver/datadogreceiver/receiver_test.go
@@ -621,6 +621,7 @@ func TestDatadogServices_EndToEnd(t *testing.T) {
 	metrics := got.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics()
 	assert.Equal(t, 1, metrics.Len())
 	metric := metrics.At(0)
+	assert.Equal(t, "app.working", metric.Name())
 	assert.Equal(t, pmetric.MetricTypeGauge, metric.Type())
 	dps := metric.Gauge().DataPoints()
 	assert.Equal(t, 1, dps.Len())


### PR DESCRIPTION
#### Description

Use the `Check` name supplied in the Service Check structure rather than hard-coding the resulting metric as `service_check`.

Unit tests and e2e test updated accordingly.