### PR TITLE
[processor/probabilisticsampler] Added Spans Count Metric

### DIFF
--- a/processor/probabilisticsamplerprocessor/documentation.md
+++ b/processor/probabilisticsamplerprocessor/documentation.md
@@ -14,6 +14,14 @@ Count of logs that were sampled or not
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
+### otelcol_processor_probabilistic_sampler_count_spans_sampled
+
+Count of spans that were sampled or not
+
+| Unit | Metric Type | Value Type | Monotonic |
+| ---- | ----------- | ---------- | --------- |
+| 1 | Sum | Int | true |
+
 ### otelcol_processor_probabilistic_sampler_count_traces_sampled
 
 Count of traces that were sampled or not

--- a/processor/probabilisticsamplerprocessor/documentation.md
+++ b/processor/probabilisticsamplerprocessor/documentation.md
@@ -14,14 +14,6 @@ Count of logs that were sampled or not
 | ---- | ----------- | ---------- | --------- |
 | 1 | Sum | Int | true |
 
-### otelcol_processor_probabilistic_sampler_count_spans_sampled
-
-Count of spans that were sampled or not
-
-| Unit | Metric Type | Value Type | Monotonic |
-| ---- | ----------- | ---------- | --------- |
-| 1 | Sum | Int | true |
-
 ### otelcol_processor_probabilistic_sampler_count_traces_sampled
 
 Count of traces that were sampled or not

--- a/processor/probabilisticsamplerprocessor/generated_component_test.go
+++ b/processor/probabilisticsamplerprocessor/generated_component_test.go
@@ -39,14 +39,14 @@ func TestComponentLifecycle(t *testing.T) {
 		{
 			name: "logs",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateLogs(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateLogsProcessor(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 
 		{
 			name: "traces",
 			createFn: func(ctx context.Context, set processor.Settings, cfg component.Config) (component.Component, error) {
-				return factory.CreateTraces(ctx, set, cfg, consumertest.NewNop())
+				return factory.CreateTracesProcessor(ctx, set, cfg, consumertest.NewNop())
 			},
 		},
 	}

--- a/processor/probabilisticsamplerprocessor/generated_package_test.go
+++ b/processor/probabilisticsamplerprocessor/generated_package_test.go
@@ -3,9 +3,8 @@
 package probabilisticsamplerprocessor
 
 import (
-	"testing"
-
 	"go.uber.org/goleak"
+	"testing"
 )
 
 func TestMain(m *testing.M) {

--- a/processor/probabilisticsamplerprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/probabilisticsamplerprocessor/internal/metadata/generated_telemetry.go
@@ -30,6 +30,7 @@ func Tracer(settings component.TelemetrySettings) trace.Tracer {
 type TelemetryBuilder struct {
 	meter                                           metric.Meter
 	ProcessorProbabilisticSamplerCountLogsSampled   metric.Int64Counter
+	ProcessorProbabilisticSamplerCountSpansSampled  metric.Int64Counter
 	ProcessorProbabilisticSamplerCountTracesSampled metric.Int64Counter
 	meters                                          map[configtelemetry.Level]metric.Meter
 }
@@ -57,6 +58,12 @@ func NewTelemetryBuilder(settings component.TelemetrySettings, options ...Teleme
 	builder.ProcessorProbabilisticSamplerCountLogsSampled, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
 		"otelcol_processor_probabilistic_sampler_count_logs_sampled",
 		metric.WithDescription("Count of logs that were sampled or not"),
+		metric.WithUnit("1"),
+	)
+	errs = errors.Join(errs, err)
+	builder.ProcessorProbabilisticSamplerCountSpansSampled, err = builder.meters[configtelemetry.LevelBasic].Int64Counter(
+		"otelcol_processor_probabilistic_sampler_count_spans_sampled",
+		metric.WithDescription("Count of spans that were sampled or not"),
 		metric.WithUnit("1"),
 	)
 	errs = errors.Join(errs, err)

--- a/processor/probabilisticsamplerprocessor/metadata.yaml
+++ b/processor/probabilisticsamplerprocessor/metadata.yaml
@@ -28,3 +28,10 @@ telemetry:
       sum:
         value_type: int
         monotonic: true
+    processor_probabilistic_sampler_count_spans_sampled:
+      enabled: true
+      description: Count of spans that were sampled or not
+      unit: "1"
+      sum:
+        value_type: int
+        monotonic: true

--- a/processor/probabilisticsamplerprocessor/metadata.yaml
+++ b/processor/probabilisticsamplerprocessor/metadata.yaml
@@ -29,7 +29,7 @@ telemetry:
         value_type: int
         monotonic: true
     processor_probabilistic_sampler_count_spans_sampled:
-      enabled: true
+      enabled: false
       description: Count of spans that were sampled or not
       unit: "1"
       sum:

--- a/processor/probabilisticsamplerprocessor/tracesprocessor.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor.go
@@ -174,6 +174,7 @@ func (tp *traceProcessor) processTraces(ctx context.Context, td ptrace.Traces) (
 	td.ResourceSpans().RemoveIf(func(rs ptrace.ResourceSpans) bool {
 		rs.ScopeSpans().RemoveIf(func(ils ptrace.ScopeSpans) bool {
 			ils.Spans().RemoveIf(func(s ptrace.Span) bool {
+				tp.telemetryBuilder.ProcessorProbabilisticSamplerCountSpansSampled.Add(ctx, 1)
 				return !commonShouldSampleLogic(
 					ctx,
 					s,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Generated spans count metric using the `metadata.yaml` and incremented the counter with each span processing.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes: #34272 

<!--Describe what testing was performed and which tests were added.-->

<!--Describe the documentation added.-->

<!--Please delete paragraphs that you did not use before submitting.-->
