### PR TITLE
[chore]: enable whitespace linter for receivers

### DIFF
--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/accumulator.go
@@ -38,7 +38,6 @@ func (acc *metricDataAccumulator) getMetricsData(containerStatsMap map[string]*C
 			acc.accumulate(convertToOTLPMetrics(containerPrefix, containerMetrics, containerResource, timestamp))
 			aggregateTaskMetrics(&taskMetrics, containerMetrics)
 		} else if containerMetadata.FinishedAt != "" && containerMetadata.StartedAt != "" {
-
 			duration, err := calculateDuration(containerMetadata.StartedAt, containerMetadata.FinishedAt)
 
 			if err != nil {

--- a/receiver/k8sobjectsreceiver/config.go
+++ b/receiver/k8sobjectsreceiver/config.go
@@ -57,7 +57,6 @@ type Config struct {
 }
 
 func (c *Config) Validate() error {
-
 	validObjects, err := c.getValidObjects()
 	if err != nil {
 		return err
@@ -149,7 +148,6 @@ func (c *Config) getValidObjects() (map[string][]*schema.GroupVersionResource, e
 				Resource: resource.Name,
 			})
 		}
-
 	}
 	return validObjects, nil
 }

--- a/receiver/k8sobjectsreceiver/mock_dynamic_client_test.go
+++ b/receiver/k8sobjectsreceiver/mock_dynamic_client_test.go
@@ -30,7 +30,6 @@ func newMockDynamicClient() mockDynamicClient {
 	return mockDynamicClient{
 		client: fakeClient,
 	}
-
 }
 
 func (c mockDynamicClient) getMockDynamicClient() (dynamic.Interface, error) {

--- a/receiver/k8sobjectsreceiver/receiver.go
+++ b/receiver/k8sobjectsreceiver/receiver.go
@@ -154,9 +154,7 @@ func (kr *k8sobjectsreceiver) startPull(ctx context.Context, config *K8sObjectsC
 		case <-stopperChan:
 			return
 		}
-
 	}
-
 }
 
 func (kr *k8sobjectsreceiver) startWatch(ctx context.Context, config *K8sObjectsConfig, resource dynamic.ResourceInterface) {

--- a/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
+++ b/receiver/k8sobjectsreceiver/unstructured_to_logdata_test.go
@@ -89,7 +89,6 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		assert.False(t, ok)
 		assert.Equal(t, 1, rl.ScopeLogs().Len())
 		assert.Equal(t, 3, logRecords.Len())
-
 	})
 
 	t.Run("Test event.name in watch events", func(t *testing.T) {
@@ -129,7 +128,6 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		eventName, ok := attrs.Get("event.name")
 		require.True(t, ok)
 		assert.EqualValues(t, "generic-name", eventName.AsRaw())
-
 	})
 
 	t.Run("Test event observed timestamp is present", func(t *testing.T) {
@@ -168,5 +166,4 @@ func TestUnstructuredListToLogData(t *testing.T) {
 		assert.Positive(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix())
 		assert.Equal(t, logRecords.At(0).ObservedTimestamp().AsTime().Unix(), observedAt.Unix())
 	})
-
 }

--- a/receiver/kafkametricsreceiver/broker_scraper.go
+++ b/receiver/kafkametricsreceiver/broker_scraper.go
@@ -47,7 +47,6 @@ func (s *brokerScraper) shutdown(context.Context) error {
 }
 
 func (s *brokerScraper) scrape(context.Context) (pmetric.Metrics, error) {
-
 	var scrapeErrors = scrapererror.ScrapeErrors{}
 
 	if s.client == nil {

--- a/receiver/kafkareceiver/header_extraction_test.go
+++ b/receiver/kafkareceiver/header_extraction_test.go
@@ -85,7 +85,6 @@ func TestHeaderExtractionTraces(t *testing.T) {
 	}
 	cancelFunc()
 	wg.Wait()
-
 }
 
 func TestHeaderExtractionLogs(t *testing.T) {
@@ -147,7 +146,6 @@ func TestHeaderExtractionLogs(t *testing.T) {
 	}
 	cancelFunc()
 	wg.Wait()
-
 }
 
 func TestHeaderExtractionMetrics(t *testing.T) {
@@ -210,7 +208,6 @@ func TestHeaderExtractionMetrics(t *testing.T) {
 	}
 	cancelFunc()
 	wg.Wait()
-
 }
 
 func validateHeader(t *testing.T, rs pcommon.Resource, headerKey string, headerValue string) {

--- a/receiver/kubeletstatsreceiver/config_test.go
+++ b/receiver/kubeletstatsreceiver/config_test.go
@@ -303,7 +303,6 @@ func TestLoadConfig(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, cfg)
 			}
-
 		})
 	}
 }

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata.go
@@ -207,7 +207,6 @@ func (m *Metadata) getContainerID(podUID string, containerName string) (string, 
 					return stripContainerID(containerStatus.ContainerID), nil
 				}
 			}
-
 		}
 	}
 

--- a/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
+++ b/receiver/kubeletstatsreceiver/internal/kubelet/metadata_test.go
@@ -390,7 +390,6 @@ func TestSetExtraLabelsForVolumeTypes(t *testing.T) {
 
 // Test happy paths for volume type metadata.
 func TestCpuAndMemoryGetters(t *testing.T) {
-
 	tests := []struct {
 		name                       string
 		metadata                   Metadata

--- a/receiver/kubeletstatsreceiver/scraper_test.go
+++ b/receiver/kubeletstatsreceiver/scraper_test.go
@@ -303,7 +303,6 @@ func TestScraperWithMetadata(t *testing.T) {
 				pmetrictest.IgnoreMetricDataPointsOrder(),
 				pmetrictest.IgnoreTimestamp(),
 				pmetrictest.IgnoreMetricsOrder()))
-
 		})
 	}
 }

--- a/receiver/lokireceiver/factory.go
+++ b/receiver/lokireceiver/factory.go
@@ -56,7 +56,6 @@ func createLogsReceiver(
 	cfg component.Config,
 	consumer consumer.Logs,
 ) (receiver.Logs, error) {
-
 	rCfg := cfg.(*Config)
 	return newLokiReceiver(rCfg, consumer, settings)
 }

--- a/receiver/lokireceiver/loki_test.go
+++ b/receiver/lokireceiver/loki_test.go
@@ -365,7 +365,6 @@ func TestSendingPushRequestToGRPCEndpoint(t *testing.T) {
 }
 
 func TestExpectedStatus(t *testing.T) {
-
 	testcases := []struct {
 		name              string
 		err               error

--- a/receiver/mongodbatlasreceiver/alerts.go
+++ b/receiver/mongodbatlasreceiver/alerts.go
@@ -498,7 +498,6 @@ func payloadToLogs(now time.Time, payload []byte) (plog.Logs, error) {
 
 		attrs.PutStr("net.peer.name", host)
 		attrs.PutInt("net.peer.port", port)
-
 	}
 
 	return logs, nil

--- a/receiver/mongodbatlasreceiver/alerts_test.go
+++ b/receiver/mongodbatlasreceiver/alerts_test.go
@@ -243,7 +243,6 @@ func TestVerifyHMACSignature(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
-
 		})
 	}
 }

--- a/receiver/mongodbatlasreceiver/events.go
+++ b/receiver/mongodbatlasreceiver/events.go
@@ -239,7 +239,6 @@ func (er *eventsReceiver) transformOrgEvents(now pcommon.Timestamp, events []*mo
 
 func (er *eventsReceiver) transformEvents(now pcommon.Timestamp, events []*mongodbatlas.Event, resourceLogs *plog.ResourceLogs) {
 	for _, event := range events {
-
 		logRecord := resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 		bodyBytes, err := json.Marshal(event)
 		if err != nil {

--- a/receiver/mongodbatlasreceiver/factory.go
+++ b/receiver/mongodbatlasreceiver/factory.go
@@ -31,7 +31,6 @@ func NewFactory() receiver.Factory {
 		createDefaultConfig,
 		receiver.WithMetrics(createMetricsReceiver, metadata.MetricsStability),
 		receiver.WithLogs(createCombinedLogReceiver, metadata.LogsStability))
-
 }
 
 func createMetricsReceiver(

--- a/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
+++ b/receiver/mongodbatlasreceiver/internal/mongodb_atlas_client.go
@@ -217,7 +217,6 @@ func (s *MongoDBAtlasClient) GetOrganization(ctx context.Context, orgID string) 
 		return nil, fmt.Errorf("error retrieving project page: %w", err)
 	}
 	return org, nil
-
 }
 
 // Projects returns a list of projects accessible within the provided organization
@@ -719,7 +718,6 @@ type GetAccessLogsOptions struct {
 
 // GetAccessLogs returns the access logs specified for the cluster requested
 func (s *MongoDBAtlasClient) GetAccessLogs(ctx context.Context, groupID string, clusterName string, opts *GetAccessLogsOptions) (ret []*mongodbatlas.AccessLogs, err error) {
-
 	options := mongodbatlas.AccessLogOptions{
 		// Earliest Timestamp in epoch milliseconds from when Atlas should access log results
 		Start: fmt.Sprintf("%d", opts.MinDate.UTC().UnixMilli()),

--- a/receiver/mongodbatlasreceiver/logs_test.go
+++ b/receiver/mongodbatlasreceiver/logs_test.go
@@ -41,7 +41,6 @@ func TestFilterClusters(t *testing.T) {
 	ic, err := filterClusters(clusters, includeProject)
 	require.NoError(t, err)
 	require.Equal(t, []mongodbatlas.Cluster{{Name: "cluster1", ID: "1"}, {Name: "cluster3", ID: "3"}}, ic)
-
 }
 
 func TestDefaultLoggingConfig(t *testing.T) {

--- a/receiver/mongodbatlasreceiver/receiver.go
+++ b/receiver/mongodbatlasreceiver/receiver.go
@@ -211,7 +211,6 @@ func (s *mongodbatlasreceiver) getNodeClusterNameMap(
 			// Remove the port from the node
 			n, _, _ := strings.Cut(node, ":")
 			clusterMap[n] = cluster.Name
-
 		}
 
 		providerMap[cluster.Name] = providerValues{

--- a/receiver/mongodbreceiver/client_test.go
+++ b/receiver/mongodbreceiver/client_test.go
@@ -92,7 +92,6 @@ func TestListDatabaseNames(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "admin", dbNames[0])
 	})
-
 }
 
 type commandString = string
@@ -232,7 +231,6 @@ func TestGetVersionFailures(t *testing.T) {
 			require.ErrorContains(t, err, tc.partialError)
 		})
 	}
-
 }
 
 func loadDBStats() (bson.D, error) {

--- a/receiver/mysqlreceiver/scraper_test.go
+++ b/receiver/mysqlreceiver/scraper_test.go
@@ -123,7 +123,6 @@ func TestScrape(t *testing.T) {
 		// and the other failure comes from a row that fails to parse as a number
 		require.Equal(t, 5, partialError.Failed, "Expected partial error count to be 5")
 	})
-
 }
 
 var _ client = (*mockClient)(nil)
@@ -194,7 +193,6 @@ func (c *mockClient) getTableStats() ([]TableStats, error) {
 		stats = append(stats, s)
 	}
 	return stats, nil
-
 }
 
 func (c *mockClient) getTableIoWaitsStats() ([]TableIoWaitsStats, error) {

--- a/receiver/opencensusreceiver/internal/octrace/opencensus.go
+++ b/receiver/opencensusreceiver/internal/octrace/opencensus.go
@@ -33,7 +33,6 @@ type Receiver struct {
 
 // New creates a new opencensus.Receiver reference.
 func New(nextConsumer consumer.Traces, set receiver.Settings) (*Receiver, error) {
-
 	obsrecv, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 		ReceiverID:             set.ID,
 		Transport:              receiverTransport,

--- a/receiver/opencensusreceiver/opencensus.go
+++ b/receiver/opencensusreceiver/opencensus.go
@@ -189,7 +189,6 @@ func (ocr *ocReceiver) Start(ctx context.Context, host component.Host) error {
 
 // Shutdown is a method to turn off receiving.
 func (ocr *ocReceiver) Shutdown(context.Context) error {
-
 	if ocr.cancel != nil {
 		ocr.cancel()
 	}

--- a/receiver/opencensusreceiver/opencensus_test.go
+++ b/receiver/opencensusreceiver/opencensus_test.go
@@ -303,7 +303,6 @@ func TestStartWithoutConsumersShouldFail(t *testing.T) {
 }
 
 func TestStartListenerClosed(t *testing.T) {
-
 	addr := testutil.GetAvailableLocalAddress(t)
 
 	// Set the buffer count to 1 to make it flush the test span immediately.
@@ -503,7 +502,6 @@ func TestOCReceiverTrace_HandleNextConsumerResponse(t *testing.T) {
 		t *testing.T,
 		cc *grpc.ClientConn,
 		msg *agenttracepb.ExportTraceServiceRequest) error {
-
 		acc := agenttracepb.NewTraceServiceClient(cc)
 		stream, err := acc.Export(context.Background())
 		require.NoError(t, err)
@@ -661,7 +659,6 @@ func TestOCReceiverMetrics_HandleNextConsumerResponse(t *testing.T) {
 		t *testing.T,
 		cc *grpc.ClientConn,
 		msg *agentmetricspb.ExportMetricsServiceRequest) error {
-
 		acc := agentmetricspb.NewMetricsServiceClient(cc)
 		stream, err := acc.Export(context.Background())
 		require.NoError(t, err)

--- a/receiver/oracledbreceiver/config.go
+++ b/receiver/oracledbreceiver/config.go
@@ -41,7 +41,6 @@ func (c Config) Validate() error {
 
 	// If DataSource is defined it takes precedence over the rest of the connection options.
 	if c.DataSource == "" {
-
 		if c.Endpoint == "" {
 			allErrs = multierr.Append(allErrs, errEmptyEndpoint)
 		}

--- a/receiver/oracledbreceiver/scraper_test.go
+++ b/receiver/oracledbreceiver/scraper_test.go
@@ -40,7 +40,6 @@ var queryResponses = map[string][]metricRow{
 }
 
 func TestScraper_Scrape(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		dbclientFn func(db *sql.DB, s string, logger *zap.Logger) dbClient
@@ -165,5 +164,4 @@ func TestScraper_Scrape(t *testing.T) {
 			assert.Equal(t, int64(78944), found.Sum().DataPoints().At(0).IntValue())
 		})
 	}
-
 }

--- a/receiver/otelarrowreceiver/config_test.go
+++ b/receiver/otelarrowreceiver/config_test.go
@@ -85,7 +85,6 @@ func TestUnmarshalConfig(t *testing.T) {
 				WaiterLimit:     100,
 			},
 		}, cfg)
-
 }
 
 // Tests that a deprecated config validation sets RequestLimitMiB and WaiterLimit in the correct config block.

--- a/receiver/otelarrowreceiver/internal/arrow/arrow.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow.go
@@ -545,7 +545,6 @@ func (id *inFlightData) anyDone(ctx context.Context) {
 // tracks everything that needs to be used by instrumention when the
 // batch finishes.
 func (r *receiverStream) recvOne(streamCtx context.Context, serverStream anyStreamServer, hrcv *headerReceiver, pendingCh chan<- batchResp, method string, ac arrowRecord.ConsumerAPI) (retErr error) {
-
 	// Receive a batch corresponding with one ptrace.Traces, pmetric.Metrics,
 	// or plog.Logs item.
 	req, recvErr := serverStream.Recv()
@@ -565,12 +564,10 @@ func (r *receiverStream) recvOne(streamCtx context.Context, serverStream anyStre
 	if recvErr != nil {
 		if errors.Is(recvErr, io.EOF) {
 			return recvErr
-
 		} else if errors.Is(recvErr, context.Canceled) {
 			// This is a special case to avoid introducing a span error
 			// for a canceled operation.
 			return io.EOF
-
 		} else if status, ok := status.FromError(recvErr); ok && status.Code() == codes.Canceled {
 			// This is a special case to avoid introducing a span error
 			// for a canceled operation.
@@ -773,7 +770,6 @@ func (r *receiverStream) srvSendLoop(ctx context.Context, serverStream anyStream
 // slice of pdata objects of the corresponding data type as `any`.
 // along with the number of items and true uncompressed size.
 func (r *Receiver) consumeBatch(arrowConsumer arrowRecord.ConsumerAPI, records *arrowpb.BatchArrowRecords) (retData any, numItems int, uncompSize int64, retErr error) {
-
 	payloads := records.GetArrowPayloads()
 	if len(payloads) == 0 {
 		return nil, 0, 0, nil

--- a/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
+++ b/receiver/otelarrowreceiver/internal/arrow/arrow_test.go
@@ -1275,7 +1275,6 @@ func testReceiverAuthHeaders(t *testing.T, includeMeta bool, dataAuth bool) {
 			batch = copyBatch(batch)
 
 			if len(md) != 0 {
-
 				hpb.Reset()
 				for key, vals := range md {
 					for _, val := range vals {

--- a/receiver/podmanreceiver/libpod_client_test.go
+++ b/receiver/podmanreceiver/libpod_client_test.go
@@ -238,7 +238,6 @@ func TestEvents(t *testing.T) {
 
 loop:
 	for {
-
 		select {
 		case err := <-errs:
 			if err != nil && !errors.Is(err, io.EOF) {
@@ -252,5 +251,4 @@ loop:
 	}
 
 	assert.Equal(t, expectedEvents, actualEvents)
-
 }

--- a/receiver/podmanreceiver/podman.go
+++ b/receiver/podmanreceiver/podman.go
@@ -98,7 +98,6 @@ EVENT_LOOP:
 	for {
 		eventCh, errCh := pc.events(ctx, filters)
 		for {
-
 			select {
 			case <-ctx.Done():
 				return
@@ -132,7 +131,6 @@ EVENT_LOOP:
 					}
 				}
 			}
-
 		}
 	}
 }

--- a/receiver/prometheusreceiver/config.go
+++ b/receiver/prometheusreceiver/config.go
@@ -144,7 +144,6 @@ func validateHTTPClientConfig(cfg *commonconfig.HTTPClientConfig) error {
 		return err
 	}
 	return nil
-
 }
 
 func checkFile(fn string) error {

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -1742,7 +1742,6 @@ func TestMetricBuilderSummary(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func TestMetricBuilderNativeHistogram(t *testing.T) {
@@ -2003,5 +2002,4 @@ func assertEquivalentMetrics(t *testing.T, want, got pmetric.Metrics) {
 			assert.EqualValues(t, wmap, gmap)
 		}
 	}
-
 }

--- a/receiver/prometheusreceiver/metrics_receiver_helper_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_helper_test.go
@@ -185,7 +185,6 @@ func waitForScrapeResults(t *testing.T, targets []*testData, cms *consumertest.M
 					// only count target pages that are not 404, matching mock ServerHTTP func response logic
 					want++
 				}
-
 			}
 			if len(scrapes) < want {
 				// If we don't have enough scrapes yet lets return false and wait for another tick

--- a/receiver/prometheusreceiver/metrics_receiver_labels_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_labels_test.go
@@ -722,7 +722,6 @@ func verifyRelabelJobInstance(t *testing.T, td *testData, rms []pmetric.Resource
 				},
 			},
 		})(t, rms[0])
-
 }
 
 const targetResourceAttsInTargetInfo = `

--- a/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
+++ b/receiver/prometheusreceiver/metrics_receiver_open_metrics_test.go
@@ -92,7 +92,6 @@ func verifyFailTarget(t *testing.T, td *testData, mds []pmetric.ResourceMetrics)
 
 // Test open metrics negative test cases
 func TestOpenMetricsFail(t *testing.T) {
-
 	targetsMap := getOpenMetricsFailTestData()
 	var targets []*testData
 	for k, v := range targetsMap {
@@ -127,7 +126,6 @@ func verifyInvalidTarget(t *testing.T, td *testData, mds []pmetric.ResourceMetri
 }
 
 func TestOpenMetricsInvalid(t *testing.T) {
-
 	targetsMap := getOpenMetricsInvalidTestData()
 	var targets []*testData
 	for k, v := range targetsMap {
@@ -229,7 +227,6 @@ func TestInfoStatesetMetrics(t *testing.T) {
 	}
 
 	testComponent(t, targets, nil)
-
 }
 
 func verifyInfoStatesetMetrics(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {

--- a/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
+++ b/receiver/prometheusreceiver/metrics_reciever_metric_rename_test.go
@@ -102,7 +102,6 @@ func TestMetricRenamingKeepAction(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 func verifyRenameMetric(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {
@@ -266,7 +265,6 @@ func TestLabelRenaming(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 func verifyRenameLabel(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {
@@ -373,7 +371,6 @@ func TestLabelRenamingKeepAction(t *testing.T) {
 			}
 		}
 	})
-
 }
 
 func verifyRenameLabelKeepAction(t *testing.T, td *testData, resourceMetrics []pmetric.ResourceMetrics) {

--- a/receiver/prometheusreceiver/targetallocator/config.go
+++ b/receiver/prometheusreceiver/targetallocator/config.go
@@ -87,7 +87,6 @@ func validateHTTPClientConfig(cfg *commonconfig.HTTPClientConfig) error {
 		return err
 	}
 	return nil
-
 }
 
 func checkFile(fn string) error {

--- a/receiver/pulsarreceiver/factory.go
+++ b/receiver/pulsarreceiver/factory.go
@@ -55,7 +55,6 @@ func withLogsUnmarshalers(logsUnmarshalers ...LogsUnmarshaler) FactoryOption {
 
 // NewFactory creates Pulsar receiver factory.
 func NewFactory(options ...FactoryOption) receiver.Factory {
-
 	f := &pulsarReceiverFactory{
 		tracesUnmarshalers:  defaultTracesUnmarshalers(),
 		metricsUnmarshalers: defaultMetricsUnmarshalers(),

--- a/receiver/rabbitmqreceiver/config_test.go
+++ b/receiver/rabbitmqreceiver/config_test.go
@@ -92,7 +92,6 @@ func TestValidate(t *testing.T) {
 			} else {
 				require.NoError(t, actualErr)
 			}
-
 		})
 	}
 }

--- a/receiver/rabbitmqreceiver/scraper.go
+++ b/receiver/rabbitmqreceiver/scraper.go
@@ -78,7 +78,6 @@ func (r *rabbitmqScraper) scrape(ctx context.Context) (pmetric.Metrics, error) {
 
 	// Collect metrics for each queue
 	for _, queue := range queues {
-
 		r.collectQueue(queue, now)
 	}
 

--- a/receiver/rabbitmqreceiver/scraper_test.go
+++ b/receiver/rabbitmqreceiver/scraper_test.go
@@ -101,7 +101,6 @@ func TestScaperScrape(t *testing.T) {
 				return &mockClient
 			},
 			expectedMetricGen: func(*testing.T) pmetric.Metrics {
-
 				return pmetric.NewMetrics()
 			},
 			expectedErr: errors.New("some api error"),

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -321,7 +321,6 @@ func TestOnAddForTraces(t *testing.T) {
 				t.Fatalf("unexpected startedComponent: %T", v)
 			}
 			require.Equal(t, test.expectedReceiverConfig, actualConfig)
-
 		})
 	}
 }

--- a/receiver/riakreceiver/config_test.go
+++ b/receiver/riakreceiver/config_test.go
@@ -93,7 +93,6 @@ func TestValidate(t *testing.T) {
 			} else {
 				require.NoError(t, actualErr)
 			}
-
 		})
 	}
 }

--- a/receiver/saphanareceiver/config_test.go
+++ b/receiver/saphanareceiver/config_test.go
@@ -93,5 +93,4 @@ func TestLoadConfig(t *testing.T) {
 	if diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{}), cmpopts.IgnoreUnexported(metadata.ResourceAttributeConfig{})); diff != "" {
 		t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 	}
-
 }

--- a/receiver/signalfxreceiver/receiver.go
+++ b/receiver/signalfxreceiver/receiver.go
@@ -123,7 +123,6 @@ func (r *sfxReceiver) RegisterLogsConsumer(lc consumer.Logs) {
 // By convention the consumer of the received data is set when the receiver
 // instance is created.
 func (r *sfxReceiver) Start(ctx context.Context, host component.Host) error {
-
 	if r.server != nil {
 		return nil
 	}

--- a/receiver/skywalkingreceiver/factory.go
+++ b/receiver/skywalkingreceiver/factory.go
@@ -66,7 +66,6 @@ func createTracesReceiver(
 	cfg component.Config,
 	nextConsumer consumer.Traces,
 ) (receiver.Traces, error) {
-
 	// Convert settings in the source c to configuration struct
 	// that Skywalking receiver understands.
 	rCfg := cfg.(*Config)
@@ -94,7 +93,6 @@ func createMetricsReceiver(
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
-
 	// Convert settings in the source c to configuration struct
 	// that Skywalking receiver understands.
 	rCfg := cfg.(*Config)

--- a/receiver/skywalkingreceiver/factory_test.go
+++ b/receiver/skywalkingreceiver/factory_test.go
@@ -57,7 +57,6 @@ func TestCreateReceiver(t *testing.T) {
 	mReceiver, err := factory.CreateMetrics(context.Background(), set, cfg, metricSink)
 	assert.NoError(t, err, "metric receiver creation failed")
 	assert.NotNil(t, mReceiver, "metric receiver creation failed")
-
 }
 
 func TestCreateReceiverGeneralConfig(t *testing.T) {

--- a/receiver/skywalkingreceiver/internal/metrics/metric_report_service.go
+++ b/receiver/skywalkingreceiver/internal/metrics/metric_report_service.go
@@ -65,5 +65,4 @@ func consumeMetrics(ctx context.Context, collection *agent.JVMMetricCollection, 
 	}
 	pmd := SwMetricsToMetrics(collection)
 	return nextConsumer.ConsumeMetrics(ctx, pmd)
-
 }

--- a/receiver/skywalkingreceiver/internal/metrics/skywalkingproto_to_metrics.go
+++ b/receiver/skywalkingreceiver/internal/metrics/skywalkingproto_to_metrics.go
@@ -96,7 +96,6 @@ func memoryPoolMetricToMetrics(timestamp int64, memoryPools []*agent.MemoryPool,
 		fillNumberDataPointIntValue(timestamp, memoryPool.Used, dpsMp[MemoryPoolUsedName].AppendEmpty(), attrs)
 		fillNumberDataPointIntValue(timestamp, memoryPool.Committed, dpsMp[MemoryPoolCommittedName].AppendEmpty(), attrs)
 	}
-
 }
 
 func buildMemoryPoolAttrs(pool *agent.MemoryPool) pcommon.Map {
@@ -110,7 +109,6 @@ func buildMemoryPoolAttrs(pool *agent.MemoryPool) pcommon.Map {
 	case agent.PoolType_NEWGEN_USAGE, agent.PoolType_OLDGEN_USAGE, agent.PoolType_SURVIVOR_USAGE:
 		memoryType = "heap"
 	default:
-
 	}
 	attrs.PutStr("jvm.memory.type", memoryType)
 	return attrs

--- a/receiver/skywalkingreceiver/skywalking_receiver_test.go
+++ b/receiver/skywalkingreceiver/skywalking_receiver_test.go
@@ -83,7 +83,6 @@ func TestStartAndShutdown(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sr.Start(context.Background(), componenttest.NewNopHost()))
 	t.Cleanup(func() { require.NoError(t, sr.Shutdown(context.Background())) })
-
 }
 
 func TestGRPCReception(t *testing.T) {
@@ -151,7 +150,6 @@ func TestHttpReception(t *testing.T) {
 	// verify
 	assert.NoError(t, err, "send skywalking segment successful.")
 	assert.NotNil(t, response)
-
 }
 
 func mockGrpcTraceSegment(sequence int) *agent.SegmentObject {

--- a/receiver/snmpreceiver/config.go
+++ b/receiver/snmpreceiver/config.go
@@ -500,7 +500,6 @@ func validateScalarOID(metricName string, scalarOID ScalarOID, cfg *Config) erro
 			combinedErr = errors.Join(combinedErr, fmt.Errorf(errMsgScalarMetricHasIndexedResourceAttribute, metricName, name))
 			continue
 		}
-
 	}
 
 	if len(scalarOID.Attributes) == 0 {
@@ -593,7 +592,6 @@ func validateResourceAttributeConfigs(cfg *Config) error {
 
 	// Make sure each Resource Attribute has exactly one of OID or ScalarOID or IndexedValuePrefix, and check that scalar and column OIDs end in the right digit
 	for attrName, attrCfg := range resourceAttributes {
-
 		hasOID := attrCfg.OID != ""
 		hasScalarOID := attrCfg.ScalarOID != ""
 		hasIVP := attrCfg.IndexedValuePrefix != ""

--- a/receiver/snmpreceiver/scraper_test.go
+++ b/receiver/snmpreceiver/scraper_test.go
@@ -42,7 +42,6 @@ func (_m *MockClient) Close() error {
 
 // Connect provides a mock function with given fields:
 func (_m *MockClient) Connect() error {
-
 	ret := _m.Called()
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
@@ -101,7 +100,6 @@ func TestStart(t *testing.T) {
 		{
 			desc: "Valid Config",
 			testFunc: func(t *testing.T) {
-
 				scraper := &snmpScraper{
 					cfg:      createDefaultConfig().(*Config),
 					settings: receivertest.NewNopSettings(),

--- a/receiver/solacereceiver/messaging_service.go
+++ b/receiver/solacereceiver/messaging_service.go
@@ -69,7 +69,6 @@ func newAMQPMessagingServiceFactory(cfg *Config, logger *zap.Logger) (messagingS
 			logger:         logger,
 		}
 	}, nil
-
 }
 
 type amqpConnectConfig struct {

--- a/receiver/solacereceiver/receiver.go
+++ b/receiver/solacereceiver/receiver.go
@@ -69,7 +69,6 @@ type solaceTracesReceiver struct {
 
 // newTracesReceiver creates a new solaceTraceReceiver as a receiver.Traces
 func newTracesReceiver(config *Config, set receiver.Settings, nextConsumer consumer.Traces) (receiver.Traces, error) {
-
 	factory, err := newAMQPMessagingServiceFactory(config, set.Logger)
 	if err != nil {
 		set.Logger.Warn("Error validating messaging service configuration", zap.Any("error", err))
@@ -222,7 +221,6 @@ func (s *solaceTracesReceiver) receiveMessages(ctx context.Context, service mess
 			return err
 		}
 	}
-
 }
 
 // receiveMessage is the heart of the receiver's control flow. It will receive messages, unmarshal the message and forward the trace.

--- a/receiver/solacereceiver/unmarshaller_move.go
+++ b/receiver/solacereceiver/unmarshaller_move.go
@@ -70,7 +70,6 @@ func (u *brokerTraceMoveUnmarshallerV1) mapResourceSpanAttributes(spanData *move
 }
 
 func (u *brokerTraceMoveUnmarshallerV1) mapMoveSpanTracingInfo(spanData *move_v1.SpanData, span ptrace.Span) {
-
 	// hard coded to internal span
 	// SPAN_KIND_CONSUMER == 1
 	span.SetKind(ptrace.SpanKindInternal)

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -426,7 +426,6 @@ func (s *splunkScraper) scrapeIndexerPipelineQueues(ctx context.Context, now pco
 			errs <- errMaxSearchWaitTimeExceeded
 			return
 		}
-
 	}
 	// Record the results
 	var host string
@@ -1665,7 +1664,6 @@ func (s *splunkScraper) scrapeSearchArtifacts(ctx context.Context, now pcommon.T
 	}
 
 	for _, f := range da.Entries {
-
 		if s.conf.MetricsBuilderConfig.Metrics.SplunkServerSearchartifactsAdhoc.Enabled {
 			adhocCount, err := strconv.ParseInt(f.Content.AdhocCount, 10, 64)
 			if err != nil {

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -455,7 +455,6 @@ func (r *splunkReceiver) handleReq(resp http.ResponseWriter, req *http.Request) 
 			}
 			events = append(events, &msg)
 		}
-
 	}
 	resourceCustomizer := r.createResourceCustomizer(req)
 	if r.logsConsumer != nil && len(events) > 0 {

--- a/receiver/splunkhecreceiver/receiver_test.go
+++ b/receiver/splunkhecreceiver/receiver_test.go
@@ -628,7 +628,6 @@ func Test_splunkhecReceiver_AccessTokenPassthrough(t *testing.T) {
 			case <-time.After(5 * time.Second):
 				assert.Fail(t, "Timeout")
 			}
-
 		})
 	}
 }
@@ -1786,7 +1785,6 @@ func Test_splunkhecreceiver_handle_nested_fields(t *testing.T) {
 				assert.Equal(t, http.StatusBadRequest, w.Code)
 				assert.JSONEq(t, fmt.Sprintf(responseErrHandlingIndexedFields, 0), w.Body.String())
 			}
-
 		})
 	}
 }

--- a/receiver/splunkhecreceiver/splunk_to_logdata.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata.go
@@ -140,7 +140,6 @@ func convertToValue(logger *zap.Logger, src any, dest pcommon.Value) error {
 	default:
 		logger.Debug("Unsupported value conversion", zap.Any("value", src))
 		return errCannotConvertValue
-
 	}
 	return nil
 }

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -29,7 +29,6 @@ var defaultTestingHecConfig = &Config{
 }
 
 func Test_SplunkHecToLogData(t *testing.T) {
-
 	time := 0.123
 	nanoseconds := 123000000
 

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -127,7 +127,6 @@ func buildAttributes(dimensions map[string]any) pcommon.Map {
 	attributes := pcommon.NewMap()
 	attributes.EnsureCapacity(len(dimensions))
 	for key, val := range dimensions {
-
 		if strings.HasPrefix(key, "metric_name") || key == "_value" {
 			continue
 		}

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -62,7 +62,6 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 				pt.Fields["metric_name"] = "single"
 				pt.Fields["_value"] = int64Ptr(13)
 				return pt
-
 			}(),
 			wantMetricsData: buildDefaultMetricsData(nanos),
 			hecConfig:       defaultTestingHecConfig,

--- a/receiver/sqlqueryreceiver/logs_receiver.go
+++ b/receiver/sqlqueryreceiver/logs_receiver.go
@@ -48,7 +48,6 @@ func newLogsReceiver(
 	createClient sqlquery.ClientProviderFunc,
 	nextConsumer consumer.Logs,
 ) (*logsReceiver, error) {
-
 	obsr, err := receiverhelper.NewObsReport(receiverhelper.ObsReportSettings{
 		ReceiverID:             settings.ID,
 		ReceiverCreateSettings: settings,
@@ -268,7 +267,6 @@ func (queryReceiver *logsQueryReceiver) retrieveTrackingValue(ctx context.Contex
 	}
 
 	return string(storedTrackingValueBytes)
-
 }
 
 func (queryReceiver *logsQueryReceiver) collect(ctx context.Context) (plog.Logs, error) {

--- a/receiver/sqlserverreceiver/factory.go
+++ b/receiver/sqlserverreceiver/factory.go
@@ -52,7 +52,6 @@ func setupQueries(cfg *Config) []string {
 		cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLRecompilationRate.Enabled ||
 		cfg.MetricsBuilderConfig.Metrics.SqlserverBatchSQLCompilationRate.Enabled ||
 		cfg.MetricsBuilderConfig.Metrics.SqlserverUserConnectionCount.Enabled {
-
 		queries = append(queries, getSQLServerPerformanceCounterQuery(cfg.InstanceName))
 	}
 

--- a/receiver/sqlserverreceiver/queries_test.go
+++ b/receiver/sqlserverreceiver/queries_test.go
@@ -68,5 +68,4 @@ func TestQueryContents(t *testing.T) {
 			require.Equal(t, expected, actual)
 		})
 	}
-
 }

--- a/receiver/sqlserverreceiver/scraper.go
+++ b/receiver/sqlserverreceiver/scraper.go
@@ -51,7 +51,6 @@ func newSQLServerScraper(id component.ID,
 	dbProviderFunc sqlquery.DbProviderFunc,
 	clientProviderFunc sqlquery.ClientProviderFunc,
 	mb *metadata.MetricsBuilder) *sqlServerScraperHelper {
-
 	return &sqlServerScraperHelper{
 		id:                 id,
 		sqlQuery:           query,

--- a/receiver/sqlserverreceiver/scraper_test.go
+++ b/receiver/sqlserverreceiver/scraper_test.go
@@ -165,7 +165,6 @@ func readFile(fname string) ([]sqlquery.StringMap, error) {
 	}
 
 	return metrics, nil
-
 }
 
 func (mc mockClient) QueryRows(context.Context, ...any) ([]sqlquery.StringMap, error) {

--- a/receiver/sshcheckreceiver/factory.go
+++ b/receiver/sshcheckreceiver/factory.go
@@ -38,7 +38,6 @@ func createDefaultConfig() component.Config {
 }
 
 func createMetricsReceiver(_ context.Context, params receiver.Settings, rConf component.Config, consumer consumer.Metrics) (receiver.Metrics, error) {
-
 	cfg, ok := rConf.(*Config)
 	if !ok {
 		return nil, errConfigNotSSHCheck

--- a/receiver/sshcheckreceiver/scraper_test.go
+++ b/receiver/sshcheckreceiver/scraper_test.go
@@ -314,7 +314,6 @@ func TestCancellation(t *testing.T) {
 	_, err := scrpr.scrape(ctx)
 	require.Error(t, err, "should have returned error on canceled context")
 	require.EqualValues(t, err.Error(), ctx.Err().Error(), "scrape should return context's error")
-
 }
 
 // issue # 18193

--- a/receiver/statsdreceiver/config.go
+++ b/receiver/statsdreceiver/config.go
@@ -34,7 +34,6 @@ func (c *Config) Validate() error {
 
 	var TimerHistogramMappingMissingObjectName bool
 	for _, eachMap := range c.TimerHistogramMapping {
-
 		if eachMap.StatsdType == "" {
 			TimerHistogramMappingMissingObjectName = true
 			break

--- a/receiver/statsdreceiver/internal/protocol/metric_translator_test.go
+++ b/receiver/statsdreceiver/internal/protocol/metric_translator_test.go
@@ -63,7 +63,6 @@ func TestSetTimestampsForCounterMetric(t *testing.T) {
 		metric.Metrics().At(0).Sum().DataPoints().At(0).Timestamp(),
 		expectedMetrics.Metrics().At(0).Sum().DataPoints().At(0).Timestamp(),
 	)
-
 }
 
 func TestBuildGaugeMetric(t *testing.T) {
@@ -272,5 +271,4 @@ func TestBuildHistogramMetric(t *testing.T) {
 	require.Equal(t, "myvalue", val.Str())
 	val, _ = datapoint.Attributes().Get("mykey2")
 	require.Equal(t, "myvalue2", val.Str())
-
 }

--- a/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
+++ b/receiver/statsdreceiver/internal/protocol/statsd_parser_test.go
@@ -1636,7 +1636,6 @@ func TestStatsDParser_Mappings(t *testing.T) {
 }
 
 func TestStatsDParser_ScopeIsIncluded(t *testing.T) {
-
 	const devVersion = "dev-0.0.1"
 
 	p := &StatsDParser{
@@ -1671,7 +1670,6 @@ func TestStatsDParser_ScopeIsIncluded(t *testing.T) {
 		assert.Equal(t, receiverName, scope.Name())
 		assert.Equal(t, devVersion, scope.Version())
 	}
-
 }
 
 func TestTimeNowFunc(t *testing.T) {
@@ -1963,5 +1961,4 @@ func TestStatsDParser_IPOnlyAggregation(t *testing.T) {
 		Metrics().At(0).Sum().DataPoints().At(0).IntValue()
 
 	assert.Equal(t, int64(4), value)
-
 }

--- a/receiver/statsdreceiver/receiver.go
+++ b/receiver/statsdreceiver/receiver.go
@@ -46,7 +46,6 @@ func newReceiver(
 	config Config,
 	nextConsumer consumer.Metrics,
 ) (receiver.Metrics, error) {
-
 	if config.NetAddr.Endpoint == "" {
 		config.NetAddr.Endpoint = "localhost:8125"
 	}

--- a/receiver/tlscheckreceiver/config_test.go
+++ b/receiver/tlscheckreceiver/config_test.go
@@ -89,7 +89,6 @@ func TestValidate(t *testing.T) {
 			} else {
 				require.NoError(t, actualErr)
 			}
-
 		})
 	}
 }

--- a/receiver/vcenterreceiver/config_test.go
+++ b/receiver/vcenterreceiver/config_test.go
@@ -110,5 +110,4 @@ func TestLoadConfig(t *testing.T) {
 	if diff := cmp.Diff(expected, cfg, cmpopts.IgnoreUnexported(metadata.MetricConfig{}), cmpopts.IgnoreUnexported(metadata.ResourceAttributeConfig{})); diff != "" {
 		t.Errorf("Config mismatch (-expected +actual):\n%s", diff)
 	}
-
 }

--- a/receiver/vcenterreceiver/metrics.go
+++ b/receiver/vcenterreceiver/metrics.go
@@ -73,7 +73,6 @@ func (v *vcenterMetricScraper) recordDatacenterStats(
 	v.mb.RecordVcenterDatacenterDiskSpaceDataPoint(ts, dcStat.DiskFree, metadata.AttributeDiskStateAvailable)
 	v.mb.RecordVcenterDatacenterCPULimitDataPoint(ts, dcStat.CPULimit)
 	v.mb.RecordVcenterDatacenterMemoryLimitDataPoint(ts, dcStat.MemoryLimit)
-
 }
 
 func getEntityStatusAttribute(status types.ManagedEntityStatus) (metadata.AttributeEntityStatus, bool) {
@@ -200,7 +199,6 @@ func (v *vcenterMetricScraper) recordResourcePoolStats(
 
 	v.mb.RecordVcenterResourcePoolCPUSharesDataPoint(ts, int64(s.Config.CpuAllocation.Shares.Shares))
 	v.mb.RecordVcenterResourcePoolMemorySharesDataPoint(ts, int64(s.Config.MemoryAllocation.Shares.Shares))
-
 }
 
 // recordClusterStats records stat metrics for a vSphere Host
@@ -312,7 +310,6 @@ func (v *vcenterMetricScraper) recordVMStats(
 
 	cpuReadiness := vm.Summary.QuickStats.OverallCpuReadiness
 	v.mb.RecordVcenterVMCPUReadinessDataPoint(ts, int64(cpuReadiness))
-
 }
 
 var hostPerfMetricList = []string{

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -58,5 +58,4 @@ func appendMetadata(resourceLog plog.ResourceLogs, query url.Values) {
 			resourceLog.Resource().Attributes().PutStr(k, query.Get(k))
 		}
 	}
-
 }

--- a/receiver/zipkinreceiver/trace_receiver.go
+++ b/receiver/zipkinreceiver/trace_receiver.go
@@ -254,7 +254,6 @@ func (zr *zipkinReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		_, _ = w.Write(errNextConsumerRespBody)
 	}
-
 }
 
 func transportType(r *http.Request, asZipkinv1 bool) string {

--- a/receiver/zookeeperreceiver/metrics.go
+++ b/receiver/zookeeperreceiver/metrics.go
@@ -111,7 +111,6 @@ func (m *metricCreator) generateComputedMetrics(logger *zap.Logger, ts pcommon.T
 	if err := m.computeNotSyncedFollowersMetric(ts); err != nil {
 		logger.Debug("metric computation failed", zap.Error(err))
 	}
-
 }
 
 func (m *metricCreator) computeNotSyncedFollowersMetric(ts pcommon.Timestamp) error {


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
