### PR TITLE
[exporter/elasticsearch]: add automatic mapping mode

### DIFF
--- a/.chloggen/elasticsearchexporter-automatic-mapping-mode.yaml
+++ b/.chloggen/elasticsearchexporter-automatic-mapping-mode.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for automatic mapping mode using a client header.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36092]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -175,6 +175,17 @@ behaviours, which may be configured through the following settings:
     for ECS mode, and never for other modes): When enabled attributes with `.`
     will be split into proper json objects.
 
+It is also possible to configure the mapping mode dynamically by setting the metadata `X-Elastic-Mapping-Mode` using the [open-telemetry client](https://pkg.go.dev/go.opentelemetry.io/collector/client):
+
+```go
+cl := client.FromContext(ctx)
+cl.Metadata = client.NewMetadata(map[string][]string{"X-Elastic-Mapping-Mode": {"ecs"}})
+// Propagate the context down the pipeline
+next.ConsumeLogs(ctx, td)
+```
+
+A mapping mode set in the metadata will take precedence over the configuration and will only apply to the current request. If the metadata is not set, the values from the configuration will be used instead.
+
 #### ECS mapping mode
 
 > [!WARNING]

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -20,6 +20,10 @@ import (
 	"go.uber.org/zap"
 )
 
+// HeaderXElasticMappingMode is the HTTP header key used to specify a
+// mapping mode for a specific request.
+const HeaderXElasticMappingMode = "X-Elastic-Mapping-Mode"
+
 // Config defines configuration for Elastic exporter.
 type Config struct {
 	QueueSettings exporterhelper.QueueConfig `mapstructure:"sending_queue"`

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.113.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tidwall/gjson v1.18.0
+	go.opentelemetry.io/collector/client v1.19.0
 	go.opentelemetry.io/collector/component v0.113.0
 	go.opentelemetry.io/collector/config/configauth v0.113.0
 	go.opentelemetry.io/collector/config/configcompression v1.19.0
@@ -63,7 +64,6 @@ require (
 	go.elastic.co/apm/module/apmzap/v2 v2.6.0 // indirect
 	go.elastic.co/apm/v2 v2.6.0 // indirect
 	go.elastic.co/fastjson v1.3.0 // indirect
-	go.opentelemetry.io/collector/client v1.19.0 // indirect
 	go.opentelemetry.io/collector/config/configretry v1.19.0 // indirect
 	go.opentelemetry.io/collector/config/configtelemetry v0.113.0 // indirect
 	go.opentelemetry.io/collector/config/configtls v1.19.0 // indirect


### PR DESCRIPTION
#### Description

This adds support for detecting the mapping mode based on a metadata field set by the client, this mapping mode takes precedence over the configuration.

#### Link to tracking issue
Fixes #36092

#### Testing

Unit tests added for the presence/absence of the header value.

#### Documentation

Added README docs next to existing mapping mode section.
