### PR TITLE
[exporter/clickhouseexporter] Sort attribute maps before insertion #33634

### DIFF
--- a/.chloggen/clickhouseexporter-ordered-attributes.yaml
+++ b/.chloggen/clickhouseexporter-ordered-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: clickhouseexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Exporter now sorts attribute maps' keys during INSERT, yielding better compression and predictable aggregates"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33634]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -93,9 +94,9 @@ func TestExporter_pushLogsData(t *testing.T) {
 		initClickhouseTestServer(t, func(query string, values []driver.Value) error {
 			if strings.HasPrefix(query, "INSERT") {
 				require.Equal(t, "https://opentelemetry.io/schemas/1.4.0", values[8])
-				require.Equal(t, map[string]string{
+				require.Equal(t, orderedmap.FromMap(map[string]string{
 					"service.name": "test-service",
-				}, values[9])
+				}), values[9])
 			}
 			return nil
 		})
@@ -108,9 +109,9 @@ func TestExporter_pushLogsData(t *testing.T) {
 				require.Equal(t, "https://opentelemetry.io/schemas/1.7.0", values[10])
 				require.Equal(t, "io.opentelemetry.contrib.clickhouse", values[11])
 				require.Equal(t, "1.0.0", values[12])
-				require.Equal(t, map[string]string{
+				require.Equal(t, orderedmap.FromMap(map[string]string{
 					"lib": "clickhouse",
-				}, values[13])
+				}), values[13])
 			}
 			return nil
 		})

--- a/exporter/clickhouseexporter/exporter_metrics.go
+++ b/exporter/clickhouseexporter/exporter_metrics.go
@@ -77,7 +77,7 @@ func (e *metricsExporter) pushMetricsData(ctx context.Context, md pmetric.Metric
 	metricsMap := internal.NewMetricsModel(e.tablesConfig)
 	for i := 0; i < md.ResourceMetrics().Len(); i++ {
 		metrics := md.ResourceMetrics().At(i)
-		resAttr := attributesToMap(metrics.Resource().Attributes())
+		resAttr := metrics.Resource().Attributes()
 		for j := 0; j < metrics.ScopeMetrics().Len(); j++ {
 			rs := metrics.ScopeMetrics().At(j).Metrics()
 			scopeInstr := metrics.ScopeMetrics().At(j).Scope()

--- a/exporter/clickhouseexporter/internal/exponential_histogram_metrics.go
+++ b/exporter/clickhouseexporter/internal/exponential_histogram_metrics.go
@@ -130,27 +130,24 @@ func (e *expHistogramMetrics) insert(ctx context.Context, db *sql.DB) error {
 		}()
 
 		for _, model := range e.expHistogramModels {
-			var serviceName string
-			if v, ok := model.metadata.ResAttr[conventions.AttributeServiceName]; ok {
-				serviceName = v
-			}
+			serviceName, _ := model.metadata.ResAttr.Get(conventions.AttributeServiceName)
 
 			for i := 0; i < model.expHistogram.DataPoints().Len(); i++ {
 				dp := model.expHistogram.DataPoints().At(i)
 				attrs, times, values, traceIDs, spanIDs := convertExemplars(dp.Exemplars())
 				_, err = statement.ExecContext(ctx,
-					model.metadata.ResAttr,
+					AttributesToMap(model.metadata.ResAttr),
 					model.metadata.ResURL,
 					model.metadata.ScopeInstr.Name(),
 					model.metadata.ScopeInstr.Version(),
-					attributesToMap(model.metadata.ScopeInstr.Attributes()),
+					AttributesToMap(model.metadata.ScopeInstr.Attributes()),
 					model.metadata.ScopeInstr.DroppedAttributesCount(),
 					model.metadata.ScopeURL,
-					serviceName,
+					serviceName.AsString(),
 					model.metricName,
 					model.metricDescription,
 					model.metricUnit,
-					attributesToMap(dp.Attributes()),
+					AttributesToMap(dp.Attributes()),
 					dp.StartTimestamp().AsTime(),
 					dp.Timestamp().AsTime(),
 					dp.Count(),
@@ -190,7 +187,7 @@ func (e *expHistogramMetrics) insert(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func (e *expHistogramMetrics) Add(resAttr map[string]string, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (e *expHistogramMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
 	expHistogram, ok := metrics.(pmetric.ExponentialHistogram)
 	if !ok {
 		return fmt.Errorf("metrics param is not type of ExponentialHistogram")

--- a/exporter/clickhouseexporter/internal/histogram_metrics.go
+++ b/exporter/clickhouseexporter/internal/histogram_metrics.go
@@ -121,27 +121,24 @@ func (h *histogramMetrics) insert(ctx context.Context, db *sql.DB) error {
 		}()
 
 		for _, model := range h.histogramModel {
-			var serviceName string
-			if v, ok := model.metadata.ResAttr[conventions.AttributeServiceName]; ok {
-				serviceName = v
-			}
+			serviceName, _ := model.metadata.ResAttr.Get(conventions.AttributeServiceName)
 
 			for i := 0; i < model.histogram.DataPoints().Len(); i++ {
 				dp := model.histogram.DataPoints().At(i)
 				attrs, times, values, traceIDs, spanIDs := convertExemplars(dp.Exemplars())
 				_, err = statement.ExecContext(ctx,
-					model.metadata.ResAttr,
+					AttributesToMap(model.metadata.ResAttr),
 					model.metadata.ResURL,
 					model.metadata.ScopeInstr.Name(),
 					model.metadata.ScopeInstr.Version(),
-					attributesToMap(model.metadata.ScopeInstr.Attributes()),
+					AttributesToMap(model.metadata.ScopeInstr.Attributes()),
 					model.metadata.ScopeInstr.DroppedAttributesCount(),
 					model.metadata.ScopeURL,
-					serviceName,
+					serviceName.AsString(),
 					model.metricName,
 					model.metricDescription,
 					model.metricUnit,
-					attributesToMap(dp.Attributes()),
+					AttributesToMap(dp.Attributes()),
 					dp.StartTimestamp().AsTime(),
 					dp.Timestamp().AsTime(),
 					dp.Count(),
@@ -177,7 +174,7 @@ func (h *histogramMetrics) insert(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func (h *histogramMetrics) Add(resAttr map[string]string, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (h *histogramMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
 	histogram, ok := metrics.(pmetric.Histogram)
 	if !ok {
 		return fmt.Errorf("metrics param is not type of Histogram")

--- a/exporter/clickhouseexporter/internal/metrics_model_test.go
+++ b/exporter/clickhouseexporter/internal/metrics_model_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/ClickHouse/clickhouse-go/v2/lib/column/orderedmap"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -20,15 +21,15 @@ func Test_attributesToMap(t *testing.T) {
 	attributes.PutBool("bool", true)
 	attributes.PutInt("int", 0)
 	attributes.PutDouble("double", 0.0)
-	result := attributesToMap(attributes)
+	result := AttributesToMap(attributes)
 	require.Equal(
 		t,
-		map[string]string{
+		orderedmap.FromMap(map[string]string{
 			"key":    "value",
 			"bool":   "true",
 			"int":    "0",
 			"double": "0",
-		},
+		}),
 		result,
 	)
 }
@@ -58,7 +59,7 @@ func Test_convertExemplars(t *testing.T) {
 		exemplar.FilteredAttributes().PutStr("key2", "value2")
 
 		attrs, times, values, traceIDs, spanIDs := convertExemplars(exemplars)
-		require.Equal(t, clickhouse.ArraySet{map[string]string{"key1": "value1", "key2": "value2"}}, attrs)
+		require.Equal(t, clickhouse.ArraySet{orderedmap.FromMap(map[string]string{"key1": "value1", "key2": "value2"})}, attrs)
 		require.Equal(t, clickhouse.ArraySet{time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)}, times)
 		require.Equal(t, clickhouse.ArraySet{0.0}, values)
 		require.Equal(t, clickhouse.ArraySet{"00000000000000000000000000000000"}, traceIDs)
@@ -70,7 +71,7 @@ func Test_convertExemplars(t *testing.T) {
 		exemplar.SetTimestamp(pcommon.NewTimestampFromTime(time.Unix(1672218930, 0)))
 
 		attrs, times, values, traceIDs, spanIDs := convertExemplars(exemplars)
-		require.Equal(t, clickhouse.ArraySet{map[string]string{}}, attrs)
+		require.Equal(t, clickhouse.ArraySet{orderedmap.FromMap(map[string]string{})}, attrs)
 		require.Equal(t, clickhouse.ArraySet{time.Unix(1672218930, 0).UTC()}, times)
 		require.Equal(t, clickhouse.ArraySet{0.0}, values)
 		require.Equal(t, clickhouse.ArraySet{"00000000000000000000000000000000"}, traceIDs)
@@ -82,7 +83,7 @@ func Test_convertExemplars(t *testing.T) {
 		exemplar.SetDoubleValue(15.0)
 
 		attrs, times, values, traceIDs, spanIDs := convertExemplars(exemplars)
-		require.Equal(t, clickhouse.ArraySet{map[string]string{}}, attrs)
+		require.Equal(t, clickhouse.ArraySet{orderedmap.FromMap(map[string]string{})}, attrs)
 		require.Equal(t, clickhouse.ArraySet{time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)}, times)
 		require.Equal(t, clickhouse.ArraySet{15.0}, values)
 		require.Equal(t, clickhouse.ArraySet{"00000000000000000000000000000000"}, traceIDs)
@@ -94,7 +95,7 @@ func Test_convertExemplars(t *testing.T) {
 		exemplar.SetIntValue(20)
 
 		attrs, times, values, traceIDs, spanIDs := convertExemplars(exemplars)
-		require.Equal(t, clickhouse.ArraySet{map[string]string{}}, attrs)
+		require.Equal(t, clickhouse.ArraySet{orderedmap.FromMap(map[string]string{})}, attrs)
 		require.Equal(t, clickhouse.ArraySet{time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)}, times)
 		require.Equal(t, clickhouse.ArraySet{20.0}, values)
 		require.Equal(t, clickhouse.ArraySet{"00000000000000000000000000000000"}, traceIDs)
@@ -106,7 +107,7 @@ func Test_convertExemplars(t *testing.T) {
 		exemplar.SetSpanID([8]byte{1, 2, 3, 4})
 
 		attrs, times, values, traceIDs, spanIDs := convertExemplars(exemplars)
-		require.Equal(t, clickhouse.ArraySet{map[string]string{}}, attrs)
+		require.Equal(t, clickhouse.ArraySet{orderedmap.FromMap(map[string]string{})}, attrs)
 		require.Equal(t, clickhouse.ArraySet{time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)}, times)
 		require.Equal(t, clickhouse.ArraySet{0.0}, values)
 		require.Equal(t, clickhouse.ArraySet{"00000000000000000000000000000000"}, traceIDs)
@@ -118,7 +119,7 @@ func Test_convertExemplars(t *testing.T) {
 		exemplar.SetTraceID([16]byte{1, 2, 3, 4})
 
 		attrs, times, values, traceIDs, spanIDs := convertExemplars(exemplars)
-		require.Equal(t, clickhouse.ArraySet{map[string]string{}}, attrs)
+		require.Equal(t, clickhouse.ArraySet{orderedmap.FromMap(map[string]string{})}, attrs)
 		require.Equal(t, clickhouse.ArraySet{time.Date(1970, time.January, 1, 0, 0, 0, 0, time.UTC)}, times)
 		require.Equal(t, clickhouse.ArraySet{0.0}, values)
 		require.Equal(t, clickhouse.ArraySet{"01020304000000000000000000000000"}, traceIDs)
@@ -145,7 +146,7 @@ func Test_convertExemplars(t *testing.T) {
 		exemplar.SetTraceID([16]byte{1, 2, 3, 5})
 
 		attrs, times, values, traceIDs, spanIDs := convertExemplars(exemplars)
-		require.Equal(t, clickhouse.ArraySet{map[string]string{"key1": "value1", "key2": "value2"}, map[string]string{"key3": "value3", "key4": "value4"}}, attrs)
+		require.Equal(t, clickhouse.ArraySet{orderedmap.FromMap(map[string]string{"key1": "value1", "key2": "value2"}), orderedmap.FromMap(map[string]string{"key3": "value3", "key4": "value4"})}, attrs)
 		require.Equal(t, clickhouse.ArraySet{time.Unix(1672218930, 0).UTC(), time.Unix(1672219930, 0).UTC()}, times)
 		require.Equal(t, clickhouse.ArraySet{20.0, 16.0}, values)
 		require.Equal(t, clickhouse.ArraySet{"01020304000000000000000000000000", "01020305000000000000000000000000"}, traceIDs)

--- a/exporter/clickhouseexporter/internal/sum_metrics.go
+++ b/exporter/clickhouseexporter/internal/sum_metrics.go
@@ -113,27 +113,24 @@ func (s *sumMetrics) insert(ctx context.Context, db *sql.DB) error {
 		}()
 
 		for _, model := range s.sumModel {
-			var serviceName string
-			if v, ok := model.metadata.ResAttr[conventions.AttributeServiceName]; ok {
-				serviceName = v
-			}
+			serviceName, _ := model.metadata.ResAttr.Get(conventions.AttributeServiceName)
 
 			for i := 0; i < model.sum.DataPoints().Len(); i++ {
 				dp := model.sum.DataPoints().At(i)
 				attrs, times, values, traceIDs, spanIDs := convertExemplars(dp.Exemplars())
 				_, err = statement.ExecContext(ctx,
-					model.metadata.ResAttr,
+					AttributesToMap(model.metadata.ResAttr),
 					model.metadata.ResURL,
 					model.metadata.ScopeInstr.Name(),
 					model.metadata.ScopeInstr.Version(),
-					attributesToMap(model.metadata.ScopeInstr.Attributes()),
+					AttributesToMap(model.metadata.ScopeInstr.Attributes()),
 					model.metadata.ScopeInstr.DroppedAttributesCount(),
 					model.metadata.ScopeURL,
-					serviceName,
+					serviceName.AsString(),
 					model.metricName,
 					model.metricDescription,
 					model.metricUnit,
-					attributesToMap(dp.Attributes()),
+					AttributesToMap(dp.Attributes()),
 					dp.StartTimestamp().AsTime(),
 					dp.Timestamp().AsTime(),
 					getValue(dp.IntValue(), dp.DoubleValue(), dp.ValueType()),
@@ -165,7 +162,7 @@ func (s *sumMetrics) insert(ctx context.Context, db *sql.DB) error {
 	return nil
 }
 
-func (s *sumMetrics) Add(resAttr map[string]string, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
+func (s *sumMetrics) Add(resAttr pcommon.Map, resURL string, scopeInstr pcommon.InstrumentationScope, scopeURL string, metrics any, name string, description string, unit string) error {
 	sum, ok := metrics.(pmetric.Sum)
 	if !ok {
 		return fmt.Errorf("metrics param is not type of Sum")


### PR DESCRIPTION
#### Description
Our attributes are stored as Map(String, String) in CH.
By default the order of keys is undefined and as described in #33634 leads to worse compression and duplicates in `group by` (unless carefully accounted for).
This PR uses the `column.IterableOrderedMap` facility from clickhouse-go to ensure fixed attribute key order.

It is a reimplementation of #34598 that uses less allocations and is (arguably) somewhat more straightforward.

I'm **opening this as a draft**, because this PR (and #34598) are blocked by https://github.com/ClickHouse/clickhouse-go/issues/1365 (fixed in https://github.com/ClickHouse/clickhouse-go/pull/1418)

In addition, I'm trying to add the implementation of `column.IterableOrderedMap` used to clickhouse-go upstream: https://github.com/ClickHouse/clickhouse-go/pull/1417
If it is accepted, I will amend this PR accordingly.

#### Link to tracking issue
Fixes #33634

#### Testing
The IOM implementation was used in production independently.
I'm planning to build otelcollector with this PR and cut over my production to it in the next few of days.