### PR TITLE
[exporter/signalfx] Add more default metrics related to Kubernetes

### DIFF
--- a/.chloggen/signalfxexporter-add-k8s-default-metrics.yaml
+++ b/.chloggen/signalfxexporter-add-k8s-default-metrics.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: signalfxexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add more default metrics related to Kubernetes cronjobs, jobs, statefulset, and hpa
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36026]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -600,7 +600,7 @@ func TestDefaultExcludes_not_translated(t *testing.T) {
 	require.NoError(t, err)
 
 	md := getMetrics(metrics)
-	require.Equal(t, 68, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
+	require.Equal(t, 54, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().Len())
 	dps := converter.MetricsToSignalFxV2(md)
 	require.Empty(t, dps)
 }

--- a/exporter/signalfxexporter/internal/translation/default_metrics.go
+++ b/exporter/signalfxexporter/internal/translation/default_metrics.go
@@ -85,21 +85,6 @@ exclude_metrics:
 
 # k8s metrics.
 - metric_names:
-  - k8s.cronjob.active_jobs
-  - k8s.job.active_pods
-  - k8s.job.desired_successful_pods
-  - k8s.job.failed_pods
-  - k8s.job.max_parallel_pods
-  - k8s.job.successful_pods
-  - k8s.statefulset.desired_pods
-  - k8s.statefulset.current_pods
-  - k8s.statefulset.ready_pods
-  - k8s.statefulset.updated_pods
-  - k8s.hpa.max_replicas
-  - k8s.hpa.min_replicas
-  - k8s.hpa.current_replicas
-  - k8s.hpa.desired_replicas
-
   # matches all container limit metrics but k8s.container.cpu_limit and k8s.container.memory_limit
   - /^k8s\.container\..+_limit$/
   - '!k8s.container.memory_limit'

--- a/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
+++ b/exporter/signalfxexporter/testdata/json/non_default_metrics_otel_convention.json
@@ -60,48 +60,6 @@
     "system.network.tcp_connections": null
   },
   {
-    "k8s.cronjob.active_jobs": null
-  },
-  {
-    "k8s.job.active_pods": null
-  },
-  {
-    "k8s.job.desired_successful_pods": null
-  },
-  {
-    "k8s.job.failed_pods": null
-  },
-  {
-    "k8s.job.max_parallel_pods": null
-  },
-  {
-    "k8s.job.successful_pods": null
-  },
-  {
-    "k8s.statefulset.desired_pods": null
-  },
-  {
-    "k8s.statefulset.current_pods": null
-  },
-  {
-    "k8s.statefulset.ready_pods": null
-  },
-  {
-    "k8s.statefulset.updated_pods": null
-  },
-  {
-    "k8s.hpa.max_replicas": null
-  },
-  {
-    "k8s.hpa.min_replicas": null
-  },
-  {
-    "k8s.hpa.current_replicas": null
-  },
-  {
-    "k8s.hpa.desired_replicas": null
-  },
-  {
     "k8s.container.ephemeral-storage_limit": null
   },
   {


### PR DESCRIPTION
- Add more default metrics related to Kubernetes cronjobs, jobs, statefulset, and hpa.
- Only unit tests need to be updated for this PR in this repository. Tests in downstream projects will be updated to accommodate these changes as well.