### PR TITLE
[chore] fix error to match go best practices

### DIFF
--- a/extension/encoding/jsonlogencodingextension/extension.go
+++ b/extension/encoding/jsonlogencodingextension/extension.go
@@ -35,7 +35,7 @@ func (e *jsonLogExtension) MarshalLogs(ld plog.Logs) ([]byte, error) {
 	case pcommon.ValueTypeMap:
 		raw = logRecord.Map().AsRaw()
 	default:
-		return nil, fmt.Errorf("Marshal: Expected 'Map' found '%v'", logRecord.Type().String())
+		return nil, fmt.Errorf("marshal: expected 'Map' found '%v'", logRecord.Type().String())
 	}
 	buf, err := jsoniter.Marshal(raw)
 	if err != nil {

--- a/extension/encoding/jsonlogencodingextension/json_test.go
+++ b/extension/encoding/jsonlogencodingextension/json_test.go
@@ -37,7 +37,7 @@ func TestInvalidMarshal(t *testing.T) {
 	p := plog.NewLogs()
 	p.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("NOT A MAP")
 	_, err := e.MarshalLogs(p)
-	assert.ErrorContains(t, err, "Marshal: Expected 'Map' found 'Str'")
+	assert.ErrorContains(t, err, "marshal: expected 'Map' found 'Str'")
 }
 
 func TestInvalidUnmarshal(t *testing.T) {


### PR DESCRIPTION
Do not use uppercase in golang errors.