### PR TITLE
[fix][prometheusexporter] Race condition between start and shutdown

### DIFF
--- a/.chloggen/fix_prometheusexporter-shutdown-server-2.yaml
+++ b/.chloggen/fix_prometheusexporter-shutdown-server-2.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes a race condition between the exporter start and shutdown functions."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36139]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/prometheusexporter/prometheus.go
+++ b/exporter/prometheusexporter/prometheus.go
@@ -6,13 +6,14 @@ package prometheusexporter // import "github.com/open-telemetry/opentelemetry-co
 import (
 	"context"
 	"errors"
+	"net/http"
+	"strings"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/exporter"
 	"go.opentelemetry.io/collector/pdata/pmetric"
-	"net/http"
-	"strings"
 )
 
 type prometheusExporter struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adjusted the Start and Shutdown sequence of the prometheusexporter to prevent a race condition causing the `close tcp 127.0.0.1:8999: use of closed network connection` error as observed in #36139.

The behaviour was changed in the following ways:

- If an error occurs during the creation of the server, close the listener immediately, leaving shutdown a noop
- Since `srv.Shutdown` will close all open listeners, the explicit call to `ln.Close` in the shutdown routine was removed

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36139

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit testing, I temporarily increased the number of iterations on `TestPrometheusExporter` to 2000. The error did no longer occur. However sporadically another error occured:

```
=== RUN   TestPrometheusExporter
    prometheus_test.go:103: 
        	Error Trace:	C:/development/code/opentelemetry-collector-contrib/exporter/prometheusexporter/prometheus_test.go:84
        	Error:      	Received unexpected error:
        	            	listen tcp 127.0.0.1:8999: bind: Only one usage of each socket address (protocol/network address/port) is normally permitted.
        	Test:       	TestPrometheusExporter
--- FAIL: TestPrometheusExporter (1.16s)
```

I assume that this is because the OS (in my case Windows) won't always close the underlying sockets immediately, blocking it for some time afterwards. I'm not sure there is anything we can do about that.

<!--Describe the documentation added.-->
#### Documentation

n/a
<!--Please delete paragraphs that you did not use before submitting.-->
