### PR TITLE
[pkg/stanza] Fix - Operators with DropOnErrorQuiet should drop log entries on error

### DIFF
--- a/.chloggen/operator-silent-errors.yaml
+++ b/.chloggen/operator-silent-errors.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixed bug causing Operators with DropOnErrorQuiet to send log entries to the next operator.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35010]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This issue was introduced by a bug fix meant to ensure Silent Operators are not logging errors (#35010). With this fix,
+  this side effect bug has been resolved.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/helper/parser.go
+++ b/pkg/stanza/operator/helper/parser.go
@@ -109,6 +109,10 @@ func (p *ParserOperator) ProcessWithCallback(ctx context.Context, entry *entry.E
 	}
 
 	if err = p.ParseWith(ctx, entry, parse); err != nil {
+		if p.OnError == DropOnErrorQuiet || p.OnError == SendOnErrorQuiet {
+			return nil
+		}
+
 		return err
 	}
 	if cb != nil {

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -106,10 +106,6 @@ func (t *TransformerOperator) HandleEntryError(ctx context.Context, entry *entry
 		}
 	}
 
-	if t.OnError == SendOnErrorQuiet || t.OnError == DropOnErrorQuiet {
-		return nil
-	}
-
 	return err
 }
 

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -141,7 +141,7 @@ func TestTransformerDropOnErrorQuiet(t *testing.T) {
 	}
 
 	err := transformer.ProcessWith(ctx, testEntry, transform)
-	require.NoError(t, err)
+	require.Error(t, err)
 	output.AssertNotCalled(t, "Process", mock.Anything, mock.Anything)
 
 	// Test output logs
@@ -231,7 +231,7 @@ func TestTransformerSendOnErrorQuiet(t *testing.T) {
 	}
 
 	err := transformer.ProcessWith(ctx, testEntry, transform)
-	require.NoError(t, err)
+	require.Error(t, err)
 	output.AssertCalled(t, "Process", mock.Anything, mock.Anything)
 
 	// Test output logs


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fixed issue in which Operators with DropOnErrorQuiet are not dropping log entries on error.

Note:   This issue was introduced by a bug fix meant to ensure Silent Operators are not logging errors (#35010). With this fix,
this side effect bug has been resolved.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes 35010

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added UT
