### PR TITLE
[receiver/windowseventlog] Fix panic when rendering excessively long offset

### DIFF
--- a/.chloggen/fix-panic-wel.yaml
+++ b/.chloggen/fix-panic-wel.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/windowseventlog
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix panic when rendering long event messages.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36179]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/stanza/operator/input/windows/buffer.go
+++ b/pkg/stanza/operator/input/windows/buffer.go
@@ -23,6 +23,9 @@ type Buffer struct {
 
 // ReadBytes will read UTF-8 bytes from the buffer, where offset is the number of bytes to be read
 func (b *Buffer) ReadBytes(offset uint32) ([]byte, error) {
+	if offset > uint32(len(b.buffer)) {
+		offset = uint32(len(b.buffer))
+	}
 	utf16 := b.buffer[:offset]
 	utf8, err := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewDecoder().Bytes(utf16)
 	if err != nil {

--- a/pkg/stanza/operator/input/windows/buffer_test.go
+++ b/pkg/stanza/operator/input/windows/buffer_test.go
@@ -21,6 +21,17 @@ func TestBufferReadBytes(t *testing.T) {
 	require.Equal(t, utf8, bytes)
 }
 
+func TestBufferReadBytesOverflow(t *testing.T) {
+	buffer := NewBuffer()
+	utf8 := []byte("test")
+	utf16, _ := unicode.UTF16(unicode.LittleEndian, unicode.UseBOM).NewEncoder().Bytes(utf8)
+	copy(buffer.buffer, utf16)
+	offset := uint32(len(utf16))
+	bytes, err := buffer.ReadBytes(offset * 2)
+	require.NoError(t, err)
+	require.Equal(t, utf8, bytes)
+}
+
 func TestBufferReadWideBytes(t *testing.T) {
 	buffer := NewBuffer()
 	utf8 := []byte("test")


### PR DESCRIPTION
A user observed a panic in the receiver after updating to v0.112.0, where rendering info is expanded by default:
```
goroutine 69 [running]:
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows.(*Buffer).ReadBytes(0x37?, 0x19?)
    C:/Users/runneradmin/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.112.0/operator/input/windows/buffer.go:26 +0x165
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows.(*Buffer).ReadWideChars(...)
    C:/Users/runneradmin/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.112.0/operator/input/windows/buffer.go:37
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows.(*Event).RenderDeep(0xc002aaf998, {{0xc003120000, 0x4000, 0x4000}}, {0x8c1b918?})
    C:/Users/runneradmin/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza@v0.112.0/operator/input/windows/event.go:117 +0x155
github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/input/windows.(*Input).renderDeepAndSend(0xc001ee3dc0, {0x9977160, 0xc00312c460}, {0x19}, {0x13b480ccd58?})
```

@pjanotti This is a quick fix to avoid the panic by reading the full buffer, but not trying to read more. There may be a better behavior than this but I am not familiar with how the buffer size is established so am proposing to just read the full content for now.