### PR TITLE
[processor/span] Add 'keep_original_name'

### DIFF
--- a/.chloggen/span-rpocessor-keep-original-name.yaml
+++ b/.chloggen/span-rpocessor-keep-original-name.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note:
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/span-rpocessor-keep-original-name.yaml
+++ b/.chloggen/span-rpocessor-keep-original-name.yaml
@@ -1,16 +1,16 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: enhancement
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component:
+component: processor/spanprocessor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note:
+note: "Add a new configuration option to keep the original span name when extracting attributes from the span name."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [36120]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
@@ -24,4 +24,4 @@ subtext:
 # Include 'user' if the change is relevant to end users.
 # Include 'api' if there is a change to a library API.
 # Default: '[user]'
-change_logs: []
+change_logs: [user]

--- a/processor/spanprocessor/README.md
+++ b/processor/spanprocessor/README.md
@@ -81,6 +81,9 @@ span name that is the output after processing the previous rule.
 - `break_after_match` (default = false): specifies if processing of rules should stop after the first
 match. If it is false rule processing will continue to be performed over the
 modified span name.
+- `keep_original_name` (default = false): specifies if the original span name should be kept after 
+processing the rules. If it is true, the original span name will be kept,
+otherwise it will be replaced with the placeholders of the captured attributes.
 
 ```yaml
 span/to_attributes:
@@ -92,7 +95,7 @@ span/to_attributes:
         - regexp-rule3
         ...
       break_after_match: <true|false>
-
+      keep_original_name: <true|false>
 ```
 
 Example:
@@ -104,6 +107,15 @@ Example:
 span/to_attributes:
   name:
     to_attributes:
+      rules:
+        - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
+
+# This example will add the same new "documentId"="12345678" attribute,
+# but now resulting in an unchanged span name (/api/v1/document/12345678/update).
+span/to_attributes_keep_original_name:
+  name:
+    to_attributes:
+      keep_original_name: true
       rules:
         - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
 ```

--- a/processor/spanprocessor/config.go
+++ b/processor/spanprocessor/config.go
@@ -68,6 +68,11 @@ type ToAttributes struct {
 	// match. If it is false rule processing will continue to be performed over the
 	// modified span name.
 	BreakAfterMatch bool `mapstructure:"break_after_match"`
+
+	// KeepOriginalName specifies if the original span name should be kept after
+	// processing the rules. If it is true the original span name will be kept,
+	// otherwise it will be replaced with the placeholders of the captured attributes.
+	KeepOriginalName bool `mapstructure:"keep_original_name"`
 }
 
 type Status struct {

--- a/processor/spanprocessor/config_test.go
+++ b/processor/spanprocessor/config_test.go
@@ -46,7 +46,19 @@ func TestLoadingConfig(t *testing.T) {
 			expected: &Config{
 				Rename: Name{
 					ToAttributes: &ToAttributes{
-						Rules: []string{`^\/api\/v1\/document\/(?P<documentId>.*)\/update$`},
+						Rules:            []string{`^\/api\/v1\/document\/(?P<documentId>.*)\/update$`},
+						KeepOriginalName: false,
+					},
+				},
+			},
+		},
+		{
+			id: component.MustNewIDWithName("span", "to_attributes_keep_original_name"),
+			expected: &Config{
+				Rename: Name{
+					ToAttributes: &ToAttributes{
+						Rules:            []string{`^\/api\/v1\/document\/(?P<documentId>.*)\/update$`},
+						KeepOriginalName: true,
 					},
 				},
 			},

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -213,7 +213,9 @@ func (sp *spanProcessor) processToAttributes(span ptrace.Span) {
 		}
 
 		// Set new span name.
-		span.SetName(sb.String())
+		if !sp.config.Rename.ToAttributes.KeepOriginalName {
+			span.SetName(sb.String())
+		}
 
 		if sp.config.Rename.ToAttributes.BreakAfterMatch {
 			// Stop processing, break after first match is requested.

--- a/processor/spanprocessor/testdata/config.yaml
+++ b/processor/spanprocessor/testdata/config.yaml
@@ -61,6 +61,15 @@ span/to_attributes:
       rules:
         - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
 
+# This example will add the same new "documentId"="12345678" attribute,
+# but now resulting in an unchanged span name (/api/v1/document/12345678/update).
+span/to_attributes_keep_original_name:
+  name:
+    to_attributes:
+      keep_original_name: true
+      rules:
+        - ^\/api\/v1\/document\/(?P<documentId>.*)\/update$
+
 # The following demonstrates renaming the span name to `{operation_website}`
 # and adding the attribute {Key: operation_website, Value: <old span name> }
 # when the span has the following properties


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Some tracing libraries add some attributes into the span name ([ex for the `db.system`](https://github.com/DataDog/dd-trace-java/blob/a420d2c66ade70af0ebc8c58ee2d4784bb0de38a/dd-java-agent/agent-otel/otel-shim/src/main/java/datadog/opentelemetry/shim/trace/OtelConventions.java#L168)), which can be further used to extract it as span attributes with this very processor. However, when that is done, the span name is replaced by a placeholder containing the attribute name.

This PR adds the possibility of keeping the original span name unchanged with a `keep_original_name` config property, but keeping the existing behavior (renaming the span) as the default option.