### PR TITLE
[ottl] Demonstrate simpler context constructors

### DIFF
--- a/pkg/ottl/contexts/ottldatapoint/datapoint.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint.go
@@ -60,6 +60,11 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 
 type Option func(*ottl.Parser[TransformContext])
 
+func NewTransformContextSimple(dataPoint any, metric pmetric.Metric, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics) TransformContext {
+	return NewTransformContext(dataPoint, metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetrics.Resource(), scopeMetrics, resourceMetrics)
+}
+
+// Deprecated: Use NewTransformContextSimple instead.
 func NewTransformContext(dataPoint any, metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics) TransformContext {
 	return TransformContext{
 		dataPoint:            dataPoint,

--- a/pkg/ottl/contexts/ottllog/log.go
+++ b/pkg/ottl/contexts/ottllog/log.go
@@ -67,6 +67,11 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 
 type Option func(*ottl.Parser[TransformContext])
 
+func NewTransformContextSimple(logRecord plog.LogRecord, scopeLogs plog.ScopeLogs, resourceLogs plog.ResourceLogs) TransformContext {
+	return NewTransformContext(logRecord, scopeLogs.Scope(), resourceLogs.Resource(), scopeLogs, resourceLogs)
+}
+
+// Deprecated: Use NewTransformContextSimple instead.
 func NewTransformContext(logRecord plog.LogRecord, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeLogs plog.ScopeLogs, resourceLogs plog.ResourceLogs) TransformContext {
 	return TransformContext{
 		logRecord:            logRecord,

--- a/pkg/ottl/contexts/ottlmetric/metrics.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics.go
@@ -31,6 +31,11 @@ type TransformContext struct {
 
 type Option func(*ottl.Parser[TransformContext])
 
+func NewTransformContextSimple(metric pmetric.Metric, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics) TransformContext {
+	return NewTransformContext(metric, scopeMetrics.Metrics(), scopeMetrics.Scope(), resourceMetrics.Resource(), scopeMetrics, resourceMetrics)
+}
+
+// Deprecated: Use NewTransformContextSimple instead.
 func NewTransformContext(metric pmetric.Metric, metrics pmetric.MetricSlice, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeMetrics pmetric.ScopeMetrics, resourceMetrics pmetric.ResourceMetrics) TransformContext {
 	return TransformContext{
 		metric:               metric,

--- a/pkg/ottl/contexts/ottlspan/span.go
+++ b/pkg/ottl/contexts/ottlspan/span.go
@@ -41,6 +41,11 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 
 type Option func(*ottl.Parser[TransformContext])
 
+func NewTransformContextSimple(span ptrace.Span, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans) TransformContext {
+	return NewTransformContext(span, scopeSpans.Scope(), resourceSpans.Resource(), scopeSpans, resourceSpans)
+}
+
+// Deprecated: Use NewTransformContextSimple instead.
 func NewTransformContext(span ptrace.Span, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans) TransformContext {
 	return TransformContext{
 		span:                 span,

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -44,6 +44,11 @@ func (tCtx TransformContext) MarshalLogObject(encoder zapcore.ObjectEncoder) err
 
 type Option func(*ottl.Parser[TransformContext])
 
+func NewTransformContextSimple(spanEvent ptrace.SpanEvent, span ptrace.Span, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans) TransformContext {
+	return NewTransformContext(spanEvent, span, scopeSpans.Scope(), resourceSpans.Resource(), scopeSpans, resourceSpans)
+}
+
+// Deprecated: Use NewTransformContextSimple instead.
 func NewTransformContext(spanEvent ptrace.SpanEvent, span ptrace.Span, instrumentationScope pcommon.InstrumentationScope, resource pcommon.Resource, scopeSpans ptrace.ScopeSpans, resourceSpans ptrace.ResourceSpans) TransformContext {
 	return TransformContext{
 		spanEvent:            spanEvent,


### PR DESCRIPTION
This is just a proof of concept PR, rather than an issue. 

I've been working with OTTL contexts lately and noticed that some of the parameters seem to be redundant. Looking back at the commit history, I believe the context constructors were created prior to some refactoring in pdata packages, so the redundancy appears to have been inherited from upstream changes.

My question is whether or not we could introduce a simpler set of constructors at this point, and potentially deprecate the old ones, maybe even push these changes down into the functions (which could access the same information). 