### PR TITLE
[chore]: enable whitespace linter for processor and receiver

### DIFF
--- a/processor/attributesprocessor/attributes_metric.go
+++ b/processor/attributesprocessor/attributes_metric.go
@@ -62,7 +62,6 @@ func (a *metricAttributesProcessor) processMetrics(ctx context.Context, md pmetr
 // Attributes are provided for each log and trace, but not at the metric level
 // Need to process attributes for every data point within a metric.
 func (a *metricAttributesProcessor) processMetricAttributes(ctx context.Context, m pmetric.Metric) {
-
 	// This is a lot of repeated code, but since there is no single parent superclass
 	// between metric data types, we can't use polymorphism.
 	//exhaustive:enforce

--- a/processor/attributesprocessor/factory.go
+++ b/processor/attributesprocessor/factory.go
@@ -92,7 +92,6 @@ func createMetricsProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Metrics,
 ) (processor.Metrics, error) {
-
 	oCfg := cfg.(*Config)
 	attrProc, err := attraction.NewAttrProc(&oCfg.Settings)
 	if err != nil {

--- a/processor/deltatocumulativeprocessor/internal/data/expo_test.go
+++ b/processor/deltatocumulativeprocessor/internal/data/expo_test.go
@@ -117,7 +117,6 @@ func TestExpoAdd(t *testing.T) {
 		}
 		t.Run(cs.name, run(cs.dp, cs.in))
 	}
-
 }
 
 func rawbs(data []uint64, offset int32) expo.Buckets {

--- a/processor/deltatocumulativeprocessor/internal/delta/delta_test.go
+++ b/processor/deltatocumulativeprocessor/internal/delta/delta_test.go
@@ -222,7 +222,6 @@ func TestErrs(t *testing.T) {
 			require.Equal(t, r1.IntValue(), r2.IntValue())
 		})
 	}
-
 }
 
 func time(ts int) pcommon.Timestamp {

--- a/processor/deltatocumulativeprocessor/processor_test.go
+++ b/processor/deltatocumulativeprocessor/processor_test.go
@@ -72,7 +72,6 @@ func TestProcessor(t *testing.T) {
 				}
 			}
 		})
-
 	}
 }
 

--- a/processor/deltatorateprocessor/processor_test.go
+++ b/processor/deltatorateprocessor/processor_test.go
@@ -172,7 +172,6 @@ func TestCumulativeToDeltaProcessor(t *testing.T) {
 						require.Equal(t, eDataPoints.At(j).DoubleValue(), aDataPoints.At(j).DoubleValue())
 					}
 				}
-
 			}
 
 			require.NoError(t, mgp.Shutdown(ctx))

--- a/processor/filterprocessor/config_test.go
+++ b/processor/filterprocessor/config_test.go
@@ -97,7 +97,6 @@ func TestLoadingConfigStrict(t *testing.T) {
 
 // TestLoadingConfigStrictLogs tests loading testdata/config_logs_strict.yaml
 func TestLoadingConfigStrictLogs(t *testing.T) {
-
 	testDataLogPropertiesInclude := &LogMatchProperties{
 		LogMatchType: strictType,
 		ResourceAttributes: []filterconfig.Attribute{
@@ -180,7 +179,6 @@ func TestLoadingConfigStrictLogs(t *testing.T) {
 
 // TestLoadingConfigSeverityLogsStrict tests loading testdata/config_logs_severity_strict.yaml
 func TestLoadingConfigSeverityLogsStrict(t *testing.T) {
-
 	testDataLogPropertiesInclude := &LogMatchProperties{
 		LogMatchType:  strictType,
 		SeverityTexts: []string{"INFO"},
@@ -305,7 +303,6 @@ func TestLoadingConfigSeverityLogsRegexp(t *testing.T) {
 
 // TestLoadingConfigBodyLogsStrict tests loading testdata/config_logs_body_strict.yaml
 func TestLoadingConfigBodyLogsStrict(t *testing.T) {
-
 	testDataLogPropertiesInclude := &LogMatchProperties{
 		LogMatchType: strictType,
 		LogBodies:    []string{"This is an important event"},
@@ -368,7 +365,6 @@ func TestLoadingConfigBodyLogsStrict(t *testing.T) {
 
 // TestLoadingConfigBodyLogsStrict tests loading testdata/config_logs_body_regexp.yaml
 func TestLoadingConfigBodyLogsRegexp(t *testing.T) {
-
 	testDataLogPropertiesInclude := &LogMatchProperties{
 		LogMatchType: regexpType,
 		LogBodies:    []string{"^IMPORTANT:"},
@@ -832,7 +828,6 @@ func TestLogSeverity_severityValidate(t *testing.T) {
 }
 
 func TestLoadingConfigOTTL(t *testing.T) {
-
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config_ottl.yaml"))
 	require.NoError(t, err)
 

--- a/processor/filterprocessor/logs_test.go
+++ b/processor/filterprocessor/logs_test.go
@@ -794,7 +794,6 @@ func TestFilterLogProcessorTelemetry(t *testing.T) {
 	}
 
 	tel.assertMetrics(t, want)
-
 }
 
 func constructLogs() plog.Logs {
@@ -825,7 +824,6 @@ func fillLogOne(log plog.LogRecord) {
 	log.Attributes().PutStr("http.path", "/health")
 	log.Attributes().PutStr("http.url", "http://localhost/health")
 	log.Attributes().PutStr("flags", "A|B|C")
-
 }
 
 func fillLogTwo(log plog.LogRecord) {
@@ -836,5 +834,4 @@ func fillLogTwo(log plog.LogRecord) {
 	log.Attributes().PutStr("http.path", "/health")
 	log.Attributes().PutStr("http.url", "http://localhost/health")
 	log.Attributes().PutStr("flags", "C|D")
-
 }

--- a/processor/filterprocessor/metrics_test.go
+++ b/processor/filterprocessor/metrics_test.go
@@ -943,7 +943,6 @@ func TestFilterMetricProcessorWithOTTL(t *testing.T) {
 			if tt.filterEverything {
 				assert.Equal(t, processorhelper.ErrSkipProcessingData, err)
 			} else {
-
 				exTd := constructMetrics()
 				tt.want(exTd)
 				assert.Equal(t, exTd, got)

--- a/processor/filterprocessor/traces_test.go
+++ b/processor/filterprocessor/traces_test.go
@@ -273,7 +273,6 @@ func TestFilterTraceProcessorWithOTTL(t *testing.T) {
 			if tt.filterEverything {
 				assert.Equal(t, processorhelper.ErrSkipProcessingData, err)
 			} else {
-
 				exTd := constructTraces()
 				tt.want(exTd)
 				assert.Equal(t, exTd, got)

--- a/processor/geoipprocessor/factory.go
+++ b/processor/geoipprocessor/factory.go
@@ -77,7 +77,6 @@ func createGeoIPProviders(
 		}
 
 		providers = append(providers, provider)
-
 	}
 
 	return providers, nil

--- a/processor/groupbyattrsprocessor/attribute_groups.go
+++ b/processor/groupbyattrsprocessor/attribute_groups.go
@@ -64,7 +64,6 @@ func (mg *metricsGroup) findOrCreateResourceMetrics(originResource pcommon.Resou
 	referenceResource.MoveTo(rm.Resource())
 	mg.resourceHashes = append(mg.resourceHashes, referenceResourceHash)
 	return rm
-
 }
 
 type logsGroup struct {

--- a/processor/groupbyattrsprocessor/factory.go
+++ b/processor/groupbyattrsprocessor/factory.go
@@ -65,7 +65,6 @@ func createTracesProcessor(
 	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Traces) (processor.Traces, error) {
-
 	oCfg := cfg.(*Config)
 	gap, err := createGroupByAttrsProcessor(set, oCfg.GroupByKeys)
 	if err != nil {
@@ -87,7 +86,6 @@ func createLogsProcessor(
 	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Logs) (processor.Logs, error) {
-
 	oCfg := cfg.(*Config)
 	gap, err := createGroupByAttrsProcessor(set, oCfg.GroupByKeys)
 	if err != nil {
@@ -109,7 +107,6 @@ func createMetricsProcessor(
 	set processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Metrics) (processor.Metrics, error) {
-
 	oCfg := cfg.(*Config)
 	gap, err := createGroupByAttrsProcessor(set, oCfg.GroupByKeys)
 	if err != nil {

--- a/processor/groupbyattrsprocessor/processor.go
+++ b/processor/groupbyattrsprocessor/processor.go
@@ -90,7 +90,6 @@ func (gap *groupByAttrsProcessor) processLogs(ctx context.Context, ld plog.Logs)
 				log.CopyTo(lr)
 			}
 		}
-
 	}
 
 	// Copy the grouped data into output
@@ -114,7 +113,6 @@ func (gap *groupByAttrsProcessor) processMetrics(ctx context.Context, md pmetric
 
 				//exhaustive:enforce
 				switch metric.Type() {
-
 				case pmetric.MetricTypeGauge:
 					for pointIndex := 0; pointIndex < metric.Gauge().DataPoints().Len(); pointIndex++ {
 						dataPoint := metric.Gauge().DataPoints().At(pointIndex)
@@ -174,7 +172,6 @@ func deleteAttributes(attrsForRemoval, targetAttrs pcommon.Map) {
 //   - whether any attribute matched (true) or none (false)
 //   - the extracted AttributeMap of matching keys and their corresponding values
 func (gap *groupByAttrsProcessor) extractGroupingAttributes(attrMap pcommon.Map) (bool, pcommon.Map) {
-
 	groupingAttributes := pcommon.NewMap()
 	foundMatch := false
 
@@ -191,7 +188,6 @@ func (gap *groupByAttrsProcessor) extractGroupingAttributes(attrMap pcommon.Map)
 
 // Searches for metric with same name in the specified InstrumentationLibrary and returns it. If nothing is found, create it.
 func getMetricInInstrumentationLibrary(ilm pmetric.ScopeMetrics, searchedMetric pmetric.Metric) pmetric.Metric {
-
 	// Loop through all metrics and try to find the one that matches with the one we search for
 	// (name and type)
 	for i := 0; i < ilm.Metrics().Len(); i++ {
@@ -211,7 +207,6 @@ func getMetricInInstrumentationLibrary(ilm pmetric.ScopeMetrics, searchedMetric 
 	// Move other special type specific values
 	//exhaustive:enforce
 	switch searchedMetric.Type() {
-
 	case pmetric.MetricTypeHistogram:
 		metric.SetEmptyHistogram().SetAggregationTemporality(searchedMetric.Histogram().AggregationTemporality())
 
@@ -243,7 +238,6 @@ func (gap *groupByAttrsProcessor) getGroupedMetricsFromAttributes(
 	metric pmetric.Metric,
 	attributes pcommon.Map,
 ) pmetric.Metric {
-
 	toBeGrouped, requiredAttributes := gap.extractGroupingAttributes(attributes)
 	if toBeGrouped {
 		gap.telemetryBuilder.ProcessorGroupbyattrsNumGroupedMetrics.Add(ctx, 1)
@@ -262,5 +256,4 @@ func (gap *groupByAttrsProcessor) getGroupedMetricsFromAttributes(
 
 	// Return the metric in this resource
 	return getMetricInInstrumentationLibrary(groupedInstrumentationLibrary, metric)
-
 }

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -845,7 +845,6 @@ func someExponentialHistogramMetrics(attrs pcommon.Map, instrumentationLibraryCo
 }
 
 func TestMetricAdvancedGrouping(t *testing.T) {
-
 	// Input:
 	//
 	// Resource {host.name="localhost"}

--- a/processor/groupbytraceprocessor/factory.go
+++ b/processor/groupbytraceprocessor/factory.go
@@ -30,7 +30,6 @@ var (
 
 // NewFactory returns a new factory for the Filter processor.
 func NewFactory() processor.Factory {
-
 	return processor.NewFactory(
 		metadata.Type,
 		createDefaultConfig,
@@ -56,7 +55,6 @@ func createTracesProcessor(
 	params processor.Settings,
 	cfg component.Config,
 	nextConsumer consumer.Traces) (processor.Traces, error) {
-
 	oCfg := cfg.(*Config)
 
 	var st storage

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -538,7 +538,6 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 
 // This function removes all data from the Pod except what is required by extraction rules and pod association
 func removeUnnecessaryPodData(pod *api_v1.Pod, rules ExtractionRules) *api_v1.Pod {
-
 	// name, namespace, uid, start time and ip are needed for identifying Pods
 	// there's room to optimize this further, it's kept this way for simplicity
 	transformedPod := api_v1.Pod{

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -88,7 +88,6 @@ func podAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
 	assert.Equal(t, "2.2.2.2", got.Address)
 	assert.Equal(t, "podC", got.Name)
 	assert.Equal(t, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", got.PodUID)
-
 }
 
 func namespaceAddAndUpdateTest(t *testing.T, c *WatchClient, handler func(obj any)) {
@@ -290,7 +289,6 @@ func TestReplicaSetHandler(t *testing.T) {
 		Obj: replicaset,
 	})
 	assert.Empty(t, c.ReplicaSets)
-
 }
 
 func TestPodHostNetwork(t *testing.T) {
@@ -1373,7 +1371,6 @@ func TestFilters(t *testing.T) {
 			assert.Equal(t, tc.fields, inf.fieldSelector.String())
 		})
 	}
-
 }
 
 func TestPodIgnorePatterns(t *testing.T) {

--- a/processor/k8sattributesprocessor/internal/kube/informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/informer.go
@@ -70,7 +70,6 @@ func informerListFuncWithSelectors(client kubernetes.Interface, namespace string
 		opts.FieldSelector = fs.String()
 		return client.CoreV1().Pods(namespace).List(context.Background(), opts)
 	}
-
 }
 
 func informerWatchFuncWithSelectors(client kubernetes.Interface, namespace string, ls labels.Selector, fs fields.Selector) cache.WatchFunc {
@@ -120,7 +119,6 @@ func namespaceInformerListFunc(client kubernetes.Interface) cache.ListFunc {
 	return func(opts metav1.ListOptions) (runtime.Object, error) {
 		return client.CoreV1().Namespaces().List(context.Background(), opts)
 	}
-
 }
 
 func namespaceInformerWatchFunc(client kubernetes.Interface) cache.WatchFunc {

--- a/processor/k8sattributesprocessor/options_test.go
+++ b/processor/k8sattributesprocessor/options_test.go
@@ -490,7 +490,6 @@ func TestWithFilterLabels(t *testing.T) {
 }
 
 func TestWithFilterFields(t *testing.T) {
-
 	tests := []struct {
 		name  string
 		args  []FieldFilterConfig

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -321,7 +321,6 @@ func (strAddr) Network() string {
 }
 
 func TestIPDetectionFromContext(t *testing.T) {
-
 	addresses := []net.Addr{
 		&net.IPAddr{
 			IP: net.IPv4(1, 1, 1, 1),
@@ -357,7 +356,6 @@ func TestIPDetectionFromContext(t *testing.T) {
 			assertResourceHasStringAttribute(t, r, "k8s.pod.ip", "1.1.1.1")
 		})
 	}
-
 }
 
 func TestNilBatch(t *testing.T) {
@@ -1352,7 +1350,6 @@ func TestMetricsProcessorHostname(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
@@ -1435,7 +1432,6 @@ func TestMetricsProcessorHostnameWithPodAssociation(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestPassthroughStart(t *testing.T) {

--- a/processor/logstransformprocessor/processor.go
+++ b/processor/logstransformprocessor/processor.go
@@ -79,7 +79,6 @@ func (ltp *logsTransformProcessor) Shutdown(ctx context.Context) error {
 }
 
 func (ltp *logsTransformProcessor) Start(ctx context.Context, _ component.Host) error {
-
 	wkrCount := int(math.Max(1, float64(runtime.NumCPU())))
 	ltp.fromConverter = adapter.NewFromPdataConverter(ltp.set, wkrCount)
 

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -205,7 +205,6 @@ type laggyOperator struct {
 }
 
 func (t *laggyOperator) Process(ctx context.Context, e *entry.Entry) error {
-
 	// Wait for a large amount of time every 100 logs
 	if t.logsCount%100 == 0 {
 		time.Sleep(100 * time.Millisecond)

--- a/processor/metricsgenerationprocessor/factory_test.go
+++ b/processor/metricsgenerationprocessor/factory_test.go
@@ -40,7 +40,6 @@ func TestCreateProcessors(t *testing.T) {
 	for k := range cm.ToStringMap() {
 		// Check if all processor variations that are defined in test config can be actually created
 		t.Run(k, func(t *testing.T) {
-
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()
 

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -325,10 +325,8 @@ func TestMetricsGenerationProcessor(t *testing.T) {
 						case pmetric.NumberDataPointValueTypeInt:
 							require.Equal(t, eDataPoints.At(j).IntValue(), aDataPoints.At(j).IntValue())
 						}
-
 					}
 				}
-
 			}
 
 			require.NoError(t, mgp.Shutdown(ctx))

--- a/processor/metricstransformprocessor/factory.go
+++ b/processor/metricstransformprocessor/factory.go
@@ -127,7 +127,6 @@ func validateConfiguration(config *Config) error {
 func buildHelperConfig(config *Config, version string) ([]internalTransform, error) {
 	helperDataTransforms := make([]internalTransform, len(config.Transforms))
 	for i, t := range config.Transforms {
-
 		if t.MetricIncludeFilter.MatchType == "" {
 			t.MetricIncludeFilter.MatchType = strictMatchType
 		}

--- a/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_otlp.go
@@ -368,7 +368,6 @@ func canBeCombined(metrics []pmetric.Metric) error {
 					"metrics cannot be combined as they have different aggregation temporalities: %v (%v) and %v (%v)",
 					firstMetric.Name(), firstMetric.Histogram().AggregationTemporality(), metric.Name(),
 					metric.Histogram().AggregationTemporality())
-
 			}
 		case pmetric.MetricTypeExponentialHistogram:
 			if firstMetric.ExponentialHistogram().AggregationTemporality() != metric.ExponentialHistogram().AggregationTemporality() {
@@ -376,7 +375,6 @@ func canBeCombined(metrics []pmetric.Metric) error {
 					"metrics cannot be combined as they have different aggregation temporalities: %v (%v) and %v (%v)",
 					firstMetric.Name(), firstMetric.ExponentialHistogram().AggregationTemporality(), metric.Name(),
 					metric.ExponentialHistogram().AggregationTemporality())
-
 			}
 		}
 	}

--- a/processor/probabilisticsamplerprocessor/logsprocessor.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor.go
@@ -268,7 +268,6 @@ func (lsp *logsProcessor) logRecordToPriorityThreshold(logRec plog.LogRecord) sa
 				// The record has supplied a valid alternative sampling probability
 				return th
 			}
-
 		}
 	}
 	return sampling.NeverSampleThreshold

--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -385,7 +385,6 @@ func TestLogsSamplingState(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(fmt.Sprint(tt.name), func(t *testing.T) {
-
 			sink := new(consumertest.LogsSink)
 			cfg := &Config{}
 			if tt.cfg != nil {
@@ -473,7 +472,6 @@ func TestLogsMissingRandomness(t *testing.T) {
 			{100, traceIDAttributeSource, false, true},
 		} {
 			t.Run(fmt.Sprint(tt.pct, "_", tt.source, "_", tt.failClosed, "_", mode), func(t *testing.T) {
-
 				ctx := context.Background()
 				logs := plog.NewLogs()
 				record := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -222,7 +222,6 @@ func Test_tracesamplerprocessor_SamplingPercentageRange_MultipleResourceSpans(t 
 				assert.Equal(t, tt.resourceSpanPerTrace*tt.numTracesPerBatch, sink.SpanCount())
 				sink.Reset()
 			}
-
 		})
 	}
 }
@@ -246,7 +245,6 @@ func Test_tracessamplerprocessor_MissingRandomness(t *testing.T) {
 		{100, false, true},
 	} {
 		t.Run(fmt.Sprint(tt.pct, "_", tt.failClosed), func(t *testing.T) {
-
 			ctx := context.Background()
 			traces := ptrace.NewTraces()
 			span := traces.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty().Spans().AppendEmpty()
@@ -388,7 +386,6 @@ func Test_tracesamplerprocessor_SpanSamplingPriority(t *testing.T) {
 	for _, mode := range AllModes {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-
 				sink := new(consumertest.TracesSink)
 
 				cfg := &Config{}
@@ -846,7 +843,6 @@ func Test_tracesamplerprocessor_TraceState(t *testing.T) {
 	for _, tt := range tests {
 		for _, mode := range []SamplerMode{Equalizing, Proportional} {
 			t.Run(fmt.Sprint(mode, "_", tt.name), func(t *testing.T) {
-
 				sink := new(consumertest.TracesSink)
 				cfg := &Config{}
 				if tt.cfg != nil {
@@ -1013,7 +1009,6 @@ func Test_tracesamplerprocessor_TraceStateErrors(t *testing.T) {
 				expectMessage := ""
 				if tt.sf != nil {
 					expectMessage = tt.sf(mode)
-
 				}
 
 				tsp, err := newTracesProcessor(context.Background(), set, cfg, sink)

--- a/processor/remotetapprocessor/processor_test.go
+++ b/processor/remotetapprocessor/processor_test.go
@@ -60,7 +60,6 @@ func TestConsumeMetrics(t *testing.T) {
 			processor.cs.closeAndRemove(idx)
 			wg.Wait()
 			assert.Equal(t, c.limit, receiveNum)
-
 		})
 	}
 }

--- a/processor/resourcedetectionprocessor/internal/heroku/heroku_test.go
+++ b/processor/resourcedetectionprocessor/internal/heroku/heroku_test.go
@@ -81,7 +81,6 @@ func TestDetectTruePartialMissingDynoId(t *testing.T) {
 }
 
 func TestDetectFalse(t *testing.T) {
-
 	detector, err := NewDetector(processortest.NewNopSettings(), CreateDefaultConfig())
 	require.NoError(t, err)
 	res, schemaURL, err := detector.Detect(context.Background())

--- a/processor/resourcedetectionprocessor/internal/system/system_test.go
+++ b/processor/resourcedetectionprocessor/internal/system/system_test.go
@@ -178,7 +178,6 @@ func TestDetectFQDNAvailable(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, res.Attributes().AsRaw())
-
 }
 
 func TestFallbackHostname(t *testing.T) {
@@ -368,7 +367,6 @@ func TestDetectCPUInfo(t *testing.T) {
 	}
 
 	assert.Equal(t, expected, res.Attributes().AsRaw())
-
 }
 
 func newTestDetector(mock *mockMetadata, hostnameSources []string, resCfg metadata.ResourceAttributesConfig) *Detector {

--- a/processor/routingprocessor/extract.go
+++ b/processor/routingprocessor/extract.go
@@ -53,7 +53,6 @@ func (e extractor) extractFromContext(ctx context.Context) string {
 }
 
 func (e extractor) extractFromGRPCContext(ctx context.Context) ([]string, bool) {
-
 	md, ok := metadata.FromIncomingContext(ctx)
 
 	if !ok {

--- a/processor/routingprocessor/metrics_test.go
+++ b/processor/routingprocessor/metrics_test.go
@@ -187,7 +187,6 @@ func TestMetrics_RoutingWorks_Context(t *testing.T) {
 			"metric should not be routed to non default exporter",
 		)
 	})
-
 }
 
 func TestMetrics_RoutingWorks_ResourceAttribute(t *testing.T) {

--- a/processor/routingprocessor/traces_test.go
+++ b/processor/routingprocessor/traces_test.go
@@ -497,7 +497,6 @@ func TestTracesAttributeWithOTTLDoesNotCauseCrash(t *testing.T) {
 	// verify
 	assert.Len(t, defaultExp.AllTraces(), 1)
 	assert.Empty(t, firstExp.AllTraces())
-
 }
 
 func TestTraceProcessorCapabilities(t *testing.T) {

--- a/processor/schemaprocessor/internal/migrate/attributes_test.go
+++ b/processor/schemaprocessor/internal/migrate/attributes_test.go
@@ -268,7 +268,6 @@ func TestNewAttributeChangeSetSliceApplyRollback(t *testing.T) {
 			),
 			attr: testHelperBuildMap(func(m pcommon.Map) {
 				m.PutStr("application.service.version", "v0.0.1")
-
 			}),
 			expect: testHelperBuildMap(func(m pcommon.Map) {
 				m.PutStr("service_version", "v0.0.1")

--- a/processor/spanprocessor/factory.go
+++ b/processor/spanprocessor/factory.go
@@ -53,7 +53,6 @@ func createTracesProcessor(
 	cfg component.Config,
 	nextConsumer consumer.Traces,
 ) (processor.Traces, error) {
-
 	// 'from_attributes' or 'to_attributes' under 'name' has to be set for the span
 	// processor to be valid. If not set and not enforced, the processor would do no work.
 	oCfg := cfg.(*Config)

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -294,7 +294,6 @@ func TestSpanProcessor_MissingKeys(t *testing.T) {
 // TestSpanProcessor_Separator ensures naming a span with a single key and separator will only contain the value from
 // the single key.
 func TestSpanProcessor_Separator(t *testing.T) {
-
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
@@ -323,7 +322,6 @@ func TestSpanProcessor_Separator(t *testing.T) {
 
 // TestSpanProcessor_NoSeparatorMultipleKeys tests naming a span using multiple keys and no separator.
 func TestSpanProcessor_NoSeparatorMultipleKeys(t *testing.T) {
-
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
@@ -353,7 +351,6 @@ func TestSpanProcessor_NoSeparatorMultipleKeys(t *testing.T) {
 
 // TestSpanProcessor_SeparatorMultipleKeys tests naming a span with multiple keys and a separator.
 func TestSpanProcessor_SeparatorMultipleKeys(t *testing.T) {
-
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
@@ -388,7 +385,6 @@ func TestSpanProcessor_SeparatorMultipleKeys(t *testing.T) {
 
 // TestSpanProcessor_NilName tests naming a span when the input span had no name.
 func TestSpanProcessor_NilName(t *testing.T) {
-
 	factory := NewFactory()
 	cfg := factory.CreateDefaultConfig()
 	oCfg := cfg.(*Config)
@@ -417,7 +413,6 @@ func TestSpanProcessor_NilName(t *testing.T) {
 
 // TestSpanProcessor_ToAttributes
 func TestSpanProcessor_ToAttributes(t *testing.T) {
-
 	testCases := []struct {
 		rules           []string
 		breakAfterMatch bool

--- a/processor/sumologicprocessor/processor_test.go
+++ b/processor/sumologicprocessor/processor_test.go
@@ -1318,7 +1318,6 @@ func TestLogFieldsConversionLogs(t *testing.T) {
 				attribute4, found := outputLogs.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0).Attributes().Get("traceid")
 				assert.True(t, found)
 				assert.Equal(t, "01010101010101010101010101010101", attribute4.Str())
-
 			},
 		},
 	}

--- a/processor/sumologicprocessor/translate_attributes_processor_test.go
+++ b/processor/sumologicprocessor/translate_attributes_processor_test.go
@@ -110,7 +110,6 @@ func assertAttribute(t *testing.T, metadata pcommon.Map, attributeName string, e
 	} else {
 		assert.True(t, exists)
 		assert.Equal(t, expectedValue, value.Str())
-
 	}
 }
 

--- a/processor/tailsamplingprocessor/internal/sampling/and.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and.go
@@ -20,7 +20,6 @@ func NewAnd(
 	logger *zap.Logger,
 	subpolicies []PolicyEvaluator,
 ) PolicyEvaluator {
-
 	return &And{
 		subpolicies: subpolicies,
 		logger:      logger,
@@ -39,7 +38,6 @@ func (c *And) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *Trac
 		if decision == NotSampled || decision == InvertNotSampled {
 			return decision, nil
 		}
-
 	}
 	return Sampled, nil
 }

--- a/processor/tailsamplingprocessor/internal/sampling/and_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and_test.go
@@ -36,7 +36,6 @@ func TestAndEvaluatorNotSampled(t *testing.T) {
 	decision, err := and.Evaluate(context.Background(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
 	assert.Equal(t, NotSampled, decision)
-
 }
 
 func TestAndEvaluatorSampled(t *testing.T) {
@@ -62,7 +61,6 @@ func TestAndEvaluatorSampled(t *testing.T) {
 	decision, err := and.Evaluate(context.Background(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
 	assert.Equal(t, Sampled, decision)
-
 }
 
 func TestAndEvaluatorStringInvertSampled(t *testing.T) {
@@ -88,7 +86,6 @@ func TestAndEvaluatorStringInvertSampled(t *testing.T) {
 	decision, err := and.Evaluate(context.Background(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
 	assert.Equal(t, Sampled, decision)
-
 }
 
 func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
@@ -114,5 +111,4 @@ func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
 	decision, err := and.Evaluate(context.Background(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
 	assert.Equal(t, InvertNotSampled, decision)
-
 }

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestBooleanTagFilter(t *testing.T) {
-
 	var empty = map[string]any{}
 	filter := NewBooleanAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", true, false)
 
@@ -55,7 +54,6 @@ func TestBooleanTagFilter(t *testing.T) {
 }
 
 func TestBooleanTagFilterInverted(t *testing.T) {
-
 	var empty = map[string]any{}
 	filter := NewBooleanAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", true, true)
 

--- a/processor/tailsamplingprocessor/internal/sampling/composite.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite.go
@@ -53,7 +53,6 @@ func NewComposite(
 	subPolicyParams []SubPolicyEvalParams,
 	timeProvider TimeProvider,
 ) PolicyEvaluator {
-
 	var subpolicies []*subpolicy
 
 	for i := 0; i < len(subPolicyParams); i++ {

--- a/processor/tailsamplingprocessor/internal/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite_test.go
@@ -57,7 +57,6 @@ func newTraceWithKV(traceID pcommon.TraceID, key string, val int64) *TraceData {
 }
 
 func TestCompositeEvaluatorNotSampled(t *testing.T) {
-
 	// Create 2 policies which do not match any trace
 	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 200, 300, false)
@@ -75,7 +74,6 @@ func TestCompositeEvaluatorNotSampled(t *testing.T) {
 }
 
 func TestCompositeEvaluatorSampled(t *testing.T) {
-
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
 	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
@@ -92,7 +90,6 @@ func TestCompositeEvaluatorSampled(t *testing.T) {
 }
 
 func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
-
 	timeProvider := &FakeTimeProvider{second: 0}
 
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
@@ -128,7 +125,6 @@ func TestCompositeEvaluator_OverflowAlwaysSampled(t *testing.T) {
 }
 
 func TestCompositeEvaluatorSampled_AlwaysSampled(t *testing.T) {
-
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
 	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
@@ -147,7 +143,6 @@ func TestCompositeEvaluatorSampled_AlwaysSampled(t *testing.T) {
 }
 
 func TestCompositeEvaluatorInverseSampled_AlwaysSampled(t *testing.T) {
-
 	// The first policy does not match, the second matches through invert
 	n1 := NewStringAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", []string{"foo"}, false, 0, false)
 	n2 := NewStringAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", []string{"foo"}, false, 0, true)
@@ -166,7 +161,6 @@ func TestCompositeEvaluatorInverseSampled_AlwaysSampled(t *testing.T) {
 }
 
 func TestCompositeEvaluatorThrottling(t *testing.T) {
-
 	// Create only one subpolicy, with 100% Sampled policy.
 	n1 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	timeProvider := &FakeTimeProvider{second: 0}
@@ -207,7 +201,6 @@ func TestCompositeEvaluatorThrottling(t *testing.T) {
 }
 
 func TestCompositeEvaluator2SubpolicyThrottling(t *testing.T) {
-
 	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
 	timeProvider := &FakeTimeProvider{second: 0}

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestNumericTagFilter(t *testing.T) {
-
 	var empty = map[string]any{}
 	filter := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", math.MinInt32, math.MaxInt32, false)
 
@@ -86,7 +85,6 @@ func TestNumericTagFilter(t *testing.T) {
 }
 
 func TestNumericTagFilterInverted(t *testing.T) {
-
 	var empty = map[string]any{}
 	filter := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", math.MinInt32, math.MaxInt32, true)
 

--- a/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/string_tag_filter_test.go
@@ -23,7 +23,6 @@ type TestStringAttributeCfg struct {
 }
 
 func TestStringTagFilter(t *testing.T) {
-
 	cases := []struct {
 		Desc      string
 		Trace     *TraceData

--- a/processor/tailsamplingprocessor/internal/sampling/trace_state_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/trace_state_filter_test.go
@@ -20,7 +20,6 @@ type TestTraceStateCfg struct {
 }
 
 func TestTraceStateFilter(t *testing.T) {
-
 	cases := []struct {
 		Desc      string
 		Trace     *TraceData

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -472,7 +472,6 @@ func TestSubSecondDecisionTime(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return len(msp.AllTraces()) == 1
 	}, time.Second, 10*time.Millisecond)
-
 }
 
 func TestPolicyLoggerAddsPolicyName(t *testing.T) {

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -216,7 +216,6 @@ func parseGlobalExpr[K any](
 	conditions []string,
 	pc parserCollection,
 	standardFuncs map[string]ottl.Factory[K]) (expr.BoolExpr[K], error) {
-
 	if len(conditions) > 0 {
 		return boolExprFunc(conditions, standardFuncs, pc.errorMode, pc.settings)
 	}

--- a/processor/transformprocessor/internal/logs/processor_test.go
+++ b/processor/transformprocessor/internal/logs/processor_test.go
@@ -536,7 +536,6 @@ func fillLogOne(log plog.LogRecord) {
 	log.Attributes().PutStr("http.url", "http://localhost/health")
 	log.Attributes().PutStr("flags", "A|B|C")
 	log.Attributes().PutStr("total.string", "123456789")
-
 }
 
 func fillLogTwo(log plog.LogRecord) {
@@ -548,5 +547,4 @@ func fillLogTwo(log plog.LogRecord) {
 	log.Attributes().PutStr("http.url", "http://localhost/health")
 	log.Attributes().PutStr("flags", "C|D")
 	log.Attributes().PutStr("total.string", "345678")
-
 }

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist.go
@@ -46,7 +46,6 @@ func createconvertExponentialHistToExplicitHistFunction(_ ottl.FunctionContext, 
 
 	if _, ok := distributionFnMap[args.DistributionFn]; !ok {
 		return nil, fmt.Errorf("invalid conversion function: %s, must be one of [upper, midpoint, random, uniform]", args.DistributionFn)
-
 	}
 
 	return convertExponentialHistToExplicitHist(args.DistributionFn, args.ExplicitBounds)
@@ -54,7 +53,6 @@ func createconvertExponentialHistToExplicitHistFunction(_ ottl.FunctionContext, 
 
 // convertExponentialHistToExplicitHist converts an exponential histogram to a bucketed histogram
 func convertExponentialHistToExplicitHist(distributionFn string, explicitBounds []float64) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
-
 	if len(explicitBounds) == 0 {
 		return nil, fmt.Errorf("explicit bounds cannot be empty: %v", explicitBounds)
 	}

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
@@ -91,7 +91,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{1.0, 2.0, 3.0, 4.0, 5.0},
 			distribution: "upper",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("response_time")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -109,7 +108,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1.0, 2.0, 3.0, 4.0, 5.0)
-
 			},
 		},
 		{
@@ -120,7 +118,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{1000.0, 2000.0, 3000.0, 4000.0, 5000.0},
 			distribution: "upper",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("response_time")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -138,7 +135,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1000.0, 2000.0, 3000.0, 4000.0, 5000.0)
-
 			},
 		},
 		{
@@ -148,7 +144,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{160.0, 170.0, 180.0, 190.0, 200.0},
 			distribution: "upper",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("response_time")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -166,7 +161,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(160.0, 170.0, 180.0, 190.0, 200.0)
-
 			},
 		},
 		{
@@ -175,7 +169,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{160.0, 170.0, 180.0, 190.0, 200.0},
 			distribution: "upper",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("response_time")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -193,7 +186,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(160.0, 170.0, 180.0, 190.0, 200.0)
-
 			},
 		},
 		{
@@ -328,7 +320,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1.0, 2.0, 3.0, 4.0, 5.0)
-
 			},
 		},
 		{
@@ -339,7 +330,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{1000.0, 2000.0, 3000.0, 4000.0, 5000.0},
 			distribution: "midpoint",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("test-metric")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -357,7 +347,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1000.0, 2000.0, 3000.0, 4000.0, 5000.0)
-
 			},
 		},
 		{
@@ -367,7 +356,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0},
 			distribution: "midpoint",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("test-metric")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -385,7 +373,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0)
-
 			},
 		},
 		{
@@ -399,7 +386,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0},
 			distribution: "midpoint",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("test-metric")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -417,7 +403,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0)
-
 			},
 		},
 		{
@@ -519,7 +504,6 @@ func TestUniforn_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1.0, 2.0, 3.0, 4.0, 5.0)
-
 			},
 		},
 		{
@@ -530,7 +514,6 @@ func TestUniforn_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{1000.0, 2000.0, 3000.0, 4000.0, 5000.0},
 			distribution: "uniform",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("test-metric")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -548,7 +531,6 @@ func TestUniforn_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1000.0, 2000.0, 3000.0, 4000.0, 5000.0)
-
 			},
 		},
 		{
@@ -558,7 +540,6 @@ func TestUniforn_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0},
 			distribution: "uniform",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("test-metric")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -576,7 +557,6 @@ func TestUniforn_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0)
-
 			},
 		},
 	}
@@ -654,7 +634,6 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1.0, 2.0, 3.0, 4.0, 5.0)
-
 			},
 		},
 		{
@@ -665,7 +644,6 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{1000.0, 2000.0, 3000.0, 4000.0, 5000.0},
 			distribution: "random",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("test-metric")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)
@@ -683,7 +661,6 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 
 				// set explictbounds
 				dp.ExplicitBounds().Append(1000.0, 2000.0, 3000.0, 4000.0, 5000.0)
-
 			},
 		},
 		{
@@ -693,7 +670,6 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			arg:          []float64{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0},
 			distribution: "random",
 			want: func(metric pmetric.Metric) {
-
 				metric.SetName("test-metric")
 				dp := metric.SetEmptyHistogram().DataPoints().AppendEmpty()
 				metric.Histogram().SetAggregationTemporality(1)

--- a/processor/transformprocessor/internal/metrics/functions_test.go
+++ b/processor/transformprocessor/internal/metrics/functions_test.go
@@ -46,7 +46,6 @@ func Test_DataPointFunctions(t *testing.T) {
 		},
 		)
 	}
-
 }
 
 func Test_MetricFunctions(t *testing.T) {

--- a/receiver/splunkenterprisereceiver/scraper.go
+++ b/receiver/splunkenterprisereceiver/scraper.go
@@ -1732,6 +1732,5 @@ func (s *splunkScraper) scrapeSearchArtifacts(ctx context.Context, now pcommon.T
 			}
 			s.mb.RecordSplunkServerSearchartifactsJobCacheCountDataPoint(now, cacheTotalEntries, s.conf.SHEndpoint.Endpoint)
 		}
-
 	}
 }


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
