### PR TITLE
[chore] skip encoded-compare in testifylint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -137,6 +137,7 @@ linters-settings:
       - float-compare
       - require-error
       - suite-subtest-run
+      - encoded-compare # has false positives that cannot be fixed with testifylint-fix
     enable-all: true
 
 linters:

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -78,7 +78,7 @@ GOTESTSUM           := $(TOOLS_BIN_DIR)/gotestsum
 TESTIFYLINT         := $(TOOLS_BIN_DIR)/testifylint
 
 GOTESTSUM_OPT?= --rerun-fails=1
-TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subtest-run
+TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subtest-run,encoded-compare
 
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release


### PR DESCRIPTION
This caused CI failure on mainline: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/11432753950/job/31803801806

This lint failure seems a false positive because changing the test to `JSONEq` leads to test failure `invalid JSON fomart...`