### PR TITLE
[connector/routing] Add ability to route logs by request context

### DIFF
--- a/.chloggen/routing-connector-by-request.yaml
+++ b/.chloggen/routing-connector-by-request.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add ability to route logs by request metadata.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [19738]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/routingconnector/config_test.go
+++ b/connector/routingconnector/config_test.go
@@ -232,7 +232,37 @@ func TestValidateConfig(t *testing.T) {
 					},
 				},
 			},
-			error: "log context is not supported with match_once: false",
+			error: `"log" context is not supported with "match_once: false"`,
+		},
+		{
+			name: "request context with statement",
+			config: &Config{
+				Table: []RoutingTableItem{
+					{
+						Context:   "request",
+						Statement: `route() where attributes["attr"] == "acme"`,
+						Pipelines: []pipeline.ID{
+							pipeline.NewIDWithName(pipeline.SignalTraces, "otlp"),
+						},
+					},
+				},
+			},
+			error: `"request" context requires a 'condition'`,
+		},
+		{
+			name: "request context with invalid condition",
+			config: &Config{
+				Table: []RoutingTableItem{
+					{
+						Context:   "request",
+						Condition: `attributes["attr"] == "acme"`,
+						Pipelines: []pipeline.ID{
+							pipeline.NewIDWithName(pipeline.SignalTraces, "otlp"),
+						},
+					},
+				},
+			},
+			error: `condition must have format 'request["<name>"] <comparator> <value>'`,
 		},
 	}
 

--- a/connector/routingconnector/go.mod
+++ b/connector/routingconnector/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.112.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.112.0
 	github.com/stretchr/testify v1.9.0
+	go.opentelemetry.io/collector/client v1.18.0
 	go.opentelemetry.io/collector/component v0.112.0
 	go.opentelemetry.io/collector/confmap v1.18.0
 	go.opentelemetry.io/collector/connector v0.112.0
@@ -17,6 +18,8 @@ require (
 	go.opentelemetry.io/collector/pipeline v0.112.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
+	google.golang.org/grpc v1.67.1
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -68,10 +71,8 @@ require (
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240822170219-fc7c04adadcd // indirect
-	google.golang.org/grpc v1.67.1 // indirect
 	google.golang.org/protobuf v1.35.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl => ../../pkg/ottl

--- a/connector/routingconnector/go.sum
+++ b/connector/routingconnector/go.sum
@@ -85,6 +85,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 go.opentelemetry.io/collector v0.112.0 h1:yyA9hC2FTIRs4T418cQHxgei82oa9uNugFQIeNjRzv0=
 go.opentelemetry.io/collector v0.112.0/go.mod h1:AgSN5Wd8mcHaOnBTgo0zdS03E9HuFp2ccKpVRs5YFz8=
+go.opentelemetry.io/collector/client v1.18.0 h1:wk+R3wpeleTIrk+xX85ICKBJ6GeZQ50Hk5DthRpOpUQ=
+go.opentelemetry.io/collector/client v1.18.0/go.mod h1:33ntN6gwIfa1JCnQfQDSImIBY8Gfe66kv+MjQ/C37Fk=
 go.opentelemetry.io/collector/component v0.112.0 h1:Hw125Tdb427yKkzFx3U/OsfPATYXsbURkc27dn19he8=
 go.opentelemetry.io/collector/component v0.112.0/go.mod h1:hV9PEgkNlVAySX+Oo/g7+NcLe234L04kRXw6uGj3VEw=
 go.opentelemetry.io/collector/config/configtelemetry v0.112.0 h1:MVBrWJUoqfKrORI38dY8OV0i5d1RRHR/ACIBu9TOcZ8=

--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -475,6 +475,13 @@ func TestLogsConnectorCapabilities(t *testing.T) {
 
 func TestLogsConnectorDetailed(t *testing.T) {
 	testCases := []string{
+		filepath.Join("testdata", "logs", "request_context", "match_any_value"),
+		filepath.Join("testdata", "logs", "request_context", "match_grpc_value"),
+		filepath.Join("testdata", "logs", "request_context", "match_http_value"),
+		filepath.Join("testdata", "logs", "request_context", "match_http_value2"),
+		filepath.Join("testdata", "logs", "request_context", "match_no_grpc_value"),
+		filepath.Join("testdata", "logs", "request_context", "match_no_http_value"),
+		filepath.Join("testdata", "logs", "request_context", "no_request_values"),
 		filepath.Join("testdata", "logs", "resource_context", "all_match_first_only"),
 		filepath.Join("testdata", "logs", "resource_context", "all_match_last_only"),
 		filepath.Join("testdata", "logs", "resource_context", "all_match_once"),
@@ -489,8 +496,12 @@ func TestLogsConnectorDetailed(t *testing.T) {
 		filepath.Join("testdata", "logs", "log_context", "with_resource_condition"),
 		filepath.Join("testdata", "logs", "log_context", "with_scope_condition"),
 		filepath.Join("testdata", "logs", "log_context", "with_resource_and_scope_conditions"),
-		filepath.Join("testdata", "logs", "mixed_context", "match_resource_then_logs"),
+		filepath.Join("testdata", "logs", "mixed_context", "match_logs_then_grpc_request"),
+		filepath.Join("testdata", "logs", "mixed_context", "match_logs_then_http_request"),
 		filepath.Join("testdata", "logs", "mixed_context", "match_logs_then_resource"),
+		filepath.Join("testdata", "logs", "mixed_context", "match_resource_then_grpc_request"),
+		filepath.Join("testdata", "logs", "mixed_context", "match_resource_then_http_request"),
+		filepath.Join("testdata", "logs", "mixed_context", "match_resource_then_logs"),
 	}
 
 	for _, tt := range testCases {
@@ -539,10 +550,17 @@ func TestLogsConnectorDetailed(t *testing.T) {
 				t.Fatalf("Error reading sink_default.yaml: %v", readErr)
 			}
 
+			ctx := context.Background()
+			if ctxFromFile, readErr := createContextFromFile(t, filepath.Join(tt, "request.yaml")); readErr == nil {
+				ctx = ctxFromFile
+			} else if !os.IsNotExist(readErr) {
+				t.Fatalf("Error reading request.yaml: %v", readErr)
+			}
+
 			input, readErr := golden.ReadLogs(filepath.Join(tt, "input.yaml"))
 			require.NoError(t, readErr)
 
-			require.NoError(t, conn.ConsumeLogs(context.Background(), input))
+			require.NoError(t, conn.ConsumeLogs(ctx, input))
 
 			if expected0 == nil {
 				assert.Empty(t, sink0.AllLogs(), "sink0 should be empty")

--- a/connector/routingconnector/request.go
+++ b/connector/routingconnector/request.go
@@ -1,0 +1,105 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package routingconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/collector/client"
+	"google.golang.org/grpc/metadata"
+)
+
+// This file defines an extremely simple request condition grammar. The goal is to provide a similar feel to OTTL,
+// but it's not clear that anything more than a simple comparison is needed.  We can expand this grammar in the
+// future if needed. For now, it expects the condition to be in exactly the format:
+// 'request["<name>"] <comparator> <value>' where <comparator> is either '==' or '!='.
+
+var requestFieldRegex = regexp.MustCompile(`request\[".*"\]`)
+var valueFieldRegex = regexp.MustCompile(`".*"`)
+var comparatorRegex = regexp.MustCompile(`==|!=`)
+
+type requestCondition struct {
+	attributeName string
+	compareFunc   func(string) bool
+}
+
+func parseRequestCondition(condition string) (*requestCondition, error) {
+	if condition == "" {
+		return nil, errors.New("condition is empty")
+	}
+
+	comparators := comparatorRegex.FindAllString(condition, 2)
+	switch {
+	case len(comparators) == 0:
+		return nil, errors.New("condition does not contain a valid comparator")
+	case len(comparators) > 1:
+		return nil, errors.New("condition contains multiple comparators")
+	}
+
+	parts := strings.Split(condition, comparators[0])
+	if len(parts) < 2 {
+		return nil, errors.New("condition does not contain a valid comparator")
+	}
+	if len(parts) > 2 {
+		return nil, errors.New("condition contains multiple comparators")
+	}
+	parts[0] = strings.TrimSpace(parts[0])
+	parts[1] = strings.TrimSpace(parts[1])
+
+	if !requestFieldRegex.MatchString(parts[0]) {
+		return nil, errors.New(`condition must have format 'request["<name>"] <comparator> <value>'`)
+	}
+	if !valueFieldRegex.MatchString(parts[1]) {
+		return nil, errors.New(`condition must have format 'request["<name>"] <comparator> "<value>"'`)
+	}
+	valueWithoutQuotes := strings.TrimSuffix(strings.TrimPrefix(parts[1], `"`), `"`)
+
+	compareFunc := func(value string) bool {
+		return value == valueWithoutQuotes
+	}
+	if comparators[0] == "!=" {
+		compareFunc = func(value string) bool {
+			return value != valueWithoutQuotes
+		}
+	}
+
+	return &requestCondition{
+		attributeName: strings.TrimSuffix(strings.TrimPrefix(parts[0], `request["`), `"]`),
+		compareFunc:   compareFunc,
+	}, nil
+}
+
+func (rc *requestCondition) matchRequest(ctx context.Context) bool {
+	return rc.matchGRPC(ctx) || rc.matchHTTP(ctx)
+}
+
+func (rc *requestCondition) matchGRPC(ctx context.Context) bool {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return false
+	}
+	values, ok := md[strings.ToLower(rc.attributeName)]
+	if !ok {
+		return false
+	}
+	for _, value := range values {
+		if rc.compareFunc(value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (rc *requestCondition) matchHTTP(ctx context.Context) bool {
+	values := client.FromContext(ctx).Metadata.Get(rc.attributeName)
+	for _, value := range values {
+		if rc.compareFunc(value) {
+			return true
+		}
+	}
+	return false
+}

--- a/connector/routingconnector/request_test.go
+++ b/connector/routingconnector/request_test.go
@@ -1,0 +1,42 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package routingconnector // import "github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector"
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"go.opentelemetry.io/collector/client"
+	"google.golang.org/grpc/metadata"
+	"gopkg.in/yaml.v3"
+)
+
+type ctxConfig struct {
+	GRPC map[string]string   `mapstructure:"grpc"`
+	HTTP map[string][]string `mapstructure:"http"`
+}
+
+func createContextFromFile(t *testing.T, filePath string) (context.Context, error) {
+	t.Helper()
+
+	b, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	var cfg ctxConfig
+	if err := yaml.Unmarshal(b, &cfg); err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	if len(cfg.GRPC) > 0 {
+		ctx = metadata.NewIncomingContext(ctx, metadata.New(cfg.GRPC))
+	}
+	if len(cfg.HTTP) > 0 {
+		ctx = client.NewContext(ctx, client.Info{Metadata: client.NewMetadata(cfg.HTTP)})
+	}
+	return ctx, nil
+}

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/config.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: attributes["logName"] == "logA"
+      pipelines:
+        - logs/0
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/input.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/request.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/request.yaml
@@ -1,0 +1,2 @@
+grpc:
+  X-Tenant: acme

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/sink_0.yaml
@@ -1,0 +1,105 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_grpc_request/sink_1.yaml
@@ -1,0 +1,105 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/config.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: log
+      condition: attributes["logName"] == "logA"
+      pipelines:
+        - logs/0
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/input.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/request.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/request.yaml
@@ -1,0 +1,2 @@
+http:
+  X-Tenant: [ acme ]

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/sink_0.yaml
@@ -1,0 +1,105 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_logs_then_http_request/sink_1.yaml
@@ -1,0 +1,105 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/config.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: resource
+      condition: attributes["resourceName"] == "resourceA"
+      pipelines:
+        - logs/0
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/input.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/request.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/request.yaml
@@ -1,0 +1,2 @@
+grpc:
+  X-Tenant: acme

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/sink_0.yaml
@@ -1,0 +1,72 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_grpc_request/sink_1.yaml
@@ -1,0 +1,71 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/config.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/config.yaml
@@ -1,0 +1,13 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: resource
+      condition: attributes["resourceName"] == "resourceA"
+      pipelines:
+        - logs/0
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/1

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/input.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/request.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/request.yaml
@@ -1,0 +1,2 @@
+http:
+  X-Tenant: [ acme ]

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/sink_0.yaml
@@ -1,0 +1,72 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+

--- a/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/sink_1.yaml
+++ b/connector/routingconnector/testdata/logs/mixed_context/match_resource_then_http_request/sink_1.yaml
@@ -1,0 +1,71 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_any_value/config.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_any_value/config.yaml
@@ -1,0 +1,9 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/0

--- a/connector/routingconnector/testdata/logs/request_context/match_any_value/input.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_any_value/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_any_value/request.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_any_value/request.yaml
@@ -1,0 +1,4 @@
+grpc:
+  X-Tenant: notacme
+http:
+  X-Tenant: [ notacme, acme ]

--- a/connector/routingconnector/testdata/logs/request_context/match_any_value/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_any_value/sink_0.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_grpc_value/config.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_grpc_value/config.yaml
@@ -1,0 +1,9 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/0

--- a/connector/routingconnector/testdata/logs/request_context/match_grpc_value/input.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_grpc_value/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_grpc_value/request.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_grpc_value/request.yaml
@@ -1,0 +1,2 @@
+grpc:
+  X-Tenant: acme

--- a/connector/routingconnector/testdata/logs/request_context/match_grpc_value/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_grpc_value/sink_0.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value/config.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value/config.yaml
@@ -1,0 +1,9 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/0

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value/input.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value/request.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value/request.yaml
@@ -1,0 +1,2 @@
+http:
+  X-Tenant: [ acme ]

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value/sink_0.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value2/config.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value2/config.yaml
@@ -1,0 +1,9 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/0

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value2/input.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value2/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value2/request.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value2/request.yaml
@@ -1,0 +1,2 @@
+http:
+  X-Tenant: [ notacme, acme ]

--- a/connector/routingconnector/testdata/logs/request_context/match_http_value2/sink_0.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_http_value2/sink_0.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/config.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/config.yaml
@@ -1,0 +1,9 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/0

--- a/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/input.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/request.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/request.yaml
@@ -1,0 +1,2 @@
+grpc:
+  X-Tenant: notacme

--- a/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_grpc_value/sink_default.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_no_http_value/config.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_http_value/config.yaml
@@ -1,0 +1,9 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/0

--- a/connector/routingconnector/testdata/logs/request_context/match_no_http_value/input.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_http_value/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/match_no_http_value/request.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_http_value/request.yaml
@@ -1,0 +1,2 @@
+http:
+  X-Tenant: [ notacme ]

--- a/connector/routingconnector/testdata/logs/request_context/match_no_http_value/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/match_no_http_value/sink_default.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/no_request_values/config.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/no_request_values/config.yaml
@@ -1,0 +1,9 @@
+routing:
+  match_once: true
+  default_pipelines:
+    - logs/default
+  table:
+    - context: request
+      condition: request["X-Tenant"] == "acme"
+      pipelines:
+        - logs/0

--- a/connector/routingconnector/testdata/logs/request_context/no_request_values/input.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/no_request_values/input.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0

--- a/connector/routingconnector/testdata/logs/request_context/no_request_values/sink_default.yaml
+++ b/connector/routingconnector/testdata/logs/request_context/no_request_values/sink_default.yaml
@@ -1,0 +1,141 @@
+resourceLogs:
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceA
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceA
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0
+  - resource:
+      attributes:
+        - key: resourceName
+          value:
+            stringValue: resourceB
+        - key: resourceNameAgain
+          value:
+            stringValue: resourceB
+    schemaUrl: https://opentelemetry.io/schemas/1.6.1
+    scopeLogs:
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeA
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeA
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeA
+          version: v0.1.0
+      - attributes:
+          - key: scopeName
+            value:
+              stringValue: scopeB
+          - key: scopeNameAgain
+            value:
+              stringValue: scopeB
+        logRecords:
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logA
+              - key: logNameAgain
+                value:
+                  stringValue: logA
+            body:
+              stringValue: logA
+          - attributes:
+              - key: logName
+                value:
+                  stringValue: logB
+              - key: logNameAgain
+                value:
+                  stringValue: logB
+            body:
+              stringValue: logB
+        schemaUrl: https://opentelemetry.io/schemas/1.6.1
+        scope:
+          name: scopeB
+          version: v0.1.0


### PR DESCRIPTION
This PR adds the ability to route logs based on request context. Specifically, [values from an incoming context](https://github.com/grpc/grpc-go/blob/v1.67.1/metadata/metadata.go#L216) as defined in `google.golang.org/grpc/metadata` and [client metadata](https://pkg.go.dev/go.opentelemetry.io/collector/client#Metadata) values as defined in `go.opentelemetry.io/collector/client`.

Request based routing is implemented as a feature of an individual route. This allows mixing of contexts within a table, so that e.g. you can route low severity logs to one route, route some logs based on resource, and then route the remainder based on request metadata. Notably, when request metadata is matched, this indicates a match for the entire `plog.Logs`, so all remaining data in that structure (i.e. data that hasn't already matched a previous route) will be routed immediately.