### PR TITLE
Enhance the unit conversion in the EMF Exporter

### DIFF
--- a/.chloggen/awsemfexporter-enhancements.yaml
+++ b/.chloggen/awsemfexporter-enhancements.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Improvement unit conversion during EMF log translation"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35937]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -192,6 +192,11 @@ func translateUnit(metric pmetric.Metric, descriptor map[string]MetricDescriptor
 		}
 	}
 	switch unit {
+	case "1":
+		unit = ""
+	case "ns":
+		// CloudWatch doesn't support Nanoseconds
+		unit = ""
 	case "ms":
 		unit = "Milliseconds"
 	case "s":
@@ -200,7 +205,7 @@ func translateUnit(metric pmetric.Metric, descriptor map[string]MetricDescriptor
 		unit = "Microseconds"
 	case "By":
 		unit = "Bytes"
-	case "Bi":
+	case "bit":
 		unit = "Bits"
 	}
 	return unit

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -488,10 +488,12 @@ func TestTranslateUnit(t *testing.T) {
 	translateUnitCases := map[string]string{
 		"Count": "Count",
 		"ms":    "Milliseconds",
+		"ns":    "",
+		"1":     "",
 		"s":     "Seconds",
 		"us":    "Microseconds",
 		"By":    "Bytes",
-		"Bi":    "Bits",
+		"bit":   "Bits",
 	}
 	for input, output := range translateUnitCases {
 		t.Run(input, func(_ *testing.T) {


### PR DESCRIPTION
#### Description
1. Fix bits unit conversion.
2. Use default unit `None` in translating unit type `1` and `ns`.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
- [x] Unit test.
- [x] E2E test.

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
