### PR TITLE
[receiver/splunkhec] Avoid a memory leak 

### DIFF
--- a/.chloggen/receiver_ops.yaml
+++ b/.chloggen/receiver_ops.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: splunkhecreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid a memory leak by not recording obsreports if the receiver is used for both logs and metrics.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35294]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -432,10 +432,10 @@ func (r *splunkReceiver) validateChannelHeader(channelID string) error {
 
 func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	if r.logsConsumer != nil {
+	if r.logsConsumer != nil && r.metricsConsumer == nil {
 		ctx = r.obsrecv.StartLogsOp(ctx)
 	}
-	if r.metricsConsumer != nil {
+	if r.metricsConsumer != nil && r.logsConsumer == nil {
 		ctx = r.obsrecv.StartMetricsOp(ctx)
 	}
 
@@ -551,10 +551,10 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 	if ackErr != nil {
 		r.failRequest(ctx, resp, http.StatusInternalServerError, errInternalServerError, len(events)+len(metricEvents), ackErr)
 	} else {
-		if r.logsConsumer != nil {
+		if r.logsConsumer != nil && r.metricsConsumer == nil {
 			r.obsrecv.EndLogsOp(ctx, metadata.Type.String(), len(events), nil)
 		}
-		if r.metricsConsumer != nil {
+		if r.metricsConsumer != nil && r.logsConsumer == nil {
 			r.obsrecv.EndMetricsOp(ctx, metadata.Type.String(), len(metricEvents), nil)
 		}
 	}
@@ -591,10 +591,10 @@ func (r *splunkReceiver) failRequest(
 		}
 	}
 
-	if r.logsConsumer != nil {
+	if r.logsConsumer != nil && r.metricsConsumer == nil {
 		r.obsrecv.EndLogsOp(ctx, metadata.Type.String(), numRecordsReceived, err)
 	}
-	if r.metricsConsumer != nil {
+	if r.metricsConsumer != nil && r.logsConsumer == nil {
 		r.obsrecv.EndMetricsOp(ctx, metadata.Type.String(), numRecordsReceived, err)
 	}
 


### PR DESCRIPTION
#### Description
Avoid a memory leak by not recording obsreports if the receiver is used for both logs and metrics.
#### Link to tracking issue
Fixes #35294
