### PR TITLE
[connector/routing] Add ability to route log records based on OTTL log context

### DIFF
--- a/.chloggen/split-log-records.yaml
+++ b/.chloggen/split-log-records.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: connector/routing
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to route log records individually using OTTL log record context.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [19738]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/routingconnector/config.go
+++ b/connector/routingconnector/config.go
@@ -67,6 +67,16 @@ func (c *Config) Validate() error {
 		if len(item.Pipelines) == 0 {
 			return errNoPipelines
 		}
+
+		switch item.Context {
+		case "", "resource": // ok
+		case "log":
+			if !c.MatchOnce {
+				return errors.New("log context is not supported with match_once: false")
+			}
+		default:
+			return errors.New("invalid context: " + item.Context)
+		}
 	}
 
 	return nil
@@ -74,6 +84,10 @@ func (c *Config) Validate() error {
 
 // RoutingTableItem specifies how data should be routed to the different pipelines
 type RoutingTableItem struct {
+	// One of "resource" or "log" (other OTTL contexts will be added in the future)
+	// Optional. Default "resource".
+	Context string `mapstructure:"context"`
+
 	// Statement is a OTTL statement used for making a routing decision.
 	// One of 'Statement' or 'Condition' must be provided.
 	Statement string `mapstructure:"statement"`

--- a/connector/routingconnector/config_test.go
+++ b/connector/routingconnector/config_test.go
@@ -203,6 +203,37 @@ func TestValidateConfig(t *testing.T) {
 			},
 			error: "invalid route: both condition and statement provided",
 		},
+		{
+			name: "invalid context",
+			config: &Config{
+				Table: []RoutingTableItem{
+					{
+						Context:   "invalid",
+						Statement: `route() where attributes["attr"] == "acme"`,
+						Pipelines: []pipeline.ID{
+							pipeline.NewIDWithName(pipeline.SignalTraces, "otlp"),
+						},
+					},
+				},
+			},
+			error: "invalid context: invalid",
+		},
+		{
+			name: "log context with match_once false",
+			config: &Config{
+				MatchOnce: false,
+				Table: []RoutingTableItem{
+					{
+						Context:   "log",
+						Statement: `route() where attributes["attr"] == "acme"`,
+						Pipelines: []pipeline.ID{
+							pipeline.NewIDWithName(pipeline.SignalTraces, "otlp"),
+						},
+					},
+				},
+			},
+			error: "log context is not supported with match_once: false",
+		},
 	}
 
 	for _, tt := range tests {

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector/internal/plogutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottllog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlresource"
 )
 
@@ -74,29 +75,36 @@ func (c *logsConnector) switchLogs(ctx context.Context, ld plog.Logs) error {
 	var errs error
 	for _, route := range c.router.routeSlice {
 		matchedLogs := plog.NewLogs()
-
-		plogutil.MoveResourcesIf(ld, matchedLogs,
-			func(rl plog.ResourceLogs) bool {
-				rtx := ottlresource.NewTransformContext(rl.Resource(), rl)
-				_, isMatch, err := route.statement.Execute(ctx, rtx)
-				errs = errors.Join(errs, err)
-				return isMatch
-			},
-		)
-
+		switch route.statementContext {
+		case "", "resource":
+			plogutil.MoveResourcesIf(ld, matchedLogs,
+				func(rl plog.ResourceLogs) bool {
+					rtx := ottlresource.NewTransformContext(rl.Resource(), rl)
+					_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
+					errs = errors.Join(errs, err)
+					return isMatch
+				},
+			)
+		case "log":
+			plogutil.MoveRecordsWithContextIf(ld, matchedLogs,
+				func(rl plog.ResourceLogs, sl plog.ScopeLogs, lr plog.LogRecord) bool {
+					ltx := ottllog.NewTransformContext(lr, sl.Scope(), rl.Resource(), sl, rl)
+					_, isMatch, err := route.logStatement.Execute(ctx, ltx)
+					errs = errors.Join(errs, err)
+					return isMatch
+				},
+			)
+		}
 		if errs != nil {
 			if c.config.ErrorMode == ottl.PropagateError {
 				return errs
 			}
 			groupAll(groups, c.router.defaultConsumer, matchedLogs)
-
 		}
 		groupAll(groups, route.consumer, matchedLogs)
 	}
-
 	// anything left wasn't matched by any route. Send to default consumer
 	groupAll(groups, c.router.defaultConsumer, ld)
-
 	for consumer, group := range groups {
 		errs = errors.Join(errs, consumer.ConsumeLogs(ctx, group))
 	}
@@ -110,14 +118,12 @@ func (c *logsConnector) matchAll(ctx context.Context, ld plog.Logs) error {
 	// higher CPU usage.
 	groups := make(map[consumer.Logs]plog.Logs)
 	var errs error
-
 	for i := 0; i < ld.ResourceLogs().Len(); i++ {
 		rlogs := ld.ResourceLogs().At(i)
 		rtx := ottlresource.NewTransformContext(rlogs.Resource(), rlogs)
-
 		noRoutesMatch := true
 		for _, route := range c.router.routeSlice {
-			_, isMatch, err := route.statement.Execute(ctx, rtx)
+			_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 			if err != nil {
 				if c.config.ErrorMode == ottl.PropagateError {
 					return err
@@ -129,9 +135,7 @@ func (c *logsConnector) matchAll(ctx context.Context, ld plog.Logs) error {
 				noRoutesMatch = false
 				group(groups, route.consumer, rlogs)
 			}
-
 		}
-
 		if noRoutesMatch {
 			// no route conditions are matched, add resource logs to default exporters group
 			group(groups, c.router.defaultConsumer, rlogs)

--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -481,6 +481,16 @@ func TestLogsConnectorDetailed(t *testing.T) {
 		filepath.Join("testdata", "logs", "resource_context", "each_matches_one"),
 		filepath.Join("testdata", "logs", "resource_context", "match_none_with_default"),
 		filepath.Join("testdata", "logs", "resource_context", "match_none_without_default"),
+		filepath.Join("testdata", "logs", "log_context", "all_match_first_only"),
+		filepath.Join("testdata", "logs", "log_context", "all_match_last_only"),
+		filepath.Join("testdata", "logs", "log_context", "match_none_with_default"),
+		filepath.Join("testdata", "logs", "log_context", "match_none_without_default"),
+		filepath.Join("testdata", "logs", "log_context", "some_match_each_route"),
+		filepath.Join("testdata", "logs", "log_context", "with_resource_condition"),
+		filepath.Join("testdata", "logs", "log_context", "with_scope_condition"),
+		filepath.Join("testdata", "logs", "log_context", "with_resource_and_scope_conditions"),
+		filepath.Join("testdata", "logs", "mixed_context", "match_resource_then_logs"),
+		filepath.Join("testdata", "logs", "mixed_context", "match_logs_then_resource"),
 	}
 
 	for _, tt := range testCases {

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -73,7 +73,7 @@ func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metric
 
 		noRoutesMatch := true
 		for _, route := range c.router.routeSlice {
-			_, isMatch, err := route.statement.Execute(ctx, rtx)
+			_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 			if err != nil {
 				if c.config.ErrorMode == ottl.PropagateError {
 					return err

--- a/connector/routingconnector/testdata/logs/log_context/all_match_first_only/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/all_match_first_only/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: attributes["logName"] != nil
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logY"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/all_match_first_only/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/all_match_first_only/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/all_match_first_only/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/all_match_first_only/sink_0.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/all_match_last_only/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/all_match_last_only/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: attributes["logName"] == "logX"
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] != nil
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/all_match_last_only/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/all_match_last_only/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/all_match_last_only/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/all_match_last_only/sink_1.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/match_none_with_default/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/match_none_with_default/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: attributes["logName"] == "logX"
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logY"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/match_none_with_default/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/match_none_with_default/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/match_none_with_default/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/match_none_with_default/sink_default.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/match_none_without_default/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/match_none_without_default/config.yaml
@@ -1,0 +1,12 @@
+routing:
+  match_once: true
+  # no default pipelines
+  table:
+    - context: log
+      condition: attributes["logName"] == "logX"
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logY"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/match_none_without_default/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/match_none_without_default/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/some_match_each_route/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/some_match_each_route/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: attributes["logName"] == "logA" and resource.attributes["resourceName"] == "resourceA"
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logB" and resource.attributes["resourceName"] == "resourceB"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/some_match_each_route/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/some_match_each_route/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/some_match_each_route/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/some_match_each_route/sink_0.yaml
@@ -1,0 +1,53 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/some_match_each_route/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/some_match_each_route/sink_1.yaml
@@ -1,0 +1,53 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/some_match_each_route/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/some_match_each_route/sink_default.yaml
@@ -1,0 +1,105 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: resource.attributes["resourceName"] == "resourceB" and instrumentation_scope.name == "scopeA" and attributes["logName"] != nil
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logY"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/sink_0.yaml
@@ -1,0 +1,41 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_and_scope_conditions/sink_default.yaml
@@ -1,0 +1,111 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_condition/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_condition/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: resource.attributes["resourceName"] == "resourceB" and attributes["logName"] != nil
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logY"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_condition/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_condition/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_condition/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_condition/sink_0.yaml
@@ -1,0 +1,71 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_resource_condition/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_resource_condition/sink_default.yaml
@@ -1,0 +1,71 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_scope_condition/config.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_scope_condition/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: instrumentation_scope.name == "scopeB" and attributes["logName"] != nil
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logY"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/log_context/with_scope_condition/input.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_scope_condition/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_scope_condition/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_scope_condition/sink_0.yaml
@@ -1,0 +1,81 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/log_context/with_scope_condition/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/log_context/with_scope_condition/sink_default.yaml
@@ -1,0 +1,81 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/config.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: attributes["logName"] == "logA"
+      pipelines:
+        - logs/0
+    - context: resource
+      condition: attributes["resourceName"] == "resourceB"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/input.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/sink_0.yaml
@@ -1,0 +1,105 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/sink_1.yaml
@@ -1,0 +1,53 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_resource/sink_default.yaml
@@ -1,0 +1,53 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/config.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: resource
+      condition: attributes["resourceName"] == "resourceA"
+      pipelines:
+        - logs/0
+    - context: log
+      condition: attributes["logName"] == "logB"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/input.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/sink_0.yaml
@@ -1,0 +1,71 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/sink_1.yaml
@@ -1,0 +1,53 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_logs/sink_default.yaml
@@ -1,0 +1,53 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -72,7 +72,7 @@ func (c *tracesConnector) ConsumeTraces(ctx context.Context, t ptrace.Traces) er
 
 		noRoutesMatch := true
 		for _, route := range c.router.routeSlice {
-			_, isMatch, err := route.statement.Execute(ctx, rtx)
+			_, isMatch, err := route.resourceStatement.Execute(ctx, rtx)
 			if err != nil {
 				if c.config.ErrorMode == ottl.PropagateError {
 					return err


### PR DESCRIPTION
This PR resolves https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35948 by adding a `context` field to routing table items. The default value of `context` is `resource`, so that existing users will not see a difference. `log` context may also be used. Each routing table item may have a difference context. `match_once` must be `true` in order to use `log` context.