### PR TITLE
deltatocumulativeprocessor:  update max_streams in the readme

### DIFF
--- a/processor/deltatocumulativeprocessor/README.md
+++ b/processor/deltatocumulativeprocessor/README.md
@@ -30,7 +30,7 @@ processors:
  
         # upper limit of streams to track. new streams exceeding this limit
         # will be dropped
-        [ max_streams: <int> | default = 0 (off) ]
+        [ max_streams: <int> | default = 9223372036854775807 (max int) ]
 
 ```
 

--- a/processor/deltatocumulativeprocessor/config.go
+++ b/processor/deltatocumulativeprocessor/config.go
@@ -35,7 +35,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		MaxStale: 5 * time.Minute,
 
-		// disable. TODO: find good default
+		// TODO: find good default
 		// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/31603
 		MaxStreams: math.MaxInt,
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The max_streams default value was changed in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35048 but it was not updated in the readme.
