### PR TITLE
[chore]: enable gofumpt linter for testbed

### DIFF
--- a/testbed/correctnesstests/metrics/results.go
+++ b/testbed/correctnesstests/metrics/results.go
@@ -23,7 +23,7 @@ type result struct {
 }
 
 func (r *results) Init(resultsDir string) {
-	err := os.MkdirAll(resultsDir, os.FileMode(0755))
+	err := os.MkdirAll(resultsDir, os.FileMode(0o755))
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/testbed/datareceivers/datadog.go
+++ b/testbed/datareceivers/datadog.go
@@ -34,7 +34,6 @@ func (dd *datadogDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ c
 	set := receiver.Settings{}
 	var err error
 	dd.receiver, err = factory.CreateTraces(context.Background(), set, cfg, tc)
-
 	if err != nil {
 		return err
 	}

--- a/testbed/datareceivers/zipkin.go
+++ b/testbed/datareceivers/zipkin.go
@@ -36,7 +36,6 @@ func (zr *zipkinDataReceiver) Start(tc consumer.Traces, _ consumer.Metrics, _ co
 	set := receivertest.NewNopSettings()
 	var err error
 	zr.receiver, err = factory.CreateTraces(context.Background(), set, cfg, tc)
-
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/datadog_agent_exporter.go
+++ b/testbed/datasenders/datadog_agent_exporter.go
@@ -42,7 +42,6 @@ func (dd *datadogDataSender) Start() error {
 	params.Logger = zap.L()
 
 	exp, err := factory.CreateTraces(context.Background(), params, cfg)
-
 	if err != nil {
 		return err
 	}

--- a/testbed/datasenders/fluent.go
+++ b/testbed/datasenders/fluent.go
@@ -54,7 +54,7 @@ func NewFluentLogsForwarder(t *testing.T, port int) *FluentLogsForwarder {
 	// file FLUENT_DATA_SENDER_DATA_FILE and forward data to FLUENT_DATA_SENDER_RECEIVER_PORT
 	// on 127.0.0.1.
 	if dataFileName := os.Getenv(fluentDatafileVar); dataFileName != "" {
-		f.dataFile, err = os.OpenFile(dataFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+		f.dataFile, err = os.OpenFile(dataFileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 		require.NoError(t, err)
 	} else {
 		logger, err := fluent.New(fluent.Config{FluentPort: port, Async: true})

--- a/testbed/datasenders/jaeger.go
+++ b/testbed/datasenders/jaeger.go
@@ -155,7 +155,6 @@ func (s *protoGRPCSender) pushTraces(
 		_, err := s.client.PostSpans(
 			ctx,
 			&jaegerproto.PostSpansRequest{Batch: *batch}, grpc.WaitForReady(s.waitForReady))
-
 		if err != nil {
 			s.settings.Logger.Debug("failed to push trace data to Jaeger", zap.Error(err))
 			return fmt.Errorf("failed to push trace data via Jaeger exporter: %w", err)

--- a/testbed/datasenders/syslog.go
+++ b/testbed/datasenders/syslog.go
@@ -88,6 +88,7 @@ func (f *SyslogWriter) GenConfigYAMLStr() string {
       listen_address: "%s"
 `, f.network, f.GetEndpoint())
 }
+
 func (f *SyslogWriter) Send(lr plog.LogRecord) error {
 	ts := time.Unix(int64(lr.Timestamp()/1_000_000_000), int64(lr.Timestamp()%1_000_000_000)).Format(time.RFC3339Nano)
 	sdid := strings.Builder{}

--- a/testbed/datasenders/tcpudp.go
+++ b/testbed/datasenders/tcpudp.go
@@ -87,6 +87,7 @@ func (f *TCPUDPWriter) GenConfigYAMLStr() string {
     listen_address: "%s"
 `, f.network, f.GetEndpoint())
 }
+
 func (f *TCPUDPWriter) Send(lr plog.LogRecord) error {
 	ts := time.Unix(int64(lr.Timestamp()/1_000_000_000), int64(lr.Timestamp()%1_000_000_000)).Format(time.RFC3339Nano)
 	sdid := strings.Builder{}

--- a/testbed/mockdatasenders/mockdatadogagentexporter/factory.go
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/factory.go
@@ -17,10 +17,8 @@ import (
 
 // This file implements factory for awsxray receiver.
 
-var (
-	// The value of "type" key in configuration.
-	compType = component.MustNewType("datadog")
-)
+// The value of "type" key in configuration.
+var compType = component.MustNewType("datadog")
 
 func NewFactory() exporter.Factory {
 	return exporter.NewFactory(compType,

--- a/testbed/mockdatasenders/mockdatadogagentexporter/traces_exporter.go
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/traces_exporter.go
@@ -52,7 +52,7 @@ func (dd *ddExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
 			ils := resSpans.ScopeSpans().At(i)
 			for s := 0; s < ils.Spans().Len(); s++ {
 				span := ils.Spans().At(s)
-				var newSpan = pb.Span{
+				newSpan := pb.Span{
 					Service:  "test",
 					Name:     "test",
 					Resource: "test",

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -22,8 +22,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var errNonPermanent = errors.New("non permanent error")
-var errPermanent = errors.New("permanent error")
+var (
+	errNonPermanent = errors.New("non permanent error")
+	errPermanent    = errors.New("permanent error")
+)
 
 type decisionFunc func() error
 

--- a/testbed/testbed/results.go
+++ b/testbed/testbed/results.go
@@ -70,7 +70,7 @@ func (r *PerformanceResults) Init(resultsDir string) {
 	r.benchmarkResults = []*benchmarkResult{}
 
 	// Create resultsSummary file
-	if err := os.MkdirAll(resultsDir, os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll(resultsDir, os.FileMode(0o755)); err != nil {
 		log.Fatal(err)
 	}
 	var err error
@@ -160,7 +160,7 @@ func (r *PerformanceResults) Add(_ string, result any) {
 func (r *PerformanceResults) saveBenchmarks() {
 	path := path.Join(r.resultsDir, "benchmarks.json")
 	j, _ := json.MarshalIndent(r.benchmarkResults, "", "  ")
-	_ = os.WriteFile(path, j, 0600)
+	_ = os.WriteFile(path, j, 0o600)
 }
 
 // CorrectnessResults implements the TestResultsSummary interface with fields suitable for reporting data translation
@@ -202,7 +202,7 @@ func (r *CorrectnessResults) Init(resultsDir string) {
 	r.perTestResults = []*CorrectnessTestResult{}
 
 	// Create resultsSummary file
-	if err := os.MkdirAll(resultsDir, os.FileMode(0755)); err != nil {
+	if err := os.MkdirAll(resultsDir, os.FileMode(0o755)); err != nil {
 		log.Fatal(err)
 	}
 	var err error

--- a/testbed/testbed/test_bed.go
+++ b/testbed/testbed/test_bed.go
@@ -64,7 +64,6 @@ func DoTestMain(m *testing.M, resultsSummary TestResultsSummary) {
 
 	// Load the test bed config first.
 	err := Start(resultsSummary)
-
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/testbed/testbed/test_case.go
+++ b/testbed/testbed/test_case.go
@@ -58,8 +58,10 @@ type TestCase struct {
 	decision decisionFunc
 }
 
-const mibibyte = 1024 * 1024
-const testcaseDurationVar = "TESTCASE_DURATION"
+const (
+	mibibyte            = 1024 * 1024
+	testcaseDurationVar = "TESTCASE_DURATION"
+)
 
 // NewTestCase creates a new TestCase. It expects agent-config.yaml in the specified directory.
 func NewTestCase(

--- a/testbed/testbed/validator.go
+++ b/testbed/testbed/validator.go
@@ -445,7 +445,8 @@ func (v *CorrectnessTestValidator) diffSpanStatus(sentSpan ptrace.Span, recdSpan
 }
 
 func (v *CorrectnessTestValidator) diffAttributeMap(spanName string,
-	sentAttrs pcommon.Map, recdAttrs pcommon.Map, fmtStr string) {
+	sentAttrs pcommon.Map, recdAttrs pcommon.Map, fmtStr string,
+) {
 	sentAttrs.Range(func(sentKey string, sentVal pcommon.Value) bool {
 		recdVal, ok := recdAttrs.Get(sentKey)
 		if !ok {
@@ -470,7 +471,8 @@ func (v *CorrectnessTestValidator) diffAttributeMap(spanName string,
 }
 
 func (v *CorrectnessTestValidator) compareSimpleValues(spanName string, sentVal pcommon.Value, recdVal pcommon.Value,
-	fmtStr string, attrKey string) {
+	fmtStr string, attrKey string,
+) {
 	if reflect.DeepEqual(sentVal.AsRaw(), recdVal.AsRaw()) {
 		sentStr := sentVal.AsString()
 		recdStr := recdVal.AsString()
@@ -488,7 +490,8 @@ func (v *CorrectnessTestValidator) compareSimpleValues(spanName string, sentVal 
 }
 
 func (v *CorrectnessTestValidator) compareKeyValueList(
-	spanName string, sentVal pcommon.Value, recdVal pcommon.Value, fmtStr string, attrKey string) {
+	spanName string, sentVal pcommon.Value, recdVal pcommon.Value, fmtStr string, attrKey string,
+) {
 	switch recdVal.Type() {
 	case pcommon.ValueTypeMap:
 		v.diffAttributeMap(spanName, sentVal.Map(), recdVal.Map(), fmtStr)

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -22,9 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/testbed/testbed"
 )
 
-var (
-	performanceResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
-)
+var performanceResultsSummary testbed.TestResultsSummary = &testbed.PerformanceResults{}
 
 type ProcessorNameAndConfigBody struct {
 	Name string

--- a/testbed/tests/trace_test.go
+++ b/testbed/tests/trace_test.go
@@ -193,7 +193,7 @@ func TestTraceNoBackend10kSPS(t *testing.T) {
 
 	noLimitProcessors := []ProcessorNameAndConfigBody{}
 
-	var processorsConfig = []processorConfig{
+	processorsConfig := []processorConfig{
 		{
 			Name:                "NoMemoryLimit",
 			Processor:           noLimitProcessors,


### PR DESCRIPTION
#### Description

[gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) enforces a stricter format than gofmt

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36363