### PR TITLE
[pkg/stanza][operators] Retain Operator should proagate unreleated fields of the original log entry

### DIFF
--- a/.chloggen/stanza-operators-retain.yaml
+++ b/.chloggen/stanza-operators-retain.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza/operator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Retain Operator should propagate the severity field
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35832]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The retain operator should propagate the severity field like it does with timestamps. 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/transformer/retain/transformer_test.go
+++ b/pkg/stanza/operator/transformer/retain/transformer_test.go
@@ -58,6 +58,46 @@ func TestBuildAndProcess(t *testing.T) {
 			},
 		},
 		{
+			"retain_unrelated_fields",
+			false,
+			func() *Config {
+				cfg := NewConfig()
+				cfg.Fields = append(cfg.Fields, entry.NewBodyField("key"))
+				return cfg
+			}(),
+			func() *entry.Entry {
+				e := newTestEntry()
+
+				e.Severity = entry.Debug3
+				e.SeverityText = "debug"
+				e.Timestamp = time.Unix(1000, 1000)
+				e.ObservedTimestamp = time.Unix(2000, 2000)
+				e.TraceID = []byte{0x01}
+				e.SpanID = []byte{0x01}
+				e.TraceFlags = []byte{0x01}
+				e.ScopeName = "scope"
+
+				return e
+			},
+			func() *entry.Entry {
+				e := newTestEntry()
+
+				e.Severity = entry.Debug3
+				e.SeverityText = "debug"
+				e.Timestamp = time.Unix(1000, 1000)
+				e.ObservedTimestamp = time.Unix(2000, 2000)
+				e.TraceID = []byte{0x01}
+				e.SpanID = []byte{0x01}
+				e.TraceFlags = []byte{0x01}
+				e.ScopeName = "scope"
+
+				e.Body = map[string]any{
+					"key": "val",
+				}
+				return e
+			},
+		},
+		{
 			"retain_multi",
 			false,
 			func() *Config {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The retain operator should propagate the severity field like it does with timestamps. 
This fix will ensure that is the case.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added UT to cover the use case.
