### PR TITLE
[chore]: enable whitespace linter for pkg and internal

### DIFF
--- a/internal/aws/awsutil/conn.go
+++ b/internal/aws/awsutil/conn.go
@@ -137,7 +137,6 @@ func GetAWSConfigSession(logger *zap.Logger, cn ConnAttr, cfg *AWSSessionSetting
 				logger.Debug("Fetch region from ec2 metadata", zap.String("region", awsRegion))
 			}
 		}
-
 	}
 
 	if awsRegion == "" {

--- a/internal/aws/containerinsight/utils_test.go
+++ b/internal/aws/containerinsight/utils_test.go
@@ -133,7 +133,6 @@ func convertToFloat64(value any) float64 {
 
 func checkMetricsAreExpected(t *testing.T, md pmetric.Metrics, fields map[string]any, tags map[string]string,
 	expectedUnits map[string]string) {
-
 	rms := md.ResourceMetrics()
 	assert.Equal(t, 1, rms.Len())
 
@@ -265,7 +264,6 @@ func TestConvertToOTLPMetricsForClusterMetrics(t *testing.T) {
 	}
 	md = ConvertToOTLPMetrics(fields, tags, zap.NewNop())
 	checkMetricsAreExpected(t, md, fields, tags, expectedUnits)
-
 }
 
 func TestConvertToOTLPMetricsForContainerMetrics(t *testing.T) {

--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -122,7 +122,6 @@ func (client *Client) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput, retr
 				client.logger.Error("cwlog_client: Error occurs in PutLogEvents", zap.Error(awsErr))
 				return err
 			}
-
 		}
 
 		//TODO: Should have metrics to provide visibility of these failures

--- a/internal/aws/cwlogs/pusher.go
+++ b/internal/aws/cwlogs/pusher.go
@@ -195,7 +195,6 @@ type logPusher struct {
 // NewPusher creates a logPusher instance
 func NewPusher(streamKey StreamKey, retryCnt int,
 	svcStructuredLog Client, logger *zap.Logger) Pusher {
-
 	pusher := newLogPusher(streamKey, svcStructuredLog, logger)
 
 	pusher.retryCnt = defaultRetryCount
@@ -250,7 +249,6 @@ func (p *logPusher) ForceFlush() error {
 }
 
 func (p *logPusher) pushEventBatch(req any) error {
-
 	// http://docs.aws.amazon.com/goto/SdkForGoV1/logs-2014-03-28/PutLogEvents
 	// The log events in the batch must be in chronological ordered by their
 	// timestamp (the time the event occurred, expressed as the number of milliseconds
@@ -296,7 +294,6 @@ func (p *logPusher) addLogEvent(logEvent *Event) *eventBatch {
 }
 
 func (p *logPusher) renewEventBatch() *eventBatch {
-
 	var prevBatch *eventBatch
 	if len(p.logEventBatch.putLogEventsInput.LogEvents) > 0 {
 		prevBatch = p.logEventBatch

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -172,7 +172,6 @@ func TestPusher_addLogEventBatch(t *testing.T) {
 	p.logEventBatch.byteTotal = 1
 	assert.Nil(t, p.addLogEvent(nil))
 	assert.Len(t, p.logEventBatch.putLogEventsInput.LogEvents, 1)
-
 }
 
 func TestAddLogEventWithValidation(t *testing.T) {

--- a/internal/aws/k8s/k8sclient/obj_store.go
+++ b/internal/aws/k8s/k8sclient/obj_store.go
@@ -80,7 +80,6 @@ func (s *ObjStore) Update(obj any) error {
 // Delete implements the Delete method of the store interface.
 // Delete deletes an existing entry in the ObjStore.
 func (s *ObjStore) Delete(obj any) error {
-
 	o, err := meta.Accessor(obj)
 	if err != nil {
 		return err

--- a/internal/aws/metrics/metric_calculator.go
+++ b/internal/aws/metrics/metric_calculator.go
@@ -157,7 +157,6 @@ func (m *MapWithExpiry) Shutdown() error {
 		return errors.New("shutdown called on an already closed channel")
 	default:
 		close(m.doneChan)
-
 	}
 	return nil
 }

--- a/internal/aws/xray/tracesegment_test.go
+++ b/internal/aws/xray/tracesegment_test.go
@@ -598,7 +598,6 @@ func TestTraceBodyUnMarshalling(t *testing.T) {
 						ExceptionID: String("abcdefghijklmnop"),
 					},
 				}, actualSeg, testCase+": unmarshalled segment is different from the expected")
-
 			},
 		},
 		{

--- a/internal/aws/xray/xray_client_test.go
+++ b/internal/aws/xray/xray_client_test.go
@@ -39,5 +39,4 @@ func TestUserAgent(t *testing.T) {
 	assert.Contains(t, req.HTTPRequest.UserAgent(), "xray-otel-exporter/")
 	assert.Contains(t, req.HTTPRequest.UserAgent(), "exec-env/")
 	assert.Contains(t, req.HTTPRequest.UserAgent(), "OS/")
-
 }

--- a/internal/coreinternal/aggregateutil/aggregate.go
+++ b/internal/coreinternal/aggregateutil/aggregate.go
@@ -188,7 +188,6 @@ func mergeNumberDataPoints(dpsMap map[string]pmetric.NumberDataPointSlice, agg A
 						dp.SetDoubleValue((medianNumbers[mNumber-1] + medianNumbers[mNumber]) / 2)
 					}
 				}
-
 			}
 		case pmetric.NumberDataPointValueTypeInt:
 			medianNumbers := []int64{dp.IntValue()}

--- a/internal/coreinternal/attraction/attraction_test.go
+++ b/internal/coreinternal/attraction/attraction_test.go
@@ -86,7 +86,6 @@ func TestAttributes_InsertValue(t *testing.T) {
 }
 
 func TestAttributes_InsertFromAttribute(t *testing.T) {
-
 	testCases := []testCase{
 		// Ensure no attribute is inserted because because attributes do not exist.
 		{
@@ -144,7 +143,6 @@ func TestAttributes_InsertFromAttribute(t *testing.T) {
 }
 
 func TestAttributes_UpdateValue(t *testing.T) {
-
 	testCases := []testCase{
 		// Ensure no changes to the span as there is no attributes map.
 		{
@@ -190,7 +188,6 @@ func TestAttributes_UpdateValue(t *testing.T) {
 }
 
 func TestAttributes_UpdateFromAttribute(t *testing.T) {
-
 	testCases := []testCase{
 		// Ensure no changes to the span as there is no attributes map.
 		{
@@ -418,7 +415,6 @@ func TestAttributes_Extract(t *testing.T) {
 }
 
 func TestAttributes_UpsertFromAttribute(t *testing.T) {
-
 	testCases := []testCase{
 		// Ensure `new_user_key` is not set for spans with no attributes.
 		{
@@ -926,7 +922,6 @@ func TestValidConfiguration(t *testing.T) {
 		{Key: "five", FromAttribute: "two", Action: UPSERT},
 		{Key: "two", Regex: compiledRegex, AttrNames: []string{"", "documentId"}, Action: EXTRACT},
 	}, ap.actions)
-
 }
 
 func hash(b []byte) string {
@@ -950,7 +945,6 @@ func (a mockInfoAuth) GetAttributeNames() []string {
 }
 
 func TestFromContext(t *testing.T) {
-
 	mdCtx := client.NewContext(context.TODO(), client.Info{
 		Metadata: client.NewMetadata(map[string][]string{
 			"source_single_val":   {"single_val"},

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -132,7 +132,6 @@ func TestFetchingTimeouts(t *testing.T) {
 		t, time.Now().UnixNano(), shouldHaveTaken,
 		"Client timeouts don't appear to have been exercised.",
 	)
-
 }
 
 func TestToStatsJSONErrorHandling(t *testing.T) {

--- a/internal/filter/filterexpr/matcher_test.go
+++ b/internal/filter/filterexpr/matcher_test.go
@@ -111,7 +111,6 @@ func testMetricNameMatch(t *testing.T, dataType pmetric.MetricType) {
 	matched, err = matcher.MatchMetric(m)
 	assert.NoError(t, err)
 	assert.True(t, matched)
-
 }
 
 func TestMatchIntGaugeDataPointByMetricAndSecondPointLabelValue(t *testing.T) {

--- a/internal/filter/filterlog/filterlog.go
+++ b/internal/filter/filterlog/filterlog.go
@@ -28,7 +28,6 @@ var useOTTLBridge = featuregate.GlobalRegistry().MustRegister(
 // The logic determining if a log should be processed is based on include and exclude settings.
 // Include properties are checked before exclude settings are checked.
 func NewSkipExpr(mp *filterconfig.MatchConfig) (expr.BoolExpr[ottllog.TransformContext], error) {
-
 	if useOTTLBridge.IsEnabled() {
 		return filterottl.NewLogSkipExprBridge(mp)
 	}

--- a/internal/filter/filtermatcher/attributematcher.go
+++ b/internal/filter/filtermatcher/attributematcher.go
@@ -37,7 +37,6 @@ func NewAttributesMatcher(config filterset.Config, attributes []filterconfig.Att
 	// Convert attribute values from mp representation to in-memory representation.
 	var rawAttributes []AttributeMatcher
 	for _, attribute := range attributes {
-
 		if attribute.Key == "" {
 			return nil, errors.New("can't have empty key in the list of attributes")
 		}
@@ -73,7 +72,6 @@ func NewAttributesMatcher(config filterset.Config, attributes []filterconfig.Att
 				}
 			default:
 				return nil, filterset.NewUnrecognizedMatchTypeError(config.MatchType)
-
 			}
 		}
 

--- a/internal/filter/filterspan/filterspan_test.go
+++ b/internal/filter/filterspan/filterspan_test.go
@@ -304,7 +304,6 @@ func TestServiceNameForResource(t *testing.T) {
 	resource := td.ResourceSpans().At(0).Resource()
 	name = serviceNameForResource(resource)
 	require.Equal(t, "<nil-service-name>", name)
-
 }
 
 func Test_NewSkipExpr_With_Bridge(t *testing.T) {

--- a/internal/k8stest/client.go
+++ b/internal/k8stest/client.go
@@ -21,7 +21,6 @@ type K8sClient struct {
 }
 
 func NewK8sClient(kubeconfigPath string) (*K8sClient, error) {
-
 	if kubeconfigPath == "" {
 		return nil, errors.New("Please provide file path to load kubeconfig")
 	}

--- a/internal/k8stest/k8s_collector.go
+++ b/internal/k8stest/k8s_collector.go
@@ -103,7 +103,6 @@ func WaitForCollectorToStart(t *testing.T, client *K8sClient, podNamespace strin
 			return true
 		}
 		return false
-
 	}, time.Duration(podTimeoutMinutes)*time.Minute, 2*time.Second,
 		"collector pods were not ready within %d minutes", podTimeoutMinutes)
 }

--- a/internal/kafka/authentication.go
+++ b/internal/kafka/authentication.go
@@ -93,7 +93,6 @@ func configurePlaintext(config PlainTextConfig, saramaConfig *sarama.Config) {
 }
 
 func configureSASL(config SASLConfig, saramaConfig *sarama.Config) error {
-
 	if config.Username == "" {
 		return fmt.Errorf("username have to be provided")
 	}

--- a/internal/kafka/awsmsk/iam_scram_client_test.go
+++ b/internal/kafka/awsmsk/iam_scram_client_test.go
@@ -112,5 +112,4 @@ func TestValidatingServerResponse(t *testing.T) {
 
 	_, err := new(IAMSASLClient).Step("")
 	assert.ErrorIs(t, err, ErrInvalidStateReached, "Must be an invalid step when not set up correctly")
-
 }

--- a/internal/kafka/scram_client.go
+++ b/internal/kafka/scram_client.go
@@ -34,7 +34,6 @@ func (x *XDGSCRAMClient) Begin(userName, password, authzID string) (err error) {
 // completes is also an error.
 func (x *XDGSCRAMClient) Step(challenge string) (response string, err error) {
 	return x.ClientConversation.Step(challenge)
-
 }
 
 // Done returns true if the conversation is completed or has errored.

--- a/internal/kubelet/client.go
+++ b/internal/kubelet/client.go
@@ -101,7 +101,6 @@ func (p *kubeConfigClientProvider) BuildClient() (Client, error) {
 		tok:        nil,
 		logger:     p.logger,
 	}, nil
-
 }
 
 type readOnlyClientProvider struct {
@@ -121,7 +120,6 @@ func (p *readOnlyClientProvider) BuildClient() (Client, error) {
 		tok:        nil,
 		logger:     p.logger,
 	}, nil
-
 }
 
 type tlsClientProvider struct {

--- a/internal/metadataproviders/system/metadata.go
+++ b/internal/metadataproviders/system/metadata.go
@@ -199,7 +199,6 @@ func (p systemMetadataProvider) HostIPs() (ips []net.IP, err error) {
 
 			ips = append(ips, ip)
 		}
-
 	}
 	return ips, err
 }

--- a/internal/otelarrow/compression/zstd/zstd.go
+++ b/internal/otelarrow/compression/zstd/zstd.go
@@ -218,7 +218,6 @@ func SetDecoderConfig(cfg DecoderConfig) error {
 		updateOne(&staticInstances.byLevel[level].dec)
 	}
 	return nil
-
 }
 
 func (cfg EncoderConfig) options() (opts []zstdlib.EOption) {

--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -179,7 +179,6 @@ func basicTestConfig(t *testing.T, tp testParams, cfgF CfgFunc) (*testConsumer, 
 	require.NoError(t, err)
 
 	return testCon, exporter, receiver
-
 }
 
 func testIntegrationTraces(ctx context.Context, t *testing.T, tp testParams, cfgf CfgFunc, mkgen MkGen, errf ConsumerErrFunc, endf EndFunc) {
@@ -294,7 +293,6 @@ func bulkyGenFunc() MkGen {
 			return tracesGen.Generate(1000, time.Minute)
 		}
 	}
-
 }
 
 func standardEnding(t *testing.T, params testParams, testCon *testConsumer, expect [][]ptrace.Traces) (rops, eops map[string]int) {
@@ -601,7 +599,6 @@ func TestIntegrationSelfTracing(t *testing.T) {
 	var params = testParams{
 		threadCount: 10,
 		requestWhileTrue: func(test *testConsumer) bool {
-
 			cnt := 0
 			for _, span := range test.expSpans.GetSpans() {
 				if span.Name == "opentelemetry.proto.experimental.arrow.v1.ArrowTracesService/ArrowTraces" {

--- a/pkg/batchpersignal/batchpersignal_test.go
+++ b/pkg/batchpersignal/batchpersignal_test.go
@@ -65,7 +65,6 @@ func TestSplitDifferentTracesIntoDifferentBatches(t *testing.T) {
 	assert.Equal(t, library.Name(), secondOutILS.Scope().Name())
 	assert.Equal(t, secondSpan.Name(), secondOutILS.Spans().At(0).Name())
 	assert.Equal(t, ils.SchemaUrl(), secondOutILS.SchemaUrl())
-
 }
 
 func TestSplitTracesWithNilTraceID(t *testing.T) {

--- a/pkg/golden/sort_metrics_test.go
+++ b/pkg/golden/sort_metrics_test.go
@@ -42,7 +42,6 @@ func TestSortAttributes(t *testing.T) {
 			t.Errorf("Incorrect key at index %d. Expected: %s, Actual: %s", i, key, actualKeys[i])
 		}
 	}
-
 }
 
 func TestSortMetricsResourceAndScope(t *testing.T) {
@@ -56,5 +55,4 @@ func TestSortMetricsResourceAndScope(t *testing.T) {
 	after, err := ReadMetrics(afterPath)
 	require.NoError(t, err)
 	require.Equal(t, before, after)
-
 }

--- a/pkg/ottl/boolean_value.go
+++ b/pkg/ottl/boolean_value.go
@@ -94,7 +94,6 @@ func (p *Parser[K]) newComparisonEvaluator(comparison *comparison) (BoolExpr[K],
 		}
 		return p.compare(a, b, comparison.Op), nil
 	}}, nil
-
 }
 
 func (p *Parser[K]) newBoolExpr(expr *booleanExpression) (BoolExpr[K], error) {

--- a/pkg/ottl/contexts/internal/metric_test.go
+++ b/pkg/ottl/contexts/internal/metric_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func Test_MetricPathGetSetter(t *testing.T) {
-
 	refMetric := createMetricTelemetry()
 
 	newMetric := pmetric.NewMetric()

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -496,7 +496,6 @@ func Test_newPathGetSetter_NumberDataPoint(t *testing.T) {
 			tt.modified(exNumberDataPoint)
 
 			assert.Equal(t, exNumberDataPoint, numberDataPoint)
-
 		})
 	}
 }

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -181,7 +181,6 @@ func Test_newPathGetSetter(t *testing.T) {
 				fmt.Println(log.Body().Slice().At(0).AsString())
 				newBodySlice.CopyTo(log.Body().Slice())
 				fmt.Println(log.Body().Slice().At(0).AsString())
-
 			},
 			bodyType: "slice",
 		},

--- a/pkg/ottl/contexts/ottlmetric/metrics_test.go
+++ b/pkg/ottl/contexts/ottlmetric/metrics_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func Test_newPathGetSetter(t *testing.T) {
-
 	refMetric := createMetricTelemetry()
 
 	newCache := pcommon.NewMap()

--- a/pkg/ottl/contexts/ottlspanevent/span_events.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events.go
@@ -179,7 +179,6 @@ func (pep *pathExpressionParser) parsePath(path ottl.Path[TransformContext]) (ot
 	default:
 		return nil, internal.FormatDefaultErrorMessage(path.Name(), path.String(), "Span Event", internal.SpanEventRef)
 	}
-
 }
 func accessCache() ottl.StandardGetSetter[TransformContext] {
 	return ottl.StandardGetSetter[TransformContext]{

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -285,7 +285,6 @@ func Test_e2e_editors(t *testing.T) {
 				sv, _ := v.Map().Get("slice")
 				s := sv.Slice()
 				s.AppendEmpty().SetStr("sample_value")
-
 			},
 		},
 		{
@@ -295,7 +294,6 @@ func Test_e2e_editors(t *testing.T) {
 				s := v.Map().PutEmptySlice("flags")
 				s.AppendEmpty().SetStr("pass")
 				s.AppendEmpty().SetStr("sample_value")
-
 			},
 		},
 		{
@@ -971,7 +969,6 @@ func Test_e2e_converters(t *testing.T) {
 				m := tCtx.GetLogRecord().Attributes().PutEmptyMap("test")
 				m.PutInt("foo", 2)
 				m.PutInt("bar", 5)
-
 			},
 		},
 	}

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -172,7 +172,6 @@ func (m *mapGetter[K]) Get(ctx context.Context, tCtx K) (any, error) {
 		default:
 			evaluated[k] = t
 		}
-
 	}
 	result := pcommon.NewMap()
 	if err := result.FromRaw(evaluated); err != nil {

--- a/pkg/ottl/math_test.go
+++ b/pkg/ottl/math_test.go
@@ -576,7 +576,6 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 					assert.Error(t, err)
 					assert.ErrorContains(t, err, tt.errorMsg)
 				}
-
 			} else {
 				parsed, err := mathParser.ParseString("", tt.input)
 				assert.NoError(t, err)
@@ -588,7 +587,6 @@ func Test_evaluateMathExpression_error(t *testing.T) {
 				assert.Nil(t, result)
 				assert.Error(t, err)
 			}
-
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_base64decode.go
+++ b/pkg/ottl/ottlfuncs/func_base64decode.go
@@ -30,7 +30,6 @@ func createBase64DecodeFunction[K any](_ ottl.FunctionContext, oArgs ottl.Argume
 }
 
 func Base64Decode[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
-
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_decode_test.go
+++ b/pkg/ottl/ottlfuncs/func_decode_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestDecode(t *testing.T) {
-
 	testByteSlice := pcommon.NewByteSlice()
 	testByteSlice.FromRaw([]byte("test string"))
 	testByteSliceB64 := pcommon.NewByteSlice()

--- a/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_extract_grok_patterns_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func Test_extractGrokPatterns_patterns(t *testing.T) {
-
 	tests := []struct {
 		name              string
 		targetString      string

--- a/pkg/ottl/ottlfuncs/func_flatten_test.go
+++ b/pkg/ottl/ottlfuncs/func_flatten_test.go
@@ -147,7 +147,6 @@ func Test_flatten(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			m := pcommon.NewMap()
 			err := m.FromRaw(tt.target)
 			assert.NoError(t, err)

--- a/pkg/ottl/ottlfuncs/func_fnv.go
+++ b/pkg/ottl/ottlfuncs/func_fnv.go
@@ -30,7 +30,6 @@ func createFnvFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ott
 }
 
 func FNVHashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
-
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_keep_matching_keys_test.go
+++ b/pkg/ottl/ottlfuncs/func_keep_matching_keys_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func Test_keepMatchingKeys(t *testing.T) {
-
 	in := pcommon.NewMap()
 	in.PutStr("foo", "bar")
 	in.PutStr("foo1", "bar")

--- a/pkg/ottl/ottlfuncs/func_md5.go
+++ b/pkg/ottl/ottlfuncs/func_md5.go
@@ -31,7 +31,6 @@ func createMD5Function[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ott
 }
 
 func MD5HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
-
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_merge_maps_test.go
+++ b/pkg/ottl/ottlfuncs/func_merge_maps_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func Test_MergeMaps(t *testing.T) {
-
 	input := pcommon.NewMap()
 	input.PutStr("attr1", "value1")
 

--- a/pkg/ottl/ottlfuncs/func_parse_json_test.go
+++ b/pkg/ottl/ottlfuncs/func_parse_json_test.go
@@ -109,7 +109,6 @@ func Test_ParseJSON(t *testing.T) {
 				},
 			},
 			wantSlice: func(expectedSlice pcommon.Slice) {
-
 				expectedSlice.AppendEmpty().SetEmptyMap().PutStr("test", "value")
 				expectedSlice.AppendEmpty().SetEmptyMap().PutStr("test", "value")
 			},
@@ -186,7 +185,6 @@ func Test_ParseJSON(t *testing.T) {
 				tt.wantSlice(expected)
 				assert.Equal(t, expected, resultSlice)
 			}
-
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_pattern_test.go
@@ -35,7 +35,6 @@ func createTestFunction[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ot
 }
 
 func hashString[K any](target ottl.StringGetter[K]) ottl.ExprFunc[K] {
-
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {
@@ -245,7 +244,6 @@ func Test_replacePattern(t *testing.T) {
 			tt.want(expected)
 
 			assert.Equal(t, expected, scenarioValue)
-
 		})
 	}
 }

--- a/pkg/ottl/ottlfuncs/func_sha1.go
+++ b/pkg/ottl/ottlfuncs/func_sha1.go
@@ -31,7 +31,6 @@ func createSHA1Function[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (ot
 }
 
 func SHA1HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
-
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_sha256.go
+++ b/pkg/ottl/ottlfuncs/func_sha256.go
@@ -31,7 +31,6 @@ func createSHA256Function[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (
 }
 
 func SHA256HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
-
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_sha512.go
+++ b/pkg/ottl/ottlfuncs/func_sha512.go
@@ -31,7 +31,6 @@ func createSHA512Function[K any](_ ottl.FunctionContext, oArgs ottl.Arguments) (
 }
 
 func SHA512HashString[K any](target ottl.StringGetter[K]) (ottl.ExprFunc[K], error) {
-
 	return func(ctx context.Context, tCtx K) (any, error) {
 		val, err := target.Get(ctx, tCtx)
 		if err != nil {

--- a/pkg/ottl/ottlfuncs/func_sort_test.go
+++ b/pkg/ottl/ottlfuncs/func_sort_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func Test_Sort(t *testing.T) {
-
 	pMap := pcommon.NewValueMap().SetEmptyMap()
 	pMap.PutStr("k", "v")
 	emptySlice := pcommon.NewValueSlice().SetEmptySlice()

--- a/pkg/ottl/ottlfuncs/func_to_key_value_string.go
+++ b/pkg/ottl/ottlfuncs/func_to_key_value_string.go
@@ -73,7 +73,6 @@ func toKeyValueString[K any](target ottl.PMapGetter[K], d ottl.Optional[string],
 
 // convertMapToKV converts a pcommon.Map to a key value string
 func convertMapToKV(target pcommon.Map, delimiter string, pairDelimiter string, sortOutput bool) string {
-
 	var kvStrings []string
 	if sortOutput {
 		var keyValues []struct {

--- a/pkg/pdatatest/pmetrictest/options.go
+++ b/pkg/pdatatest/pmetrictest/options.go
@@ -63,7 +63,6 @@ func maskMetricSliceValues(metrics pmetric.MetricSlice, metricNames ...string) {
 			default:
 				panic(fmt.Sprintf("data type not supported: %s", metrics.At(i).Type()))
 			}
-
 		}
 	}
 }
@@ -516,7 +515,6 @@ func matchMetricSliceAttributeValues(metrics pmetric.MetricSlice, attributeName 
 					return false
 				})
 			}
-
 		}
 	}
 }
@@ -630,7 +628,6 @@ func maskSubsequentDataPoints(metrics pmetric.Metrics, metricNames []string) {
 							return n > 1
 						})
 					}
-
 				}
 			}
 		}

--- a/pkg/resourcetotelemetry/resource_to_telemetry_test.go
+++ b/pkg/resourcetotelemetry/resource_to_telemetry_test.go
@@ -52,7 +52,6 @@ func TestConvertResourceToAttributesAllDataTypesEmptyDataPoint(t *testing.T) {
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(4).Histogram().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(5).Summary().DataPoints().At(0).Attributes().Len())
 	assert.Equal(t, 1, md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(6).ExponentialHistogram().DataPoints().At(0).Attributes().Len())
-
 }
 
 func BenchmarkJoinAttributes(b *testing.B) {
@@ -111,7 +110,6 @@ func BenchmarkJoinAttributes(b *testing.B) {
 			}
 		})
 	}
-
 }
 
 func initMetricAttributes(capacity int, idx int) pcommon.Map {

--- a/pkg/stanza/adapter/benchmark_test.go
+++ b/pkg/stanza/adapter/benchmark_test.go
@@ -86,7 +86,6 @@ const (
 )
 
 func BenchmarkEndToEnd(b *testing.B) {
-
 	// These values may have meaningful performance implications, so benchmarks
 	// should cover a variety of values in order to highlight impacts.
 	var (

--- a/pkg/stanza/adapter/frompdataconverter_test.go
+++ b/pkg/stanza/adapter/frompdataconverter_test.go
@@ -126,7 +126,6 @@ func BenchmarkFromPdataConverter(b *testing.B) {
 	for _, wc := range workerCounts {
 		b.Run(fmt.Sprintf("worker_count=%d", wc), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-
 				converter := NewFromPdataConverter(componenttest.NewNopTelemetrySettings(), wc)
 				converter.Start()
 				defer converter.Stop()

--- a/pkg/stanza/adapter/receiver_test.go
+++ b/pkg/stanza/adapter/receiver_test.go
@@ -466,7 +466,6 @@ func (t *testInputOperator) Start(_ operator.Persister) error {
 				return
 			}
 		}
-
 	}()
 	return nil
 }

--- a/pkg/stanza/adapter/storage.go
+++ b/pkg/stanza/adapter/storage.go
@@ -27,7 +27,6 @@ func GetStorageClient(ctx context.Context, host component.Host, storageID *compo
 	}
 
 	return storageExtension.GetClient(ctx, component.KindReceiver, componentID, "")
-
 }
 
 func (r *receiver) setStorageClient(ctx context.Context, host component.Host) error {

--- a/pkg/stanza/fileconsumer/attrs/attrs_test.go
+++ b/pkg/stanza/fileconsumer/attrs/attrs_test.go
@@ -18,7 +18,6 @@ func TestResolver(t *testing.T) {
 	t.Parallel()
 
 	for i := 0; i < 64; i++ {
-
 		// Create a 6 bit string where each bit represents the value of a config option
 		bitString := fmt.Sprintf("%06b", i)
 

--- a/pkg/stanza/fileconsumer/file_test.go
+++ b/pkg/stanza/fileconsumer/file_test.go
@@ -141,7 +141,6 @@ func TestReadUsingNopEncoding(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.testName, func(t *testing.T) {
-
 			tempDir := t.TempDir()
 			cfg := NewConfig().includeDir(tempDir)
 			cfg.StartAt = "beginning"
@@ -225,7 +224,6 @@ func TestNopEncodingDifferentLogSizes(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.testName, func(t *testing.T) {
-
 			tempDir := t.TempDir()
 			cfg := NewConfig().includeDir(tempDir)
 			cfg.StartAt = "beginning"

--- a/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint_test.go
+++ b/pkg/stanza/fileconsumer/internal/checkpoint/checkpoint_test.go
@@ -141,7 +141,6 @@ func TestMigrateHeaderAttributes(t *testing.T) {
 			},
 		},
 	}, reloaded)
-
 }
 
 func saveDeprecated(t *testing.T, persister operator.Persister, dep *deprecatedMetadata) {

--- a/pkg/stanza/fileconsumer/internal/fileset/fileset_test.go
+++ b/pkg/stanza/fileconsumer/internal/fileset/fileset_test.go
@@ -55,7 +55,6 @@ func match[T Matchable](ele T, expect bool) func(t *testing.T, fileset *Fileset[
 			require.Nil(t, r)
 			require.Equal(t, pr, fileset.Len())
 		}
-
 	}
 }
 

--- a/pkg/stanza/fileconsumer/internal/reader/factory.go
+++ b/pkg/stanza/fileconsumer/internal/reader/factory.go
@@ -64,7 +64,6 @@ func (f *Factory) NewReader(file *os.File, fp *fingerprint.Fingerprint) (*Reader
 }
 
 func (f *Factory) NewReaderFromMetadata(file *os.File, m *Metadata) (r *Reader, err error) {
-
 	r = &Reader{
 		Metadata:             m,
 		set:                  f.TelemetrySettings,

--- a/pkg/stanza/operator/input/windows/xml_test.go
+++ b/pkg/stanza/operator/input/windows/xml_test.go
@@ -422,7 +422,6 @@ func TestParseEventData(t *testing.T) {
 func TestInvalidUnmarshal(t *testing.T) {
 	_, err := unmarshalEventXML([]byte("Test \n Invalid \t Unmarshal"))
 	require.Error(t, err)
-
 }
 func TestUnmarshalWithEventData(t *testing.T) {
 	data, err := os.ReadFile(filepath.Join("testdata", "xmlSample.xml"))

--- a/pkg/stanza/operator/parser/container/parser.go
+++ b/pkg/stanza/operator/parser/container/parser.go
@@ -282,7 +282,6 @@ func (p *Parser) extractk8sMetaFromFilePath(e *entry.Entry) error {
 		if err := newField.Set(e, parsedValues[originalKey]); err != nil {
 			return fmt.Errorf("failed to set %v as metadata at %v", originalKey, attributeKey)
 		}
-
 	}
 	return nil
 }

--- a/pkg/stanza/operator/parser/container/parser_test.go
+++ b/pkg/stanza/operator/parser/container/parser_test.go
@@ -633,7 +633,6 @@ func TestCRIRecombineProcessWithFailedDownstreamOperator(t *testing.T) {
 }
 
 func TestProcessWithTimeRemovalFlagDisabled(t *testing.T) {
-
 	require.NoError(t, featuregate.GlobalRegistry().Set(removeOriginalTimeField.ID(), false))
 	t.Cleanup(func() {
 		require.NoError(t, featuregate.GlobalRegistry().Set(removeOriginalTimeField.ID(), true))

--- a/pkg/stanza/operator/parser/jsonarray/config_test.go
+++ b/pkg/stanza/operator/parser/jsonarray/config_test.go
@@ -96,5 +96,4 @@ func TestBuildWithFeatureGate(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/stanza/operator/parser/syslog/parser.go
+++ b/pkg/stanza/operator/parser/syslog/parser.go
@@ -38,10 +38,8 @@ type Parser struct {
 
 // Process will parse an entry field as syslog.
 func (p *Parser) Process(ctx context.Context, entry *entry.Entry) error {
-
 	// if pri header is missing and this is an expected behavior then facility and severity values should be skipped.
 	if !p.enableOctetCounting && p.allowSkipPriHeader {
-
 		bytes, err := toBytes(entry.Body)
 		if err != nil {
 			return err

--- a/pkg/stanza/operator/transformer/recombine/transformer_test.go
+++ b/pkg/stanza/operator/transformer/recombine/transformer_test.go
@@ -815,7 +815,6 @@ func BenchmarkRecombineLimitTrigger(b *testing.B) {
 		require.NoError(b, recombine.Process(ctx, next))
 		recombine.flushAllSources(ctx)
 	}
-
 }
 
 func TestTimeout(t *testing.T) {
@@ -900,7 +899,6 @@ func TestTimeoutWhenAggregationKeepHappen(t *testing.T) {
 				return
 			case <-ticker.C:
 				assert.NoError(t, recombine.Process(ctx, next))
-
 			}
 		}
 	}()

--- a/pkg/stanza/operator/transformer/retain/config_test.go
+++ b/pkg/stanza/operator/transformer/retain/config_test.go
@@ -92,5 +92,4 @@ func TestUnmarshal(t *testing.T) {
 			},
 		},
 	}.Run(t)
-
 }

--- a/pkg/status/aggregator_test.go
+++ b/pkg/status/aggregator_test.go
@@ -127,7 +127,6 @@ func TestAggregateStatusVerbose(t *testing.T) {
 			st.ComponentStatusMap[tracesKey].ComponentStatusMap[toComponentKey(traces.ExporterID)],
 		)
 	})
-
 }
 
 func TestAggregateStatusPriorityRecoverable(t *testing.T) {

--- a/pkg/translator/azure/resourcelogs_to_logs_test.go
+++ b/pkg/translator/azure/resourcelogs_to_logs_test.go
@@ -361,7 +361,6 @@ func TestExtractRawAttributes(t *testing.T) {
 			assert.Equal(t, tt.expected, extractRawAttributes(tt.log))
 		})
 	}
-
 }
 
 func TestUnmarshalLogs(t *testing.T) {

--- a/pkg/translator/azurelogs/resourcelogs_to_logs_test.go
+++ b/pkg/translator/azurelogs/resourcelogs_to_logs_test.go
@@ -451,7 +451,6 @@ func TestExtractRawAttributes(t *testing.T) {
 			assert.Equal(t, tt.expected, extractRawAttributes(tt.log))
 		})
 	}
-
 }
 
 func TestUnmarshalLogs(t *testing.T) {

--- a/pkg/translator/jaeger/jaegerproto_to_traces_test.go
+++ b/pkg/translator/jaeger/jaegerproto_to_traces_test.go
@@ -178,7 +178,6 @@ func TestJTagsToInternalAttributes(t *testing.T) {
 }
 
 func TestProtoToTraces(t *testing.T) {
-
 	tests := []struct {
 		name string
 		jb   []*model.Batch
@@ -379,7 +378,6 @@ func TestProtoBatchToInternalTracesWithTwoLibraries(t *testing.T) {
 }
 
 func TestSetInternalSpanStatus(t *testing.T) {
-
 	emptyStatus := ptrace.NewStatus()
 
 	okStatus := ptrace.NewStatus()

--- a/pkg/translator/jaeger/jaegerthrift_to_traces_test.go
+++ b/pkg/translator/jaeger/jaegerthrift_to_traces_test.go
@@ -65,7 +65,6 @@ func TestJThriftTagsToInternalAttributes(t *testing.T) {
 }
 
 func TestThriftBatchToInternalTraces(t *testing.T) {
-
 	tests := []struct {
 		name string
 		jb   *jaeger.Batch

--- a/pkg/translator/jaeger/traces_to_jaegerproto.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto.go
@@ -90,7 +90,6 @@ func resourceToJaegerProtoProcess(resource pcommon.Resource) *model.Process {
 	tags := make([]model.KeyValue, 0, attrsCount)
 	process.Tags = appendTagsFromResourceAttributes(tags, attrs)
 	return process
-
 }
 
 func appendTagsFromResourceAttributes(dest []model.KeyValue, attrs pcommon.Map) []model.KeyValue {
@@ -355,7 +354,6 @@ func getErrorTagFromStatusCode(statusCode ptrace.StatusCode) (model.KeyValue, bo
 		}, true
 	}
 	return model.KeyValue{}, false
-
 }
 
 func getTagFromStatusMsg(statusMsg string) (model.KeyValue, bool) {

--- a/pkg/translator/jaeger/traces_to_jaegerproto_test.go
+++ b/pkg/translator/jaeger/traces_to_jaegerproto_test.go
@@ -164,7 +164,6 @@ func TestGetTagFromSpanKind(t *testing.T) {
 }
 
 func TestAttributesToJaegerProtoTags(t *testing.T) {
-
 	attributes := pcommon.NewMap()
 	attributes.PutBool("bool-val", true)
 	attributes.PutInt("int-val", 123)
@@ -215,7 +214,6 @@ func TestAttributesToJaegerProtoTags(t *testing.T) {
 }
 
 func TestInternalTracesToJaegerProto(t *testing.T) {
-
 	tests := []struct {
 		name string
 		td   ptrace.Traces

--- a/pkg/translator/loki/convert.go
+++ b/pkg/translator/loki/convert.go
@@ -187,7 +187,6 @@ func convertLogToLokiEntry(lr plog.LogRecord, res pcommon.Resource, format strin
 	default:
 		return nil, fmt.Errorf("invalid format %s. Expected one of: %s, %s, %s", format, formatJSON, formatLogfmt, formatRaw)
 	}
-
 }
 
 func timestampFromLogRecord(lr plog.LogRecord) time.Time {

--- a/pkg/translator/loki/encode.go
+++ b/pkg/translator/loki/encode.go
@@ -179,7 +179,6 @@ func valueToKeyvals(key string, value pcommon.Value) []any {
 			prefix = key + "_"
 		}
 		value.Map().Range(func(k string, v pcommon.Value) bool {
-
 			keyvals = append(keyvals, valueToKeyvals(prefix+k, v)...)
 			return true
 		})

--- a/pkg/translator/loki/encode_test.go
+++ b/pkg/translator/loki/encode_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func exampleLog() (plog.LogRecord, pcommon.Resource, pcommon.InstrumentationScope) {
-
 	buffer := plog.NewLogRecord()
 	buffer.Body().SetStr("Example log")
 	buffer.SetSeverityText("error")
@@ -66,7 +65,6 @@ func TestEncodeJsonWithInstrumentationScopeAttributes(t *testing.T) {
 }
 
 func TestSerializeComplexBody(t *testing.T) {
-
 	arrayval := pcommon.NewValueSlice()
 	arrayval.Slice().AppendEmpty().SetStr("a")
 	arrayval.Slice().AppendEmpty().SetStr("b")

--- a/pkg/translator/opencensus/traces_to_oc.go
+++ b/pkg/translator/opencensus/traces_to_oc.go
@@ -159,7 +159,6 @@ func spanKindToOCAttribute(kind ptrace.SpanKind) *octrace.AttributeValue {
 	case ptrace.SpanKindServer: // explicitly handled as SpanKind
 	case ptrace.SpanKindClient: // explicitly handled as SpanKind
 	default:
-
 	}
 
 	if string(ocKind) == "" {

--- a/pkg/translator/prometheus/normalize_label.go
+++ b/pkg/translator/prometheus/normalize_label.go
@@ -25,7 +25,6 @@ var dropSanitizationGate = featuregate.GlobalRegistry().MustRegister(
 //
 // Exception is made for double-underscores which are allowed
 func NormalizeLabel(label string) string {
-
 	// Trivial case
 	if len(label) == 0 {
 		return label

--- a/pkg/translator/prometheus/normalize_label_test.go
+++ b/pkg/translator/prometheus/normalize_label_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestSanitize(t *testing.T) {
-
 	defer testutil.SetFeatureGateForTest(t, dropSanitizationGate, false)()
 
 	require.Equal(t, "", NormalizeLabel(""), "")
@@ -24,7 +23,6 @@ func TestSanitize(t *testing.T) {
 }
 
 func TestSanitizeDropSanitization(t *testing.T) {
-
 	defer testutil.SetFeatureGateForTest(t, dropSanitizationGate, true)()
 
 	require.Equal(t, "", NormalizeLabel(""))

--- a/pkg/translator/prometheus/normalize_name.go
+++ b/pkg/translator/prometheus/normalize_name.go
@@ -106,7 +106,6 @@ func BuildCompliantName(metric pmetric.Metric, namespace string, addMetricSuffix
 
 // Build a normalized name for the specified metric
 func normalizeName(metric pmetric.Metric, namespace string) string {
-
 	// Split metric name in "tokens" (remove all non-alphanumeric)
 	nameTokens := strings.FieldsFunc(
 		metric.Name(),
@@ -138,7 +137,6 @@ func normalizeName(metric pmetric.Metric, namespace string) string {
 				}
 			}
 		}
-
 	}
 
 	// Append _total for Counters

--- a/pkg/translator/prometheus/normalize_name_test.go
+++ b/pkg/translator/prometheus/normalize_name_test.go
@@ -14,97 +14,70 @@ import (
 )
 
 func TestByte(t *testing.T) {
-
 	require.Equal(t, "system_filesystem_usage_bytes", normalizeName(createGauge("system.filesystem.usage", "By"), ""))
-
 }
 
 func TestByteCounter(t *testing.T) {
-
 	require.Equal(t, "system_io_bytes_total", normalizeName(createCounter("system.io", "By"), ""))
 	require.Equal(t, "network_transmitted_bytes_total", normalizeName(createCounter("network_transmitted_bytes_total", "By"), ""))
-
 }
 
 func TestWhiteSpaces(t *testing.T) {
-
 	require.Equal(t, "system_filesystem_usage_bytes", normalizeName(createGauge("\t system.filesystem.usage       ", "  By\t"), ""))
-
 }
 
 func TestNonStandardUnit(t *testing.T) {
-
 	require.Equal(t, "system_network_dropped", normalizeName(createGauge("system.network.dropped", "{packets}"), ""))
-
 }
 
 func TestNonStandardUnitCounter(t *testing.T) {
-
 	require.Equal(t, "system_network_dropped_total", normalizeName(createCounter("system.network.dropped", "{packets}"), ""))
-
 }
 
 func TestBrokenUnit(t *testing.T) {
-
 	require.Equal(t, "system_network_dropped_packets", normalizeName(createGauge("system.network.dropped", "packets"), ""))
 	require.Equal(t, "system_network_packets_dropped", normalizeName(createGauge("system.network.packets.dropped", "packets"), ""))
 	require.Equal(t, "system_network_packets", normalizeName(createGauge("system.network.packets", "packets"), ""))
-
 }
 
 func TestBrokenUnitCounter(t *testing.T) {
-
 	require.Equal(t, "system_network_dropped_packets_total", normalizeName(createCounter("system.network.dropped", "packets"), ""))
 	require.Equal(t, "system_network_packets_dropped_total", normalizeName(createCounter("system.network.packets.dropped", "packets"), ""))
 	require.Equal(t, "system_network_packets_total", normalizeName(createCounter("system.network.packets", "packets"), ""))
-
 }
 
 func TestRatio(t *testing.T) {
-
 	require.Equal(t, "hw_gpu_memory_utilization_ratio", normalizeName(createGauge("hw.gpu.memory.utilization", "1"), ""))
 	require.Equal(t, "hw_fan_speed_ratio", normalizeName(createGauge("hw.fan.speed_ratio", "1"), ""))
 	require.Equal(t, "objects_total", normalizeName(createCounter("objects", "1"), ""))
-
 }
 
 func TestHertz(t *testing.T) {
-
 	require.Equal(t, "hw_cpu_speed_limit_hertz", normalizeName(createGauge("hw.cpu.speed_limit", "Hz"), ""))
-
 }
 
 func TestPer(t *testing.T) {
-
 	require.Equal(t, "broken_metric_speed_km_per_hour", normalizeName(createGauge("broken.metric.speed", "km/h"), ""))
 	require.Equal(t, "astro_light_speed_limit_meters_per_second", normalizeName(createGauge("astro.light.speed_limit", "m/s"), ""))
-
 }
 
 func TestPercent(t *testing.T) {
-
 	require.Equal(t, "broken_metric_success_ratio_percent", normalizeName(createGauge("broken.metric.success_ratio", "%"), ""))
 	require.Equal(t, "broken_metric_success_percent", normalizeName(createGauge("broken.metric.success_percent", "%"), ""))
-
 }
 
 func TestEmpty(t *testing.T) {
-
 	require.Equal(t, "test_metric_no_unit", normalizeName(createGauge("test.metric.no_unit", ""), ""))
 	require.Equal(t, "test_metric_spaces", normalizeName(createGauge("test.metric.spaces", "   \t  "), ""))
-
 }
 
 func TestUnsupportedRunes(t *testing.T) {
-
 	require.Equal(t, "unsupported_metric_temperature_F", normalizeName(createGauge("unsupported.metric.temperature", "°F"), ""))
 	require.Equal(t, "unsupported_metric_weird", normalizeName(createGauge("unsupported.metric.weird", "+=.:,!* & #"), ""))
 	require.Equal(t, "unsupported_metric_redundant_test_per_C", normalizeName(createGauge("unsupported.metric.redundant", "__test $/°C"), ""))
-
 }
 
 func TestOtelReceivers(t *testing.T) {
-
 	require.Equal(t, "active_directory_ds_replication_network_io_bytes_total", normalizeName(createCounter("active_directory.ds.replication.network.io", "By"), ""))
 	require.Equal(t, "active_directory_ds_replication_sync_object_pending_total", normalizeName(createCounter("active_directory.ds.replication.sync.object.pending", "{objects}"), ""))
 	require.Equal(t, "active_directory_ds_replication_object_rate_per_second", normalizeName(createGauge("active_directory.ds.replication.object.rate", "{objects}/s"), ""))
@@ -127,7 +100,6 @@ func TestOtelReceivers(t *testing.T) {
 	require.Equal(t, "nginx_connections_accepted", normalizeName(createGauge("nginx.connections_accepted", "connections"), ""))
 	require.Equal(t, "nsxt_node_memory_usage_kilobytes", normalizeName(createGauge("nsxt.node.memory.usage", "KBy"), ""))
 	require.Equal(t, "redis_latest_fork_microseconds", normalizeName(createGauge("redis.latest_fork", "us"), ""))
-
 }
 
 func TestTrimPromSuffixes(t *testing.T) {
@@ -158,7 +130,6 @@ func TestTrimPromSuffixes(t *testing.T) {
 	assert.Equal(t, "memcached_operation_hit_ratio_percent", TrimPromSuffixes("memcached_operation_hit_ratio_percent", pmetric.MetricTypeGauge, "%"))
 	assert.Equal(t, "active_directory_ds_replication_object_rate_per_second", TrimPromSuffixes("active_directory_ds_replication_object_rate_per_second", pmetric.MetricTypeGauge, "{objects}/s"))
 	assert.Equal(t, "system_disk_operation_time_seconds", TrimPromSuffixes("system_disk_operation_time_seconds_total", pmetric.MetricTypeSum, "s"))
-
 }
 
 func TestNamespace(t *testing.T) {
@@ -176,23 +147,18 @@ func TestCleanUpString(t *testing.T) {
 }
 
 func TestUnitMapGetOrDefault(t *testing.T) {
-
 	require.Equal(t, "", unitMapGetOrDefault(""))
 	require.Equal(t, "seconds", unitMapGetOrDefault("s"))
 	require.Equal(t, "invalid", unitMapGetOrDefault("invalid"))
-
 }
 
 func TestPerUnitMapGetOrDefault(t *testing.T) {
-
 	require.Equal(t, "", perUnitMapGetOrDefault(""))
 	require.Equal(t, "second", perUnitMapGetOrDefault("s"))
 	require.Equal(t, "invalid", perUnitMapGetOrDefault("invalid"))
-
 }
 
 func TestRemoveItem(t *testing.T) {
-
 	require.Equal(t, []string{}, removeItem([]string{}, "test"))
 	require.Equal(t, []string{}, removeItem([]string{}, ""))
 	require.Equal(t, []string{"a", "b", "c"}, removeItem([]string{"a", "b", "c"}, "d"))
@@ -200,11 +166,9 @@ func TestRemoveItem(t *testing.T) {
 	require.Equal(t, []string{"a", "b"}, removeItem([]string{"a", "b", "c"}, "c"))
 	require.Equal(t, []string{"a", "c"}, removeItem([]string{"a", "b", "c"}, "b"))
 	require.Equal(t, []string{"b", "c"}, removeItem([]string{"a", "b", "c"}, "a"))
-
 }
 
 func TestBuildCompliantNameWithNormalize(t *testing.T) {
-
 	defer testutil.SetFeatureGateForTest(t, normalizeNameGate, true)()
 	addUnitAndTypeSuffixes := true
 	require.Equal(t, "system_io_bytes_total", BuildCompliantName(createCounter("system.io", "By"), "", addUnitAndTypeSuffixes))
@@ -213,11 +177,9 @@ func TestBuildCompliantNameWithNormalize(t *testing.T) {
 	require.Equal(t, "envoy_rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", addUnitAndTypeSuffixes))
 	require.Equal(t, "foo_bar", BuildCompliantName(createGauge(":foo::bar", ""), "", addUnitAndTypeSuffixes))
 	require.Equal(t, "foo_bar_total", BuildCompliantName(createCounter(":foo::bar", ""), "", addUnitAndTypeSuffixes))
-
 }
 
 func TestBuildCompliantNameWithSuffixesFeatureGateDisabled(t *testing.T) {
-
 	defer testutil.SetFeatureGateForTest(t, normalizeNameGate, false)()
 	addUnitAndTypeSuffixes := true
 	require.Equal(t, "system_io", BuildCompliantName(createCounter("system.io", "By"), "", addUnitAndTypeSuffixes))
@@ -227,11 +189,9 @@ func TestBuildCompliantNameWithSuffixesFeatureGateDisabled(t *testing.T) {
 	require.Equal(t, "envoy__rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", addUnitAndTypeSuffixes))
 	require.Equal(t, ":foo::bar", BuildCompliantName(createGauge(":foo::bar", ""), "", addUnitAndTypeSuffixes))
 	require.Equal(t, ":foo::bar", BuildCompliantName(createCounter(":foo::bar", ""), "", addUnitAndTypeSuffixes))
-
 }
 
 func TestBuildCompliantNameWithoutSuffixes(t *testing.T) {
-
 	defer testutil.SetFeatureGateForTest(t, normalizeNameGate, false)()
 	addUnitAndTypeSuffixes := false
 	require.Equal(t, "system_io", BuildCompliantName(createCounter("system.io", "By"), "", addUnitAndTypeSuffixes))
@@ -241,5 +201,4 @@ func TestBuildCompliantNameWithoutSuffixes(t *testing.T) {
 	require.Equal(t, "envoy__rule_engine_zlib_buf_error", BuildCompliantName(createGauge("envoy__rule_engine_zlib_buf_error", ""), "", addUnitAndTypeSuffixes))
 	require.Equal(t, ":foo::bar", BuildCompliantName(createGauge(":foo::bar", ""), "", addUnitAndTypeSuffixes))
 	require.Equal(t, ":foo::bar", BuildCompliantName(createCounter(":foo::bar", ""), "", addUnitAndTypeSuffixes))
-
 }

--- a/pkg/translator/prometheus/testutils_test.go
+++ b/pkg/translator/prometheus/testutils_test.go
@@ -10,11 +10,9 @@ import (
 var ilm pmetric.ScopeMetrics
 
 func init() {
-
 	metrics := pmetric.NewMetrics()
 	resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
 	ilm = resourceMetrics.ScopeMetrics().AppendEmpty()
-
 }
 
 // Returns a new Metric of type "Gauge" with specified name and unit

--- a/pkg/translator/prometheus/unit_to_ucum_test.go
+++ b/pkg/translator/prometheus/unit_to_ucum_test.go
@@ -57,5 +57,4 @@ func TestUnitWordToUCUM(t *testing.T) {
 			assert.Equal(t, tc.expected, got)
 		})
 	}
-
 }

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -221,7 +221,6 @@ func (c *prometheusConverter) addHistogramDataPoints(dataPoints pmetric.Histogra
 
 			sumlabels := createLabels(baseName+sumStr, baseLabels)
 			c.addSample(sum, sumlabels)
-
 		}
 
 		// treat count as a sample in an individual TimeSeries

--- a/pkg/translator/prometheusremotewrite/number_data_points_v2_test.go
+++ b/pkg/translator/prometheusremotewrite/number_data_points_v2_test.go
@@ -122,7 +122,6 @@ func TestPrometheusConverterV2_addGaugeNumberDataPoints(t *testing.T) {
 
 			diff := cmp.Diff(w, converter.unique, cmpopts.EquateNaNs())
 			assert.Empty(t, diff)
-
 		})
 	}
 }
@@ -172,5 +171,4 @@ func TestPrometheusConverterV2_addGaugeNumberDataPointsDuplicate(t *testing.T) {
 	converter.addGaugeNumberDataPoints(metric2.Gauge().DataPoints(), pcommon.NewResource(), settings, metric2.Name())
 
 	assert.Equal(t, want(), converter.unique)
-
 }

--- a/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata_test.go
+++ b/pkg/translator/prometheusremotewrite/otlp_to_openmetrics_metadata_test.go
@@ -226,7 +226,6 @@ func TestOtelMetricsToMetadata(t *testing.T) {
 				assert.Equal(t, tt.want[i].MetricFamilyName, metaData[i].MetricFamilyName)
 				assert.Equal(t, tt.want[i].Help, metaData[i].Help)
 			}
-
 		})
 	}
 }

--- a/pkg/translator/zipkin/zipkinv1/json.go
+++ b/pkg/translator/zipkin/zipkinv1/json.go
@@ -167,7 +167,6 @@ func jsonBinAnnotationsToSpanAttributes(span ptrace.Span, binAnnotations []*bina
 	sMapper := &statusMapper{}
 	var localComponent string
 	for _, binAnnotation := range binAnnotations {
-
 		if binAnnotation.Endpoint != nil && binAnnotation.Endpoint.ServiceName != "" {
 			fallbackServiceName = binAnnotation.Endpoint.ServiceName
 		}

--- a/pkg/translator/zipkin/zipkinv2/from_translator.go
+++ b/pkg/translator/zipkin/zipkinv2/from_translator.go
@@ -98,7 +98,6 @@ func spanToZipkinSpan(
 	localServiceName string,
 	zTags map[string]string,
 ) (*zipkinmodel.SpanModel, error) {
-
 	tags := aggregateSpanTags(span, zTags)
 
 	zs := &zipkinmodel.SpanModel{}
@@ -318,7 +317,6 @@ func zipkinEndpointFromTags(
 	remoteEndpoint bool,
 	redundantKeys map[string]bool,
 ) (endpoint *zipkinmodel.Endpoint) {
-
 	serviceName := localServiceName
 	if peerSvc, ok := zTags[conventions.AttributePeerService]; ok && remoteEndpoint {
 		serviceName = peerSvc


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
