### PR TITLE
[exporter/loadbalancing] Add top level sending_queue, retry_on_failure and timeout settings

### DIFF
--- a/.chloggen/feat_loadbalancing-exporter-queue.yaml
+++ b/.chloggen/feat_loadbalancing-exporter-queue.yaml
@@ -15,7 +15,9 @@ issues: [35378,16826]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: OTLP sub-exporter queue will be automatically disabled if loadbalancing exporter queue is enabled to avoid data loss
+subtext: |
+  When switching to top-level sending_queue configuration - users should carefully review queue size
+  In some rare cases setting top-level queue size to n*queueSize might be not enough to prevent data loss
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/feat_loadbalancing-exporter-queue.yaml
+++ b/.chloggen/feat_loadbalancing-exporter-queue.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: loadbalancingexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adding sending_queue, retry_on_failure and timeout settings to loadbalancing exporter configuration
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35378,16826]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: OTLP sub-exporter queue will be automatically disabled if loadbalancing exporter queue is enabled to avoid data loss
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/loadbalancingexporter/config.go
+++ b/exporter/loadbalancingexporter/config.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/servicediscovery/types"
+	"go.opentelemetry.io/collector/config/configretry"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 )
 
@@ -30,6 +32,10 @@ const (
 
 // Config defines configuration for the exporter.
 type Config struct {
+	TimeoutSettings           exporterhelper.TimeoutConfig `mapstructure:",squash"`
+	configretry.BackOffConfig `mapstructure:"retry_on_failure"`
+	QueueSettings             exporterhelper.QueueConfig `mapstructure:"sending_queue"`
+
 	Protocol   Protocol         `mapstructure:"protocol"`
 	Resolver   ResolverSettings `mapstructure:"resolver"`
 	RoutingKey string           `mapstructure:"routing_key"`

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -7,12 +7,20 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"fmt"
 
 	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/exporter"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
+)
+
+const (
+	zapEndpointKey = "endpoint"
 )
 
 // NewFactory creates a factory for the exporter.
@@ -32,20 +40,98 @@ func createDefaultConfig() component.Config {
 	otlpDefaultCfg.Endpoint = "placeholder:4317"
 
 	return &Config{
+		TimeoutSettings: exporterhelper.NewDefaultTimeoutConfig(),
+		QueueSettings:   exporterhelper.NewDefaultQueueConfig(),
+		BackOffConfig:   configretry.NewDefaultBackOffConfig(),
 		Protocol: Protocol{
 			OTLP: *otlpDefaultCfg,
 		},
 	}
 }
 
-func createTracesExporter(_ context.Context, params exporter.Settings, cfg component.Config) (exporter.Traces, error) {
-	return newTracesExporter(params, cfg)
+func buildExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
+	oCfg := cfg.Protocol.OTLP
+	oCfg.Endpoint = endpoint
+	// If top level queue is enabled - per-endpoint queue must be disable
+	// This helps us to avoid unexpected issues with mixing 2 level of exporter queues
+	if cfg.QueueSettings.Enabled {
+		oCfg.QueueConfig.Enabled = false
+	}
+	return oCfg
 }
 
-func createLogsExporter(_ context.Context, params exporter.Settings, cfg component.Config) (exporter.Logs, error) {
-	return newLogsExporter(params, cfg)
+func buildExporterSettings(params exporter.Settings, endpoint string) exporter.Settings {
+	// Override child exporter ID to segregate metrics from loadbalancing top level
+	childName := endpoint
+	if params.ID.Name() != "" {
+		childName = fmt.Sprintf("%s_%s", params.ID.Name(), childName)
+	}
+	params.ID = component.NewIDWithName(params.ID.Type(), childName)
+	// Add "endpoint" attribute to child exporter logger to segregate logs from loadbalancing top level
+	params.Logger = params.Logger.With(zap.String(zapEndpointKey, endpoint))
+
+	return params
 }
 
-func createMetricsExporter(_ context.Context, params exporter.Settings, cfg component.Config) (exporter.Metrics, error) {
-	return newMetricsExporter(params, cfg)
+func createTracesExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Traces, error) {
+	c := cfg.(*Config)
+	exporter, err := newTracesExporter(params, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("cannot configure loadbalancing traces exporter: %w", err)
+	}
+
+	return exporterhelper.NewTraces(
+		ctx,
+		params,
+		cfg,
+		exporter.ConsumeTraces,
+		exporterhelper.WithStart(exporter.Start),
+		exporterhelper.WithShutdown(exporter.Shutdown),
+		exporterhelper.WithCapabilities(exporter.Capabilities()),
+		exporterhelper.WithTimeout(c.TimeoutSettings),
+		exporterhelper.WithQueue(c.QueueSettings),
+		exporterhelper.WithRetry(c.BackOffConfig),
+	)
+	}
+
+func createLogsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Logs, error) {
+	c := cfg.(*Config)
+	exporter, err := newLogsExporter(params, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("cannot configure loadbalancing logs exporter: %w", err)
+}
+
+	return exporterhelper.NewLogs(
+		ctx,
+		params,
+		cfg,
+		exporter.ConsumeLogs,
+		exporterhelper.WithStart(exporter.Start),
+		exporterhelper.WithShutdown(exporter.Shutdown),
+		exporterhelper.WithCapabilities(exporter.Capabilities()),
+		exporterhelper.WithTimeout(c.TimeoutSettings),
+		exporterhelper.WithQueue(c.QueueSettings),
+		exporterhelper.WithRetry(c.BackOffConfig),
+	)
+}
+
+func createMetricsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Metrics, error) {
+	c := cfg.(*Config)
+	exporter, err := newMetricsExporter(params, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("cannot configure loadbalancing metrics exporter: %w", err)
+}
+
+	return exporterhelper.NewMetrics(
+		ctx,
+		params,
+		cfg,
+		exporter.ConsumeMetrics,
+		exporterhelper.WithStart(exporter.Start),
+		exporterhelper.WithShutdown(exporter.Shutdown),
+		exporterhelper.WithCapabilities(exporter.Capabilities()),
+		exporterhelper.WithTimeout(c.TimeoutSettings),
+		exporterhelper.WithQueue(c.QueueSettings),
+		exporterhelper.WithRetry(c.BackOffConfig),
+	)
 }

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -52,11 +52,7 @@ func createDefaultConfig() component.Config {
 func buildExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
 	oCfg := cfg.Protocol.OTLP
 	oCfg.Endpoint = endpoint
-	// If top level queue is enabled - per-endpoint queue must be disable
-	// This helps us to avoid unexpected issues with mixing 2 level of exporter queues
-	if cfg.QueueSettings.Enabled {
-		oCfg.QueueConfig.Enabled = false
-	}
+
 	return oCfg
 }
 

--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -92,14 +92,14 @@ func createTracesExporter(ctx context.Context, params exporter.Settings, cfg com
 		exporterhelper.WithQueue(c.QueueSettings),
 		exporterhelper.WithRetry(c.BackOffConfig),
 	)
-	}
+}
 
 func createLogsExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Logs, error) {
 	c := cfg.(*Config)
 	exporter, err := newLogsExporter(params, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure loadbalancing logs exporter: %w", err)
-}
+	}
 
 	return exporterhelper.NewLogs(
 		ctx,
@@ -120,7 +120,7 @@ func createMetricsExporter(ctx context.Context, params exporter.Settings, cfg co
 	exporter, err := newMetricsExporter(params, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure loadbalancing metrics exporter: %w", err)
-}
+	}
 
 	return exporterhelper.NewMetrics(
 		ctx,

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -91,9 +91,6 @@ func TestBuildExporterConfig(t *testing.T) {
 	// verify
 	grpcSettings := defaultCfg.ClientConfig
 	grpcSettings.Endpoint = "the-endpoint"
-	if c.(*Config).QueueSettings.Enabled {
-		defaultCfg.QueueConfig.Enabled = false
-	}
 	assert.Equal(t, grpcSettings, exporterCfg.ClientConfig)
 
 	assert.Equal(t, defaultCfg.TimeoutConfig, exporterCfg.TimeoutConfig)

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -101,38 +101,6 @@ func TestBuildExporterConfig(t *testing.T) {
 	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
 }
 
-func TestBuildExporterConfigUnknown(t *testing.T) {
-	// prepare
-	factories, err := otelcoltest.NopFactories()
-	require.NoError(t, err)
-
-	factories.Exporters[metadata.Type] = NewFactory()
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
-	// nolint:staticcheck
-	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "test-build-exporter-config.yaml"), factories)
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	c := cfg.Exporters[component.NewID(metadata.Type)]
-	require.NotNil(t, c)
-
-	// test
-	defaultCfg := otlpexporter.NewFactory().CreateDefaultConfig().(*otlpexporter.Config)
-	exporterCfg := buildExporterConfig(c.(*Config), "the-endpoint")
-
-	// verify
-	grpcSettings := defaultCfg.ClientConfig
-	grpcSettings.Endpoint = "the-endpoint"
-	if c.(*Config).QueueSettings.Enabled {
-		defaultCfg.QueueConfig.Enabled = false
-	}
-	assert.Equal(t, grpcSettings, exporterCfg.ClientConfig)
-
-	assert.Equal(t, defaultCfg.TimeoutConfig, exporterCfg.TimeoutConfig)
-	assert.Equal(t, defaultCfg.QueueConfig, exporterCfg.QueueConfig)
-	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
-}
-
 func TestBuildExporterSettings(t *testing.T) {
 	// prepare
 	creationParams := exportertest.NewNopSettings()

--- a/exporter/loadbalancingexporter/factory_test.go
+++ b/exporter/loadbalancingexporter/factory_test.go
@@ -5,10 +5,20 @@ package loadbalancingexporter
 
 import (
 	"context"
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter/exportertest"
+	"go.opentelemetry.io/collector/exporter/otlpexporter"
+	"go.opentelemetry.io/collector/otelcol/otelcoltest"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 )
 
 func TestTracesExporterGetsCreatedWithValidConfiguration(t *testing.T) {
@@ -57,4 +67,94 @@ func TestOTLPConfigIsValid(t *testing.T) {
 
 	// verify
 	assert.NoError(t, otlpCfg.Validate())
+}
+
+func TestBuildExporterConfig(t *testing.T) {
+	// prepare
+	factories, err := otelcoltest.NopFactories()
+	require.NoError(t, err)
+
+	factories.Exporters[metadata.Type] = NewFactory()
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
+	// nolint:staticcheck
+	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "test-build-exporter-config.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	c := cfg.Exporters[component.NewID(metadata.Type)]
+	require.NotNil(t, c)
+
+	// test
+	defaultCfg := otlpexporter.NewFactory().CreateDefaultConfig().(*otlpexporter.Config)
+	exporterCfg := buildExporterConfig(c.(*Config), "the-endpoint")
+
+	// verify
+	grpcSettings := defaultCfg.ClientConfig
+	grpcSettings.Endpoint = "the-endpoint"
+	if c.(*Config).QueueSettings.Enabled {
+		defaultCfg.QueueConfig.Enabled = false
+	}
+	assert.Equal(t, grpcSettings, exporterCfg.ClientConfig)
+
+	assert.Equal(t, defaultCfg.TimeoutConfig, exporterCfg.TimeoutConfig)
+	assert.Equal(t, defaultCfg.QueueConfig, exporterCfg.QueueConfig)
+	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
+}
+
+func TestBuildExporterConfigUnknown(t *testing.T) {
+	// prepare
+	factories, err := otelcoltest.NopFactories()
+	require.NoError(t, err)
+
+	factories.Exporters[metadata.Type] = NewFactory()
+	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
+	// nolint:staticcheck
+	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "test-build-exporter-config.yaml"), factories)
+	require.NoError(t, err)
+	require.NotNil(t, cfg)
+
+	c := cfg.Exporters[component.NewID(metadata.Type)]
+	require.NotNil(t, c)
+
+	// test
+	defaultCfg := otlpexporter.NewFactory().CreateDefaultConfig().(*otlpexporter.Config)
+	exporterCfg := buildExporterConfig(c.(*Config), "the-endpoint")
+
+	// verify
+	grpcSettings := defaultCfg.ClientConfig
+	grpcSettings.Endpoint = "the-endpoint"
+	if c.(*Config).QueueSettings.Enabled {
+		defaultCfg.QueueConfig.Enabled = false
+	}
+	assert.Equal(t, grpcSettings, exporterCfg.ClientConfig)
+
+	assert.Equal(t, defaultCfg.TimeoutConfig, exporterCfg.TimeoutConfig)
+	assert.Equal(t, defaultCfg.QueueConfig, exporterCfg.QueueConfig)
+	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
+}
+
+func TestBuildExporterSettings(t *testing.T) {
+	// prepare
+	creationParams := exportertest.NewNopSettings()
+	testEndpoint := "the-endpoint"
+	observedZapCore, observedLogs := observer.New(zap.InfoLevel)
+	creationParams.Logger = zap.New(observedZapCore)
+
+	// test
+	exporterParams := buildExporterSettings(creationParams, testEndpoint)
+	exporterParams.Logger.Info("test")
+
+	// verify
+	expectedID := component.NewIDWithName(
+		creationParams.ID.Type(),
+		fmt.Sprintf("%s_%s", creationParams.ID.Name(), testEndpoint),
+	)
+	assert.Equal(t, expectedID, exporterParams.ID)
+
+	allLogs := observedLogs.All()
+	require.Equal(t, 1, observedLogs.Len())
+	assert.Contains(t,
+		allLogs[0].Context,
+		zap.String(zapEndpointKey, testEndpoint),
+	)
 }

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.114.0
 	go.opentelemetry.io/collector/component/componenttest v0.114.0
+	go.opentelemetry.io/collector/config/configretry v1.20.0
 	go.opentelemetry.io/collector/config/configtelemetry v0.114.0
 	go.opentelemetry.io/collector/confmap v1.20.0
 	go.opentelemetry.io/collector/consumer v0.114.0

--- a/exporter/loadbalancingexporter/go.mod
+++ b/exporter/loadbalancingexporter/go.mod
@@ -114,7 +114,6 @@ require (
 	go.opentelemetry.io/collector/config/configgrpc v0.114.0 // indirect
 	go.opentelemetry.io/collector/config/confignet v1.20.0 // indirect
 	go.opentelemetry.io/collector/config/configopaque v1.20.0 // indirect
-	go.opentelemetry.io/collector/config/configretry v1.20.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.20.0 // indirect
 	go.opentelemetry.io/collector/config/internal v0.114.0 // indirect
 	go.opentelemetry.io/collector/confmap/provider/envprovider v1.20.0 // indirect

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -41,7 +41,9 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 	exporterFactory := otlpexporter.NewFactory()
 	cfFunc := func(ctx context.Context, endpoint string) (component.Component, error) {
 		oCfg := buildExporterConfig(cfg.(*Config), endpoint)
-		return exporterFactory.CreateLogs(ctx, params, &oCfg)
+		oParams := buildExporterSettings(params, endpoint)
+
+		return exporterFactory.CreateLogs(ctx, oParams, &oCfg)
 	}
 
 	lb, err := newLoadBalancer(params.Logger, cfg, cfFunc, telemetry)

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -43,7 +43,9 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 	exporterFactory := otlpexporter.NewFactory()
 	cfFunc := func(ctx context.Context, endpoint string) (component.Component, error) {
 		oCfg := buildExporterConfig(cfg.(*Config), endpoint)
-		return exporterFactory.CreateMetrics(ctx, params, &oCfg)
+		oParams := buildExporterSettings(params, endpoint)
+
+		return exporterFactory.CreateMetrics(ctx, oParams, &oCfg)
 	}
 
 	lb, err := newLoadBalancer(params.Logger, cfg, cfFunc, telemetry)

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -24,14 +24,11 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
-	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"gopkg.in/yaml.v2"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/pmetrictest"
 )
@@ -671,35 +668,6 @@ func TestConsumeMetricsUnexpectedExporterType(t *testing.T) {
 	// verify
 	assert.Error(t, res)
 	assert.EqualError(t, res, fmt.Sprintf("unable to export metrics, unexpected exporter type: expected exporter.Metrics but got %T", newNopMockExporter()))
-}
-
-func TestBuildExporterConfigUnknown(t *testing.T) {
-	// prepare
-	factories, err := otelcoltest.NopFactories()
-	require.NoError(t, err)
-
-	factories.Exporters[metadata.Type] = NewFactory()
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
-	// nolint:staticcheck
-	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "test-build-exporter-config.yaml"), factories)
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	c := cfg.Exporters[component.NewID(metadata.Type)]
-	require.NotNil(t, c)
-
-	// test
-	defaultCfg := otlpexporter.NewFactory().CreateDefaultConfig().(*otlpexporter.Config)
-	exporterCfg := buildExporterConfig(c.(*Config), "the-endpoint")
-
-	// verify
-	grpcSettings := defaultCfg.ClientConfig
-	grpcSettings.Endpoint = "the-endpoint"
-	assert.Equal(t, grpcSettings, exporterCfg.ClientConfig)
-
-	assert.Equal(t, defaultCfg.TimeoutConfig, exporterCfg.TimeoutConfig)
-	assert.Equal(t, defaultCfg.QueueConfig, exporterCfg.QueueConfig)
-	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
 }
 
 func TestBatchWithTwoMetrics(t *testing.T) {

--- a/exporter/loadbalancingexporter/testdata/config.yaml
+++ b/exporter/loadbalancingexporter/testdata/config.yaml
@@ -1,6 +1,6 @@
 loadbalancing:
   protocol:
-    # the OTLP exporter configuration. "endpoint" values will be ignored
+    # the OTLP exporter configuration "endpoint" values will be ignored
     otlp:
       timeout: 1s
 
@@ -38,3 +38,12 @@ loadbalancing/4:
       namespace: cloudmap-1
       service_name: service-1
       port: 4319
+
+loadbalancing/5:
+  # the OTLP exporter configuration "sending_queue" values will be ignored
+  sending_queue:
+    enabled: true
+  protocol:
+    otlp:
+      sending_queue:
+        enabled: false

--- a/exporter/loadbalancingexporter/trace_exporter.go
+++ b/exporter/loadbalancingexporter/trace_exporter.go
@@ -45,7 +45,9 @@ func newTracesExporter(params exporter.Settings, cfg component.Config) (*traceEx
 	exporterFactory := otlpexporter.NewFactory()
 	cfFunc := func(ctx context.Context, endpoint string) (component.Component, error) {
 		oCfg := buildExporterConfig(cfg.(*Config), endpoint)
-		return exporterFactory.CreateTraces(ctx, params, &oCfg)
+		oParams := buildExporterSettings(params, endpoint)
+
+		return exporterFactory.CreateTraces(ctx, oParams, &oCfg)
 	}
 
 	lb, err := newLoadBalancer(params.Logger, cfg, cfFunc, telemetry)
@@ -67,12 +69,6 @@ func newTracesExporter(params exporter.Settings, cfg component.Config) (*traceEx
 		return nil, fmt.Errorf("unsupported routing_key: %s", cfg.(*Config).RoutingKey)
 	}
 	return &traceExporter, nil
-}
-
-func buildExporterConfig(cfg *Config, endpoint string) otlpexporter.Config {
-	oCfg := cfg.Protocol.OTLP
-	oCfg.Endpoint = endpoint
-	return oCfg
 }
 
 func (e *traceExporterImp) Capabilities() consumer.Capabilities {

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -23,13 +22,9 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.opentelemetry.io/collector/exporter/otlpexporter"
-	"go.opentelemetry.io/collector/otelcol/otelcoltest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 )
 
 func TestNewTracesExporter(t *testing.T) {
@@ -347,35 +342,6 @@ func TestConsumeTracesUnexpectedExporterType(t *testing.T) {
 	// verify
 	assert.Error(t, res)
 	assert.EqualError(t, res, fmt.Sprintf("unable to export traces, unexpected exporter type: expected exporter.Traces but got %T", newNopMockExporter()))
-}
-
-func TestBuildExporterConfig(t *testing.T) {
-	// prepare
-	factories, err := otelcoltest.NopFactories()
-	require.NoError(t, err)
-
-	factories.Exporters[metadata.Type] = NewFactory()
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
-	// nolint:staticcheck
-	cfg, err := otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "test-build-exporter-config.yaml"), factories)
-	require.NoError(t, err)
-	require.NotNil(t, cfg)
-
-	c := cfg.Exporters[component.NewID(metadata.Type)]
-	require.NotNil(t, c)
-
-	// test
-	defaultCfg := otlpexporter.NewFactory().CreateDefaultConfig().(*otlpexporter.Config)
-	exporterCfg := buildExporterConfig(c.(*Config), "the-endpoint")
-
-	// verify
-	grpcSettings := defaultCfg.ClientConfig
-	grpcSettings.Endpoint = "the-endpoint"
-	assert.Equal(t, grpcSettings, exporterCfg.ClientConfig)
-
-	assert.Equal(t, defaultCfg.TimeoutConfig, exporterCfg.TimeoutConfig)
-	assert.Equal(t, defaultCfg.QueueConfig, exporterCfg.QueueConfig)
-	assert.Equal(t, defaultCfg.RetryConfig, exporterCfg.RetryConfig)
 }
 
 func TestBatchWithTwoTraces(t *testing.T) {


### PR DESCRIPTION
#### Description
##### Problem statement
`loadbalancing` exporter is actually a wrapper that's creates and manages set of actual `otlp` exporters
Those `otlp` exporters technically shares same configuration parameters that are defined on `loadbalancing` exporter level, including `sending_queue` configuration. The only difference is `endpoint` parameter that are substituted by `loadbalancing` exporter itself
This means, that `sending_queue`, `retry_on_failure` and `timeout` settings can be defined only on `otlp` sub-exporters, while top-level `loadbalancing` exporter is missing all those settings
This configuration approach produces several issue, that are already reported by users:
* Impossibility to use Persistent Queue in `loadbalancing` exporter (see #16826). That's happens because `otlp` sub-exporters are sharing the same configurations, including configuration of the queue, i.e. they all are using the same `storage` instance at the same time which is not possible at the moment
* Data loss even using `sending_queue` configuration (see #35378). That's happens because Queue is defined on level of `otlp` sub-exporters and if this exporter cannot flush data from queue (for example, endpoint is not available anymore) there is no other options that just to discard data from queue, i.e. there is no higher level queue and persistent storage where data can be returned is case of permanent failure

There might be some other potential issue that was already tracked and related to current configuration approach

##### Proposed solution
The easiest way to solve issues above - is to use standard approach for queue, retry and timeout configuration using `exporterhelper`
This will bring queue, retry and timeout functionality to the top-level of `loadbalancing` exporter, instead of `otlp` sub-exporters 
Related to mentioned issues it will bring:
* Single Persistent Queue, that is used by all `otlp` sub-exporters (not directly of course)
* Queue will not be discarded/destroyed if any (or all) of endpoint that are unreachable anymore, top-level queue will keep data until new endpoints will be available
* Scale-up and scale-down event for next layer of OpenTelemetry Collectors in K8s environments will be more predictable, and will not include data loss anymore (potential fix for #33959). There is still a big chance of inconsistency when some data will be send to incorrect endpoint, but it's already better state that we have right now

##### Noticeable changes
* `loadbalancing` exporter on top-level now uses `exporterhelper` with all supported functionality by it
* `sending_queue` will be automatically disabled on `otlp` exporters when it already present on top-level `loadbalancing` exporter. This change is done to prevent data loss on `otlp` exporters because queue there doesn't provide expected result. Also it will prevent potential misconfiguration from user side and as result - irrelevant reported issues 
* `exporter` attribute for metrics generated from `otlp` sub-exporters now includes endpoint for better visibility and to segregate them from top-level `loadbalancing` exporter - was `"exporter": "loadbalancing"`, now `"exporter": "loadbalancing/127.0.0.1:4317"`
* logs, generated by `otlp` sub-exporters now includes additional attribute `endpoint` with endpoint value with the same reasons as for metrics

#### Link to tracking issue
Fixes #35378
Fixes #16826

#### Testing
Proposed changes was heavily tested on large K8s environment with set of different scale-up/scale-down event using persistent queue configuration - no data loss were detected, everything works as expected

#### Documentation
`README.md` was updated to reflect new configuration parameters available. Sample `config.yaml` was updated as well