### PR TITLE
[exporter/signalfx] Retry property update without tags

### DIFF
--- a/.chloggen/signalfx-exp-retry-dim-update-without-tags.yaml
+++ b/.chloggen/signalfx-exp-retry-dim-update-without-tags.yaml
@@ -1,0 +1,27 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: exporter/signalfx
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Enabling retrying for dimension properties update without tags in case of 400 response error.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36044]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Property and tag updates are done using the same API call. After this change, the exporter will retry once to sync
+  properties in case of 400 response error.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]


### PR DESCRIPTION
Property and tag updates are done using the same API call. Sometimes, there might be too many tags associated with a dimension key/value pair, so the backend rejects the request. We want to retry the call without tags in that situation, given that properties are more valuable and should not be lost because of an excessive amount of tags coming with them.

There is no easy way to add a unit test for this change to the current unit tests framework due to its limitations. I'm working on changing it, which will come in a separate PR.