### PR TITLE
Do not associate ingress controller pod entities with many services

### DIFF
--- a/.chloggen/k8s-cluster-do-not-add-many-service-accosiations.yaml
+++ b/.chloggen/k8s-cluster-do-not-add-many-service-accosiations.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/k8scluster
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not associate pod entities with services if number of matching services more than 10.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35764]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If pod has many matching services, it's typically a sign that the pod is an ingress controller. 
+  In this case, associating the pod with all the services doesn't provide any useful information.
+  This change is intended to avoid the overhead of associating the pod with all the services.
+  It only affects the experimental entity signal exported by the receiver, it doesn't affect metrics.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/k8sclusterreceiver/internal/service/service_test.go
+++ b/receiver/k8sclusterreceiver/internal/service/service_test.go
@@ -4,11 +4,15 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/testutils"
 )
 
 func TestTransform(t *testing.T) {
@@ -52,4 +56,99 @@ func TestTransform(t *testing.T) {
 		},
 	}
 	assert.EqualValues(t, wantService, Transform(originalService))
+}
+
+func TestGetPodServiceTags(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Labels: map[string]string{
+				"app": "my-app",
+			},
+		},
+	}
+	tests := []struct {
+		name     string
+		services cache.Store
+		want     map[string]string
+	}{
+		{
+			name: "no services",
+			services: &testutils.MockStore{
+				Cache: map[string]any{},
+			},
+			want: map[string]string{},
+		},
+		{
+			name: "no matching services",
+			services: &testutils.MockStore{
+				Cache: map[string]any{
+					"my-service": &corev1.Service{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "my-service",
+							Namespace: "default",
+						},
+						Spec: corev1.ServiceSpec{
+							Selector: map[string]string{
+								"app": "another-app",
+							},
+						},
+					},
+				},
+			},
+			want: map[string]string{},
+		},
+		{
+			name:     "one service",
+			services: generateFakeServices(1),
+			want: map[string]string{
+				"k8s.service.service-0": "",
+			},
+		},
+		{
+			name:     "ten services",
+			services: generateFakeServices(10),
+			want: map[string]string{
+				"k8s.service.service-0": "",
+				"k8s.service.service-1": "",
+				"k8s.service.service-2": "",
+				"k8s.service.service-3": "",
+				"k8s.service.service-4": "",
+				"k8s.service.service-5": "",
+				"k8s.service.service-6": "",
+				"k8s.service.service-7": "",
+				"k8s.service.service-8": "",
+				"k8s.service.service-9": "",
+			},
+		},
+		{
+			name:     "more than ten services",
+			services: generateFakeServices(11),
+			want:     nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPodServiceTags(pod, tt.services)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func generateFakeServices(count int) cache.Store {
+	c := make(map[string]any)
+	for i := 0; i < count; i++ {
+		c[fmt.Sprintf("service-%d", i)] = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      fmt.Sprintf("service-%d", i),
+				Namespace: "default",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app": "my-app",
+				},
+			},
+		}
+	}
+	return &testutils.MockStore{Cache: c}
 }


### PR DESCRIPTION
If pod has many matching services, it's typically a sign that the pod is an ingress controller. In this case, associating the pod with all the services doesn't provide any useful information. This change is intended to avoid the overhead of associating the pod with all the services. It only affects the experimental entity signal exported by the receiver, it doesn't affect metrics.
