### PR TITLE
[processor/metricsgeneration] Remove "experimental_" prefix

### DIFF
--- a/.chloggen/remove-experimental-metrics-generator-prefix.yaml
+++ b/.chloggen/remove-experimental-metrics-generator-prefix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/metricsgeneration
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove "experimental_" prefix from metrics generator processor name.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35426]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/metricsgenerationprocessor/README.md
+++ b/processor/metricsgenerationprocessor/README.md
@@ -16,7 +16,7 @@
 
 ## Description
 
-The metrics generation processor (`experimental_metricsgenerationprocessor`) can be used to create new metrics using existing metrics following a given rule. This processor currently supports the following two rule types for creating a new metric.
+The metrics generation processor (`metricsgenerationprocessor`) can be used to create new metrics using existing metrics following a given rule. This processor currently supports the following two rule types for creating a new metric.
 
 1. `calculate`: It can create a new metric from two existing metrics by applying one of the following arithmetic operations: add, subtract, multiply, divide, or percent. One use case is to calculate the `pod.memory.utilization` metric like the following equation-
 `pod.memory.utilization` = (`pod.memory.usage.bytes` / `node.memory.limit`)
@@ -42,8 +42,8 @@ match the given metric names and apply the specified operation to those metrics.
 
 ```yaml
 processors:
-    # processor name: experimental_metricsgeneration
-    experimental_metricsgeneration:
+    # processor name: metricsgeneration
+    metricsgeneration:
 
         # specify the metric generation rules
         rules:

--- a/processor/metricsgenerationprocessor/generated_component_test.go
+++ b/processor/metricsgenerationprocessor/generated_component_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestComponentFactoryType(t *testing.T) {
-	require.Equal(t, "experimental_metricsgeneration", NewFactory().Type().String())
+	require.Equal(t, "metricsgeneration", NewFactory().Type().String())
 }
 
 func TestComponentConfigStruct(t *testing.T) {

--- a/processor/metricsgenerationprocessor/internal/metadata/generated_status.go
+++ b/processor/metricsgenerationprocessor/internal/metadata/generated_status.go
@@ -7,7 +7,7 @@ import (
 )
 
 var (
-	Type      = component.MustNewType("experimental_metricsgeneration")
+	Type      = component.MustNewType("metricsgeneration")
 	ScopeName = "github.com/open-telemetry/opentelemetry-collector-contrib/processor/metricsgenerationprocessor"
 )
 

--- a/processor/metricsgenerationprocessor/metadata.yaml
+++ b/processor/metricsgenerationprocessor/metadata.yaml
@@ -1,4 +1,4 @@
-type: experimental_metricsgeneration
+type: metricsgeneration
 
 status:
   class: processor

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -527,7 +527,7 @@ func TestGoldenFileMetrics(t *testing.T) {
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
 
-			sub, err := cm.Sub(fmt.Sprintf("%s/%s", "experimental_metricsgeneration", testCase.name))
+			sub, err := cm.Sub(fmt.Sprintf("%s/%s", "metricsgeneration", testCase.name))
 			require.NoError(t, err)
 			require.NoError(t, sub.Unmarshal(cfg))
 

--- a/processor/metricsgenerationprocessor/testdata/config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/config.yaml
@@ -1,4 +1,4 @@
-experimental_metricsgeneration:
+metricsgeneration:
   rules:
     - name: new_metric
       unit: percent
@@ -13,7 +13,7 @@ experimental_metricsgeneration:
       scale_by: 1000
       operation: multiply
 
-experimental_metricsgeneration/invalid_generation_type:
+metricsgeneration/invalid_generation_type:
   rules:
     - name: new_metric
       type: invalid # invalid generation type
@@ -21,7 +21,7 @@ experimental_metricsgeneration/invalid_generation_type:
       metric2: metric2
       operation: percent
 
-experimental_metricsgeneration/invalid_operation:
+metricsgeneration/invalid_operation:
   rules:
     - name: new_metric
       type: calculate
@@ -29,7 +29,7 @@ experimental_metricsgeneration/invalid_operation:
       metric2: metric2
       operation: invalid # invalid operation type
 
-experimental_metricsgeneration/missing_new_metric:
+metricsgeneration/missing_new_metric:
   rules:
     # missing name
     - type: calculate
@@ -37,7 +37,7 @@ experimental_metricsgeneration/missing_new_metric:
       metric2: metric2
       operation: percent
 
-experimental_metricsgeneration/missing_operand1:
+metricsgeneration/missing_operand1:
   rules:
     # missing operand1 metric
     - name: new_metric
@@ -45,7 +45,7 @@ experimental_metricsgeneration/missing_operand1:
       metric2: metric2
       operation: percent
 
-experimental_metricsgeneration/missing_operand2:
+metricsgeneration/missing_operand2:
   rules:
     # missing operand2 metric
     - name: new_metric
@@ -53,7 +53,7 @@ experimental_metricsgeneration/missing_operand2:
       metric1: metric1
       operation: percent
 
-experimental_metricsgeneration/missing_scale_by:
+metricsgeneration/missing_scale_by:
   rules:
     # missing scale_by
     - name: new_metric
@@ -61,7 +61,7 @@ experimental_metricsgeneration/missing_scale_by:
       metric1: metric1
       operation: multiply
 
-experimental_metricsgeneration/missing_type:
+metricsgeneration/missing_type:
   rules:
     # missing generation type
     - name: new_metric

--- a/processor/metricsgenerationprocessor/testdata/input_metric_types/config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/input_metric_types/config.yaml
@@ -1,4 +1,4 @@
-experimental_metricsgeneration/sum_gauge_metric:
+metricsgeneration/sum_gauge_metric:
   rules:
     - name: system.filesystem.capacity
       unit: bytes
@@ -6,7 +6,7 @@ experimental_metricsgeneration/sum_gauge_metric:
       metric1: system.filesystem.usage
       metric2: system.filesystem.utilization
       operation: divide
-experimental_metricsgeneration/sum_gauge_metric_match_attrs:
+metricsgeneration/sum_gauge_metric_match_attrs:
   rules:
     - name: system.filesystem.capacity
       unit: bytes

--- a/processor/metricsgenerationprocessor/testdata/match_attributes/config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/match_attributes/config.yaml
@@ -1,11 +1,11 @@
-experimental_metricsgeneration/match_attributes_disabled:
+metricsgeneration/match_attributes_disabled:
   rules:
     - name: new_metric
       metric1: capacity.total
       metric2: capacity.used
       operation: add
       type: calculate
-experimental_metricsgeneration/match_attributes_enabled:
+metricsgeneration/match_attributes_enabled:
   rules:
     - name: new_metric
       metric1: capacity.total

--- a/processor/metricsgenerationprocessor/testdata/metric2_zero_value/config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/metric2_zero_value/config.yaml
@@ -1,32 +1,32 @@
-experimental_metricsgeneration/metric2_zero_add:
+metricsgeneration/metric2_zero_add:
   rules:
     - name: new_metric
       metric1: capacity.total
       metric2: capacity.used
       operation: add
       type: calculate
-experimental_metricsgeneration/metric2_zero_subtract:
+metricsgeneration/metric2_zero_subtract:
   rules:
     - name: new_metric
       metric1: capacity.total
       metric2: capacity.used
       operation: subtract
       type: calculate
-experimental_metricsgeneration/metric2_zero_multiply:
+metricsgeneration/metric2_zero_multiply:
   rules:
     - name: new_metric
       metric1: capacity.total
       metric2: capacity.used
       operation: multiply
       type: calculate
-experimental_metricsgeneration/metric2_zero_divide:
+metricsgeneration/metric2_zero_divide:
   rules:
     - name: new_metric
       metric1: capacity.total
       metric2: capacity.used
       operation: divide
       type: calculate
-experimental_metricsgeneration/metric2_zero_percent:
+metricsgeneration/metric2_zero_percent:
   rules:
     - name: new_metric
       metric1: capacity.total

--- a/processor/metricsgenerationprocessor/testdata/result_metric_types/config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/result_metric_types/config.yaml
@@ -1,4 +1,4 @@
-experimental_metricsgeneration/add_sum_sum:
+metricsgeneration/add_sum_sum:
   rules:
     - name: new_metric
       unit: percent
@@ -6,7 +6,7 @@ experimental_metricsgeneration/add_sum_sum:
       metric1: sum
       metric2: sum
       operation: add
-experimental_metricsgeneration/add_gauge_gauge:
+metricsgeneration/add_gauge_gauge:
   rules:
     - name: new_metric
       unit: percent
@@ -14,7 +14,7 @@ experimental_metricsgeneration/add_gauge_gauge:
       metric1: gauge
       metric2: gauge
       operation: add
-experimental_metricsgeneration/add_gauge_sum:
+metricsgeneration/add_gauge_sum:
   rules:
     - name: new_metric
       unit: percent
@@ -22,7 +22,7 @@ experimental_metricsgeneration/add_gauge_sum:
       metric1: gauge
       metric2: sum
       operation: add
-experimental_metricsgeneration/add_sum_gauge:
+metricsgeneration/add_sum_gauge:
   rules:
     - name: new_metric
       unit: percent
@@ -30,7 +30,7 @@ experimental_metricsgeneration/add_sum_gauge:
       metric1: sum
       metric2: gauge
       operation: add
-experimental_metricsgeneration/multiply_gauge_sum:
+metricsgeneration/multiply_gauge_sum:
   rules:
     - name: new_metric
       unit: percent
@@ -38,7 +38,7 @@ experimental_metricsgeneration/multiply_gauge_sum:
       metric1: gauge
       metric2: sum
       operation: multiply
-experimental_metricsgeneration/multiply_sum_gauge:
+metricsgeneration/multiply_sum_gauge:
   rules:
     - name: new_metric
       unit: percent
@@ -46,7 +46,7 @@ experimental_metricsgeneration/multiply_sum_gauge:
       metric1: sum
       metric2: gauge
       operation: multiply
-experimental_metricsgeneration/divide_gauge_sum:
+metricsgeneration/divide_gauge_sum:
   rules:
     - name: new_metric
       unit: percent
@@ -54,7 +54,7 @@ experimental_metricsgeneration/divide_gauge_sum:
       metric1: gauge
       metric2: sum
       operation: multiply
-experimental_metricsgeneration/divide_sum_gauge:
+metricsgeneration/divide_sum_gauge:
   rules:
     - name: new_metric
       unit: percent
@@ -62,7 +62,7 @@ experimental_metricsgeneration/divide_sum_gauge:
       metric1: sum
       metric2: gauge
       operation: divide
-experimental_metricsgeneration/subtract_gauge_sum:
+metricsgeneration/subtract_gauge_sum:
   rules:
     - name: new_metric
       unit: percent
@@ -70,7 +70,7 @@ experimental_metricsgeneration/subtract_gauge_sum:
       metric1: gauge
       metric2: sum
       operation: subtract
-experimental_metricsgeneration/subtract_sum_gauge:
+metricsgeneration/subtract_sum_gauge:
   rules:
     - name: new_metric
       unit: percent
@@ -78,7 +78,7 @@ experimental_metricsgeneration/subtract_sum_gauge:
       metric1: sum
       metric2: gauge
       operation: subtract
-experimental_metricsgeneration/percent_gauge_sum:
+metricsgeneration/percent_gauge_sum:
   rules:
     - name: new_metric
       unit: percent
@@ -86,7 +86,7 @@ experimental_metricsgeneration/percent_gauge_sum:
       metric1: gauge
       metric2: sum
       operation: percent
-experimental_metricsgeneration/percent_sum_gauge:
+metricsgeneration/percent_sum_gauge:
   rules:
     - name: new_metric
       unit: percent

--- a/reports/distributions/contrib.yaml
+++ b/reports/distributions/contrib.yaml
@@ -81,12 +81,12 @@ components:
         - cumulativetodelta
         - deltatocumulative
         - deltatorate
-        - experimental_metricsgeneration
         - filter
         - geoip
         - groupbyattrs
         - groupbytrace
         - k8sattributes
+        - metricsgeneration
         - metricstransform
         - probabilistic_sampler
         - redaction


### PR DESCRIPTION
The processor now has to be defined as `metricsgeneration` instead of `experimental_metricsgeneration` in OTel collector configuration files.

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35426