### PR TITLE
[receiver/hostmetrics] fix filesystem scraper root_path support

### DIFF
--- a/.chloggen/hostmetrics.yaml
+++ b/.chloggen/hostmetrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix filesystem scraper to respect root_path"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35990]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/hostmetricsreceiver/hostmetrics_linux.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_linux.go
@@ -20,7 +20,7 @@ var gopsutilEnvVars = map[common.EnvKeyType]string{
 	common.HostVarEnvKey:     "/var",
 	common.HostRunEnvKey:     "/run",
 	common.HostDevEnvKey:     "/dev",
-	common.HostProcMountinfo: "",
+	common.HostProcMountinfo: "/proc/1",
 }
 
 // This exists to validate that different instances of the hostmetricsreceiver do not

--- a/receiver/hostmetricsreceiver/hostmetrics_linux_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_linux_test.go
@@ -52,7 +52,7 @@ func TestLoadConfigRootPath(t *testing.T) {
 	cpuScraperCfg.SetEnvMap(common.EnvMap{
 		common.HostDevEnvKey:     "testdata/dev",
 		common.HostEtcEnvKey:     "testdata/etc",
-		common.HostProcMountinfo: "testdata",
+		common.HostProcMountinfo: "testdata/proc/1",
 		common.HostRunEnvKey:     "testdata/run",
 		common.HostSysEnvKey:     "testdata/sys",
 		common.HostVarEnvKey:     "testdata/var",


### PR DESCRIPTION
#### Description

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35990

Looks like filesystem scraper stopped respecting root_path

The issue it seems to be that the default value in this map is wrong:
```
var gopsutilEnvVars = map[common.EnvKeyType]string{
	common.HostProcEnvKey:    "/proc",
	common.HostSysEnvKey:     "/sys",
	common.HostEtcEnvKey:     "/etc",
	common.HostVarEnvKey:     "/var",
	common.HostRunEnvKey:     "/run",
	common.HostDevEnvKey:     "/dev",
	common.HostProcMountinfo: "",
}
```
and this function fails to correctly set envvars:

```
func setGoPsutilEnvVars(rootPath string, env environment) common.EnvMap {
	m := common.EnvMap{}
	if rootPath == "" || rootPath == "/" {
		return m
	}

	for envVarKey, defaultValue := range gopsutilEnvVars {
		_, ok := env.Lookup(string(envVarKey))
		if ok {
			continue // don't override if existing env var is set
		}
		m[envVarKey] = filepath.Join(rootPath, defaultValue)
	}
	return m
}
```

Gops utils docs:
> You can set an alternative location to /proc/N/mountinfo by setting the HOST_PROC_MOUNTINFO environment variable.

Ref: https://github.com/shirou/gopsutil/blob/6be0508aeb80711cfb45a829590fb4b2b9972bba/disk/disk_linux.go#L260-L261

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Tested in local computer


<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
