### PR TITLE
[pkg/ottl] Fix handling of slice values in `flatten` function by considering `depth` option

### DIFF
--- a/.chloggen/ottl-flatten-fix-top-level-slice-handling.yaml
+++ b/.chloggen/ottl-flatten-fix-top-level-slice-handling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type:
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix handling of slice values in `flatten` function by considering `depth` option
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36161]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/ottl-flatten-fix-top-level-slice-handling.yaml
+++ b/.chloggen/ottl-flatten-fix-top-level-slice-handling.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Fix handling of slice values in `flatten` function by considering `depth` option
+note: Respect the `depth` option when flattening slices using `flatten`
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [36161]
@@ -15,7 +15,7 @@ issues: [36161]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: The `depth` option is also now required to be at least `1`.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/ottl-flatten-fix-top-level-slice-handling.yaml
+++ b/.chloggen/ottl-flatten-fix-top-level-slice-handling.yaml
@@ -1,7 +1,7 @@
 # Use this changelog template to create an entry for release notes.
 
 # One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
-change_type:
+change_type: bug_fix
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
 component: pkg/ottl

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -107,16 +107,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `flatten(attributes, depth=0)`,
-			want: func(tCtx ottllog.TransformContext) {
-				tCtx.GetLogRecord().Attributes().Remove("things")
-				m1 := tCtx.GetLogRecord().Attributes().PutEmptyMap("things.0")
-				m1.PutStr("name", "foo")
-				m1.PutInt("value", 2)
-
-				m2 := tCtx.GetLogRecord().Attributes().PutEmptyMap("things.1")
-				m2.PutStr("name", "bar")
-				m2.PutInt("value", 5)
-			},
+			want:      func(tCtx ottllog.TransformContext) {},
 		},
 		{
 			statement: `flatten(attributes, depth=1)`,
@@ -131,7 +122,7 @@ func Test_e2e_editors(t *testing.T) {
 				m.PutStr("foo.flags", "pass")
 				m.PutStr("foo.bar", "pass")
 				m.PutStr("foo.flags", "pass")
-				m.PutStr("foo.slice.0", "val")
+				m.PutEmptySlice("foo.slice").AppendEmpty().SetStr("val")
 
 				m1 := m.PutEmptyMap("things.0")
 				m1.PutStr("name", "foo")

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -106,10 +106,6 @@ func Test_e2e_editors(t *testing.T) {
 			},
 		},
 		{
-			statement: `flatten(attributes, depth=0)`,
-			want:      func(_ ottllog.TransformContext) {},
-		},
-		{
 			statement: `flatten(attributes, depth=1)`,
 			want: func(tCtx ottllog.TransformContext) {
 				m := pcommon.NewMap()

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -107,7 +107,7 @@ func Test_e2e_editors(t *testing.T) {
 		},
 		{
 			statement: `flatten(attributes, depth=0)`,
-			want:      func(tCtx ottllog.TransformContext) {},
+			want:      func(_ ottllog.TransformContext) {},
 		},
 		{
 			statement: `flatten(attributes, depth=1)`,

--- a/pkg/ottl/ottlfuncs/func_flatten.go
+++ b/pkg/ottl/ottlfuncs/func_flatten.go
@@ -37,8 +37,8 @@ func flatten[K any](target ottl.PMapGetter[K], p ottl.Optional[string], d ottl.O
 	depth := int64(math.MaxInt64)
 	if !d.IsEmpty() {
 		depth = d.Get()
-		if depth < 0 {
-			return nil, fmt.Errorf("invalid depth for flatten function, %d cannot be negative", depth)
+		if depth < 1 {
+			return nil, fmt.Errorf("invalid depth '%d' for flatten function, must be greater than 0", depth)
 		}
 	}
 

--- a/pkg/ottl/ottlfuncs/func_flatten.go
+++ b/pkg/ottl/ottlfuncs/func_flatten.go
@@ -69,7 +69,7 @@ func flattenHelper(m pcommon.Map, result pcommon.Map, prefix string, currentDept
 		switch {
 		case v.Type() == pcommon.ValueTypeMap && currentDepth < maxDepth:
 			flattenHelper(v.Map(), result, prefix+k, currentDepth+1, maxDepth)
-		case v.Type() == pcommon.ValueTypeSlice:
+		case v.Type() == pcommon.ValueTypeSlice && currentDepth < maxDepth:
 			for i := 0; i < v.Slice().Len(); i++ {
 				v.Slice().At(i).CopyTo(result.PutEmpty(fmt.Sprintf("%v.%v", prefix+k, i)))
 			}

--- a/pkg/ottl/ottlfuncs/func_flatten_test.go
+++ b/pkg/ottl/ottlfuncs/func_flatten_test.go
@@ -144,6 +144,39 @@ func Test_flatten(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "zero depth",
+			target: map[string]any{
+				"0": map[string]any{
+					"1": map[string]any{
+						"2": map[string]any{
+							"3": "value",
+						},
+					},
+				},
+				"1": []any{
+					map[string]any{
+						"1": "value",
+					},
+				},
+			},
+			prefix: ottl.Optional[string]{},
+			depth:  ottl.NewTestingOptional[int64](0),
+			expected: map[string]any{
+				"0": map[string]any{
+					"1": map[string]any{
+						"2": map[string]any{
+							"3": "value",
+						},
+					},
+				},
+				"1": []any{
+					map[string]any{
+						"1": "value",
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/ottl/ottlfuncs/func_flatten_test.go
+++ b/pkg/ottl/ottlfuncs/func_flatten_test.go
@@ -145,7 +145,7 @@ func Test_flatten(t *testing.T) {
 			},
 		},
 		{
-			name: "zero depth",
+			name: "max depth with slice",
 			target: map[string]any{
 				"0": map[string]any{
 					"1": map[string]any{
@@ -154,23 +154,23 @@ func Test_flatten(t *testing.T) {
 						},
 					},
 				},
-				"1": []any{
-					map[string]any{
-						"1": "value",
+				"1": map[string]any{
+					"1": []any{
+						map[string]any{
+							"1": "value",
+						},
 					},
 				},
 			},
 			prefix: ottl.Optional[string]{},
-			depth:  ottl.NewTestingOptional[int64](0),
+			depth:  ottl.NewTestingOptional[int64](1),
 			expected: map[string]any{
-				"0": map[string]any{
-					"1": map[string]any{
-						"2": map[string]any{
-							"3": "value",
-						},
+				"0.1": map[string]any{
+					"2": map[string]any{
+						"3": "value",
 					},
 				},
-				"1": []any{
+				"1.1": []any{
 					map[string]any{
 						"1": "value",
 					},

--- a/pkg/ottl/ottlfuncs/func_flatten_test.go
+++ b/pkg/ottl/ottlfuncs/func_flatten_test.go
@@ -212,11 +212,29 @@ func Test_flatten_bad_target(t *testing.T) {
 }
 
 func Test_flatten_bad_depth(t *testing.T) {
-	target := &ottl.StandardPMapGetter[any]{
-		Getter: func(_ context.Context, _ any) (any, error) {
-			return pcommon.NewMap(), nil
+	tests := []struct {
+		name  string
+		depth ottl.Optional[int64]
+	}{
+		{
+			name:  "negative depth",
+			depth: ottl.NewTestingOptional[int64](-1),
+		},
+		{
+			name:  "zero depth",
+			depth: ottl.NewTestingOptional[int64](0),
 		},
 	}
-	_, err := flatten[any](target, ottl.Optional[string]{}, ottl.NewTestingOptional[int64](-1))
-	assert.Error(t, err)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target := &ottl.StandardPMapGetter[any]{
+				Getter: func(_ context.Context, _ any) (any, error) {
+					return pcommon.NewMap(), nil
+				},
+			}
+			_, err := flatten[any](target, ottl.Optional[string]{}, tt.depth)
+			assert.Error(t, err)
+		})
+	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adapts the `flatten` function to also consider the `depth` option when handling slice values. Before this change, the function flattened slice values beyond the given depth.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36161 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit and e2e tests

<!--Describe the documentation added.-->
#### Documentation

No changes here, as the docs already mention the expected behavior of the function when the `depth` option is set
<!--Please delete paragraphs that you did not use before submitting.-->
