### PR TITLE
[chore]: enable usestdlibvars linter (part 1)

### DIFF
--- a/cmd/opampsupervisor/supervisor/healthchecker/healthchecker.go
+++ b/cmd/opampsupervisor/supervisor/healthchecker/healthchecker.go
@@ -23,7 +23,7 @@ func NewHTTPHealthChecker(endpoint string) *HTTPHealthChecker {
 }
 
 func (h *HTTPHealthChecker) Check(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, "GET", h.endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.endpoint, nil)
 	if err != nil {
 		return err
 	}

--- a/examples/demo/client/main.go
+++ b/examples/demo/client/main.go
@@ -186,7 +186,7 @@ func makeRequest(ctx context.Context) {
 	}
 
 	// Make sure we pass the context to the request to avoid broken traces.
-	req, err := http.NewRequestWithContext(ctx, "GET", demoServerAddr, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, demoServerAddr, nil)
 	if err != nil {
 		handleErr(err, "failed to http request")
 	}

--- a/exporter/alertmanagerexporter/alertmanager_exporter.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter.go
@@ -132,7 +132,7 @@ func (s *alertmanagerExporter) postAlert(ctx context.Context, payload []model.Al
 		return fmt.Errorf("error marshaling alert to JSON: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", s.endpoint, bytes.NewBuffer(msg))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewBuffer(msg))
 	if err != nil {
 		return fmt.Errorf("error creating HTTP request: %w", err)
 	}

--- a/exporter/mezmoexporter/exporter.go
+++ b/exporter/mezmoexporter/exporter.go
@@ -167,7 +167,7 @@ func (m *mezmoExporter) logDataToMezmo(ld plog.Logs) error {
 }
 
 func (m *mezmoExporter) sendLinesToMezmo(post string) (errs error) {
-	req, _ := http.NewRequest("POST", m.config.IngestURL, strings.NewReader(post))
+	req, _ := http.NewRequest(http.MethodPost, m.config.IngestURL, strings.NewReader(post))
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("Content-Type", "application/json")
 	req.Header.Add("User-Agent", m.userAgentString)

--- a/exporter/opensearchexporter/integration_test.go
+++ b/exporter/opensearchexporter/integration_test.go
@@ -116,7 +116,7 @@ func TestOpenSearchTraceExporter(t *testing.T) {
 			assert.LessOrEqualf(t, requestCount, len(tc.RequestHandlers), "Test case generated more requests than it has response for.")
 			tc.RequestHandlers[requestCount].ValidateReceivedDocuments(t, requestCount, docs)
 
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			response, _ := os.ReadFile(tc.RequestHandlers[requestCount].ResponseJSONPath)
 			_, err = w.Write(response)
 			assert.NoError(t, err)
@@ -246,7 +246,7 @@ func TestOpenSearchLogExporter(t *testing.T) {
 			assert.LessOrEqualf(t, requestCount, len(tc.RequestHandlers), "Test case generated more requests than it has response for.")
 			tc.RequestHandlers[requestCount].ValidateReceivedDocuments(t, requestCount, docs)
 
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			response, _ := os.ReadFile(tc.RequestHandlers[requestCount].ResponseJSONPath)
 			_, err = w.Write(response)
 			assert.NoError(t, err)

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -326,7 +326,7 @@ func (prwe *prwExporter) execute(ctx context.Context, writeReq *prompb.WriteRequ
 
 		// 429 errors are recoverable and the exporter should retry if RetryOnHTTP429 enabled
 		// Reference: https://github.com/prometheus/prometheus/pull/12677
-		if prwe.retryOnHTTP429 && resp.StatusCode == 429 {
+		if prwe.retryOnHTTP429 && resp.StatusCode == http.StatusTooManyRequests {
 			return rerr
 		}
 

--- a/exporter/sapmexporter/exporter_test.go
+++ b/exporter/sapmexporter/exporter_test.go
@@ -370,7 +370,7 @@ func TestCompression(t *testing.T) {
 							err = sapm.Unmarshal(payload)
 							assert.NoError(t, err)
 
-							w.WriteHeader(200)
+							w.WriteHeader(http.StatusOK)
 							tracesReceived = true
 						},
 					),

--- a/exporter/sentryexporter/sentry_exporter_test.go
+++ b/exporter/sentryexporter/sentry_exporter_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"testing"
 
 	"github.com/getsentry/sentry-go"
@@ -380,7 +381,7 @@ func TestGenerateSpanDescriptors(t *testing.T) {
 			testName: "http-server",
 			name:     "/api/users/{user_id}",
 			attrs: map[string]any{
-				conventions.AttributeHTTPMethod: "POST",
+				conventions.AttributeHTTPMethod: http.MethodPost,
 			},
 			spanKind:    ptrace.SpanKindServer,
 			op:          "http.server",

--- a/exporter/signalfxexporter/internal/apm/correlations/client_test.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/client_test.go
@@ -64,7 +64,7 @@ func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode *atomic.Val
 		case http.MethodGet:
 			match := getPathRegexp.FindStringSubmatch(r.URL.Path)
 			if len(match) < 3 {
-				rw.WriteHeader(404)
+				rw.WriteHeader(http.StatusNotFound)
 				return
 			}
 			corCh <- &request{
@@ -79,7 +79,7 @@ func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode *atomic.Val
 		case http.MethodPut:
 			match := putPathRegexp.FindStringSubmatch(r.URL.Path)
 			if len(match) < 4 {
-				rw.WriteHeader(404)
+				rw.WriteHeader(http.StatusNotFound)
 				return
 			}
 
@@ -101,7 +101,7 @@ func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode *atomic.Val
 		case http.MethodDelete:
 			match := deletePathRegexp.FindStringSubmatch(r.URL.Path)
 			if len(match) < 5 {
-				rw.WriteHeader(404)
+				rw.WriteHeader(http.StatusNotFound)
 				return
 			}
 			cor = &request{
@@ -114,13 +114,13 @@ func makeHandler(t *testing.T, corCh chan<- *request, forcedRespCode *atomic.Val
 				},
 			}
 		default:
-			rw.WriteHeader(404)
+			rw.WriteHeader(http.StatusNotFound)
 			return
 		}
 
 		corCh <- cor
 
-		rw.WriteHeader(200)
+		rw.WriteHeader(http.StatusOK)
 	})
 }
 

--- a/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/dimclient_test.go
@@ -63,13 +63,13 @@ func makeHandler(dimCh chan<- dim, forcedResp *atomic.Int32) http.HandlerFunc {
 		log.Printf("Test server got request: %s", r.URL.Path)
 
 		if r.Method != "PATCH" {
-			rw.WriteHeader(404)
+			rw.WriteHeader(http.StatusNotFound)
 			return
 		}
 
 		match := patchPathRegexp.FindStringSubmatch(r.URL.Path)
 		if match == nil {
-			rw.WriteHeader(404)
+			rw.WriteHeader(http.StatusNotFound)
 			return
 		}
 
@@ -83,7 +83,7 @@ func makeHandler(dimCh chan<- dim, forcedResp *atomic.Int32) http.HandlerFunc {
 
 		dimCh <- bodyDim
 
-		rw.WriteHeader(200)
+		rw.WriteHeader(http.StatusOK)
 	}
 }
 

--- a/exporter/splunkhecexporter/internal/integrationtestutils/splunk.go
+++ b/exporter/splunkhecexporter/internal/integrationtestutils/splunk.go
@@ -47,7 +47,7 @@ func getSplunkSearchResults(user string, password string, baseURL string, jobID 
 	logger := log.New(os.Stdout, "", log.LstdFlags)
 	eventURL := fmt.Sprintf("%s/services/search/jobs/%s/events?output_mode=json", baseURL, jobID)
 	logger.Println("URL: " + eventURL)
-	reqEvents, err := http.NewRequest("GET", eventURL, nil)
+	reqEvents, err := http.NewRequest(http.MethodGet, eventURL, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -89,7 +89,7 @@ func checkSearchJobStatusCode(user string, password string, baseURL string, jobI
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	checkReqEvents, err := http.NewRequest("GET", checkEventURL, nil)
+	checkReqEvents, err := http.NewRequest(http.MethodGet, checkEventURL, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -129,7 +129,7 @@ func postSearchRequest(user string, password string, baseURL string, searchQuery
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	req, err := http.NewRequest("POST", searchURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest(http.MethodPost, searchURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		logger.Printf("Error while preparing POST request")
 		panic(err)
@@ -172,7 +172,7 @@ func CheckMetricsFromSplunk(index string, metricName string) []any {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr, Timeout: 10 * time.Second}
-	req, err := http.NewRequest("GET", apiURL, nil)
+	req, err := http.NewRequest(http.MethodGet, apiURL, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -209,7 +209,7 @@ func CreateAnIndexInSplunk(index string, indexType string) {
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 	}
 	client := &http.Client{Transport: tr}
-	req, err := http.NewRequest("POST", indexURL, strings.NewReader(data.Encode()))
+	req, err := http.NewRequest(http.MethodPost, indexURL, strings.NewReader(data.Encode()))
 	if err != nil {
 		logger.Printf("Error while preparing POST request")
 		panic(err)

--- a/exporter/sumologicexporter/sender_test.go
+++ b/exporter/sumologicexporter/sender_test.go
@@ -374,7 +374,7 @@ func TestSendLogsSplitFailedAll(t *testing.T) {
 			assert.Equal(t, "Example log", body)
 		},
 		func(w http.ResponseWriter, req *http.Request) {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 
 			body := extractBody(t, req)
 			assert.Equal(t, "Another example log", body)
@@ -741,7 +741,7 @@ func TestSendLogsJsonSplitFailedAll(t *testing.T) {
 			assert.Regexp(t, regex, body)
 		},
 		func(w http.ResponseWriter, req *http.Request) {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 
 			body := extractBody(t, req)
 
@@ -984,7 +984,7 @@ func TestInvalidPipeline(t *testing.T) {
 func TestSendCompressGzip(t *testing.T) {
 	test := prepareSenderTest(t, configcompression.TypeGzip, []func(res http.ResponseWriter, req *http.Request){
 		func(res http.ResponseWriter, req *http.Request) {
-			res.WriteHeader(200)
+			res.WriteHeader(http.StatusOK)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
 				assert.Fail(t, "err: %v", err)
@@ -1005,7 +1005,7 @@ func TestSendCompressGzip(t *testing.T) {
 func TestSendCompressGzipDeprecated(t *testing.T) {
 	test := prepareSenderTest(t, "default", []func(res http.ResponseWriter, req *http.Request){
 		func(res http.ResponseWriter, req *http.Request) {
-			res.WriteHeader(200)
+			res.WriteHeader(http.StatusOK)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
 				assert.Fail(t, "err: %v", err)
@@ -1026,7 +1026,7 @@ func TestSendCompressGzipDeprecated(t *testing.T) {
 func TestSendCompressZstd(t *testing.T) {
 	test := prepareSenderTest(t, configcompression.TypeZstd, []func(res http.ResponseWriter, req *http.Request){
 		func(res http.ResponseWriter, req *http.Request) {
-			res.WriteHeader(200)
+			res.WriteHeader(http.StatusOK)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
 				assert.Fail(t, "err: %v", err)
@@ -1047,7 +1047,7 @@ func TestSendCompressZstd(t *testing.T) {
 func TestSendCompressDeflate(t *testing.T) {
 	test := prepareSenderTest(t, configcompression.TypeDeflate, []func(res http.ResponseWriter, req *http.Request){
 		func(res http.ResponseWriter, req *http.Request) {
-			res.WriteHeader(200)
+			res.WriteHeader(http.StatusOK)
 			if _, err := res.Write([]byte("")); err != nil {
 				res.WriteHeader(http.StatusInternalServerError)
 				assert.Fail(t, "err: %v", err)
@@ -1240,7 +1240,7 @@ func TestSendMetricsSplitFailedAll(t *testing.T) {
 			assert.Equal(t, expected, body)
 		},
 		func(w http.ResponseWriter, req *http.Request) {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 
 			body := extractBody(t, req)
 			expected := `` +

--- a/exporter/zipkinexporter/zipkin_test.go
+++ b/exporter/zipkinexporter/zipkin_test.go
@@ -175,7 +175,7 @@ func (r *mockZipkinReporter) Flush() error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", r.url, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, r.url, bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/extension/headerssetterextension/extension_test.go
+++ b/extension/headerssetterextension/extension_test.go
@@ -39,7 +39,7 @@ func TestRoundTripper(t *testing.T) {
 					Metadata: tt.metadata,
 				},
 			)
-			req, err := http.NewRequestWithContext(ctx, "GET", "", nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "", nil)
 			assert.NoError(t, err)
 			assert.NotNil(t, req)
 

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -273,7 +273,7 @@ func TestOAuth2PerRPCCredentials(t *testing.T) {
 
 func TestFailContactingOAuth(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		_, err := w.Write([]byte("not-json"))
 		assert.NoError(t, err)
 	}))
@@ -306,7 +306,7 @@ func TestFailContactingOAuth(t *testing.T) {
 		Transport: roundTripper,
 	}
 
-	req, err := http.NewRequest("POST", "http://example.com/", nil)
+	req, err := http.NewRequest(http.MethodPost, "http://example.com/", nil)
 	require.NoError(t, err)
 	_, err = client.Do(req)
 	assert.ErrorIs(t, err, errFailedToGetSecurityToken)

--- a/extension/opampextension/auth.go
+++ b/extension/opampextension/auth.go
@@ -61,7 +61,7 @@ func makeHeadersFunc(logger *zap.Logger, serverCfg *OpAMPServer, host component.
 		// This is a workaround while websocket authentication is being worked on.
 		// Currently, we are waiting on the auth module to be stabilized.
 		// See for more info: https://github.com/open-telemetry/opentelemetry-collector/issues/10864
-		dummyReq, err := http.NewRequest("GET", "http://example.com", nil)
+		dummyReq, err := http.NewRequest(http.MethodGet, "http://example.com", nil)
 		if err != nil {
 			logger.Error("Failed to create dummy request for authentication.", zap.Error(err))
 			return h

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -103,10 +103,10 @@ func TestGetCredsProviderFromConfig(t *testing.T) {
 }
 
 func TestCloneRequest(t *testing.T) {
-	req1, err := http.NewRequest("GET", "https://example.com", nil)
+	req1, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	assert.NoError(t, err)
 
-	req2, err := http.NewRequest("GET", "https://example.com", nil)
+	req2, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	assert.NoError(t, err)
 	req2.Header.Add("Header1", "val1")
 

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -69,7 +69,7 @@ func TestRoundTrip(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, body, string(content))
 
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}))
 			defer server.Close()
 			serverURL, _ := url.Parse(server.URL)
@@ -79,7 +79,7 @@ func TestRoundTrip(t *testing.T) {
 			assert.NoError(t, err)
 
 			newBody := strings.NewReader(body)
-			req, err := http.NewRequest("POST", serverURL.String(), newBody)
+			req, err := http.NewRequest(http.MethodPost, serverURL.String(), newBody)
 			assert.NoError(t, err)
 
 			res, err := rt.RoundTrip(req)
@@ -95,19 +95,19 @@ func TestRoundTrip(t *testing.T) {
 }
 
 func TestInferServiceAndRegion(t *testing.T) {
-	req1, err := http.NewRequest("GET", "https://example.com", nil)
+	req1, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	assert.NoError(t, err)
 
-	req2, err := http.NewRequest("GET", "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", nil)
+	req2, err := http.NewRequest(http.MethodGet, "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", nil)
 	assert.NoError(t, err)
 
-	req3, err := http.NewRequest("GET", "https://search-my-domain.us-east-1.es.amazonaws.com/_search?q=house", nil)
+	req3, err := http.NewRequest(http.MethodGet, "https://search-my-domain.us-east-1.es.amazonaws.com/_search?q=house", nil)
 	assert.NoError(t, err)
 
-	req4, err := http.NewRequest("GET", "https://example.com", nil)
+	req4, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	assert.NoError(t, err)
 
-	req5, err := http.NewRequest("GET", "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", nil)
+	req5, err := http.NewRequest(http.MethodGet, "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", nil)
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -172,13 +172,13 @@ func TestInferServiceAndRegion(t *testing.T) {
 }
 
 func TestHashPayload(t *testing.T) {
-	req1, err := http.NewRequest("GET", "https://example.com", nil)
+	req1, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	assert.NoError(t, err)
 
-	req2, err := http.NewRequest("GET", "https://example.com", bytes.NewReader([]byte("This is a test.")))
+	req2, err := http.NewRequest(http.MethodGet, "https://example.com", bytes.NewReader([]byte("This is a test.")))
 	assert.NoError(t, err)
 
-	req3, err := http.NewRequest("GET", "https://example.com", nil)
+	req3, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
 	assert.NoError(t, err)
 	req3.GetBody = func() (io.ReadCloser, error) { return nil, errors.New("this will always fail") }
 

--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -113,7 +113,7 @@ func TestBasicStart(t *testing.T) {
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// heartbeat
 			case 3:
@@ -175,7 +175,7 @@ func TestStoreCredentials(t *testing.T) {
 				// metadata
 				case 2:
 					assert.Equal(t, metadataURL, req.URL.Path)
-					w.WriteHeader(200)
+					w.WriteHeader(http.StatusOK)
 
 				// heartbeat
 				case 3:
@@ -323,7 +323,7 @@ func TestStoreCredentials_PreexistingCredentialsAreUsed(t *testing.T) {
 				// metadata
 				case 2:
 					assert.Equal(t, metadataURL, req.URL.Path)
-					w.WriteHeader(200)
+					w.WriteHeader(http.StatusOK)
 
 				// should not produce any more requests
 				default:
@@ -418,7 +418,7 @@ func TestLocalFSCredentialsStore_WorkCorrectlyForMultipleExtensions(t *testing.T
 				// metadata
 				case 2:
 					assert.Equal(t, metadataURL, req.URL.Path)
-					w.WriteHeader(200)
+					w.WriteHeader(http.StatusOK)
 
 				// heartbeat
 				case 3:
@@ -527,7 +527,7 @@ func TestRegisterEmptyCollectorName(t *testing.T) {
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// heartbeat
 			case 3:
@@ -597,7 +597,7 @@ func TestRegisterEmptyCollectorNameForceRegistration(t *testing.T) {
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// register again because force registration was set
 			case 3:
@@ -620,7 +620,7 @@ func TestRegisterEmptyCollectorNameForceRegistration(t *testing.T) {
 			// metadata
 			case 4:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// should not produce any more requests
 			default:
@@ -690,7 +690,7 @@ func TestCollectorSendsBasicAuthHeadersOnRegistration(t *testing.T) {
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// heartbeat
 			case 3:
@@ -793,7 +793,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 						// metadata
 						case 2:
 							assert.Equal(t, metadataURL, req.URL.Path)
-							w.WriteHeader(200)
+							w.WriteHeader(http.StatusOK)
 
 						// should not produce any more requests
 						default:
@@ -857,7 +857,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 						// metadata
 						case 3:
 							assert.Equal(t, metadataURL, req.URL.Path)
-							w.WriteHeader(200)
+							w.WriteHeader(http.StatusOK)
 
 						// should not produce any more requests
 						default:
@@ -921,7 +921,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// metadata
 						case 3:
-							w.WriteHeader(200)
+							w.WriteHeader(http.StatusOK)
 
 						// heartbeat
 						case 4:
@@ -973,7 +973,7 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 
 						// metadata
 						case 2:
-							w.WriteHeader(200)
+							w.WriteHeader(http.StatusOK)
 
 						// heartbeat
 						case 3:
@@ -1070,7 +1070,7 @@ func TestRegisterEmptyCollectorNameWithBackoff(t *testing.T) {
 			// metadata
 			case reqNum == retriesLimit+1:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// heartbeat
 			case reqNum == retriesLimit+2:
@@ -1185,7 +1185,7 @@ func TestRegistrationRedirect(t *testing.T) {
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// heartbeat
 			case 3:
@@ -1200,7 +1200,7 @@ func TestRegistrationRedirect(t *testing.T) {
 			// metadata
 			case 5:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// heartbeat
 			case 6:
@@ -1325,7 +1325,7 @@ func TestCollectorReregistersAfterHTTPUnathorizedFromHeartbeat(t *testing.T) {
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 
 			// heartbeat
 			case 3:
@@ -1429,7 +1429,7 @@ func TestRegistrationRequestPayload(t *testing.T) {
 			// metadata
 			case 2:
 				assert.Equal(t, metadataURL, req.URL.Path)
-				w.WriteHeader(200)
+				w.WriteHeader(http.StatusOK)
 			}
 
 		})

--- a/internal/aws/proxy/server_test.go
+++ b/internal/aws/proxy/server_test.go
@@ -73,7 +73,7 @@ func TestHandlerHappyCase(t *testing.T) {
 	assert.NoError(t, err, "NewServer should succeed")
 
 	handler := srv.(*http.Server).Handler.ServeHTTP
-	req := httptest.NewRequest("POST",
+	req := httptest.NewRequest(http.MethodPost,
 		"https://xray.us-west-2.amazonaws.com/GetSamplingRules", strings.NewReader(`{"NextToken": null}`))
 	rec := httptest.NewRecorder()
 	handler(rec, req)
@@ -99,7 +99,7 @@ func TestHandlerIoReadSeekerCreationFailed(t *testing.T) {
 
 	expectedErr := errors.New("expected mockReadCloser error")
 	handler := srv.(*http.Server).Handler.ServeHTTP
-	req := httptest.NewRequest("POST",
+	req := httptest.NewRequest(http.MethodPost,
 		"https://xray.us-west-2.amazonaws.com/GetSamplingRules", &mockReadCloser{
 			readErr: expectedErr,
 		})
@@ -127,7 +127,7 @@ func TestHandlerNilBodyIsOk(t *testing.T) {
 	assert.NoError(t, err, "NewServer should succeed")
 
 	handler := srv.(*http.Server).Handler.ServeHTTP
-	req := httptest.NewRequest("POST",
+	req := httptest.NewRequest(http.MethodPost,
 		"https://xray.us-west-2.amazonaws.com/GetSamplingRules", nil)
 	rec := httptest.NewRecorder()
 	handler(rec, req)
@@ -151,7 +151,7 @@ func TestHandlerSignerErrorsOut(t *testing.T) {
 	assert.NoError(t, err, "NewServer should succeed")
 
 	handler := srv.(*http.Server).Handler.ServeHTTP
-	req := httptest.NewRequest("POST",
+	req := httptest.NewRequest(http.MethodPost,
 		"https://xray.us-west-2.amazonaws.com/GetSamplingRules", strings.NewReader(`{}`))
 	rec := httptest.NewRecorder()
 	handler(rec, req)

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -296,7 +296,7 @@ func (c *clientImpl) buildReq(p string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequest("GET", reqURL, nil)
+	req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/apachereceiver/scraper_test.go
+++ b/receiver/apachereceiver/scraper_test.go
@@ -172,7 +172,7 @@ func TestScraperError(t *testing.T) {
 func newMockServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.String() == "/server-status?auto" {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err := rw.Write([]byte(`ServerUptimeSeconds: 410
 Total Accesses: 14169
 Total kBytes: 20910
@@ -193,6 +193,6 @@ Scoreboard: S_DD_L_GGG_____W__IIII_C________________W___________________________
 			assert.NoError(t, err)
 			return
 		}
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 	}))
 }

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_instance_info_test.go
@@ -38,7 +38,7 @@ func TestECSInstanceInfo(t *testing.T) {
 	respBody := string(data)
 
 	httpResponse := &http.Response{
-		StatusCode:    200,
+		StatusCode:    http.StatusOK,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: 5 * 1024,
@@ -65,7 +65,7 @@ func TestECSInstanceInfo(t *testing.T) {
 
 	httpResponse = &http.Response{
 		Status:        "Bad Request",
-		StatusCode:    400,
+		StatusCode:    http.StatusBadRequest,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: 5 * 1024,

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_task_info_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/ecs_task_info_test.go
@@ -28,7 +28,7 @@ func TestECSTaskInfoSuccess(t *testing.T) {
 
 	respBody := string(data)
 	httpResponse := &http.Response{
-		StatusCode:    200,
+		StatusCode:    http.StatusOK,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: 5 * 1024,
@@ -62,7 +62,7 @@ func TestECSTaskInfoFail(t *testing.T) {
 
 	httpResponse := &http.Response{
 		Status:        "Bad Request",
-		StatusCode:    400,
+		StatusCode:    http.StatusBadRequest,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: 5 * 1024,

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils.go
@@ -98,7 +98,7 @@ func request(ctx context.Context, endpoint string, client doer) ([]byte, error) 
 }
 
 func clientGet(ctx context.Context, url string, client doer) (resp *http.Response, err error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
+++ b/receiver/awscontainerinsightreceiver/internal/ecsInfo/utils_test.go
@@ -54,7 +54,7 @@ func TestRequestSuccessWithKnownLength(t *testing.T) {
 
 	respBody := "body"
 	response := &http.Response{
-		StatusCode:    200,
+		StatusCode:    http.StatusOK,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: 5 * 1024,
@@ -79,7 +79,7 @@ func TestRequestSuccessWithUnknownLength(t *testing.T) {
 
 	respBody := "body"
 	response := &http.Response{
-		StatusCode:    200,
+		StatusCode:    http.StatusOK,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: -1,
@@ -105,7 +105,7 @@ func TestRequestWithFailedStatus(t *testing.T) {
 	respBody := "body"
 	response := &http.Response{
 		Status:        "Bad Request",
-		StatusCode:    400,
+		StatusCode:    http.StatusBadRequest,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: 5 * 1024,
@@ -130,7 +130,7 @@ func TestRequestWithLargeContentLength(t *testing.T) {
 
 	respBody := "body"
 	response := &http.Response{
-		StatusCode:    200,
+		StatusCode:    http.StatusOK,
 		Body:          io.NopCloser(bytes.NewBufferString(respBody)),
 		Header:        make(http.Header),
 		ContentLength: 5 * 1024 * 1024,

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -188,7 +188,7 @@ func TestFirehoseRequest(t *testing.T) {
 
 			requestBody := bytes.NewBuffer(body)
 
-			request := httptest.NewRequest("POST", "/", requestBody)
+			request := httptest.NewRequest(http.MethodPost, "/", requestBody)
 			request.Header.Set(headerContentType, "application/json")
 			request.Header.Set(headerContentLength, fmt.Sprintf("%d", requestBody.Len()))
 			request.Header.Set(headerFirehoseRequestID, testFirehoseRequestID)

--- a/receiver/bigipreceiver/integration_test.go
+++ b/receiver/bigipreceiver/integration_test.go
@@ -87,7 +87,7 @@ func setupMockIControlServer(t *testing.T) *httptest.Server {
 			var body loginBody
 			err = json.NewDecoder(r.Body).Decode(&body)
 			assert.NoError(t, err)
-			if body.Username == "" || body.Password == "" || r.Method != "POST" {
+			if body.Username == "" || body.Password == "" || r.Method != http.MethodPost {
 				w.WriteHeader(http.StatusUnauthorized)
 			} else {
 				_, err = w.Write(mockLoginResponse)

--- a/receiver/cloudflarereceiver/logs_integration_test.go
+++ b/receiver/cloudflarereceiver/logs_integration_test.go
@@ -82,7 +82,7 @@ func TestReceiverTLSIntegration(t *testing.T) {
 			payload, err := os.ReadFile(filepath.Join("testdata", "sample-payloads", fmt.Sprintf("%s.txt", payloadName)))
 			require.NoError(t, err)
 
-			req, err := http.NewRequest("POST", fmt.Sprintf("https://localhost:%s", testPort), bytes.NewBuffer(payload))
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://localhost:%s", testPort), bytes.NewBuffer(payload))
 			require.NoError(t, err)
 
 			client, err := clientWithCert(filepath.Join("testdata", "cert", "ca.crt"))

--- a/receiver/cloudflarereceiver/logs_test.go
+++ b/receiver/cloudflarereceiver/logs_test.go
@@ -197,7 +197,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "No secret provided",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(`{"ClientIP": "127.0.0.1"}`)),
 			},
@@ -208,7 +208,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "Invalid payload",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(`{"ClientIP": "127.0.0.1"`)),
 				Header: map[string][]string{
@@ -222,7 +222,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "Consumer fails",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(`{"ClientIP": "127.0.0.1"}`)),
 				Header: map[string][]string{
@@ -236,7 +236,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "Consumer fails - permanent error",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(`{"ClientIP": "127.0.0.1"}`)),
 				Header: map[string][]string{
@@ -251,7 +251,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "Request succeeds",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(`{"ClientIP": "127.0.0.1", "MyTimestamp": "2023-03-03T05:29:06Z"}`)),
 				Header: map[string][]string{
@@ -265,7 +265,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "Request succeeds with gzip",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(gzippedMessage(`{"ClientIP": "127.0.0.1", "MyTimestamp": "2023-03-03T05:29:06Z"}`))),
 				Header: map[string][]string{
@@ -281,7 +281,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "Request fails to unzip gzip",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(`thisisnotvalidzippedcontent`)),
 				Header: map[string][]string{
@@ -297,7 +297,7 @@ func TestHandleRequest(t *testing.T) {
 		{
 			name: "test message passes",
 			request: &http.Request{
-				Method: "POST",
+				Method: http.MethodPost,
 				URL:    &url.URL{},
 				Body:   io.NopCloser(bytes.NewBufferString(`test`)),
 				Header: map[string][]string{

--- a/receiver/collectdreceiver/receiver.go
+++ b/receiver/collectdreceiver/receiver.go
@@ -95,7 +95,7 @@ func (cdr *collectdReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	ctx = cdr.obsrecv.StartMetricsOp(ctx)
 
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
 		cdr.obsrecv.EndMetricsOp(ctx, metadata.Type.String(), 0, errors.New("invalid http verb"))
 		w.WriteHeader(http.StatusBadRequest)
 		return

--- a/receiver/couchdbreceiver/client_test.go
+++ b/receiver/couchdbreceiver/client_test.go
@@ -62,15 +62,15 @@ func TestGet(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		u, p, _ := r.BasicAuth()
 		if u == "unauthorized" || p == "unauthorized" {
-			w.WriteHeader(401)
+			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
 		if strings.Contains(r.URL.Path, "/_stats/couchdb") {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			return
 		}
 		if strings.Contains(r.URL.Path, "/invalid_endpoint") {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		if strings.Contains(r.URL.Path, "/invalid_body") {
@@ -78,7 +78,7 @@ func TestGet(t *testing.T) {
 			return
 		}
 
-		w.WriteHeader(404)
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
 
@@ -141,18 +141,18 @@ func TestGetNodeStats(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 
 		if strings.Contains(r.URL.Path, "/invalid_json") {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(`{"}`))
 			assert.NoError(t, err)
 			return
 		}
 		if strings.Contains(r.URL.Path, "/_stats/couchdb") {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			_, err := w.Write([]byte(`{"key":["value"]}`))
 			assert.NoError(t, err)
 			return
 		}
-		w.WriteHeader(404)
+		w.WriteHeader(http.StatusNotFound)
 	}))
 	defer ts.Close()
 

--- a/receiver/datadogreceiver/internal/translator/traces_translator_test.go
+++ b/receiver/datadogreceiver/internal/translator/traces_translator_test.go
@@ -195,7 +195,7 @@ func agentPayloadFromTraces(traces *pb.Traces) (agentPayload pb.AgentPayload) {
 
 func TestUpsertHeadersAttributes(t *testing.T) {
 	// Test case 1: Datadog-Meta-Tracer-Version is present in headers
-	req1, _ := http.NewRequest("GET", "http://example.com", nil)
+	req1, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	req1.Header.Set(header.TracerVersion, "1.2.3")
 	attrs1 := pcommon.NewMap()
 	upsertHeadersAttributes(req1, attrs1)
@@ -204,7 +204,7 @@ func TestUpsertHeadersAttributes(t *testing.T) {
 	assert.Equal(t, "Datadog-1.2.3", val.Str())
 
 	// Test case 2: Datadog-Meta-Lang is present in headers with ".NET"
-	req2, _ := http.NewRequest("GET", "http://example.com", nil)
+	req2, _ := http.NewRequest(http.MethodGet, "http://example.com", nil)
 	req2.Header.Set(header.Lang, ".NET")
 	attrs2 := pcommon.NewMap()
 	upsertHeadersAttributes(req2, attrs2)

--- a/receiver/elasticsearchreceiver/client.go
+++ b/receiver/elasticsearchreceiver/client.go
@@ -223,7 +223,7 @@ func (c defaultElasticsearchClient) doRequest(ctx context.Context, path string) 
 		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "GET", endpoint.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (c defaultElasticsearchClient) doRequest(ctx context.Context, path string) 
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == 200 {
+	if resp.StatusCode == http.StatusOK {
 		return io.ReadAll(resp.Body)
 	}
 
@@ -256,9 +256,9 @@ func (c defaultElasticsearchClient) doRequest(ctx context.Context, path string) 
 	)
 
 	switch resp.StatusCode {
-	case 401:
+	case http.StatusUnauthorized:
 		return nil, errUnauthenticated
-	case 403:
+	case http.StatusForbidden:
 		return nil, errUnauthorized
 	default:
 		return nil, fmt.Errorf("got non 200 status code %d", resp.StatusCode)

--- a/receiver/elasticsearchreceiver/client_test.go
+++ b/receiver/elasticsearchreceiver/client_test.go
@@ -628,28 +628,28 @@ func newMockServer(t *testing.T, opts ...mockServerOption) *httptest.Server {
 		if mock.auth != nil {
 			username, password, ok := req.BasicAuth()
 			if !ok {
-				rw.WriteHeader(401)
+				rw.WriteHeader(http.StatusUnauthorized)
 				return
 			} else if !mock.auth(username, password) {
-				rw.WriteHeader(403)
+				rw.WriteHeader(http.StatusForbidden)
 				return
 			}
 		}
 		if req.URL.Path == "/" {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err := rw.Write(mock.metadata)
 			assert.NoError(t, err)
 			return
 		}
 		for prefix, payload := range mock.prefixes {
 			if strings.HasPrefix(req.URL.Path, prefix) {
-				rw.WriteHeader(200)
+				rw.WriteHeader(http.StatusOK)
 				_, err := rw.Write(payload)
 				assert.NoError(t, err)
 				return
 			}
 		}
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 	}))
 
 	return elasticsearchMock

--- a/receiver/expvarreceiver/scraper.go
+++ b/receiver/expvarreceiver/scraper.go
@@ -51,7 +51,7 @@ func (e *expVarScraper) start(ctx context.Context, host component.Host) error {
 
 func (e *expVarScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 	emptyMetrics := pmetric.NewMetrics()
-	req, err := http.NewRequestWithContext(ctx, "GET", e.cfg.Endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, e.cfg.Endpoint, nil)
 	if err != nil {
 		return emptyMetrics, err
 	}

--- a/receiver/jaegerreceiver/trace_receiver_test.go
+++ b/receiver/jaegerreceiver/trace_receiver_test.go
@@ -55,7 +55,7 @@ func jaegerBatchToHTTPBody(b *jaegerthrift.Batch) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	r := httptest.NewRequest("POST", "/api/traces", bytes.NewReader(body))
+	r := httptest.NewRequest(http.MethodPost, "/api/traces", bytes.NewReader(body))
 	r.Header.Add("content-type", "application/x-thrift")
 	return r, nil
 }
@@ -388,7 +388,7 @@ func sendToCollector(endpoint string, batch *jaegerthrift.Batch) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("POST", endpoint, bytes.NewBuffer(buf))
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(buf))
 	if err != nil {
 		return err
 	}

--- a/receiver/lokireceiver/loki_test.go
+++ b/receiver/lokireceiver/loki_test.go
@@ -67,7 +67,7 @@ func sendToCollector(endpoint string, contentType string, contentEncoding string
 		}
 	}
 
-	req, err := http.NewRequest("POST", endpoint, &buf)
+	req, err := http.NewRequest(http.MethodPost, endpoint, &buf)
 	if err != nil {
 		return err
 	}

--- a/receiver/mongodbatlasreceiver/alerts_integration_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_integration_test.go
@@ -80,7 +80,7 @@ func TestAlertsReceiver(t *testing.T) {
 			payload, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", payloadName+".json"))
 			require.NoError(t, err)
 
-			req, err := http.NewRequest("POST", fmt.Sprintf("http://localhost:%s", testPort), bytes.NewBuffer(payload))
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://localhost:%s", testPort), bytes.NewBuffer(payload))
 			require.NoError(t, err)
 
 			b64HMAC, err := calculateHMACb64(testSecret, payload)
@@ -151,7 +151,7 @@ func TestAlertsReceiverTLS(t *testing.T) {
 			payload, err := os.ReadFile(filepath.Join("testdata", "alerts", "sample-payloads", payloadName+".json"))
 			require.NoError(t, err)
 
-			req, err := http.NewRequest("POST", fmt.Sprintf("https://localhost:%s", testPort), bytes.NewBuffer(payload))
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("https://localhost:%s", testPort), bytes.NewBuffer(payload))
 			require.NoError(t, err)
 
 			b64HMAC, err := calculateHMACb64(testSecret, payload)

--- a/receiver/mongodbatlasreceiver/alerts_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_test.go
@@ -260,7 +260,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "No ContentLength set",
 			request: &http.Request{
 				ContentLength: -1,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 				Header: map[string][]string{
@@ -275,7 +275,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "ContentLength too large",
 			request: &http.Request{
 				ContentLength: maxContentLength + 1,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 				Header: map[string][]string{
@@ -290,7 +290,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "ContentLength is incorrect for payload",
 			request: &http.Request{
 				ContentLength: 1,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 				Header: map[string][]string{
@@ -305,7 +305,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "ContentLength is larger than actual payload",
 			request: &http.Request{
 				ContentLength: 32,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 				Header: map[string][]string{
@@ -320,7 +320,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "No HMAC signature",
 			request: &http.Request{
 				ContentLength: 15,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 			},
@@ -332,7 +332,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "Incorrect HMAC signature",
 			request: &http.Request{
 				ContentLength: 15,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 				Header: map[string][]string{
@@ -347,7 +347,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "Invalid payload",
 			request: &http.Request{
 				ContentLength: 14,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"`)),
 				Header: map[string][]string{
@@ -362,7 +362,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "Consumer fails",
 			request: &http.Request{
 				ContentLength: 15,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 				Header: map[string][]string{
@@ -377,7 +377,7 @@ func TestHandleRequest(t *testing.T) {
 			name: "Request succeeds",
 			request: &http.Request{
 				ContentLength: 15,
-				Method:        "POST",
+				Method:        http.MethodPost,
 				URL:           &url.URL{},
 				Body:          io.NopCloser(bytes.NewBufferString(`{"id": "an-id"}`)),
 				Header: map[string][]string{

--- a/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
+++ b/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
@@ -77,7 +77,7 @@ func (rt *clientRoundTripper) RoundTrip(r *http.Request) (*http.Response, error)
 	if err != nil {
 		return nil, err // Can't do anything
 	}
-	if resp.StatusCode == 429 {
+	if resp.StatusCode == http.StatusTooManyRequests {
 		expBackoff := &backoff.ExponentialBackOff{
 			InitialInterval:     rt.backoffConfig.InitialInterval,
 			RandomizationFactor: backoff.DefaultRandomizationFactor,
@@ -110,7 +110,7 @@ func (rt *clientRoundTripper) RoundTrip(r *http.Request) (*http.Response, error)
 			if err != nil {
 				return nil, err
 			}
-			if resp.StatusCode != 429 {
+			if resp.StatusCode != http.StatusTooManyRequests {
 				break
 			}
 		}

--- a/receiver/nginxreceiver/scraper_test.go
+++ b/receiver/nginxreceiver/scraper_test.go
@@ -53,11 +53,11 @@ func TestScraper(t *testing.T) {
 func TestScraperError(t *testing.T) {
 	nginxMock := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/status" {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, _ = rw.Write([]byte(`Bad status page`))
 			return
 		}
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 	}))
 	t.Run("404", func(t *testing.T) {
 		sc := newNginxScraper(receivertest.NewNopSettings(), &Config{
@@ -103,7 +103,7 @@ func TestScraperFailedStart(t *testing.T) {
 func newMockServer(t *testing.T) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 		if req.URL.Path == "/status" {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err := rw.Write([]byte(`Active connections: 291
 server accepts handled requests
  16630948 16630946 31070465
@@ -112,6 +112,6 @@ Reading: 6 Writing: 179 Waiting: 106
 			assert.NoError(t, err)
 			return
 		}
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 	}))
 }

--- a/receiver/nsxtreceiver/client.go
+++ b/receiver/nsxtreceiver/client.go
@@ -170,7 +170,7 @@ func (c *nsxClient) doRequest(ctx context.Context, path string) ([]byte, error) 
 
 	body, _ := io.ReadAll(resp.Body)
 	switch resp.StatusCode {
-	case 403:
+	case http.StatusForbidden:
 		return nil, errUnauthorized
 	default:
 		c.logger.Info(fmt.Sprintf("%v", req))

--- a/receiver/nsxtreceiver/client_test.go
+++ b/receiver/nsxtreceiver/client_test.go
@@ -297,73 +297,73 @@ func mockServer(t *testing.T) *httptest.Server {
 		authUser, authPass, ok := req.BasicAuth()
 		switch {
 		case !ok:
-			rw.WriteHeader(401)
+			rw.WriteHeader(http.StatusUnauthorized)
 			return
 		case authUser == user500:
-			rw.WriteHeader(500)
+			rw.WriteHeader(http.StatusInternalServerError)
 			return
 		case authUser != goodUser || authPass != goodPassword:
-			rw.WriteHeader(403)
+			rw.WriteHeader(http.StatusForbidden)
 			return
 		}
 
 		if req.URL.Path == "/api/v1/transport-nodes" {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(tNodeBytes)
 			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == "/api/v1/cluster/nodes" {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(cNodeBytes)
 			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/cluster/nodes/%s/network/interfaces", managerNode1) {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(mNodeInterfaces)
 			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/transport-nodes/%s/status", transportNode1) {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(tNodeStatus)
 			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/transport-nodes/%s/network/interfaces", transportNode1) {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(tNodeInterfaces)
 			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/transport-nodes/%s/network/interfaces/%s/stats", transportNode1, transportNodeNic1) {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(tNodeInterfaceStats)
 			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/cluster/nodes/%s/network/interfaces/%s/stats", managerNode1, managerNodeNic1) {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(mNodeInterfaceStats)
 			assert.NoError(t, err)
 			return
 		}
 
 		if req.URL.Path == fmt.Sprintf("/api/v1/cluster/nodes/%s/status", managerNode1) {
-			rw.WriteHeader(200)
+			rw.WriteHeader(http.StatusOK)
 			_, err = rw.Write(mNodeStatus)
 			assert.NoError(t, err)
 			return
 		}
 
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 	}))
 
 	return nsxMock

--- a/receiver/podmanreceiver/libpod_client.go
+++ b/receiver/podmanreceiver/libpod_client.go
@@ -39,7 +39,7 @@ func newLibpodClient(logger *zap.Logger, cfg *Config) (PodmanClient, error) {
 }
 
 func (c *libpodClient) request(ctx context.Context, path string, params url.Values) (*http.Response, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", c.endpoint+path, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.endpoint+path, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -77,7 +77,7 @@ func (mp *mockPrometheus) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	defer mp.mu.Unlock()
 	iptr, ok := mp.accessIndex[req.URL.Path]
 	if !ok {
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
 	index := int(iptr.Load())
@@ -87,7 +87,7 @@ func (mp *mockPrometheus) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		if index == len(pages) {
 			mp.wg.Done()
 		}
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
 	switch {

--- a/receiver/prometheusreceiver/targetallocator/manager_test.go
+++ b/receiver/prometheusreceiver/targetallocator/manager_test.go
@@ -81,14 +81,14 @@ func (mta *MockTargetAllocator) ServeHTTP(rw http.ResponseWriter, req *http.Requ
 
 	iptr, ok := mta.accessIndex[req.URL.Path]
 	if !ok {
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
 	index := int(iptr.Load())
 	iptr.Add(1)
 	pages := mta.endpoints[req.URL.Path]
 	if index >= len(pages) {
-		rw.WriteHeader(404)
+		rw.WriteHeader(http.StatusNotFound)
 		return
 	}
 	rw.Header().Set("Content-Type", "application/json")

--- a/receiver/signalfxreceiver/receiver_test.go
+++ b/receiver/signalfxreceiver/receiver_test.go
@@ -194,7 +194,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest("PUT", "http://localhost", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost", nil),
 			assertResponse: func(t *testing.T, status int, body string) {
 				assert.Equal(t, http.StatusBadRequest, status)
 				assert.Equal(t, responseInvalidMethod, body)
@@ -205,7 +205,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -218,7 +218,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_type",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Header.Set("Content-Type", "application/not-protobuf")
 				return req
 			}(),
@@ -230,7 +230,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding_sfx",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
@@ -243,7 +243,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding_otlp",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Header.Set("Content-Type", otlpContentHeader)
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
@@ -256,7 +256,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "fail_to_read_body_sfx",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Body = badReqBody{}
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
@@ -269,7 +269,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "fail_to_read_body_otlp",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Body = badReqBody{}
 				req.Header.Set("Content-Type", otlpContentHeader)
 				return req
@@ -282,7 +282,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "bad_data_in_body_sfx",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader([]byte{1, 2, 3, 4}))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader([]byte{1, 2, 3, 4}))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -294,7 +294,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "bad_data_in_body_otlp",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader([]byte{1, 2, 3, 4}))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader([]byte{1, 2, 3, 4}))
 				req.Header.Set("Content-Type", otlpContentHeader)
 				return req
 			}(),
@@ -306,7 +306,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "empty_body_sfx",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(nil))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(nil))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -318,7 +318,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 		{
 			name: "empty_body_otlp",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(nil))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(nil))
 				req.Header.Set("Content-Type", otlpContentHeader)
 				return req
 			}(),
@@ -332,7 +332,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -346,7 +346,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := marshaler.MarshalMetrics(*otlpMetrics)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", otlpContentHeader)
 				return req
 			}(),
@@ -361,7 +361,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
 				msgBytes = compressGzip(t, msgBytes)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
@@ -377,7 +377,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 				msgBytes, err := marshaler.MarshalMetrics(*otlpMetrics)
 				require.NoError(t, err)
 				msgBytes = compressGzip(t, msgBytes)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", otlpContentHeader)
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
@@ -393,7 +393,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
 
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
@@ -409,7 +409,7 @@ func Test_sfxReceiver_handleReq(t *testing.T) {
 				msgBytes, err := marshaler.MarshalMetrics(*otlpMetrics)
 				require.NoError(t, err)
 
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", otlpContentHeader)
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
@@ -460,7 +460,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest("PUT", "http://localhost", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost", nil),
 			assertResponse: func(t *testing.T, status int, body string) {
 				assert.Equal(t, http.StatusBadRequest, status)
 				assert.Equal(t, responseInvalidMethod, body)
@@ -471,7 +471,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -484,7 +484,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "incorrect_content_type",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Header.Set("Content-Type", "application/x-protobuf;format=otlp")
 				return req
 			}(),
@@ -496,7 +496,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
@@ -509,7 +509,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "fail_to_read_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", nil)
 				req.Body = badReqBody{}
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
@@ -522,7 +522,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "bad_data_in_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader([]byte{1, 2, 3, 4}))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader([]byte{1, 2, 3, 4}))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -534,7 +534,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 		{
 			name: "empty_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(nil))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(nil))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -548,7 +548,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				return req
 			}(),
@@ -563,7 +563,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
 				msgBytes = compressGzip(t, msgBytes)
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
@@ -579,7 +579,7 @@ func Test_sfxReceiver_handleEventReq(t *testing.T) {
 				msgBytes, err := sFxMsg.Marshal()
 				require.NoError(t, err)
 
-				req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/x-protobuf")
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
@@ -667,7 +667,7 @@ func Test_sfxReceiver_TLS(t *testing.T) {
 
 	url := fmt.Sprintf("https://%s/v2/datapoint", addr)
 
-	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
 	require.NoErrorf(t, err, "should have no errors with new request: %v", err)
 	req.Header.Set("Content-Type", "application/x-protobuf")
 
@@ -782,7 +782,7 @@ func Test_sfxReceiver_DatapointAccessTokenPassthrough(t *testing.T) {
 				msgBytes, _ = sFxMsg.Marshal()
 				contentHeader = "application/x-protobuf"
 			}
-			req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 			req.Header.Set("Content-Type", contentHeader)
 			if tt.token != "" {
 				req.Header.Set("x-sf-token", tt.token)
@@ -861,7 +861,7 @@ func Test_sfxReceiver_EventAccessTokenPassthrough(t *testing.T) {
 			currentTime := time.Now().Unix() * 1e3
 			sFxMsg := buildSFxEventMsg(currentTime, 3)
 			msgBytes, _ := sFxMsg.Marshal()
-			req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 			req.Header.Set("Content-Type", "application/x-protobuf")
 			if tt.token != "" {
 				req.Header.Set("x-sf-token", tt.token)

--- a/receiver/skywalkingreceiver/skywalking_receiver_test.go
+++ b/receiver/skywalkingreceiver/skywalking_receiver_test.go
@@ -139,7 +139,7 @@ func TestHttpReception(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, mockSwReceiver.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, mockSwReceiver.Shutdown(context.Background())) })
-	req, err := http.NewRequest("POST", "http://127.0.0.1:12800/v3/segments", bytes.NewBuffer(traceJSON))
+	req, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:12800/v3/segments", bytes.NewBuffer(traceJSON))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -121,7 +121,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest("PUT", "http://localhost/foo", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost/foo", nil),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
 				status := resp.StatusCode
 				assert.Equal(t, http.StatusBadRequest, status)
@@ -133,7 +133,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Type", "application/not-json")
 				return req
 			}(),
@@ -149,7 +149,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/foo", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", nil)
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
 			}(),
@@ -162,7 +162,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 		{
 			name: "bad_data_in_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader([]byte{1, 2, 3, 4}))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader([]byte{1, 2, 3, 4}))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -174,7 +174,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 		{
 			name: "empty_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(nil))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(nil))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -188,7 +188,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(`{"foo":"bar"}`)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -204,7 +204,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				nilEventMsg.Event = nil
 				msgBytes, err := json.Marshal(nilEventMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -220,7 +220,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				blankEventMsg.Event = ""
 				msgBytes, err := json.Marshal(blankEventMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -234,7 +234,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -252,7 +252,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(buildSplunkHecMetricsMsg(3, 4, 3))
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -277,7 +277,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, gzipWriter.Close())
 
-				req := httptest.NewRequest("POST", "http://localhost/foo", &buf)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", &buf)
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
 			}(),
@@ -291,7 +291,7 @@ func Test_splunkhecReceiver_handleReq(t *testing.T) {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
 
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
 			}(),
@@ -350,7 +350,7 @@ func Test_consumer_err(t *testing.T) {
 	w := httptest.NewRecorder()
 	msgBytes, err := json.Marshal(splunkMsg)
 	require.NoError(t, err)
-	req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+	req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 	rcv.handleReq(w, req)
 
 	resp := w.Result()
@@ -378,7 +378,7 @@ func Test_consumer_err_metrics(t *testing.T) {
 	w := httptest.NewRecorder()
 	msgBytes, err := json.Marshal(splunkMsg)
 	require.NoError(t, err)
-	req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+	req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 	rcv.handleReq(w, req)
 
 	resp := w.Result()
@@ -452,7 +452,7 @@ func Test_splunkhecReceiver_TLS(t *testing.T) {
 
 	url := fmt.Sprintf("https://%s", addr)
 
-	req, err := http.NewRequestWithContext(context.Background(), "POST", url, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
 	require.NoErrorf(t, err, "should have no errors with new request: %v", err)
 
 	tlscs := configtls.ClientConfig{
@@ -574,7 +574,7 @@ func Test_splunkhecReceiver_AccessTokenPassthrough(t *testing.T) {
 				splunkhecMsg = buildSplunkHecMsg(currentTime, 3)
 			}
 			msgBytes, _ := json.Marshal(splunkhecMsg)
-			req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 			if tt.passthrough {
 				if tt.tokenProvided != "" {
 					req.Header.Set("Authorization", "Splunk "+tt.tokenProvided)
@@ -689,7 +689,7 @@ func Test_Logs_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			splunkhecMsg.Index = tt.index
 			splunkhecMsg.SourceType = tt.sourcetype
 			msgBytes, _ := json.Marshal(splunkhecMsg)
-			req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 
 			done := make(chan bool)
 			go func() {
@@ -790,7 +790,7 @@ func Test_Metrics_splunkhecReceiver_IndexSourceTypePassthrough(t *testing.T) {
 			splunkhecMsg.Index = tt.index
 			splunkhecMsg.SourceType = tt.sourcetype
 			msgBytes, _ := json.Marshal(splunkhecMsg)
-			req := httptest.NewRequest("POST", "http://localhost", bytes.NewReader(msgBytes))
+			req := httptest.NewRequest(http.MethodPost, "http://localhost", bytes.NewReader(msgBytes))
 
 			done := make(chan bool)
 			go func() {
@@ -898,7 +898,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest("PUT", "http://localhost/foo", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost/foo", nil),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
 				status := resp.StatusCode
 				assert.Equal(t, http.StatusBadRequest, status)
@@ -908,7 +908,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 		{
 			name: "incorrect_content_type",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/foo", strings.NewReader("foo\nbar"))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", strings.NewReader("foo\nbar"))
 				req.Header.Set("Content-Type", "application/not-json")
 				return req
 			}(),
@@ -920,7 +920,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 		{
 			name: "incorrect_content_encoding",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/foo", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", nil)
 				req.Header.Set("Content-Encoding", "superzipper")
 				return req
 			}(),
@@ -933,7 +933,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 		{
 			name: "empty_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(nil))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(nil))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -946,7 +946,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 		{
 			name: "two_logs",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/foo", strings.NewReader("foo\nbar"))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", strings.NewReader("foo\nbar"))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, _ any) {
@@ -959,7 +959,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			assertResponse: func(t *testing.T, resp *http.Response, body any) {
@@ -978,7 +978,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				require.NoError(t, err)
 				require.NoError(t, gzipWriter.Close())
 
-				req := httptest.NewRequest("POST", "http://localhost/foo", &buf)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", &buf)
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
 			}(),
@@ -992,7 +992,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
 
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
 			}(),
@@ -1008,7 +1008,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
 
-				req := httptest.NewRequest("POST", "http://localhost/service/collector/raw", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/service/collector/raw", bytes.NewReader(msgBytes))
 
 				q := req.URL.Query()
 				q.Add(queryTime, "-5")
@@ -1028,7 +1028,7 @@ func Test_splunkhecReceiver_handleRawReq(t *testing.T) {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
 
-				req := httptest.NewRequest("POST", "http://localhost/service/collector/raw", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/service/collector/raw", bytes.NewReader(msgBytes))
 
 				q := req.URL.Query()
 				q.Add(queryTime, "notANumber")
@@ -1128,7 +1128,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 	}{
 		{
 			name: "incorrect_method",
-			req:  httptest.NewRequest("PUT", "http://localhost/ack", nil),
+			req:  httptest.NewRequest(http.MethodPut, "http://localhost/ack", nil),
 			setupMockAckExtension: func() component.Component {
 				return &mockAckExtension{}
 			},
@@ -1141,7 +1141,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 		{
 			name: "no_channel_header",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/ack", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", nil)
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1156,7 +1156,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 		{
 			name: "invalid_channel_header",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/ack", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", nil)
 				req.Header.Set("X-Splunk-Request-Channel", "invalid-id")
 				return req
 			}(),
@@ -1172,7 +1172,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 		{
 			name: "empty_request_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/ack", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", nil)
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1190,7 +1190,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(buildSplunkHecAckMsg([]uint64{}))
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/ack", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1206,7 +1206,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 		{
 			name: "invalid_request_body",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/ack", bytes.NewReader([]byte(`hi there`)))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", bytes.NewReader([]byte(`hi there`)))
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1224,7 +1224,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(buildSplunkHecAckMsg([]uint64{1, 2, 3}))
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/ack", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1254,7 +1254,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(buildSplunkHecAckMsg([]uint64{1, 2, 3}))
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/ack", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack", bytes.NewReader(msgBytes))
 				req.Header.Set("x-splunk-request-channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1284,7 +1284,7 @@ func Test_splunkhecReceiver_handleAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(buildSplunkHecAckMsg([]uint64{1, 2, 3}))
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/ack?channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/ack?channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1364,7 +1364,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1379,7 +1379,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "")
 				return req
 			}(),
@@ -1397,7 +1397,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "invalid-id")
 				return req
 			}(),
@@ -1415,7 +1415,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1437,7 +1437,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("x-splunk-request-channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1459,7 +1459,7 @@ func Test_splunkhecReceiver_handleRawReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo?Channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo?Channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1530,7 +1530,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1548,7 +1548,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "")
 				return req
 			}(),
@@ -1569,7 +1569,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "invalid-id")
 				return req
 			}(),
@@ -1590,7 +1590,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("X-Splunk-Request-Channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1615,7 +1615,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(msgBytes))
 				req.Header.Set("x-splunk-request-channel", "fbd3036f-0f1c-4e98-b71c-d4cd61213f90")
 				return req
 			}(),
@@ -1640,7 +1640,7 @@ func Test_splunkhecReceiver_handleReq_WithAck(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST", "http://localhost/foo?channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90&isCheesy=true", bytes.NewReader(msgBytes))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/foo?channel=fbd3036f-0f1c-4e98-b71c-d4cd61213f90&isCheesy=true", bytes.NewReader(msgBytes))
 				return req
 			}(),
 			setupMockAckExtension: func() component.Component {
@@ -1709,7 +1709,7 @@ func Test_splunkhecreceiver_handleHealthPath(t *testing.T) {
 		assert.NoError(t, rcv.Shutdown(context.Background()))
 	}()
 	w := httptest.NewRecorder()
-	rcv.handleHealthReq(w, httptest.NewRequest("GET", "http://localhost/services/collector/health", nil))
+	rcv.handleHealthReq(w, httptest.NewRequest(http.MethodGet, "http://localhost/services/collector/health", nil))
 
 	resp := w.Result()
 	respBytes, err := io.ReadAll(resp.Body)
@@ -1774,7 +1774,7 @@ func Test_splunkhecreceiver_handle_nested_fields(t *testing.T) {
 			event.Fields["nested_map"] = tt.field
 			msgBytes, err := jsoniter.Marshal(event)
 			require.NoError(t, err)
-			req := httptest.NewRequest("POST", "http://localhost/services/collector", bytes.NewReader(msgBytes))
+			req := httptest.NewRequest(http.MethodPost, "http://localhost/services/collector", bytes.NewReader(msgBytes))
 
 			w := httptest.NewRecorder()
 			rcv.handleReq(w, req)
@@ -1821,7 +1821,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST",
+				req := httptest.NewRequest(http.MethodPost,
 					"http://localhost/foo?index=bar&source=bar&sourcetype=bar&host=bar",
 					bytes.NewReader(msgBytes))
 				return req
@@ -1846,7 +1846,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST",
+				req := httptest.NewRequest(http.MethodPost,
 					"http://localhost/foo?index=bar&source=bar",
 					bytes.NewReader(msgBytes))
 				return req
@@ -1871,7 +1871,7 @@ func Test_splunkhecReceiver_rawReqHasmetadataInResource(t *testing.T) {
 			req: func() *http.Request {
 				msgBytes, err := json.Marshal(splunkMsg)
 				require.NoError(t, err)
-				req := httptest.NewRequest("POST",
+				req := httptest.NewRequest(http.MethodPost,
 					"http://localhost/foo?foo=bar",
 					bytes.NewReader(msgBytes))
 				return req
@@ -1931,7 +1931,7 @@ func BenchmarkHandleReq(b *testing.B) {
 	}
 
 	for n := 0; n < b.N; n++ {
-		req := httptest.NewRequest("POST", "http://localhost/foo", bytes.NewReader(totalMessage))
+		req := httptest.NewRequest(http.MethodPost, "http://localhost/foo", bytes.NewReader(totalMessage))
 		rcv.handleReq(w, req)
 
 		resp := w.Result()
@@ -1954,7 +1954,7 @@ func Test_splunkhecReceiver_healthCheck_success(t *testing.T) {
 		{
 			name: "correct_healthcheck",
 			req: func() *http.Request {
-				req := httptest.NewRequest("GET", "http://localhost:0/services/collector/health", nil)
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:0/services/collector/health", nil)
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
@@ -1965,7 +1965,7 @@ func Test_splunkhecReceiver_healthCheck_success(t *testing.T) {
 		{
 			name: "correct_healthcheck_v1",
 			req: func() *http.Request {
-				req := httptest.NewRequest("GET", "http://localhost:0/services/collector/health/1.0", nil)
+				req := httptest.NewRequest(http.MethodGet, "http://localhost:0/services/collector/health/1.0", nil)
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {
@@ -1976,7 +1976,7 @@ func Test_splunkhecReceiver_healthCheck_success(t *testing.T) {
 		{
 			name: "incorrect_healthcheck_methods_v1",
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost:0/services/collector/health/1.0", nil)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost:0/services/collector/health/1.0", nil)
 				return req
 			}(),
 			assertResponse: func(t *testing.T, status int, body string) {

--- a/receiver/vcenterreceiver/internal/mockserver/client_mock.go
+++ b/receiver/vcenterreceiver/internal/mockserver/client_mock.go
@@ -53,7 +53,7 @@ func MockServer(t *testing.T, useTLS bool) *httptest.Server {
 
 		body, err := routeBody(t, requestType, sr.Envelope.Body)
 		if errors.Is(err, errNotFound) {
-			w.WriteHeader(404)
+			w.WriteHeader(http.StatusNotFound)
 			return
 		}
 		w.WriteHeader(http.StatusOK)

--- a/receiver/webhookeventreceiver/receiver_test.go
+++ b/receiver/webhookeventreceiver/receiver_test.go
@@ -83,7 +83,7 @@ func TestHandleReq(t *testing.T) {
 		{
 			desc: "Good request",
 			cfg:  *cfg,
-			req:  httptest.NewRequest("POST", "http://localhost/events", strings.NewReader("test")),
+			req:  httptest.NewRequest(http.MethodPost, "http://localhost/events", strings.NewReader("test")),
 		},
 		{
 			desc: "Good request with gzip",
@@ -107,14 +107,14 @@ func TestHandleReq(t *testing.T) {
 				_, err = gzipWriter.Write(msgJSON)
 				require.NoError(t, err, "Gzip writer failed")
 
-				req := httptest.NewRequest("POST", "http://localhost/events", &msg)
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/events", &msg)
 				return req
 			}(),
 		},
 		{
 			desc: "Multiple logs",
 			cfg:  *cfg,
-			req:  httptest.NewRequest("POST", "http://localhost/events", strings.NewReader("log1\nlog2")),
+			req:  httptest.NewRequest(http.MethodPost, "http://localhost/events", strings.NewReader("log1\nlog2")),
 		},
 	}
 
@@ -160,20 +160,20 @@ func TestFailedReq(t *testing.T) {
 		{
 			desc:   "Invalid method",
 			cfg:    *cfg,
-			req:    httptest.NewRequest("GET", "http://localhost/events", nil),
+			req:    httptest.NewRequest(http.MethodGet, "http://localhost/events", nil),
 			status: http.StatusBadRequest,
 		},
 		{
 			desc:   "Empty body",
 			cfg:    *cfg,
-			req:    httptest.NewRequest("POST", "http://localhost/events", strings.NewReader("")),
+			req:    httptest.NewRequest(http.MethodPost, "http://localhost/events", strings.NewReader("")),
 			status: http.StatusBadRequest,
 		},
 		{
 			desc: "Invalid encoding",
 			cfg:  *cfg,
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/events", strings.NewReader("test"))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/events", strings.NewReader("test"))
 				req.Header.Set("Content-Encoding", "glizzy")
 				return req
 			}(),
@@ -183,7 +183,7 @@ func TestFailedReq(t *testing.T) {
 			desc: "Valid content encoding header invalid data",
 			cfg:  *cfg,
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/events", strings.NewReader("notzipped"))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/events", strings.NewReader("notzipped"))
 				req.Header.Set("Content-Encoding", "gzip")
 				return req
 			}(),
@@ -193,7 +193,7 @@ func TestFailedReq(t *testing.T) {
 			desc: "Invalid required header value",
 			cfg:  *headerCfg,
 			req: func() *http.Request {
-				req := httptest.NewRequest("POST", "http://localhost/events", strings.NewReader("test"))
+				req := httptest.NewRequest(http.MethodPost, "http://localhost/events", strings.NewReader("test"))
 				req.Header.Set("key-present", "incorrect-value")
 				return req
 			}(),
@@ -235,7 +235,7 @@ func TestHealthCheck(t *testing.T) {
 	}()
 
 	w := httptest.NewRecorder()
-	r.handleHealthCheck(w, httptest.NewRequest("GET", "http://localhost/health", nil), httprouter.ParamsFromContext(context.Background()))
+	r.handleHealthCheck(w, httptest.NewRequest(http.MethodGet, "http://localhost/health", nil), httprouter.ParamsFromContext(context.Background()))
 
 	response := w.Result()
 	require.Equal(t, http.StatusOK, response.StatusCode)

--- a/receiver/zipkinreceiver/trace_receiver_test.go
+++ b/receiver/zipkinreceiver/trace_receiver_test.go
@@ -215,7 +215,7 @@ func TestReceiverContentTypes(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			r := httptest.NewRequest("POST", test.endpoint, requestBody)
+			r := httptest.NewRequest(http.MethodPost, test.endpoint, requestBody)
 			r.Header.Add("content-type", test.content)
 			r.Header.Add("content-encoding", test.encoding)
 
@@ -243,7 +243,7 @@ func TestReceiverContentTypes(t *testing.T) {
 func TestReceiverInvalidContentType(t *testing.T) {
 	body := `{ invalid json `
 
-	r := httptest.NewRequest("POST", "/api/v2/spans",
+	r := httptest.NewRequest(http.MethodPost, "/api/v2/spans",
 		bytes.NewBuffer([]byte(body)))
 	r.Header.Add("content-type", "application/json")
 
@@ -266,7 +266,7 @@ func TestReceiverConsumerError(t *testing.T) {
 	body, err := os.ReadFile(zipkinV2Single)
 	require.NoError(t, err)
 
-	r := httptest.NewRequest("POST", "/api/v2/spans", bytes.NewBuffer(body))
+	r := httptest.NewRequest(http.MethodPost, "/api/v2/spans", bytes.NewBuffer(body))
 	r.Header.Add("content-type", "application/json")
 
 	cfg := &Config{
@@ -288,7 +288,7 @@ func TestReceiverConsumerPermanentError(t *testing.T) {
 	body, err := os.ReadFile(zipkinV2Single)
 	require.NoError(t, err)
 
-	r := httptest.NewRequest("POST", "/api/v2/spans", bytes.NewBuffer(body))
+	r := httptest.NewRequest(http.MethodPost, "/api/v2/spans", bytes.NewBuffer(body))
 	r.Header.Add("content-type", "application/json")
 
 	cfg := &Config{
@@ -413,7 +413,7 @@ func TestReceiverConvertsStringsToTypes(t *testing.T) {
 	body, err := os.ReadFile(zipkinV2Single)
 	require.NoError(t, err, "Failed to read sample JSON file: %v", err)
 
-	r := httptest.NewRequest("POST", "/api/v2/spans", bytes.NewBuffer(body))
+	r := httptest.NewRequest(http.MethodPost, "/api/v2/spans", bytes.NewBuffer(body))
 	r.Header.Add("content-type", "application/json")
 
 	next := new(consumertest.TracesSink)


### PR DESCRIPTION
#### Description

[usestdlibvars](https://golangci-lint.run/usage/linters/#usestdlibvars) is a linter that detect the possibility to use variables/constants from the Go standard library.

Notice that's only the first part, the full conformity wil be ensured with one or two other PR as this one is already big to review