### PR TITLE
[chore] fix codeowners

### DIFF
--- a/internal/docker/metadata.yaml
+++ b/internal/docker/metadata.yaml
@@ -1,4 +1,4 @@
 status:
   codeowners:
-    active: [jamesmoessis, moviestoreguy]
+    active: [jamesmoessis, MovieStoreGuy]
     emeritus: [rmfitzpatrick]


### PR DESCRIPTION
Fix a failed CI on main: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/11353374942/job/31578361321#step:15:11

seems metadata codeowners are case sensitive