### PR TITLE
processor/deltatocumulative: testar: handle CRLF

### DIFF
--- a/processor/deltatocumulativeprocessor/internal/testar/crlf/crlf.go
+++ b/processor/deltatocumulativeprocessor/internal/testar/crlf/crlf.go
@@ -1,0 +1,29 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package crlf // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testar/crlf"
+
+import (
+	"bytes"
+	"strings"
+)
+
+const (
+	CR   = '\r'
+	LF   = '\n'
+	CRLF = "\r\n"
+)
+
+// Strip turns CRLF line endings (\r\n) into LF (\n)
+func Strip(data []byte) []byte {
+	at := bytes.IndexByte(data, LF)
+	if at == 0 || data[at-1] != CR {
+		return data
+	}
+	return bytes.ReplaceAll(data, []byte(CRLF), []byte{LF})
+}
+
+// Join concats all lines with the [CRLF] separator
+func Join(lines ...string) []byte {
+	return []byte(strings.Join(lines, CRLF))
+}

--- a/processor/deltatocumulativeprocessor/internal/testar/decode.go
+++ b/processor/deltatocumulativeprocessor/internal/testar/decode.go
@@ -21,24 +21,27 @@ package testar // import "github.com/open-telemetry/opentelemetry-collector-cont
 import (
 	"fmt"
 	"io/fs"
+	"os"
 	"reflect"
 	"strings"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testar/crlf"
 	"golang.org/x/tools/txtar"
 )
 
 // Read archive data into the fields of struct *T
 func Read[T any](data []byte, into *T, parsers ...Format) error {
+	data = crlf.Strip(data)
 	ar := txtar.Parse(data)
 	return Decode(ar, into, parsers...)
 }
 
 func ReadFile[T any](file string, into *T, parsers ...Format) error {
-	ar, err := txtar.ParseFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
-	return Decode(ar, into, parsers...)
+	return Read(data, into, parsers...)
 }
 
 func Decode[T any](ar *txtar.Archive, into *T, parsers ...Format) error {

--- a/processor/deltatocumulativeprocessor/internal/testar/read_test.go
+++ b/processor/deltatocumulativeprocessor/internal/testar/read_test.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"testing"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testar/crlf"
 )
 
 func ExampleRead() {
@@ -55,4 +58,29 @@ func ExampleParser() {
 
 	// Output:
 	// foobar: int(377927)
+}
+
+func TestCRLF(t *testing.T) {
+	data := crlf.Join(
+		"-- string --",
+		"foobar",
+	)
+
+	var into struct {
+		String string `testar:"string"`
+	}
+
+	err := Read(data, &into)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	must(t, into.String, "foobar\n")
+}
+
+func must[T string | int](t *testing.T, v, want T) {
+	t.Helper()
+	if v != want {
+		t.Fatalf("got '%q' != '%q' want", v, want)
+	}
 }


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Our test format testar is based on golang.org/x/tools/txtar, which does not properly handle CRLF line endings.

When using git on windows, git turns LF into CRLF, making our tests fail on that platform.

The Go CL (https://github.com/golang/go/issues/59264) does not appear to be active anymore, so I opted for replacing CRLF with LF for now within testar.

**Issues**
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35951