### PR TITLE
[chore] more fix on codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,9 +21,9 @@ cmd/otelcontribcol/                                                 @open-teleme
 cmd/oteltestbedcol/                                                 @open-telemetry/collector-contrib-approvers
 cmd/telemetrygen/                                                   @open-telemetry/collector-contrib-approvers @mx-psi @codeboten
 
+confmap/provider/aesprovider/                                       @open-telemetry/collector-contrib-approvers @djaglowski @shazlehu
 confmap/provider/s3provider/                                        @open-telemetry/collector-contrib-approvers @Aneurysm9
 confmap/provider/secretsmanagerprovider/                            @open-telemetry/collector-contrib-approvers @driverpt @atoulme
-confmap/provider/aesprovider/                                       @open-telemetry/collector-contrib-approvers @djaglowski @shazlehu
 
 connector/countconnector/                                           @open-telemetry/collector-contrib-approvers @djaglowski @jpkrohling
 connector/datadogconnector/                                         @open-telemetry/collector-contrib-approvers @mx-psi @dineshg13 @ankitpatel96


### PR DESCRIPTION
Fix more CI failure (that showed up after https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35940): https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/11468222898/job/31912893804