### PR TITLE
(internal/otelarrow) Remove time-based test in e2e tests

### DIFF
--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -93,13 +93,6 @@ func (tc *testConsumer) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 	timeout := time.Until(dead)
 
 	require.Equal(tc.t, tc.expectDeadline, hasDeadline, "deadline set or not set: %v", timeout)
-	if tc.expectDeadline {
-		// expect allows 1/6 of the deadline to elapse in transit,
-		// so 1m becomes 50s.
-		expect := tc.expCfg.TimeoutSettings.Timeout * 5 / 6
-		require.Less(tc.t, expect, timeout)
-		require.Greater(tc.t, tc.expCfg.TimeoutSettings.Timeout, timeout)
-	}
 
 	return tc.sink.ConsumeTraces(ctx, td)
 }


### PR DESCRIPTION
#### Description

Remove a flaky portion of the internal/otelarrow/test e2e test.
#### Link to tracking issue
Fixes #34719.

#### Testing

There was a time-based test that has proven unreliable.

#### Documentation

n/a