### PR TITLE
Add back the JSON DATA

### DIFF
--- a/.github/workflows/scripts/generate-weekly-report.js
+++ b/.github/workflows/scripts/generate-weekly-report.js
@@ -8,6 +8,7 @@ const yaml = require('js-yaml');
 
 const REPO_NAME = "opentelemetry-collector-contrib"
 const REPO_OWNER = "open-telemetry"
+const ISSUE_CHAR_LIMIT = 65536
 
 function debug(msg) {
   console.log(JSON.stringify(msg, null, 2))
@@ -76,6 +77,40 @@ async function getNewIssues({octokit, context}) {
     console.error('Error fetching issues:', error);
     return [];
   }
+}
+
+function tryAddJSONData(report, issuesData, byStatus, seekingNewCodeOwnerCounts) {
+  let reducedIssuesData = {}
+  for (const [issuesName, data] of Object.entries(issuesData)) {
+    reducedIssuesData[issuesName] = data.count
+  }
+
+  let componentData = {
+    "lookingForOwners": seekingNewCodeOwnerCounts
+  }
+  for (const [status, components] of Object.entries(byStatus)) {
+    componentData[status] = Object.keys(components).length
+  }
+  debug({mgs: "componentData", componentData})
+  out = ['', '', '## JSON Data',
+  '<!-- MACHINE GENERATED: DO NOT EDIT -->'
+  ]
+  out.push(`<details>
+<summary>Expand</summary>
+<pre>${
+  JSON.stringify({
+    issuesData: reducedIssuesData,
+    componentData: componentData
+  }, null, 2)
+}
+</pre>
+</details>`);
+
+  jsonData = out.join('\n')
+  if ((report.length + jsonData.length) < ISSUE_CHAR_LIMIT) {
+    report += jsonData
+  }
+  return report
 }
 
 async function getTargetLabelIssues({octokit, labels, filterPrs, context}) {
@@ -205,7 +240,11 @@ function generateComponentsLookingForOwnersReportSection(lookingForOwners) {
   }
 
   section.push(`</details>`)
-  return {count, section}
+  return {lookingForOwnersCount: count, section}
+}
+
+function addChangesFromPreviousWeek(li, current, previous) {
+  return li += ` (${current - previous})`
 }
 
 function generateReport({ issuesData, previousReport, componentData }) {
@@ -219,13 +258,11 @@ function generateReport({ issuesData, previousReport, componentData }) {
   for (const lbl of Object.keys(issuesData)) {
     const section = [``];
     const { count, data, title } = issuesData[lbl];
-
-    if (previousReport === null) {
-      section.push(`<li> ${title}: ${count}`);
-    } else {
-      const previousCount = previousReport.issuesData[lbl].count; 
-      section.push(`<li> ${title}: ${count} (${count - previousCount})`);
+    li = `<li> ${title}: ${count}`
+    if (previousReport !== null) {
+      li = addChangesFromPreviousWeek(li, count, previousReport.issuesData[lbl])
     }
+    section.push(li)
 
     // generate summary if issues exist
     // NOTE: the newline after <summary> is required for markdown to render correctly
@@ -251,8 +288,11 @@ function generateReport({ issuesData, previousReport, componentData }) {
     const section = [``];
     const data = byStatus[lbl];
     const count = Object.keys(data).length;
-
-    section.push(`<li> ${lbl}: ${count}`);
+    li = section.push(`<li> ${lbl}: ${count}`); 
+    if (previousReport !== null) {
+      li = addChangesFromPreviousWeek(li, count, previousReport.componentData[lbl])
+    }
+    section.push(li)
     if (data.length !== 0) {
     // NOTE: the newline after <summary> is required for markdown to render correctly
       section.push(`<details>
@@ -261,19 +301,24 @@ function generateReport({ issuesData, previousReport, componentData }) {
         const {stability} = data[compName]
         return `- [ ] ${compName}: ${JSON.stringify(stability)}`
       }).join('\n')}
-</details>`);
+      </details>`);
     }
     section.push('</li>');
     out.push(section.join('\n'));
   }
 
-  let {count, section} = generateComponentsLookingForOwnersReportSection(lookingForOwners)
-  out.push(`<li> Seeking new code owners: ${count}`)
+  let {lookingForOwnersCount, section} = generateComponentsLookingForOwnersReportSection(lookingForOwners)
+  li = `<li> Seeking new code owners: ${lookingForOwnersCount}`
+  if (previousReport !== null) {
+    li = addChangesFromPreviousWeek(li, lookingForOwnersCount, previousReport.componentData.lookingForOwners)
+  }
+  out.push(li)
   out.push(...section)
   out.push('</li>')
   out.push('</ul>');
 
-  const report = out.join('\n');
+  let report = out.join('\n');
+  report = tryAddJSONData(report, issuesData, byStatus, lookingForOwnersCount)
   return report;
 }
 
@@ -339,8 +384,6 @@ async function processIssues({ octokit, context, lookbackData }) {
   }
 
   return {issuesData, previousReport}
-
-
 }
 
 const findFilesByName = (startPath, filter) => {


### PR DESCRIPTION
The JSON DATA section is used to add the CHANGE_FROM_PREVIOUS_WEEK for each voice of the report.

The code was removed because the generate JSON would get the issue content past the allowed limit.

With these changes we are not adding the JSON data if it will bring the issue chart past the allowed limit.

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
