### PR TITLE
[cmd/opampsupervisor] Support http endpoint

### DIFF
--- a/.chloggen/opampsupervisor-http-client.yaml
+++ b/.chloggen/opampsupervisor-http-client.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support HTTP endpoint for opampsupervisor
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -394,7 +394,7 @@ func (s *Supervisor) startOpAMPClient() error {
 	case "http", "https":
 		s.opampClient = client.NewHTTP(newLoggerFromZap(s.logger))
 	default:
-		return fmt.Errorf("unsupported scheme in server endpoint: %s", parsedURL.Scheme)
+		return fmt.Errorf("unsupported scheme in server endpoint: %q", parsedURL.Scheme)
 	}
 
 	s.logger.Debug("Connecting to OpAMP server...", zap.String("endpoint", s.config.Server.Endpoint), zap.Any("headers", s.config.Server.Headers))


### PR DESCRIPTION
#### Description
- [cmd/opampsupervisor] OpAMP supports http & websocket both.:
  - > OpAMP Client implementations may choose to support either plain HTTP or WebSocket transport, depending on their needs.
  - ref. https://opentelemetry.io/docs/specs/opamp/#communication-model

  - Already opampsupervisor code considers http in the configuration, but there is no code to use http client until now.:
    - https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/8dd2b7b00f9307bde95d4391d290f59aa901f219/cmd/opampsupervisor/supervisor/config/config.go#L139