### PR TITLE
[chore][pkg/stanza/fileconsumer] Emit logs in batches

### DIFF
--- a/.chloggen/refactor-callback-token.yaml
+++ b/.chloggen/refactor-callback-token.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Change signature of `emit.Callback` function in `pkg/stanza/fileconsumer/emit` package to emit multiple tokens. Each token's body and attributes are encapsulated in a new `emit.Token` struct.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36260]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [api]

--- a/.chloggen/refactor-callback-token.yaml
+++ b/.chloggen/refactor-callback-token.yaml
@@ -7,7 +7,7 @@ change_type: breaking
 component: pkg/stanza
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Change signature of `emit.Callback` function in `pkg/stanza/fileconsumer/emit` package to emit multiple tokens. Each token's body and attributes are encapsulated in a new `emit.Token` struct.
+note: Change signature of `emit.Callback` function in `pkg/stanza/fileconsumer/emit` package to emit multiple tokens.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [36260]

--- a/pkg/stanza/fileconsumer/benchmark_test.go
+++ b/pkg/stanza/fileconsumer/benchmark_test.go
@@ -188,9 +188,12 @@ func BenchmarkFileInput(b *testing.B) {
 			cfg.PollInterval = time.Microsecond
 
 			doneChan := make(chan bool, len(files))
-			callback := func(_ context.Context, token emit.Token) error {
-				if len(token.Body) == 0 {
-					doneChan <- true
+			callback := func(_ context.Context, tokens []emit.Token) error {
+				for _, token := range tokens {
+					if len(token.Body) == 0 {
+						doneChan <- true
+						break
+					}
 				}
 				return nil
 			}

--- a/pkg/stanza/fileconsumer/emit/emit.go
+++ b/pkg/stanza/fileconsumer/emit/emit.go
@@ -7,7 +7,7 @@ import (
 	"context"
 )
 
-type Callback func(ctx context.Context, token Token) error
+type Callback func(ctx context.Context, tokens []Token) error
 
 type Token struct {
 	Body       []byte

--- a/pkg/stanza/fileconsumer/internal/emittest/nop.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/nop.go
@@ -9,6 +9,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/emit"
 )
 
-func Nop(_ context.Context, _ emit.Token) error {
+func Nop(_ context.Context, _ []emit.Token) error {
 	return nil
 }

--- a/pkg/stanza/fileconsumer/internal/emittest/nop_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/nop_test.go
@@ -13,5 +13,5 @@ import (
 )
 
 func TestNop(t *testing.T) {
-	require.NoError(t, Nop(context.Background(), emit.Token{}))
+	require.NoError(t, Nop(context.Background(), []emit.Token{}))
 }

--- a/pkg/stanza/fileconsumer/internal/emittest/sink.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink.go
@@ -57,13 +57,15 @@ func NewSink(opts ...SinkOpt) *Sink {
 	return &Sink{
 		emitChan: emitChan,
 		timeout:  cfg.timeout,
-		Callback: func(ctx context.Context, token emit.Token) error {
-			copied := make([]byte, len(token.Body))
-			copy(copied, token.Body)
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case emitChan <- &Call{copied, token.Attributes}:
+		Callback: func(ctx context.Context, tokens []emit.Token) error {
+			for _, token := range tokens {
+				copied := make([]byte, len(token.Body))
+				copy(copied, token.Body)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case emitChan <- &Call{copied, token.Attributes}:
+				}
 			}
 			return nil
 		},

--- a/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
+++ b/pkg/stanza/fileconsumer/internal/emittest/sink_test.go
@@ -204,7 +204,7 @@ func sinkTest(t *testing.T, opts ...SinkOpt) (*Sink, []*Call) {
 	}
 	go func() {
 		for _, c := range testCalls {
-			assert.NoError(t, s.Callback(context.Background(), emit.NewToken(c.Token, c.Attrs)))
+			assert.NoError(t, s.Callback(context.Background(), []emit.Token{emit.NewToken(c.Token, c.Attrs)}))
 		}
 	}()
 	return s, testCalls

--- a/pkg/stanza/fileconsumer/internal/reader/factory.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory.go
@@ -24,8 +24,9 @@ import (
 )
 
 const (
-	DefaultMaxLogSize  = 1024 * 1024
-	DefaultFlushPeriod = 500 * time.Millisecond
+	DefaultMaxLogSize   = 1024 * 1024
+	DefaultFlushPeriod  = 500 * time.Millisecond
+	DefaultMaxBatchSize = 100
 )
 
 type Factory struct {
@@ -77,6 +78,7 @@ func (f *Factory) NewReaderFromMetadata(file *os.File, m *Metadata) (r *Reader, 
 		includeFileRecordNum: f.IncludeFileRecordNumber,
 		compression:          f.Compression,
 		acquireFSLock:        f.AcquireFSLock,
+		maxBatchSize:         DefaultMaxBatchSize,
 	}
 	r.set.Logger = r.set.Logger.With(zap.String("path", r.fileName))
 

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -52,6 +52,7 @@ type Reader struct {
 	includeFileRecordNum   bool
 	compression            string
 	acquireFSLock          bool
+	maxBatchSize           int
 }
 
 // ReadToEnd will read until the end of the file
@@ -179,6 +180,8 @@ func (r *Reader) readContents(ctx context.Context) {
 	// Create the scanner to read the contents of the file.
 	s := scanner.New(r, r.maxLogSize, r.initialBufferSize, r.Offset, r.contentSplitFunc)
 
+	tokens := make([]emit.Token, 0, r.maxBatchSize)
+
 	// Iterate over the contents of the file.
 	for {
 		select {
@@ -194,7 +197,7 @@ func (r *Reader) readContents(ctx context.Context) {
 			} else if r.deleteAtEOF {
 				r.delete()
 			}
-			return
+			break
 		}
 
 		token, err := r.decoder.Decode(s.Bytes())
@@ -209,13 +212,49 @@ func (r *Reader) readContents(ctx context.Context) {
 			r.FileAttributes[attrs.LogFileRecordNumber] = r.RecordNum
 		}
 
-		err = r.emitFunc(ctx, emit.NewToken(token, r.FileAttributes))
-		if err != nil {
-			r.set.Logger.Error("failed to process token", zap.Error(err))
-		}
+		tokens = append(tokens, emit.NewToken(copyBody(token), copyAttributes(r.FileAttributes)))
 
+		if r.maxBatchSize > 0 && len(tokens) >= r.maxBatchSize {
+			for _, t := range tokens {
+				err := r.emitFunc(ctx, t)
+				if err != nil {
+					r.set.Logger.Error("failed to process token", zap.Error(err))
+				}
+			}
+			tokens = tokens[:0]
+			r.Offset = s.Pos()
+		}
+	}
+
+	if len(tokens) > 0 {
+		for _, t := range tokens {
+			err := r.emitFunc(ctx, t)
+			if err != nil {
+				r.set.Logger.Error("failed to process token", zap.Error(err))
+			}
+		}
 		r.Offset = s.Pos()
 	}
+}
+
+func copyBody(body []byte) []byte {
+	if body == nil {
+		return nil
+	}
+	copied := make([]byte, len(body))
+	copy(copied, body)
+	return copied
+}
+
+func copyAttributes(attrs map[string]any) map[string]any {
+	if attrs == nil {
+		return nil
+	}
+	copied := make(map[string]any, len(attrs))
+	for k, v := range attrs {
+		copied[k] = v
+	}
+	return copied
 }
 
 // Delete will close and delete the file

--- a/pkg/stanza/fileconsumer/internal/reader/reader.go
+++ b/pkg/stanza/fileconsumer/internal/reader/reader.go
@@ -215,11 +215,9 @@ func (r *Reader) readContents(ctx context.Context) {
 		tokens = append(tokens, emit.NewToken(copyBody(token), copyAttributes(r.FileAttributes)))
 
 		if r.maxBatchSize > 0 && len(tokens) >= r.maxBatchSize {
-			for _, t := range tokens {
-				err := r.emitFunc(ctx, t)
-				if err != nil {
-					r.set.Logger.Error("failed to process token", zap.Error(err))
-				}
+			err := r.emitFunc(ctx, tokens)
+			if err != nil {
+				r.set.Logger.Error("failed to process tokens", zap.Error(err))
 			}
 			tokens = tokens[:0]
 			r.Offset = s.Pos()
@@ -227,11 +225,9 @@ func (r *Reader) readContents(ctx context.Context) {
 	}
 
 	if len(tokens) > 0 {
-		for _, t := range tokens {
-			err := r.emitFunc(ctx, t)
-			if err != nil {
-				r.set.Logger.Error("failed to process token", zap.Error(err))
-			}
+		err := r.emitFunc(ctx, tokens)
+		if err != nil {
+			r.set.Logger.Error("failed to process tokens", zap.Error(err))
 		}
 		r.Offset = s.Pos()
 	}

--- a/pkg/stanza/operator/helper/emitter.go
+++ b/pkg/stanza/operator/helper/emitter.go
@@ -94,10 +94,19 @@ func (e *LogEmitter) Stop() error {
 	return nil
 }
 
-// Process will emit an entry to the output channel
+// Process emits an entry to the consumerFunc
 func (e *LogEmitter) Process(ctx context.Context, ent *entry.Entry) error {
 	if oldBatch := e.appendEntry(ent); len(oldBatch) > 0 {
 		e.consumerFunc(ctx, oldBatch)
+	}
+
+	return nil
+}
+
+// ProcessBatch emits the entries to the consumerFunc
+func (e *LogEmitter) ProcessBatch(ctx context.Context, entries []entry.Entry) error {
+	for _, entry := range entries {
+		e.Process(ctx, &entry)
 	}
 
 	return nil

--- a/pkg/stanza/operator/helper/input.go
+++ b/pkg/stanza/operator/helper/input.go
@@ -90,3 +90,12 @@ func (i *InputOperator) Process(_ context.Context, _ *entry.Entry) error {
 		"Ensure that operator is not configured to receive logs from other operators",
 	)
 }
+
+// ProcessBatch will always return an error if called.
+func (i *InputOperator) ProcessBatch(_ context.Context, _ []entry.Entry) error {
+	i.Logger().Error("Operator received a batch of entries, but can not process")
+	return errors.NewError(
+		"Operator can not process logs.",
+		"Ensure that operator is not configured to receive logs from other operators",
+	)
+}

--- a/pkg/stanza/operator/input/file/config.go
+++ b/pkg/stanza/operator/input/file/config.go
@@ -60,7 +60,7 @@ func (c Config) Build(set component.TelemetrySettings) (operator.Operator, error
 		toBody:        toBody,
 	}
 
-	input.fileConsumer, err = c.Config.Build(set, input.emit)
+	input.fileConsumer, err = c.Config.Build(set, input.emitBatch)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/stanza/operator/operator.go
+++ b/pkg/stanza/operator/operator.go
@@ -38,6 +38,8 @@ type Operator interface {
 	CanProcess() bool
 	// Process will process an entry from an operator.
 	Process(context.Context, *entry.Entry) error
+	// Process processes a batch of entries from an operator.
+	ProcessBatch(context.Context, []entry.Entry) error
 	// Logger returns the operator's logger
 	Logger() *zap.Logger
 }


### PR DESCRIPTION
#### Description

Modifies the File consumer to emit logs in batches as opposed to sending each log individually through the Stanza pipeline and on to the Log Emitter.

This was achieved via the following incremental changes, with the goal of making code reviews easier (multiple smaller changesets):

- https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/a584e0a36d813925f169e853d4772aa7b2e3eeb6 collect scanned tokens into batches in `Reader::ReadToEnd` method in File consumer, but still call `emit` function for each token individually
- https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/6391f55f854744114562a89504647f2cde798c6c change `emit.Callback` function signature to accept a slice of tokens and emit tokens in batches from the `Reader`. At this point, the batches are still split into individual tokens inside the `emit` function, because the Stanza operators can only process one entry at a time.
- https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/187b345bfd232497c205b32c01026f38bb1d501b add `ProcessBatch` method to Stanza operators and use it in the `emit` function. At this point, the batch of tokens is translated to a batch of entries and passed to Log Emitter as a whole. The batch is still split in the Log Emitter, which calls `consumeFunc` for each entry in a loop.
- https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/8e3197b456978dabf2dc45b026b4da8406f114f7 do not split batches in Log Emitter, call `consumeFunc` on the whole batch of entries

Note that this is currently a draft, requesting initial feedback. I haven't yet implemented the `ProcessBatch` method for all Stanza operators, as I'd like to first get feedback its definition. Specifically, should the function accept a `[]entry.Entry` or `[]*entry.Entry`?

#### Link to tracking issue

- Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35455

#### Testing

No changes in tests. The goal is for the functionality to not change and for performance to not decrease.

#### Documentation

These are internal changes, no user documentation needs changing.