### PR TITLE
[chore][stanza/fileconsumer] improve logging

### DIFF
--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -128,7 +128,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 
 		token, err := r.decoder.Decode(s.Bytes())
 		if err != nil {
-			r.set.Logger.Error("decode: %w", zap.Error(err))
+			r.set.Logger.Error("Failed to decode token", zap.Error(err))
 			r.Offset = s.Pos() // move past the bad token or we may be stuck
 			continue
 		}
@@ -145,7 +145,7 @@ func (r *Reader) ReadToEnd(ctx context.Context) {
 		}
 
 		if !errors.Is(err, header.ErrEndOfHeader) {
-			r.set.Logger.Error("process: %w", zap.Error(err))
+			r.set.Logger.Error("Failed to process token", zap.Error(err))
 			r.Offset = s.Pos() // move past the bad token or we may be stuck
 			continue
 		}


### PR DESCRIPTION
If any error is encountered while processing a token, the log message would look like:

`2024-10-01T14:57:41.620+0100    error   reader/reader.go:140    process: %w error-message`

There's no need for `%w` and we can remove it.