### PR TITLE
[exporter/elasticsearch] Translate `k8s.*.name` resource attributes in ECS mode

### DIFF
--- a/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
+++ b/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Translate `k8s.*.name` attributes to `kubernetes.*.name` in ECS mode
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36233]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
+++ b/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Translate `k8s.*.name` resource attributes to `kubernetes.*.name` in ECS mode
+note: Translate `k8s.*.name` resource attributes in ECS mode
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [36233]
@@ -15,7 +15,7 @@ issues: [36233]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: The resource attributes are `k8s.job.name`, `k8s.cronjob.name`, `k8s.statefulset.name`, `k8s.replicaset.name`, `k8s.daemonset.name`, `k8s.cluster.name`, `k8s.container.name`.
+subtext: Translate `k8s.job.name`, `k8s.cronjob.name`, `k8s.statefulset.name`, `k8s.replicaset.name`, `k8s.daemonset.name`, `k8s.container.name` to `kubernetes.*.name`. Translate `k8s.cluster.name` to `orchestrator.cluster.name`.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
+++ b/.chloggen/elasticsearchexporter_ecs-translate-k8s-names.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Translate `k8s.*.name` attributes to `kubernetes.*.name` in ECS mode
+note: Translate `k8s.*.name` resource attributes to `kubernetes.*.name` in ECS mode
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [36233]
@@ -15,7 +15,7 @@ issues: [36233]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: The resource attributes are `k8s.job.name`, `k8s.cronjob.name`, `k8s.statefulset.name`, `k8s.replicaset.name`, `k8s.daemonset.name`, `k8s.cluster.name`, `k8s.container.name`.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -268,31 +268,38 @@ If the target ECS field name is specified as an empty string (""), the converter
 
 When "Preserved" is true, the attribute will be preserved in the payload and duplicated as mapped to its ECS equivalent.
 
-| Semantic Convention Name | ECS Name | Preserve |
-|--------------------------|----------|----------|
-| cloud.platform           | cloud.service.name | false |
-| container.image.tags     | container.image.tag | false |
-| deployment.environment   | service.environment | false |
-| host.arch                | host.architecture | false |
-| host.name                | host.hostname | true |
-| k8s.deployment.name      | kubernetes.deployment.name | false |
-| k8s.namespace.name       | kubernetes.namespace | false |
-| k8s.node.name            | kubernetes.node.name | false |
-| k8s.pod.name             | kubernetes.pod.name | false |
-| k8s.pod.uid              | kubernetes.pod.uid | false |
-| os.description           | host.os.full | false |
-| os.name                  | host.os.name | false |
-| os.type                  | host.os.platform | false |
-| os.version               | host.os.version | false |
-| process.executable.path  | process.executable | false |
-| process.runtime.name     | service.runtime.name | false |
-| process.runtime.version  | service.runtime.version | false |
-| service.instance.id      | service.node.name | false |
-| telemetry.distro.name    | "" | false |
-| telemetry.distro.version | "" | false |
-| telemetry.sdk.language   | "" | false |
-| telemetry.sdk.name       | "" | false |
-| telemetry.sdk.version    | "" | false |
+| Semantic Convention Name | ECS Name                    | Preserve |
+|--------------------------|-----------------------------|----------|
+| cloud.platform           | cloud.service.name          | false    |
+| container.image.tags     | container.image.tag         | false    |
+| deployment.environment   | service.environment         | false    |
+| host.arch                | host.architecture           | false    |
+| host.name                | host.hostname               | true     |
+| k8s.cluster.name         | orchestrator.cluster.name   | false    |
+| k8s.container.name       | kubernetes.container.name   | false    |
+| k8s.cronjob.name         | kubernetes.cronjob.name     | false    |
+| k8s.daemonset.name       | kubernetes.daemonset.name   | false    |
+| k8s.deployment.name      | kubernetes.deployment.name  | false    |
+| k8s.job.name             | kubernetes.job.name         | false    |
+| k8s.namespace.name       | kubernetes.namespace        | false    |
+| k8s.node.name            | kubernetes.node.name        | false    |
+| k8s.pod.name             | kubernetes.pod.name         | false    |
+| k8s.pod.uid              | kubernetes.pod.uid          | false    |
+| k8s.replicaset.name      | kubernetes.replicaset.name  | false    |
+| k8s.statefulset.name     | kubernetes.statefulset.name | false    |
+| os.description           | host.os.full                | false    |
+| os.name                  | host.os.name                | false    |
+| os.type                  | host.os.platform            | false    |
+| os.version               | host.os.version             | false    |
+| process.executable.path  | process.executable          | false    |
+| process.runtime.name     | service.runtime.name        | false    |
+| process.runtime.version  | service.runtime.version     | false    |
+| service.instance.id      | service.node.name           | false    |
+| telemetry.distro.name    | ""                          | false    |
+| telemetry.distro.version | ""                          | false    |
+| telemetry.sdk.language   | ""                          | false    |
+| telemetry.sdk.name       | ""                          | false    |
+| telemetry.sdk.version    | ""                          | false    |
 
 ### Compound Mapping
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -57,6 +57,11 @@ var resourceAttrsConversionMap = map[string]string{
 	semconv.AttributeK8SNodeName:            "kubernetes.node.name",
 	semconv.AttributeK8SPodName:             "kubernetes.pod.name",
 	semconv.AttributeK8SPodUID:              "kubernetes.pod.uid",
+	semconv.AttributeK8SJobName:             "kubernetes.job.name",
+	semconv.AttributeK8SCronJobName:         "kubernetes.cronjob.name",
+	semconv.AttributeK8SStatefulSetName:     "kubernetes.statefulset.name",
+	semconv.AttributeK8SReplicaSetName:      "kubernetes.replicaset.name",
+	semconv.AttributeK8SDaemonSetName:       "kubernetes.daemonset.name",
 }
 
 // resourceAttrsToPreserve contains conventions that should be preserved in ECS mode.

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -62,8 +62,8 @@ var resourceAttrsConversionMap = map[string]string{
 	semconv.AttributeK8SStatefulSetName:     "kubernetes.statefulset.name",
 	semconv.AttributeK8SReplicaSetName:      "kubernetes.replicaset.name",
 	semconv.AttributeK8SDaemonSetName:       "kubernetes.daemonset.name",
-	semconv.AttributeK8SClusterName:         "kubernetes.cluster.name",
 	semconv.AttributeK8SContainerName:       "kubernetes.container.name",
+	semconv.AttributeK8SClusterName:         "orchestrator.cluster.name",
 }
 
 // resourceAttrsToPreserve contains conventions that should be preserved in ECS mode.

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -62,6 +62,8 @@ var resourceAttrsConversionMap = map[string]string{
 	semconv.AttributeK8SStatefulSetName:     "kubernetes.statefulset.name",
 	semconv.AttributeK8SReplicaSetName:      "kubernetes.replicaset.name",
 	semconv.AttributeK8SDaemonSetName:       "kubernetes.daemonset.name",
+	semconv.AttributeK8SClusterName:         "kubernetes.cluster.name",
+	semconv.AttributeK8SContainerName:       "kubernetes.container.name",
 }
 
 // resourceAttrsToPreserve contains conventions that should be preserved in ECS mode.

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -386,8 +386,8 @@ func TestEncodeLogECSMode(t *testing.T) {
 		semconv.AttributeK8SStatefulSetName:    "statefulset.name",
 		semconv.AttributeK8SReplicaSetName:     "replicaset.name",
 		semconv.AttributeK8SDaemonSetName:      "daemonset.name",
-		semconv.AttributeK8SClusterName:        "cluster.name",
 		semconv.AttributeK8SContainerName:      "container.name",
+		semconv.AttributeK8SClusterName:        "cluster.name",
 	})
 	require.NoError(t, err)
 
@@ -457,8 +457,8 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"kubernetes.statefulset.name": "statefulset.name",
 		"kubernetes.replicaset.name":  "replicaset.name",
 		"kubernetes.daemonset.name":   "daemonset.name",
-		"kubernetes.cluster.name":     "cluster.name",
-		"kubernetes.container.name":   "container.name"
+		"kubernetes.container.name":   "container.name",
+		"orchestrator.cluster.name":   "cluster.name"
 	}`, buf.String())
 }
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -381,6 +381,11 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"k8s.pod.name":                         "opentelemetry-pod-autoconf",
 		"k8s.pod.uid":                          "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff",
 		"k8s.deployment.name":                  "coredns",
+		semconv.AttributeK8SJobName:            "job.name",
+		semconv.AttributeK8SCronJobName:        "cronjob.name",
+		semconv.AttributeK8SStatefulSetName:    "statefulset.name",
+		semconv.AttributeK8SReplicaSetName:     "replicaset.name",
+		semconv.AttributeK8SDaemonSetName:      "daemonset.name",
 	})
 	require.NoError(t, err)
 
@@ -444,7 +449,12 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"kubernetes.node.name":       "node-1",
 		"kubernetes.pod.name":        "opentelemetry-pod-autoconf",
 		"kubernetes.pod.uid":         "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff",
-		"kubernetes.deployment.name": "coredns"
+		"kubernetes.deployment.name": "coredns",
+		"kubernetes.job.name":         "job.name",
+		"kubernetes.cronjob.name":     "cronjob.name",
+		"kubernetes.statefulset.name": "statefulset.name",
+		"kubernetes.replicaset.name":  "replicaset.name",
+		"kubernetes.daemonset.name":   "daemonset.name"
 	}`, buf.String())
 }
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -386,6 +386,8 @@ func TestEncodeLogECSMode(t *testing.T) {
 		semconv.AttributeK8SStatefulSetName:    "statefulset.name",
 		semconv.AttributeK8SReplicaSetName:     "replicaset.name",
 		semconv.AttributeK8SDaemonSetName:      "daemonset.name",
+		semconv.AttributeK8SClusterName:        "cluster.name",
+		semconv.AttributeK8SContainerName:      "container.name",
 	})
 	require.NoError(t, err)
 
@@ -454,7 +456,9 @@ func TestEncodeLogECSMode(t *testing.T) {
 		"kubernetes.cronjob.name":     "cronjob.name",
 		"kubernetes.statefulset.name": "statefulset.name",
 		"kubernetes.replicaset.name":  "replicaset.name",
-		"kubernetes.daemonset.name":   "daemonset.name"
+		"kubernetes.daemonset.name":   "daemonset.name",
+		"kubernetes.cluster.name":     "cluster.name",
+		"kubernetes.container.name":   "container.name"
 	}`, buf.String())
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In ECS mode:
Translate `k8s.job.name`, `k8s.cronjob.name`, `k8s.statefulset.name`, `k8s.replicaset.name`, `k8s.daemonset.name`, `k8s.container.name` to `kubernetes.*.name`. Translate `k8s.cluster.name` to `orchestrator.cluster.name`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
