### PR TITLE
(internal/otelarrow) Fix timing test flake

### DIFF
--- a/internal/otelarrow/compression/zstd/mru_test.go
+++ b/internal/otelarrow/compression/zstd/mru_test.go
@@ -75,7 +75,9 @@ func TestMRUReset(t *testing.T) {
 	require.Equal(t, 1, m.Size())
 
 	// Ensure the monotonic clock has has advanced before resetting.
-	time.Sleep(10 * time.Millisecond)
+	for time.Since(time.Time(g)) <= 0 {
+		time.Sleep(10 * time.Millisecond)
+	}
 
 	m.Reset()
 	require.Equal(t, 0, m.Size())


### PR DESCRIPTION
#### Description

Fixes MRU_Reset test.

#### Link to tracking issue

Fixes #34252 

#### Testing

This repairs a test by ensuring that a clock advances. 

#### Documentation

n/a