### PR TITLE
(otelarrowreceiver) Deprecate admission::waiter_limit

### DIFF
--- a/.chloggen/otelarrow-deprecate-waiters-limit.yaml
+++ b/.chloggen/otelarrow-deprecate-waiters-limit.yaml
@@ -7,7 +7,7 @@ change_type: deprecation
 component: otelarrowreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate the "admission::waiters_limit" flag for replacement by "admission::waiting_limit_mib"
+note: Deprecate the "admission::waiter_limit" flag for replacement by "admission::waiting_limit_mib"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [36074]

--- a/.chloggen/otelarrow-deprecate-waiters-limit.yaml
+++ b/.chloggen/otelarrow-deprecate-waiters-limit.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: otelarrowreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate the "admission::waiters_limit" flag for replacement by "admission::waiting_limit_mib"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36074]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/otelarrowreceiver/README.md
+++ b/receiver/otelarrowreceiver/README.md
@@ -84,9 +84,9 @@ In the `admission` configuration block the following settings are available:
 
 - `request_limit_mib` (default: 128): limits the number of requests that are received by the stream in terms of *uncompressed request size*. This should not be confused with `arrow.memory_limit_mib` which limits allocations made by the consumer when translating arrow records into pdata objects. i.e. request size is used to control how much traffic we admit, but does not control how much memory is used during request processing.
 
-- `waiter_limit` (default: 1000): limits the number of requests waiting on admission once `admission_limit_mib` is reached. This is another dimension of memory limiting that ensures waiters are not holding onto a significant amount of memory while waiting to be processed.
+- `waiter_limit` (default: 1000): `waiter_limit` is [DEPRECATED and will be replaced by `waiting_limit_mib`](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36074). This configuration limits the number of requests waiting on admission once `admission_limit_mib` is reached.
 
-`request_limit_mib` and `waiter_limit` are arguments supplied to [admission.BoundedQueue](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/internal/otelarrow/admission). This custom semaphore is meant to be used within receivers to help limit memory within the collector pipeline.
+`request_limit_mib` is supplied to [admission.BoundedQueue](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/internal/otelarrow/admission). This custom semaphore is meant to be used within receivers to help limit memory within the collector pipeline.
 
 ### Arrow-specific Configuration
 

--- a/receiver/otelarrowreceiver/config.go
+++ b/receiver/otelarrowreceiver/config.go
@@ -25,10 +25,16 @@ type AdmissionConfig struct {
 	// for processing.
 	RequestLimitMiB uint64 `mapstructure:"request_limit_mib"`
 
-	// WaiterLimit is the limit on the number of waiters waiting to be processed and consumed.
-	// This is a dimension of memory limiting to ensure waiters are not consuming an
-	// unexpectedly large amount of memory in the arrow receiver.
-	WaiterLimit int64 `mapstructure:"waiter_limit"`
+	// DeprecatedWaiterLimit is deprecated.  This field configures
+	// a limit defined in terms of the number of requests waiting
+	// when the request_limit_mib limit has been reached.  This field
+	// will be replaced by a limit implemented in terms of waiting
+	// request size instead of waiting request count.
+	//
+	// This field will continue to function until a new field
+	// named `waiting_limit_mib` is introduced, at which time this
+	// field will have no effect.
+	DeprecatedWaiterLimit int64 `mapstructure:"waiter_limit"`
 }
 
 // ArrowConfig support configuring the Arrow receiver.
@@ -84,8 +90,8 @@ func (cfg *Config) Unmarshal(conf *confmap.Conf) error {
 	if cfg.Admission.RequestLimitMiB == 0 && cfg.Arrow.DeprecatedAdmissionLimitMiB != 0 {
 		cfg.Admission.RequestLimitMiB = cfg.Arrow.DeprecatedAdmissionLimitMiB
 	}
-	if cfg.Admission.WaiterLimit == 0 && cfg.Arrow.DeprecatedWaiterLimit != 0 {
-		cfg.Admission.WaiterLimit = cfg.Arrow.DeprecatedWaiterLimit
+	if cfg.Admission.DeprecatedWaiterLimit == 0 && cfg.Arrow.DeprecatedWaiterLimit != 0 {
+		cfg.Admission.DeprecatedWaiterLimit = cfg.Arrow.DeprecatedWaiterLimit
 	}
 	return nil
 }

--- a/receiver/otelarrowreceiver/config_test.go
+++ b/receiver/otelarrowreceiver/config_test.go
@@ -81,8 +81,8 @@ func TestUnmarshalConfig(t *testing.T) {
 				},
 			},
 			Admission: AdmissionConfig{
-				RequestLimitMiB: 80,
-				WaiterLimit:     100,
+				RequestLimitMiB:       80,
+				DeprecatedWaiterLimit: 100,
 			},
 		}, cfg)
 
@@ -106,8 +106,8 @@ func TestValidateDeprecatedConfig(t *testing.T) {
 			},
 			Admission: AdmissionConfig{
 				// cfg.Validate should now set these fields.
-				RequestLimitMiB: 80,
-				WaiterLimit:     100,
+				RequestLimitMiB:       80,
+				DeprecatedWaiterLimit: 100,
 			},
 		}, cfg)
 }
@@ -133,8 +133,8 @@ func TestUnmarshalConfigUnix(t *testing.T) {
 				},
 			},
 			Admission: AdmissionConfig{
-				RequestLimitMiB: defaultRequestLimitMiB,
-				WaiterLimit:     defaultWaiterLimit,
+				RequestLimitMiB:       defaultRequestLimitMiB,
+				DeprecatedWaiterLimit: defaultWaiterLimit,
 			},
 		}, cfg)
 }

--- a/receiver/otelarrowreceiver/factory.go
+++ b/receiver/otelarrowreceiver/factory.go
@@ -51,8 +51,8 @@ func createDefaultConfig() component.Config {
 			},
 		},
 		Admission: AdmissionConfig{
-			RequestLimitMiB: defaultRequestLimitMiB,
-			WaiterLimit:     defaultWaiterLimit,
+			RequestLimitMiB:       defaultRequestLimitMiB,
+			DeprecatedWaiterLimit: defaultWaiterLimit,
 		},
 	}
 }

--- a/receiver/otelarrowreceiver/otelarrow.go
+++ b/receiver/otelarrowreceiver/otelarrow.go
@@ -66,7 +66,7 @@ func newOTelArrowReceiver(cfg *Config, set receiver.Settings) (*otelArrowReceive
 	if err != nil {
 		return nil, err
 	}
-	bq := admission.NewBoundedQueue(set.TracerProvider, int64(cfg.Admission.RequestLimitMiB<<20), cfg.Admission.WaiterLimit)
+	bq := admission.NewBoundedQueue(set.TracerProvider, int64(cfg.Admission.RequestLimitMiB<<20), cfg.Admission.DeprecatedWaiterLimit)
 	r := &otelArrowReceiver{
 		cfg:          cfg,
 		settings:     set,


### PR DESCRIPTION
#### Description

As described in #36074, the admission::waiters_limit feature is not working well and we will replace it with a waiter limit based on pending data size.

#### Link to tracking issue

Part of #36074.

#### Testing

Note that the feature is intact, and still tested. We will change tests when the feature is replaced.

#### Documentation

Updated.