### PR TITLE
[receiver/hostmetrics] Fix filesystems scraper behavior when root file system is mounted

### DIFF
--- a/.chloggen/fix_filesystems_scraping.yaml
+++ b/.chloggen/fix_filesystems_scraping.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: hostmetricsreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Do not set the default value of HOST_PROC_MOUNTINFO to respect root_path
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35990]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/hostmetricsreceiver/hostmetrics_linux.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_linux.go
@@ -14,13 +14,12 @@ import (
 )
 
 var gopsutilEnvVars = map[common.EnvKeyType]string{
-	common.HostProcEnvKey:    "/proc",
-	common.HostSysEnvKey:     "/sys",
-	common.HostEtcEnvKey:     "/etc",
-	common.HostVarEnvKey:     "/var",
-	common.HostRunEnvKey:     "/run",
-	common.HostDevEnvKey:     "/dev",
-	common.HostProcMountinfo: "",
+	common.HostProcEnvKey: "/proc",
+	common.HostSysEnvKey:  "/sys",
+	common.HostEtcEnvKey:  "/etc",
+	common.HostVarEnvKey:  "/var",
+	common.HostRunEnvKey:  "/run",
+	common.HostDevEnvKey:  "/dev",
 }
 
 // This exists to validate that different instances of the hostmetricsreceiver do not

--- a/receiver/hostmetricsreceiver/hostmetrics_linux_test.go
+++ b/receiver/hostmetricsreceiver/hostmetrics_linux_test.go
@@ -50,12 +50,11 @@ func TestLoadConfigRootPath(t *testing.T) {
 	cpuScraperCfg := (&cpuscraper.Factory{}).CreateDefaultConfig()
 	cpuScraperCfg.SetRootPath("testdata")
 	cpuScraperCfg.SetEnvMap(common.EnvMap{
-		common.HostDevEnvKey:     "testdata/dev",
-		common.HostEtcEnvKey:     "testdata/etc",
-		common.HostProcMountinfo: "testdata",
-		common.HostRunEnvKey:     "testdata/run",
-		common.HostSysEnvKey:     "testdata/sys",
-		common.HostVarEnvKey:     "testdata/var",
+		common.HostDevEnvKey: "testdata/dev",
+		common.HostEtcEnvKey: "testdata/etc",
+		common.HostRunEnvKey: "testdata/run",
+		common.HostSysEnvKey: "testdata/sys",
+		common.HostVarEnvKey: "testdata/var",
 	})
 	expectedConfig.Scrapers = map[string]internal.Config{cpuscraper.TypeStr: cpuScraperCfg}
 


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Do not set the default value of HOST_PROC_MOUNTINFO to respect root_path

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #35990
