### PR TITLE
[chore]: enable whitespace linter for testbed

### DIFF
--- a/testbed/correctnesstests/connectors/correctness_test.go
+++ b/testbed/correctnesstests/connectors/correctness_test.go
@@ -43,7 +43,6 @@ func TestGoldenData(t *testing.T) {
 	t.Run(sampleTest.TestName, func(t *testing.T) {
 		testWithGoldenDataset(t, sampleTest.DataSender, sampleTest.DataReceiver, sampleTest.ResourceSpec, sampleTest.DataConnector, processors)
 	})
-
 }
 
 func testWithGoldenDataset(
@@ -96,5 +95,4 @@ func testWithGoldenDataset(
 		3*time.Second, "all data items received")
 
 	tc.StopAgent()
-
 }

--- a/testbed/correctnesstests/utils.go
+++ b/testbed/correctnesstests/utils.go
@@ -33,7 +33,6 @@ func CreateConfigYaml(
 	connector testbed.DataConnector,
 	processors []ProcessorNameAndConfigBody,
 ) string {
-
 	// Prepare extra processor config section and comma-separated list of extra processor
 	// names to use in corresponding "processors" settings.
 	processorsSections := ""

--- a/testbed/datasenders/jaeger.go
+++ b/testbed/datasenders/jaeger.go
@@ -145,7 +145,6 @@ func (s *protoGRPCSender) pushTraces(
 	ctx context.Context,
 	td ptrace.Traces,
 ) error {
-
 	batches := jaeger.ProtoFromTraces(td)
 
 	if s.metadata.Len() > 0 {

--- a/testbed/datasenders/syslog.go
+++ b/testbed/datasenders/syslog.go
@@ -122,7 +122,6 @@ func (f *SyslogWriter) SendCheck() error {
 		if err != nil {
 			return nil
 		}
-
 	}
 	return nil
 }

--- a/testbed/datasenders/tcpudp.go
+++ b/testbed/datasenders/tcpudp.go
@@ -115,7 +115,6 @@ func (f *TCPUDPWriter) SendCheck() error {
 		if err != nil {
 			return nil
 		}
-
 	}
 	return nil
 }

--- a/testbed/testbed/child_process_collector.go
+++ b/testbed/testbed/child_process_collector.go
@@ -176,7 +176,6 @@ func expandExeFileName(exeName string) string {
 // the process to.
 // cmdArgs is the command line arguments to pass to the process.
 func (cp *childProcessCollector) Start(params StartParams) error {
-
 	cp.name = params.Name
 	cp.doneSignal = make(chan struct{})
 	cp.resourceSpec = params.resourceSpec
@@ -249,7 +248,6 @@ func (cp *childProcessCollector) Stop() (stopped bool, err error) {
 		return false, nil
 	}
 	cp.stopOnce.Do(func() {
-
 		if !cp.isStarted {
 			// Process wasn't started, nothing to stop.
 			return

--- a/testbed/testbed/data_providers.go
+++ b/testbed/testbed/data_providers.go
@@ -60,7 +60,6 @@ func (dp *perfTestDataProvider) GenerateTraces() (ptrace.Traces, bool) {
 
 	traceID := dp.traceIDSequence.Add(1)
 	for i := 0; i < dp.options.ItemsPerBatch; i++ {
-
 		startTime := time.Now().Add(time.Duration(i+int(traceID)*1000) * time.Second)
 		endTime := startTime.Add(time.Millisecond)
 

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -218,7 +218,6 @@ func (tc *MockTraceConsumer) ConsumeTraces(_ context.Context, td ptrace.Traces) 
 				// Ignore the seqnums for now. We will use them later.
 				_ = spanSeqnum
 				_ = traceSeqnum
-
 			}
 		}
 	}

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -345,5 +345,4 @@ func (tc *TestCase) AgentLogsContains(text string) bool {
 
 	res, _ := grep.Output()
 	return string(res) != ""
-
 }

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -48,7 +48,6 @@ func (v *LogPresentValidator) Validate(tc *TestCase) {
 }
 
 func (v *LogPresentValidator) RecordResults(tc *TestCase) {
-
 	var result string
 	if tc.t.Failed() {
 		result = "FAIL"
@@ -418,7 +417,6 @@ func (v *CorrectnessTestValidator) diffSpanLinks(sentSpan ptrace.Span, recdSpan 
 				}
 				v.assertionFailures = append(v.assertionFailures, af)
 			}
-
 		}
 	}
 	if sentSpan.DroppedLinksCount() != recdSpan.DroppedLinksCount() {

--- a/testbed/tests/e2e_test.go
+++ b/testbed/tests/e2e_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func TestIdleMode(t *testing.T) {
-
 	options := testbed.LoadOptions{DataItemsPerSecond: 10_000, ItemsPerBatch: 10}
 	dataProvider := testbed.NewPerfTestDataProvider(options)
 

--- a/testbed/tests/log_test.go
+++ b/testbed/tests/log_test.go
@@ -241,7 +241,6 @@ func TestLogOtlpSendingQueue(t *testing.T) {
 			nil,
 			nil)
 	})
-
 }
 
 func TestLogLargeFiles(t *testing.T) {

--- a/testbed/tests/metric_test.go
+++ b/testbed/tests/metric_test.go
@@ -91,7 +91,6 @@ func TestMetric10kDPS(t *testing.T) {
 			)
 		})
 	}
-
 }
 
 func TestMetricsFromFile(t *testing.T) {

--- a/testbed/tests/resource_processor_test.go
+++ b/testbed/tests/resource_processor_test.go
@@ -49,7 +49,6 @@ type resourceProcessorTestCase struct {
 }
 
 func getResourceProcessorTestCases() []resourceProcessorTestCase {
-
 	tests := []resourceProcessorTestCase{
 		{
 			name: "update_and_rename_existing_attributes",

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -44,7 +44,6 @@ func createConfigYaml(
 	processors []ProcessorNameAndConfigBody,
 	extensions map[string]string,
 ) string {
-
 	// Create a config. Note that our DataSender is used to generate a config for Collector's
 	// receiver and our DataReceiver is used to generate a config for Collector's exporter.
 	// This is because our DataSender sends to Collector's receiver and our DataReceiver
@@ -271,7 +270,6 @@ func Scenario1kSPSWithAttrs(t *testing.T, args []string, tests []TestCase, proce
 		test := tests[i]
 
 		t.Run(fmt.Sprintf("%d*%dbytes", test.attrCount, test.attrSizeByte), func(t *testing.T) {
-
 			options := constructLoadOptions(test)
 
 			agentProc := testbed.NewChildProcessCollector(testbed.WithEnvVar("GOMAXPROCS", "2"))

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -180,7 +180,6 @@ func TestTrace10kSPSJaegerGRPC(t *testing.T) {
 }
 
 func TestTraceNoBackend10kSPS(t *testing.T) {
-
 	limitProcessors := []ProcessorNameAndConfigBody{
 		{
 			Name: "memory_limiter",
@@ -277,7 +276,6 @@ func verifySingleSpan(
 	spanName string,
 	verifyReceived func(span ptrace.Span),
 ) {
-
 	// Clear previously received traces.
 	tc.MockBackend.ClearReceivedItems()
 	startCounter := tc.MockBackend.DataItemsReceived()


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
