### PR TITLE
[test] Fix opampsupervisor test on Windows

### DIFF
--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -188,7 +188,7 @@ func getSupervisorConfig(t *testing.T, configType string, extraConfigData map[st
 		"goos":        runtime.GOOS,
 		"goarch":      runtime.GOARCH,
 		"extension":   extension,
-		"storage_dir": t.TempDir(),
+		"storage_dir": strings.ReplaceAll(t.TempDir(), "\\", "\\\\"),
 	}
 
 	for key, val := range extraConfigData {


### PR DESCRIPTION
Fix #36278

The issue is that the temporary path used in the test is passed as text to an yaml file so the Windows dir separator ends up as a escape char on the yaml.