### PR TITLE
bugfix: Fix race condition where the first datapoint received of a metric could rewrite subsequent datapoints.

### DIFF
--- a/.chloggen/deltatocumulative-35872.yaml
+++ b/.chloggen/deltatocumulative-35872.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/deltatocumulative
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix race condition where the first datapoint received of a metric could rewrite subsequent datapoints.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35872]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/deltatocumulativeprocessor/linear.go
+++ b/processor/deltatocumulativeprocessor/linear.go
@@ -110,7 +110,7 @@ func (p *Linear) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 			acc, err := func() (data.Number, error) {
 				if !ok {
 					// new stream: there is no existing aggregation, so start new with current dp
-					return dp, nil
+					return dp.Clone(), nil
 				}
 				// tracked stream: add incoming delta dp to existing cumulative aggregation
 				return acc, delta.AccumulateInto(acc, dp)

--- a/processor/deltatocumulativeprocessor/processor_test.go
+++ b/processor/deltatocumulativeprocessor/processor_test.go
@@ -328,3 +328,27 @@ func TestTelemetry(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestClone(t *testing.T) {
+	proc, sink := setup(t, nil)
+
+	dir := "./testdata/clone"
+	open := func(file string) pmetric.Metrics {
+		t.Helper()
+		md, err := golden.ReadMetrics(filepath.Join(dir, file))
+		require.NoError(t, err)
+		return md
+	}
+
+	in := open("in.yaml")
+	out := open("out.yaml")
+
+	ctx := context.Background()
+
+	err := proc.ConsumeMetrics(ctx, in)
+	require.NoError(t, err)
+
+	if diff := compare.Diff(sink.AllMetrics(), []pmetric.Metrics{out}); diff != "" {
+		t.Fatal(diff)
+	}
+}

--- a/processor/deltatocumulativeprocessor/testdata/clone/in.yaml
+++ b/processor/deltatocumulativeprocessor/testdata/clone/in.yaml
@@ -1,0 +1,23 @@
+resourceMetrics:
+  - schemaUrl: https://test.com/resource
+    resource:
+      attributes:
+        - key: resattr
+          value: { stringValue: stringoo }
+    scopeMetrics:
+      - schemaUrl: https://test.com/scope
+        scope:
+          name: Test
+          version: 1.2.3
+          attributes:
+            - key: scopeattr
+              value: { stringValue: string }
+        metrics:
+          - name: test.sum
+            sum:
+              aggregationTemporality: 1
+              dataPoints:
+                - timeUnixNano: 1
+                  asDouble: 1
+                - timeUnixNano: 2
+                  asDouble: 2

--- a/processor/deltatocumulativeprocessor/testdata/clone/out.yaml
+++ b/processor/deltatocumulativeprocessor/testdata/clone/out.yaml
@@ -1,0 +1,23 @@
+resourceMetrics:
+  - schemaUrl: https://test.com/resource
+    resource:
+      attributes:
+        - key: resattr
+          value: { stringValue: stringoo }
+    scopeMetrics:
+      - schemaUrl: https://test.com/scope
+        scope:
+          name: Test
+          version: 1.2.3
+          attributes:
+            - key: scopeattr
+              value: { stringValue: string }
+        metrics:
+          - name: test.sum
+            sum:
+              aggregationTemporality: 2
+              dataPoints:
+                - timeUnixNano: 1
+                  asDouble: 1
+                - timeUnixNano: 2
+                  asDouble: 3


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fix race condition where the first datapoint received of a metric could rewrite subsequent datapoints.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #35872


