### PR TITLE
fix: slice init length

### DIFF
--- a/internal/filter/filterconfig/config.go
+++ b/internal/filter/filterconfig/config.go
@@ -161,7 +161,7 @@ func (mp *MatchProperties) ValidateForSpans() error {
 	if len(mp.SpanKinds) > 0 && mp.MatchType == "strict" {
 		for _, kind := range mp.SpanKinds {
 			if !spanKinds[kind] {
-				validSpanKinds := make([]string, len(spanKinds))
+				validSpanKinds := make([]string, 0, len(spanKinds))
 				for k := range spanKinds {
 					validSpanKinds = append(validSpanKinds, k)
 				}

--- a/internal/filter/filterspan/filterspan_test.go
+++ b/internal/filter/filterspan/filterspan_test.go
@@ -94,7 +94,7 @@ func TestSpan_validateMatchesConfiguration_InvalidConfig(t *testing.T) {
 				},
 				Attributes: []filterconfig.Attribute{},
 			},
-			errorString: "span_kinds string must match one of the standard span kinds when match_type=strict: [     SPAN_KIND_CLIENT SPAN_KIND_CONSUMER SPAN_KIND_INTERNAL SPAN_KIND_PRODUCER SPAN_KIND_SERVER]",
+			errorString: "span_kinds string must match one of the standard span kinds when match_type=strict: [SPAN_KIND_CLIENT SPAN_KIND_CONSUMER SPAN_KIND_INTERNAL SPAN_KIND_PRODUCER SPAN_KIND_SERVER]",
 		},
 	}
 	for _, tc := range testcases {

--- a/receiver/k8sobjectsreceiver/config.go
+++ b/receiver/k8sobjectsreceiver/config.go
@@ -65,7 +65,7 @@ func (c *Config) Validate() error {
 	for _, object := range c.Objects {
 		gvrs, ok := validObjects[object.Name]
 		if !ok {
-			availableResource := make([]string, len(validObjects))
+			availableResource := make([]string, 0, len(validObjects))
 			for k := range validObjects {
 				availableResource = append(availableResource, k)
 			}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The intention here is to correct the slice initialization by setting the capacity equal to the intended length and leaving the length as 0 for dynamic appending. This avoids over-allocating or pre-allocating empty values unnecessarily.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
