### PR TITLE
[chore] remove obsolete note about auth type limitations in `k8sclusterreceiver`

### DIFF
--- a/receiver/k8sclusterreceiver/README.md
+++ b/receiver/k8sclusterreceiver/README.md
@@ -18,9 +18,6 @@ The Kubernetes Cluster receiver collects cluster-level metrics and entity events
 API server. It uses the K8s API to listen for updates. A single instance of this
 receiver should be used to monitor a cluster.
 
-Currently, this receiver supports authentication via service accounts only. See [example](#example)
-for more information.
-
 ## Metrics
 
 Details about the metrics produced by this receiver can be found in [metadata.yaml](./metadata.yaml) and [documentation.md](./documentation.md).


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR removes the note about `serviceAccount` being the only auth type being supported by the `k8sclusterreceiver`, since in the meantime support for `kubeConfig` auth type has been added (also verified this manually to be safe)

<!--Describe the documentation added.-->
#### Documentation

Updated the readme of the `k8sclusterreceiver`

<!--Please delete paragraphs that you did not use before submitting.-->
