### PR TITLE
telemetrygen: wire up InsecureSkipVerify

### DIFF
--- a/.chloggen/telemetrygen-insecureskipverify.yaml
+++ b/.chloggen/telemetrygen-insecureskipverify.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: telemetrygen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enable the `--otlp-insecure-skip-verify` flag
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35735]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/telemetrygen/go.mod
+++ b/cmd/telemetrygen/go.mod
@@ -23,6 +23,7 @@ require (
 	go.opentelemetry.io/otel/sdk/log v0.6.0
 	go.opentelemetry.io/otel/sdk/metric v1.30.0
 	go.opentelemetry.io/otel/trace v1.30.0
+	go.opentelemetry.io/proto/otlp v1.3.1
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/time v0.6.0
@@ -47,7 +48,6 @@ require (
 	go.opentelemetry.io/collector/internal/globalsignal v0.110.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.110.0 // indirect
 	go.opentelemetry.io/otel/metric v1.30.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/sys v0.25.0 // indirect

--- a/cmd/telemetrygen/internal/logs/exporter.go
+++ b/cmd/telemetrygen/internal/logs/exporter.go
@@ -22,7 +22,9 @@ func grpcExporterOptions(cfg *Config) ([]otlploggrpc.Option, error) {
 	if cfg.Insecure {
 		grpcExpOpt = append(grpcExpOpt, otlploggrpc.WithInsecure())
 	} else {
-		credentials, err := common.GetTLSCredentialsForGRPCExporter(cfg.CaFile, cfg.ClientAuth)
+		credentials, err := common.GetTLSCredentialsForGRPCExporter(
+			cfg.CaFile, cfg.ClientAuth, cfg.InsecureSkipVerify,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS credentials: %w", err)
 		}
@@ -47,7 +49,9 @@ func httpExporterOptions(cfg *Config) ([]otlploghttp.Option, error) {
 	if cfg.Insecure {
 		httpExpOpt = append(httpExpOpt, otlploghttp.WithInsecure())
 	} else {
-		tlsCfg, err := common.GetTLSCredentialsForHTTPExporter(cfg.CaFile, cfg.ClientAuth)
+		tlsCfg, err := common.GetTLSCredentialsForHTTPExporter(
+			cfg.CaFile, cfg.ClientAuth, cfg.InsecureSkipVerify,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS credentials: %w", err)
 		}

--- a/cmd/telemetrygen/internal/metrics/exporter.go
+++ b/cmd/telemetrygen/internal/metrics/exporter.go
@@ -22,7 +22,9 @@ func grpcExporterOptions(cfg *Config) ([]otlpmetricgrpc.Option, error) {
 	if cfg.Insecure {
 		grpcExpOpt = append(grpcExpOpt, otlpmetricgrpc.WithInsecure())
 	} else {
-		credentials, err := common.GetTLSCredentialsForGRPCExporter(cfg.CaFile, cfg.ClientAuth)
+		credentials, err := common.GetTLSCredentialsForGRPCExporter(
+			cfg.CaFile, cfg.ClientAuth, cfg.InsecureSkipVerify,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS credentials: %w", err)
 		}
@@ -47,7 +49,9 @@ func httpExporterOptions(cfg *Config) ([]otlpmetrichttp.Option, error) {
 	if cfg.Insecure {
 		httpExpOpt = append(httpExpOpt, otlpmetrichttp.WithInsecure())
 	} else {
-		tlsCfg, err := common.GetTLSCredentialsForHTTPExporter(cfg.CaFile, cfg.ClientAuth)
+		tlsCfg, err := common.GetTLSCredentialsForHTTPExporter(
+			cfg.CaFile, cfg.ClientAuth, cfg.InsecureSkipVerify,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS credentials: %w", err)
 		}

--- a/cmd/telemetrygen/internal/traces/exporter.go
+++ b/cmd/telemetrygen/internal/traces/exporter.go
@@ -22,7 +22,9 @@ func grpcExporterOptions(cfg *Config) ([]otlptracegrpc.Option, error) {
 	if cfg.Insecure {
 		grpcExpOpt = append(grpcExpOpt, otlptracegrpc.WithInsecure())
 	} else {
-		credentials, err := common.GetTLSCredentialsForGRPCExporter(cfg.CaFile, cfg.ClientAuth)
+		credentials, err := common.GetTLSCredentialsForGRPCExporter(
+			cfg.CaFile, cfg.ClientAuth, cfg.InsecureSkipVerify,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS credentials: %w", err)
 		}
@@ -47,7 +49,9 @@ func httpExporterOptions(cfg *Config) ([]otlptracehttp.Option, error) {
 	if cfg.Insecure {
 		httpExpOpt = append(httpExpOpt, otlptracehttp.WithInsecure())
 	} else {
-		tlsCfg, err := common.GetTLSCredentialsForHTTPExporter(cfg.CaFile, cfg.ClientAuth)
+		tlsCfg, err := common.GetTLSCredentialsForHTTPExporter(
+			cfg.CaFile, cfg.ClientAuth, cfg.InsecureSkipVerify,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get TLS credentials: %w", err)
 		}

--- a/cmd/telemetrygen/internal/traces/exporter_test.go
+++ b/cmd/telemetrygen/internal/traces/exporter_test.go
@@ -13,12 +13,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
 )
 
 func TestHTTPExporterOptions_TLS(t *testing.T) {
@@ -49,7 +49,7 @@ func TestHTTPExporterOptions_TLS(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			var called bool
-			var h http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+			var h http.HandlerFunc = func(http.ResponseWriter, *http.Request) {
 				called = true
 			}
 			var srv *httptest.Server
@@ -111,7 +111,7 @@ func TestHTTPExporterOptions_HTTP(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var httpPath string
 			var header http.Header
-			var h http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+			var h http.HandlerFunc = func(_ http.ResponseWriter, r *http.Request) {
 				httpPath = r.URL.Path
 				header = r.Header
 			}

--- a/cmd/telemetrygen/internal/traces/exporter_test.go
+++ b/cmd/telemetrygen/internal/traces/exporter_test.go
@@ -129,8 +129,8 @@ func TestHTTPExporterOptions_HTTP(t *testing.T) {
 			err = client.UploadTraces(context.Background(), []*tracepb.ResourceSpans{})
 			require.NoError(t, err)
 			assert.Equal(t, tc.expectedHTTPPath, httpPath)
-			for k, v := range tc.expectedHeader {
-				assert.Equal(t, v, []string{header.Get(k)})
+			for k, expected := range tc.expectedHeader {
+				assert.Equal(t, expected, []string{header.Get(k)})
 			}
 		})
 	}

--- a/cmd/telemetrygen/internal/traces/exporter_test.go
+++ b/cmd/telemetrygen/internal/traces/exporter_test.go
@@ -1,0 +1,137 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package traces
+
+import (
+	"context"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/telemetrygen/internal/common"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPExporterOptions_TLS(t *testing.T) {
+	// TODO add test cases for mTLS
+	for name, tc := range map[string]struct {
+		tls         bool
+		tlsServerCA bool // use the httptest.Server's TLS cert as the CA
+		cfg         Config
+
+		expectTransportError bool
+	}{
+		"Insecure": {
+			tls: false,
+			cfg: Config{Config: common.Config{Insecure: true}},
+		},
+		"InsecureSkipVerify": {
+			tls: true,
+			cfg: Config{Config: common.Config{InsecureSkipVerify: true}},
+		},
+		"InsecureSkipVerifyDisabled": {
+			tls:                  true,
+			expectTransportError: true,
+		},
+		"CaFile": {
+			tls:         true,
+			tlsServerCA: true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var called bool
+			var h http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+				called = true
+			}
+			var srv *httptest.Server
+			if tc.tls {
+				srv = httptest.NewTLSServer(h)
+			} else {
+				srv = httptest.NewServer(h)
+			}
+			defer srv.Close()
+			srvURL, _ := url.Parse(srv.URL)
+
+			cfg := tc.cfg
+			cfg.CustomEndpoint = srvURL.Host
+			if tc.tlsServerCA {
+				caFile := filepath.Join(t.TempDir(), "cert.pem")
+				err := os.WriteFile(caFile, pem.EncodeToMemory(&pem.Block{
+					Type:  "CERTIFICATE",
+					Bytes: srv.TLS.Certificates[0].Certificate[0],
+				}), 0600)
+				require.NoError(t, err)
+				cfg.CaFile = caFile
+			}
+
+			opts, err := httpExporterOptions(&cfg)
+			require.NoError(t, err)
+			client := otlptracehttp.NewClient(opts...)
+
+			err = client.UploadTraces(context.Background(), []*tracepb.ResourceSpans{})
+			if tc.expectTransportError {
+				require.Error(t, err)
+				assert.False(t, called)
+			} else {
+				require.NoError(t, err)
+				assert.True(t, called)
+			}
+		})
+	}
+}
+
+func TestHTTPExporterOptions_HTTP(t *testing.T) {
+	for name, tc := range map[string]struct {
+		cfg Config
+
+		expectedHTTPPath string
+		expectedHeader   http.Header
+	}{
+		"HTTPPath": {
+			cfg:              Config{Config: common.Config{HTTPPath: "/foo"}},
+			expectedHTTPPath: "/foo",
+		},
+		"Headers": {
+			cfg: Config{
+				Config: common.Config{Headers: map[string]any{"a": "b"}},
+			},
+			expectedHTTPPath: "/v1/traces",
+			expectedHeader:   http.Header{"a": []string{"b"}},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			var httpPath string
+			var header http.Header
+			var h http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
+				httpPath = r.URL.Path
+				header = r.Header
+			}
+			srv := httptest.NewServer(h)
+			defer srv.Close()
+			srvURL, _ := url.Parse(srv.URL)
+
+			cfg := tc.cfg
+			cfg.Insecure = true
+			cfg.CustomEndpoint = srvURL.Host
+			opts, err := httpExporterOptions(&cfg)
+			require.NoError(t, err)
+			client := otlptracehttp.NewClient(opts...)
+
+			err = client.UploadTraces(context.Background(), []*tracepb.ResourceSpans{})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedHTTPPath, httpPath)
+			for k, v := range tc.expectedHeader {
+				assert.Equal(t, v, []string{header.Get(k)})
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Description

Thread the InsecureSkipVerify config through properly, so the relevant `tls.Config` struct field is set. Previously, The `--otlp-insecure-skip-verify` flag wasn't effective.

I feel like we'd be better off using https://github.com/open-telemetry/opentelemetry-go-contrib/tree/main/exporters/autoexport and configuring these things with environment variables, instead of defining flags. I will open an issue for that.

#### Link to tracking issue

None

#### Testing

I have added a test that shows the HTTP exporter honours the Insecure, InsecureSkipVerify, and CaFile config fields.

I have not done the same for gRPC due to lack of time - this can be done as a followup. OTOH the logic for HTTP & gRPC exporter options shares more now, so the HTTP path tests a fair bit of what gRPC will do anyway.