### PR TITLE
Remove access_token_passthrough from sapmreceiver

### DIFF
--- a/.chloggen/remove_access_token_passthrough_from_sapm.yaml
+++ b/.chloggen/remove_access_token_passthrough_from_sapm.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type: deprecation
+change_type: breaking
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: sapmreceiver

--- a/.chloggen/remove_access_token_passthrough_from_sapm.yaml
+++ b/.chloggen/remove_access_token_passthrough_from_sapm.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sapmreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Remove the deprecated access_token_passthrough from SAPM receiver."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35972]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/remove_access_token_passthrough_from_sapm.yaml
+++ b/.chloggen/remove_access_token_passthrough_from_sapm.yaml
@@ -15,7 +15,10 @@ issues: [35972]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: |
+  Please use `include_metadata` instead with the following config option applied to the batch processor:
+  batch:
+    metadata_keys: [X-Sf-Token]
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/sapmreceiver/config.go
+++ b/receiver/sapmreceiver/config.go
@@ -5,17 +5,9 @@ package sapmreceiver // import "github.com/open-telemetry/opentelemetry-collecto
 
 import (
 	"go.opentelemetry.io/collector/config/confighttp"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 )
 
 // Config defines configuration for SAPM receiver.
 type Config struct {
 	confighttp.ServerConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-
-	// Deprecated: `access_token_passthrough` is deprecated.
-	// Please enable include_metadata in the receiver and add the following config to the batch processor:
-	// batch:
-	// 	 metadata_keys: [X-Sf-Token]
-	splunk.AccessTokenPassthroughConfig `mapstructure:",squash"`
 }

--- a/receiver/sapmreceiver/config_test.go
+++ b/receiver/sapmreceiver/config_test.go
@@ -14,7 +14,6 @@ import (
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver/internal/metadata"
 )
 
@@ -59,9 +58,6 @@ func TestLoadConfig(t *testing.T) {
 			expected: &Config{
 				ServerConfig: confighttp.ServerConfig{
 					Endpoint: "localhost:7276",
-				},
-				AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{
-					AccessTokenPassthrough: true,
 				},
 			},
 		},

--- a/receiver/sapmreceiver/config_test.go
+++ b/receiver/sapmreceiver/config_test.go
@@ -53,14 +53,6 @@ func TestLoadConfig(t *testing.T) {
 				},
 			},
 		},
-		{
-			id: component.NewIDWithName(metadata.Type, "passthrough"),
-			expected: &Config{
-				ServerConfig: confighttp.ServerConfig{
-					Endpoint: "localhost:7276",
-				},
-			},
-		},
 	}
 
 	for _, tt := range tests {

--- a/receiver/sapmreceiver/go.mod
+++ b/receiver/sapmreceiver/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.112.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.112.0
 	github.com/signalfx/sapm-proto v0.16.0
 	github.com/stretchr/testify v1.9.0
@@ -29,7 +28,6 @@ require (
 
 require (
 	github.com/apache/thrift v0.21.0 // indirect
-	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect
@@ -56,14 +54,11 @@ require (
 	go.opentelemetry.io/collector/config/configauth v0.112.0 // indirect
 	go.opentelemetry.io/collector/config/configcompression v1.18.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.18.0 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.18.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.112.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.112.0 // indirect
 	go.opentelemetry.io/collector/consumer/consumerprofiles v0.112.0 // indirect
-	go.opentelemetry.io/collector/exporter v0.112.0 // indirect
 	go.opentelemetry.io/collector/extension v0.112.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.112.0 // indirect
-	go.opentelemetry.io/collector/extension/experimental/storage v0.112.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.18.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.112.0 // indirect
 	go.opentelemetry.io/collector/receiver/receiverprofiles v0.112.0 // indirect
@@ -83,8 +78,6 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk => ../../internal/splunk
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger => ../../pkg/translator/jaeger
 

--- a/receiver/sapmreceiver/go.sum
+++ b/receiver/sapmreceiver/go.sum
@@ -1,7 +1,5 @@
 github.com/apache/thrift v0.21.0 h1:tdPmh/ptjE1IJnhbhrcl2++TauVjy242rkV/UzJChnE=
 github.com/apache/thrift v0.21.0/go.mod h1:W1H8aR/QRtYNvrPeFXBtobyRkd0/YVhTc6i07XIAgDw=
-github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
-github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -91,8 +89,6 @@ go.opentelemetry.io/collector/config/confighttp v0.112.0 h1:f87ExBYu4f+IQjlUVrm3
 go.opentelemetry.io/collector/config/confighttp v0.112.0/go.mod h1:sim7kYS3IRvqr+RbGHCo9+YoBZaE4/u6OlyYXDuiX1s=
 go.opentelemetry.io/collector/config/configopaque v1.18.0 h1:aoEecgd5m8iZCX+S+iH6SK/lG6ULqCqtrtz7PeHw7vE=
 go.opentelemetry.io/collector/config/configopaque v1.18.0/go.mod h1:6zlLIyOoRpJJ+0bEKrlZOZon3rOp5Jrz9fMdR4twOS4=
-go.opentelemetry.io/collector/config/configretry v1.18.0 h1:2Dq9kqppBaWyV9Q29WpSaA7dxdozpsQoao1Jcu6uvI4=
-go.opentelemetry.io/collector/config/configretry v1.18.0/go.mod h1:KvQF5cfphq1rQm1dKR4eLDNQYw6iI2fY72NMZVa+0N0=
 go.opentelemetry.io/collector/config/configtelemetry v0.112.0 h1:MVBrWJUoqfKrORI38dY8OV0i5d1RRHR/ACIBu9TOcZ8=
 go.opentelemetry.io/collector/config/configtelemetry v0.112.0/go.mod h1:R0MBUxjSMVMIhljuDHWIygzzJWQyZHXXWIgQNxcFwhc=
 go.opentelemetry.io/collector/config/configtls v1.18.0 h1:IQemIIuryeHgrpBJMbLl+LgTxvFBbv7Hhi+0WwlxpCU=
@@ -109,18 +105,10 @@ go.opentelemetry.io/collector/consumer/consumerprofiles v0.112.0 h1:ym+QxemlbWwf
 go.opentelemetry.io/collector/consumer/consumerprofiles v0.112.0/go.mod h1:4PjDUpURFh85R6NLEHrEf/uZjpk4LAYmmOrqu+iZsyE=
 go.opentelemetry.io/collector/consumer/consumertest v0.112.0 h1:pGvNH+H4rMygUOql6ynVQim6UFdimTiJ0HRfQL6v0GE=
 go.opentelemetry.io/collector/consumer/consumertest v0.112.0/go.mod h1:rfVo0tYt/BaLWw3IaQKVQafjUlMsA5qTkvsSOfFrr9c=
-go.opentelemetry.io/collector/exporter v0.112.0 h1:pa7c4du+3pFzfsglQoTIHfc866i9f3dJZtiVusvlQs8=
-go.opentelemetry.io/collector/exporter v0.112.0/go.mod h1:sQdTvJjAUZ6ML8Jv/sXE1bxpDTg4qyzzkk9Dmzq1Bfg=
-go.opentelemetry.io/collector/exporter/exporterprofiles v0.112.0 h1:u6PbgR4BopBA7HIm7giJb+zGCmAotInD6Jdcg9azX+M=
-go.opentelemetry.io/collector/exporter/exporterprofiles v0.112.0/go.mod h1:qf784JQC/2XJpt+1PesdJGwg+28XjAmn6H7mcuF/SXs=
-go.opentelemetry.io/collector/exporter/exportertest v0.112.0 h1:4e1UlOBTFZWkZePpG4YPE5/EMmhT/+6yYcNOJto0fiM=
-go.opentelemetry.io/collector/exporter/exportertest v0.112.0/go.mod h1:mHt5evYj4gy9LfbMGzaq2VtU5NN4vbWxKUulo4ZJKjk=
 go.opentelemetry.io/collector/extension v0.112.0 h1:NsCDMMbuZp8dSBLoAqHn/AtbcspbAqcubc4qogXo+zc=
 go.opentelemetry.io/collector/extension v0.112.0/go.mod h1:CZrWN4sRQ2cLpEP+zb7DAG+RFSSGcmswEjTt8UvcycM=
 go.opentelemetry.io/collector/extension/auth v0.112.0 h1:GmcmreIkhUUFSNNvgekK12Rs4MjEnnmE24yS2gPm2IA=
 go.opentelemetry.io/collector/extension/auth v0.112.0/go.mod h1:3xShgnNn/iQ5vHf3MVExvqpEIUNEl6osYRlq1Comat4=
-go.opentelemetry.io/collector/extension/experimental/storage v0.112.0 h1:IBRQcwEo7RKytjTEFnEsOcd52ffvNeEmSl6FeYPZzpk=
-go.opentelemetry.io/collector/extension/experimental/storage v0.112.0/go.mod h1:+3j0GK3WRNb2noOOGdcx7b5FQUBP1AzLl+y3y+Qns1c=
 go.opentelemetry.io/collector/featuregate v1.18.0 h1:1CvP1K3XmVs7WZCs/A1j8rsC7JQWu+y+vF8vxKjLaOU=
 go.opentelemetry.io/collector/featuregate v1.18.0/go.mod h1:47xrISO71vJ83LSMm8+yIDsUbKktUp48Ovt7RR6VbRs=
 go.opentelemetry.io/collector/pdata v1.18.0 h1:/yg2rO2dxqDM2p6GutsMCxXN6sKlXwyIz/ZYyUPONBg=

--- a/testbed/datareceivers/sapm.go
+++ b/testbed/datareceivers/sapm.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
@@ -36,7 +35,6 @@ func (sr *SapmDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ cons
 		ServerConfig: confighttp.ServerConfig{
 			Endpoint: fmt.Sprintf("127.0.0.1:%d", sr.Port),
 		},
-		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{AccessTokenPassthrough: true},
 	}
 	var err error
 	params := receivertest.NewNopSettings()

--- a/testbed/go.mod
+++ b/testbed/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/zipkinexporter v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.112.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger v0.112.0
@@ -215,6 +214,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics v0.112.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/pdatautil v0.112.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.112.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk v0.112.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchperresourceattr v0.112.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.112.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.112.0 // indirect


### PR DESCRIPTION
#### Description
Remove the use access_token_passthrough from sapmreceiver after deprecation 

