### PR TITLE
[receiver/webhookevent] Pass error to EndLogsOp

### DIFF
--- a/.chloggen/webhooks-event-receiver.yaml
+++ b/.chloggen/webhooks-event-receiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: webhookeventreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Pass the consumer error to EndLogsOp
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35844]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/webhookeventreceiver/receiver.go
+++ b/receiver/webhookeventreceiver/receiver.go
@@ -200,11 +200,10 @@ func (er *eventReceiver) handleReq(w http.ResponseWriter, r *http.Request, _ htt
 
 	if consumerErr != nil {
 		er.failBadReq(ctx, w, http.StatusInternalServerError, consumerErr)
-		er.obsrecv.EndLogsOp(ctx, metadata.Type.String(), numLogs, nil)
 	} else {
 		w.WriteHeader(http.StatusOK)
-		er.obsrecv.EndLogsOp(ctx, metadata.Type.String(), numLogs, nil)
 	}
+	er.obsrecv.EndLogsOp(ctx, metadata.Type.String(), numLogs, consumerErr)
 }
 
 // Simple healthcheck endpoint.


### PR DESCRIPTION
#### Description
I noticed that we're not passing the error to `EndLogsOp`. This can cause inaccurate metrics in internal observability.
This PR fixes it.
