### PR TITLE
[chore] Pin markdown-link-check version to 3.12.2

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -84,7 +84,7 @@ jobs:
         run: make chlog-preview > changelog_preview.md
       - name: Install markdown-link-check
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
-        run: npm install -g markdown-link-check
+        run: npm install -g markdown-link-check@3.12.2
       - name: Run markdown-link-check
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |


### PR DESCRIPTION
#### Description
the changelog workflow has started failing, likely due to regressions in the tool's latest release.  Pinning until fixed

#### Link to tracking issue
probably related to
- https://github.com/tcort/markdown-link-check/issues/369
- https://github.com/tcort/markdown-link-check/issues/370
