### PR TITLE
[chore] update generated codeowners too

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,7 +126,7 @@ extension/sumologicextension/                                       @open-teleme
 internal/aws/                                                       @open-telemetry/collector-contrib-approvers @Aneurysm9 @mxiamxia
 internal/collectd/                                                  @open-telemetry/collector-contrib-approvers @atoulme
 internal/coreinternal/                                              @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
-internal/docker/                                                    @open-telemetry/collector-contrib-approvers @jamesmoessis
+internal/docker/                                                    @open-telemetry/collector-contrib-approvers @jamesmoessis @MovieStoreGuy
 internal/exp/metrics/                                               @open-telemetry/collector-contrib-approvers @sh0rez @RichieSams
 internal/filter/                                                    @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 internal/grpcutil/                                                  @open-telemetry/collector-contrib-approvers @jmacd @moh-osman3 @lquerel


### PR DESCRIPTION
Fix CI https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/11354019722/job/31580347526

This was missed out in the previous PR https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35817 (apologies!)