### PR TITLE
[chore][docs][pkg/stanza] Fix typo in field.md link to entry.md

### DIFF
--- a/pkg/stanza/docs/types/field.md
+++ b/pkg/stanza/docs/types/field.md
@@ -1,6 +1,6 @@
 ## Fields
 
-A _Field_ is a reference to a value in a log [entry](../types/field.md).
+A _Field_ is a reference to a value in a log [entry](../types/entry.md).
 
 Many [operators](../operators/README.md) use fields in their configurations. For example, parsers use fields to specify which value to parse and where to write a new value.
 


### PR DESCRIPTION
#### Description
Fixed a typo in the pkg/stanza/docs/types/field.md documentation. The link was incorrectly pointing to ../types/field.md and is now corrected to ../types/entry.md.

#### Testing

#### Documentation