### PR TITLE
[receiver/filelog] Do not file lock on aix or solaris

### DIFF
--- a/pkg/stanza/fileconsumer/internal/reader/reader_other.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_other.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !unix
+//go:build !unix || aix || solaris
 
 package reader // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
 

--- a/pkg/stanza/fileconsumer/internal/reader/reader_unix.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader_unix.go
@@ -1,7 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build unix
+//go:build unix && !aix && !solaris
 
 package reader // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/reader"
 


### PR DESCRIPTION
AIX and some versions of Solaris apparently do not support the `Flock` function. This PR effectively ignores the `acquire_fs_lock` parameter on those systems in order to avoid compiling with `Flock`. I have not documented this as I don't believe we explicitly support those operating systems, but this is a best effort attempt to allow it to build for them.