### PR TITLE
[receiver/zipkin] move global server configuration parameters to a separate parameter

### DIFF
--- a/.chloggen/refactor-zipkinreceiver.yaml
+++ b/.chloggen/refactor-zipkinreceiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: zipkinreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Move global server configuration parameters to a separate parameter."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35730]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/refactor-zipkinreceiver.yaml
+++ b/.chloggen/refactor-zipkinreceiver.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: breaking
+change_type: deprecation
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: zipkinreceiver

--- a/exporter/logzioexporter/example/config.yaml
+++ b/exporter/logzioexporter/example/config.yaml
@@ -2,7 +2,9 @@ receivers:
   opencensus:
     endpoint: :55678
   zipkin:
-    endpoint: :9411
+    protocols:
+      http:
+        endpoint: :9411
   jaeger:
     protocols:
       thrift_http:

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -67,8 +67,10 @@ func TestZipkinExporter_roundtripJSON(t *testing.T) {
 	// Run the Zipkin receiver to "receive spans upload from a client application"
 	addr := testutil.GetAvailableLocalAddress(t)
 	recvCfg := &zipkinreceiver.Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: addr,
+		Protocols: zipkinreceiver.ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: addr,
+			},
 		},
 	}
 	zi, err := zipkinreceiver.NewFactory().CreateTraces(context.Background(), receivertest.NewNopSettings(metadata.Type), recvCfg, zexp)
@@ -316,8 +318,10 @@ func TestZipkinExporter_roundtripProto(t *testing.T) {
 	// Run the Zipkin receiver to "receive spans upload from a client application"
 	addr := testutil.GetAvailableLocalAddress(t)
 	recvCfg := &zipkinreceiver.Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: addr,
+		Protocols: zipkinreceiver.ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: addr,
+			},
 		},
 	}
 	zi, err := zipkinreceiver.NewFactory().CreateTraces(context.Background(), receivertest.NewNopSettings(metadata.Type), recvCfg, zexp)

--- a/receiver/zipkinreceiver/README.md
+++ b/receiver/zipkinreceiver/README.md
@@ -24,14 +24,24 @@ receiver definitions.
 ```yaml
 receivers:
   zipkin:
+    protocols:
+      http:
+    parse_string_tags: false
 ```
 
-The following settings are configurable:
+Supported parameters:
 
 - `endpoint` (default = localhost:9411): host:port on which the receiver is going to receive data.See our [security best practices doc](https://opentelemetry.io/docs/security/config-best-practices/#protect-against-denial-of-service-attacks) to understand how to set the endpoint in different environments.  You can review the [full list of `ServerConfig`](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp).
 - `parse_string_tags` (default = false): if enabled, the receiver will attempt to parse string tags/binary annotations into int/bool/float.
+- `protocols` defines the protocol that will be used to receive data.
 
-## Advanced Configuration
+## HTTP protocol
+
+The following settings are configurable for the `http` protocol:
+
+- `endpoint` (default = localhost:9411): host:port on which the receiver is going to receive data. For full list of `ServerConfig` refer [here](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/confighttp).
+
+### Advanced Configuration
 
 Several helper files are leveraged to provide additional capabilities automatically:
 

--- a/receiver/zipkinreceiver/config.go
+++ b/receiver/zipkinreceiver/config.go
@@ -4,22 +4,89 @@
 package zipkinreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver"
 
 import (
+	"fmt"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/config/confighttp"
+	"go.opentelemetry.io/collector/confmap"
+	"go.opentelemetry.io/collector/featuregate"
+)
+
+var disallowHTTPDefaultProtocol = featuregate.GlobalRegistry().MustRegister(
+	"zipkinreceiver.httpDefaultProtocol.disallow",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, usage of the default http configuration is disallowed"),
+	featuregate.WithRegisterFromVersion("v0.114.0"),
+)
+
+const (
+	// Protocol values.
+	protoHTTP = "protocols::http"
 )
 
 // Config defines configuration for Zipkin receiver.
 type Config struct {
 	// Configures the receiver server protocol.
+	//
+	// Deprecated: Parameter exists for historical compatibility
+	// and should not be used. To set the server configurations,
+	// use the Protocols parameter instead.
 	confighttp.ServerConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
 	// If enabled the zipkin receiver will attempt to parse string tags/binary annotations into int/bool/float.
 	// Disabled by default
 	ParseStringTags bool `mapstructure:"parse_string_tags"`
+	// Protocols define the supported protocols for the receiver
+	Protocols ProtocolTypes `mapstructure:"protocols"`
+}
+
+type ProtocolTypes struct {
+	HTTP confighttp.ServerConfig `mapstructure:"http"`
 }
 
 var _ component.Config = (*Config)(nil)
 
 // Validate checks the receiver configuration is valid
 func (cfg *Config) Validate() error {
+	if isServerConfigDefined(cfg.ServerConfig) {
+		if disallowHTTPDefaultProtocol.IsEnabled() {
+			return fmt.Errorf("the server config setup is disabled, please use protocols::http or enable it by setting zipkinreceiver.httpDefaultProtocol.disallow feaure gate to false")
+		}
+		if isServerConfigDefined(cfg.Protocols.HTTP) {
+			return fmt.Errorf("cannot use protocols::http together with default server config setup")
+		}
+	}
+
 	return nil
+}
+
+// Unmarshal a confmap.Conf into the config struct.
+func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
+	// first load the config normally
+	err := conf.Unmarshal(cfg)
+	if err != nil {
+		return err
+	}
+
+	if !conf.IsSet(protoHTTP) {
+		cfg.Protocols.HTTP = cfg.ServerConfig
+		cfg.ServerConfig = confighttp.ServerConfig{}
+	}
+
+	return nil
+}
+
+// IsServerConfigDefined checks if the ServerConfig is defined by the user
+func isServerConfigDefined(cfg confighttp.ServerConfig) bool {
+	return cfg.Endpoint != "" ||
+		cfg.TLSSetting != nil ||
+		cfg.CORS != nil ||
+		cfg.Auth != nil ||
+		cfg.MaxRequestBodySize != 0 ||
+		cfg.IncludeMetadata ||
+		len(cfg.ResponseHeaders) != 0 ||
+		len(cfg.CompressionAlgorithms) != 0 ||
+		cfg.ReadHeaderTimeout != 0 ||
+		cfg.ReadTimeout != 0 ||
+		cfg.WriteTimeout != 0 ||
+		cfg.IdleTimeout != 0
 }

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -13,55 +13,118 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 	"go.opentelemetry.io/collector/confmap/xconfmap"
+	"go.opentelemetry.io/collector/featuregate"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver/internal/metadata"
 )
 
-func TestLoadConfig(t *testing.T) {
+func TestValidateConfig(t *testing.T) {
 	t.Parallel()
 
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 
 	tests := []struct {
-		id       component.ID
-		expected component.Config
+		id             component.ID
+		disallowInline bool
+		expected       component.Config
+		wantErr        string
 	}{
 		{
 			id:       component.NewID(metadata.Type),
-			expected: createDefaultConfig(),
+			expected: &Config{},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "customname"),
 			expected: &Config{
-				ServerConfig: confighttp.ServerConfig{
-					Endpoint: "localhost:8765",
+				Protocols: ProtocolTypes{
+					HTTP: confighttp.ServerConfig{
+						Endpoint: "localhost:8765",
+					},
 				},
 				ParseStringTags: false,
 			},
 		},
 		{
-			id: component.NewIDWithName(metadata.Type, "parse_strings"),
+			id:             component.NewIDWithName(metadata.Type, "customname"),
+			disallowInline: true,
 			expected: &Config{
-				ServerConfig: confighttp.ServerConfig{
-					Endpoint: defaultHTTPEndpoint,
+				Protocols: ProtocolTypes{
+					HTTP: confighttp.ServerConfig{
+						Endpoint: "localhost:8765",
+					},
 				},
-				ParseStringTags: true,
+				ParseStringTags: false,
 			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "protocols"),
+			expected: &Config{
+				Protocols: ProtocolTypes{
+					HTTP: confighttp.ServerConfig{
+						Endpoint: "localhost:8765",
+					},
+				},
+				ParseStringTags: false,
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "protocols"),
+			expected: &Config{
+				Protocols: ProtocolTypes{
+					HTTP: confighttp.ServerConfig{
+						Endpoint: "localhost:8765",
+					},
+				},
+				ParseStringTags: false,
+			},
+			disallowInline: true,
+		},
+		// {
+		// 	id: component.NewIDWithName(metadata.Type, "parse_strings"),
+		// 	expected: &Config{
+		// 		ParseStringTags: true,
+		// 	},
+		// },
+		// {
+		// 	id: component.NewIDWithName(metadata.Type, "parse_strings"),
+		// 	expected: &Config{
+		// 		ParseStringTags: true,
+		// 	},
+		// 	disallowInline: true,
+		// },
+		{
+			id:             component.NewIDWithName(metadata.Type, "deprecated"),
+			disallowInline: true,
+			wantErr:        "the server config setup is disabled, please use protocols::http or enable it by setting zipkinreceiver.httpDefaultProtocol.disallow feaure gate to false",
+		},
+		{
+			id:             component.NewIDWithName(metadata.Type, "deprecated"),
+			disallowInline: false,
+			wantErr:        "cannot use protocols::http together with default server config setup",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.id.String(), func(t *testing.T) {
-			factory := NewFactory()
-			cfg := factory.CreateDefaultConfig()
+			if tt.disallowInline {
+				require.NoError(t, featuregate.GlobalRegistry().Set(disallowHTTPDefaultProtocol.ID(), true))
+				t.Cleanup(func() {
+					require.NoError(t, featuregate.GlobalRegistry().Set(disallowHTTPDefaultProtocol.ID(), false))
+				})
+			}
+			cfg := &Config{}
 
 			sub, err := cm.Sub(tt.id.String())
 			require.NoError(t, err)
 			require.NoError(t, sub.Unmarshal(cfg))
 
-			assert.NoError(t, xconfmap.Validate(cfg))
-			assert.Equal(t, tt.expected, cfg)
+			if tt.wantErr != "" {
+				assert.Equal(t, tt.wantErr, component.ValidateConfig(cfg).Error())
+			} else {
+				assert.NoError(t, xconfmap.Validate(cfg))
+				assert.Equal(t, tt.expected, cfg)
+			}
 		})
 	}
 }

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -120,7 +120,7 @@ func TestValidateConfig(t *testing.T) {
 			require.NoError(t, sub.Unmarshal(cfg))
 
 			if tt.wantErr != "" {
-				assert.Equal(t, tt.wantErr, component.ValidateConfig(cfg).Error())
+				assert.Equal(t, tt.wantErr, xconfmap.Validate(cfg).Error())
 			} else {
 				assert.NoError(t, xconfmap.Validate(cfg))
 				assert.Equal(t, tt.expected, cfg)

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -17,7 +17,8 @@ import (
 // This file implements factory for Zipkin receiver.
 
 const (
-	defaultHTTPEndpoint = "localhost:9411"
+	defaultHTTPEndpoint  = "localhost:9411"
+	deprecationConfigMsg = "the inline setting of http server parameters has been deprecated, please use protocols::http parameter instead."
 )
 
 // NewFactory creates a new Zipkin receiver factory
@@ -32,8 +33,10 @@ func NewFactory() receiver.Factory {
 // createDefaultConfig creates the default configuration for Zipkin receiver.
 func createDefaultConfig() component.Config {
 	return &Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: defaultHTTPEndpoint,
+		Protocols: ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: defaultHTTPEndpoint,
+			},
 		},
 		ParseStringTags: false,
 	}
@@ -47,5 +50,8 @@ func createTracesReceiver(
 	nextConsumer consumer.Traces,
 ) (receiver.Traces, error) {
 	rCfg := cfg.(*Config)
+	if isServerConfigDefined(rCfg.ServerConfig) {
+		set.Logger.Warn(deprecationConfigMsg)
+	}
 	return newReceiver(rCfg, nextConsumer, set)
 }

--- a/receiver/zipkinreceiver/factory_test.go
+++ b/receiver/zipkinreceiver/factory_test.go
@@ -4,13 +4,17 @@
 package zipkinreceiver
 
 import (
+	"bytes"
 	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver/internal/metadata"
 )
@@ -39,4 +43,37 @@ func TestCreateReceiver(t *testing.T) {
 		consumertest.NewNop())
 	assert.NoError(t, err, "receiver creation failed")
 	assert.NotNil(t, tReceiver, "receiver creation failed")
+}
+
+func TestCreateReceiverDeprecatedWarning(t *testing.T) {
+	cfg := &Config{
+		ServerConfig: confighttp.ServerConfig{
+			Endpoint: defaultHTTPEndpoint,
+		},
+		ParseStringTags: false,
+	}
+
+	var buffer bytes.Buffer
+	writer := zapcore.AddSync(&buffer)
+
+	encoder := zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
+	core := zapcore.NewCore(encoder, writer, zapcore.DebugLevel)
+	logger := zap.New(core)
+
+	set := receivertest.NewNopSettings(metadata.Type)
+	set.Logger = logger
+
+	_, err := createTracesReceiver(
+		context.Background(),
+		set,
+		cfg,
+		consumertest.NewNop(),
+	)
+
+	assert.NoError(t, err)
+
+	logOutput := buffer.String()
+	if !bytes.Contains([]byte(logOutput), []byte(deprecationConfigMsg)) {
+		t.Errorf("Expected log message not found. Got: %s", logOutput)
+	}
 }

--- a/receiver/zipkinreceiver/go.mod
+++ b/receiver/zipkinreceiver/go.mod
@@ -17,11 +17,13 @@ require (
 	go.opentelemetry.io/collector/consumer v1.27.0
 	go.opentelemetry.io/collector/consumer/consumererror v0.121.0
 	go.opentelemetry.io/collector/consumer/consumertest v0.121.0
+	go.opentelemetry.io/collector/featuregate v1.27.0
 	go.opentelemetry.io/collector/pdata v1.27.0
 	go.opentelemetry.io/collector/receiver v0.121.0
 	go.opentelemetry.io/collector/receiver/receivertest v0.121.0
 	go.opentelemetry.io/collector/semconv v0.121.0
 	go.uber.org/goleak v1.3.0
+	go.uber.org/zap v1.27.0
 	google.golang.org/protobuf v1.36.5
 )
 
@@ -36,6 +38,7 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
+	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
@@ -68,7 +71,6 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.22.0 // indirect

--- a/receiver/zipkinreceiver/go.sum
+++ b/receiver/zipkinreceiver/go.sum
@@ -26,6 +26,8 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
+github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/jaegertracing/jaeger-idl v0.5.0 h1:zFXR5NL3Utu7MhPg8ZorxtCBjHrL3ReM1VoB65FOFGE=
 github.com/jaegertracing/jaeger-idl v0.5.0/go.mod h1:ON90zFo9eoyXrt9F/KN8YeF3zxcnujaisMweFY/rg5k=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -108,6 +110,8 @@ go.opentelemetry.io/collector/extension/extensionauth v0.121.0 h1:LmPwZI7+OSpE4/
 go.opentelemetry.io/collector/extension/extensionauth v0.121.0/go.mod h1:sINEH4b4YPSQJtvc/qcYTQdNRglDoKK0BUJqR+EHn94=
 go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.121.0 h1:ghfRACcBN0NaTdLOTa25d+sEOsIgvP5flzqEQcfLBYM=
 go.opentelemetry.io/collector/extension/extensionauth/extensionauthtest v0.121.0/go.mod h1:5jAEucvzRjZ4MurcznqdaNh467KeXti0+ldkPLZmw8Y=
+go.opentelemetry.io/collector/featuregate v1.27.0 h1:4LLrccoMz/gJT5uym8ojBlMzY5tr4RzUUXzwlBuiRz0=
+go.opentelemetry.io/collector/featuregate v1.27.0/go.mod h1:Y/KsHbvREENKvvN9RlpiWk/IGBK+CATBYzIIpU7nccc=
 go.opentelemetry.io/collector/pdata v1.27.0 h1:66yI7FYkUDia74h48Fd2/KG2Vk8DxZnGw54wRXykCEU=
 go.opentelemetry.io/collector/pdata v1.27.0/go.mod h1:18e8/xDZsqyj00h/5HM5GLdJgBzzG9Ei8g9SpNoiMtI=
 go.opentelemetry.io/collector/pdata/pprofile v0.121.0 h1:DFBelDRsZYxEaSoxSRtseAazsHJfqfC/Yl64uPicl2g=

--- a/receiver/zipkinreceiver/testdata/config.yaml
+++ b/receiver/zipkinreceiver/testdata/config.yaml
@@ -1,5 +1,14 @@
 zipkin:
 zipkin/customname:
   endpoint: "localhost:8765"
+zipkin/protocols:
+  protocols:
+    http:
+      endpoint: "localhost:8765"
 zipkin/parse_strings:
   parse_string_tags: true
+zipkin/deprecated:
+  endpoint: "localhost:8766"
+  protocols:
+    http:
+      endpoint: "localhost:8765"

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -95,13 +95,13 @@ func (zr *zipkinReceiver) Start(ctx context.Context, host component.Host) error 
 	}
 
 	var err error
-	zr.server, err = zr.config.ServerConfig.ToServer(ctx, host, zr.settings.TelemetrySettings, zr)
+	zr.server, err = zr.config.Protocols.HTTP.ToServer(ctx, host, zr.settings.TelemetrySettings, zr)
 	if err != nil {
 		return err
 	}
 
 	var listener net.Listener
-	listener, err = zr.config.ServerConfig.ToListener(ctx)
+	listener, err = zr.config.Protocols.HTTP.ToListener(ctx)
 	if err != nil {
 		return err
 	}

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -60,8 +60,10 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &Config{
-				ServerConfig: confighttp.ServerConfig{
-					Endpoint: tt.args.address,
+				Protocols: ProtocolTypes{
+					HTTP: confighttp.ServerConfig{
+						Endpoint: tt.args.address,
+					},
 				},
 			}
 			got, err := newReceiver(cfg, tt.args.nextConsumer, receivertest.NewNopSettings(metadata.Type))
@@ -82,8 +84,10 @@ func TestZipkinReceiverPortAlreadyInUse(t *testing.T) {
 	_, portStr, err := net.SplitHostPort(l.Addr().String())
 	require.NoError(t, err, "failed to split listener address: %v", err)
 	cfg := &Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "localhost:" + portStr,
+		Protocols: ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "localhost:" + portStr,
+			},
 		},
 	}
 	traceReceiver, err := newReceiver(cfg, consumertest.NewNop(), receivertest.NewNopSettings(metadata.Type))
@@ -130,8 +134,10 @@ func TestStartTraceReception(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			sink := new(consumertest.TracesSink)
 			cfg := &Config{
-				ServerConfig: confighttp.ServerConfig{
-					Endpoint: "localhost:0",
+				Protocols: ProtocolTypes{
+					HTTP: confighttp.ServerConfig{
+						Endpoint: "localhost:0",
+					},
 				},
 			}
 			zr, err := newReceiver(cfg, sink, receivertest.NewNopSettings(metadata.Type))
@@ -221,8 +227,10 @@ func TestReceiverContentTypes(t *testing.T) {
 
 			next := new(consumertest.TracesSink)
 			cfg := &Config{
-				ServerConfig: confighttp.ServerConfig{
-					Endpoint: "",
+				Protocols: ProtocolTypes{
+					HTTP: confighttp.ServerConfig{
+						Endpoint: "",
+					},
 				},
 			}
 			zr, err := newReceiver(cfg, next, receivertest.NewNopSettings(metadata.Type))
@@ -248,8 +256,10 @@ func TestReceiverInvalidContentType(t *testing.T) {
 	r.Header.Add("content-type", "application/json")
 
 	cfg := &Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "",
+		Protocols: ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "",
+			},
 		},
 	}
 	zr, err := newReceiver(cfg, consumertest.NewNop(), receivertest.NewNopSettings(metadata.Type))
@@ -270,8 +280,10 @@ func TestReceiverConsumerError(t *testing.T) {
 	r.Header.Add("content-type", "application/json")
 
 	cfg := &Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "localhost:9411",
+		Protocols: ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "localhost:9411",
+			},
 		},
 	}
 	zr, err := newReceiver(cfg, consumertest.NewErr(errors.New("consumer error")), receivertest.NewNopSettings(metadata.Type))
@@ -292,8 +304,10 @@ func TestReceiverConsumerPermanentError(t *testing.T) {
 	r.Header.Add("content-type", "application/json")
 
 	cfg := &Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "localhost:9411",
+		Protocols: ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "localhost:9411",
+			},
 		},
 	}
 	zr, err := newReceiver(cfg, consumertest.NewErr(consumererror.NewPermanent(errors.New("consumer error"))), receivertest.NewNopSettings(metadata.Type))
@@ -418,8 +432,10 @@ func TestReceiverConvertsStringsToTypes(t *testing.T) {
 
 	next := new(consumertest.TracesSink)
 	cfg := &Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "",
+		Protocols: ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "",
+			},
 		},
 		ParseStringTags: true,
 	}
@@ -459,8 +475,10 @@ func TestFromBytesWithNoTimestamp(t *testing.T) {
 	require.NoError(t, err, "Failed to read sample JSON file: %v", err)
 
 	cfg := &Config{
-		ServerConfig: confighttp.ServerConfig{
-			Endpoint: "",
+		Protocols: ProtocolTypes{
+			HTTP: confighttp.ServerConfig{
+				Endpoint: "",
+			},
 		},
 		ParseStringTags: true,
 	}

--- a/testbed/datareceivers/zipkin.go
+++ b/testbed/datareceivers/zipkin.go
@@ -31,7 +31,7 @@ func NewZipkinDataReceiver(port int) testbed.DataReceiver {
 func (zr *zipkinDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ consumer.Logs) error {
 	factory := zipkinreceiver.NewFactory()
 	cfg := factory.CreateDefaultConfig().(*zipkinreceiver.Config)
-	cfg.Endpoint = fmt.Sprintf("127.0.0.1:%d", zr.Port)
+	cfg.Protocols.HTTP.Endpoint = fmt.Sprintf("127.0.0.1:%d", zr.Port)
 
 	set := receivertest.NewNopSettings(factory.Type())
 	var err error

--- a/testbed/datasenders/zipkin.go
+++ b/testbed/datasenders/zipkin.go
@@ -56,7 +56,9 @@ func (zs *zipkinDataSender) Start() error {
 func (zs *zipkinDataSender) GenConfigYAMLStr() string {
 	return fmt.Sprintf(`
   zipkin:
-    endpoint: %s`, zs.GetEndpoint())
+    protocols:
+      http:
+        endpoint: %s`, zs.GetEndpoint())
 }
 
 func (zs *zipkinDataSender) ProtocolName() string {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Move global server configuration parameters to a separate parameter under `protocols` parameter to allow future support of different protocols (like UDP), more context [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35620)

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #35730

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
