### PR TITLE
[chore]: enable whitespace linter for extension

### DIFF
--- a/extension/basicauthextension/extension.go
+++ b/extension/basicauthextension/extension.go
@@ -44,7 +44,6 @@ func newClientAuthExtension(cfg *Config) auth.Client {
 }
 
 func newServerAuthExtension(cfg *Config) (auth.Server, error) {
-
 	if cfg.Htpasswd == nil || (cfg.Htpasswd.File == "" && cfg.Htpasswd.Inline == "") {
 		return nil, errNoCredentialSource
 	}

--- a/extension/basicauthextension/extension_test.go
+++ b/extension/basicauthextension/extension_test.go
@@ -273,7 +273,6 @@ func TestBasicAuth_ClientValid(t *testing.T) {
 }
 
 func TestBasicAuth_ClientInvalid(t *testing.T) {
-
 	t.Run("invalid username format", func(t *testing.T) {
 		ext := newClientAuthExtension(&Config{
 			ClientAuth: &ClientAuthSettings{

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -62,7 +62,6 @@ func TestBearerAuthenticatorHttp(t *testing.T) {
 	assert.NoError(t, err)
 	authHeaderValue := resp.Header.Get("Authorization")
 	assert.Equal(t, authHeaderValue, fmt.Sprintf("%s %s", scheme, string(cfg.BearerToken)))
-
 }
 
 func TestBearerAuthenticator(t *testing.T) {

--- a/extension/headerssetterextension/extension.go
+++ b/extension/headerssetterextension/extension.go
@@ -75,7 +75,6 @@ func newHeadersSetterExtension(cfg *Config, logger *zap.Logger) (auth.Client, er
 			return &headersPerRPC{headers: headers}, nil
 		}),
 	), nil
-
 }
 
 // headersPerRPC is a gRPC credentials.PerRPCCredentials implementation sets
@@ -89,7 +88,6 @@ func (h *headersPerRPC) GetRequestMetadata(
 	ctx context.Context,
 	_ ...string,
 ) (map[string]string, error) {
-
 	metadata := make(map[string]string, len(h.headers))
 	for _, header := range h.headers {
 		value, err := header.source.Get(ctx)

--- a/extension/healthcheckextension/healthcheckextension.go
+++ b/extension/healthcheckextension/healthcheckextension.go
@@ -29,7 +29,6 @@ type healthCheckExtension struct {
 var _ extensioncapabilities.PipelineWatcher = (*healthCheckExtension)(nil)
 
 func (hc *healthCheckExtension) Start(ctx context.Context, host component.Host) error {
-
 	hc.logger.Info("Starting health_check extension", zap.Any("config", hc.config))
 	ln, err := hc.config.ToListener(ctx)
 	if err != nil {

--- a/extension/healthcheckv2extension/internal/grpc/grpc_test.go
+++ b/extension/healthcheckv2extension/internal/grpc/grpc_test.go
@@ -741,7 +741,6 @@ func TestCheck(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestWatch(t *testing.T) {

--- a/extension/healthcheckv2extension/internal/http/server_test.go
+++ b/extension/healthcheckv2extension/internal/http/server_test.go
@@ -3143,5 +3143,4 @@ func TestConfig(t *testing.T) {
 			assert.Equal(t, tc.expectedBody, body)
 		})
 	}
-
 }

--- a/extension/jaegerremotesampling/config_test.go
+++ b/extension/jaegerremotesampling/config_test.go
@@ -72,7 +72,6 @@ func TestLoadConfig(t *testing.T) {
 }
 
 func TestValidate(t *testing.T) {
-
 	testCases := []struct {
 		desc     string
 		cfg      Config

--- a/extension/observer/ecsobserver/fetcher_test.go
+++ b/extension/observer/ecsobserver/fetcher_test.go
@@ -263,7 +263,6 @@ func TestFetcher_AttachService(t *testing.T) {
 		deployID := i % nServices
 		task.TaskDefinitionArn = aws.String(fmt.Sprintf("def%d:1", deployID))
 		task.StartedBy = aws.String(fmt.Sprintf("deploy%d", deployID))
-
 	}))
 
 	ctx := context.Background()

--- a/extension/observer/ecsobserver/internal/errctx/value_test.go
+++ b/extension/observer/ecsobserver/internal/errctx/value_test.go
@@ -83,5 +83,4 @@ func TestValueFrom(t *testing.T) {
 		assert.True(t, ok)
 		assert.Equal(t, "e2", v)
 	})
-
 }

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -111,7 +111,6 @@ func TestHostObserver(t *testing.T) {
 				assert.Equal(t, filepath.Base(exe), details.ProcessName)
 				assert.Equal(t, tt.protocol, details.Transport)
 				assert.Equal(t, isIPv6, details.IsIPv6)
-
 			}
 		})
 	}

--- a/extension/observer/k8sobserver/ingress_endpoint.go
+++ b/extension/observer/k8sobserver/ingress_endpoint.go
@@ -46,7 +46,6 @@ func convertIngressToEndpoints(idNamespace string, ingress *v1.Ingress) []observ
 				})
 			}
 		}
-
 	}
 
 	return endpoints

--- a/extension/observer/k8sobserver/pod_endpoint_test.go
+++ b/extension/observer/k8sobserver/pod_endpoint_test.go
@@ -48,5 +48,4 @@ func TestPodObjectToPortEndpoint(t *testing.T) {
 
 	endpoints := convertPodToEndpoints("namespace", podWithNamedPorts)
 	require.Equal(t, expectedEndpoints, endpoints)
-
 }

--- a/extension/opampextension/monitor_ppid_test.go
+++ b/extension/opampextension/monitor_ppid_test.go
@@ -79,9 +79,7 @@ func TestMonitorPPID(t *testing.T) {
 		case <-time.After(5 * time.Second):
 			t.Fatalf("Timed out waiting for command to stop")
 		}
-
 	})
-
 }
 
 func longRunningComand(ctx context.Context) *exec.Cmd {

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -132,7 +132,6 @@ func TestCreateAgentDescription(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			cfg := createDefaultConfig().(*Config)
 			tc.cfg(cfg)
 

--- a/extension/remotetapextension/extension.go
+++ b/extension/remotetapextension/extension.go
@@ -25,7 +25,6 @@ type remoteObserverExtension struct {
 }
 
 func (s *remoteObserverExtension) Start(ctx context.Context, host component.Host) error {
-
 	htmlContent, err := fs.Sub(httpFS, "html")
 	if err != nil {
 		return err

--- a/extension/sigv4authextension/extension_test.go
+++ b/extension/sigv4authextension/extension_test.go
@@ -44,7 +44,6 @@ func TestRoundTripper(t *testing.T) {
 	assert.Equal(t, cfg.Service, si.service)
 	assert.Equal(t, awsSDKInfo, si.awsSDKInfo)
 	assert.Equal(t, cfg.credsProvider, si.credsProvider)
-
 }
 
 func TestPerRPCCredentials(t *testing.T) {

--- a/extension/sigv4authextension/factory_test.go
+++ b/extension/sigv4authextension/factory_test.go
@@ -36,5 +36,4 @@ func TestCreate(t *testing.T) {
 	ext, err := createExtension(context.Background(), extensiontest.NewNopSettings(), cfg)
 	assert.NoError(t, err)
 	assert.NotNil(t, ext)
-
 }

--- a/extension/storage/dbstorage/extension_test.go
+++ b/extension/storage/dbstorage/extension_test.go
@@ -85,7 +85,6 @@ func testExtensionIntegrity(t *testing.T, se storage.Extension) {
 
 		// Repeatedly thrash client
 		for j := 0; j < 100; j++ {
-
 			// Make sure my values are still mine
 			for i := 0; i < len(keys); i++ {
 				v, err := c.Get(ctx, keys[i])

--- a/extension/storage/filestorage/client_test.go
+++ b/extension/storage/filestorage/client_test.go
@@ -122,7 +122,6 @@ func TestClientBatchOperations(t *testing.T) {
 	for i := range testGetEntries {
 		require.Equal(t, testGetEntries[i].Key, testEntriesDelete[i].Key)
 		require.Nil(t, testGetEntries[i].Value)
-
 	}
 }
 
@@ -175,7 +174,6 @@ func TestNewClientTransactionErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			tempDir := t.TempDir()
 			dbFile := filepath.Join(tempDir, "my_db")
 

--- a/extension/storage/filestorage/config_test.go
+++ b/extension/storage/filestorage/config_test.go
@@ -195,7 +195,6 @@ func TestDirectoryCreateConfig(t *testing.T) {
 				cfg.CreateDirectory = false
 				cfg.DirectoryPermissions = "07771"
 				return cfg
-
 			},
 			err: nil,
 		},

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -69,7 +69,6 @@ func TestExtensionIntegrity(t *testing.T) {
 
 		// Repeatedly thrash client
 		for j := 0; j < 100; j++ {
-
 			// Make sure my values are still mine
 			for i := 0; i < len(keys); i++ {
 				v, err := c.Get(ctx, keys[i])
@@ -143,7 +142,6 @@ func TestClientHandlesSimpleCases(t *testing.T) {
 	data, err = client.Get(ctx, "key")
 	require.NoError(t, err)
 	require.Nil(t, data)
-
 }
 
 func TestTwoClientsWithDifferentNames(t *testing.T) {

--- a/extension/storage/redisstorageextension/extension_test.go
+++ b/extension/storage/redisstorageextension/extension_test.go
@@ -61,7 +61,6 @@ func TestExtensionIntegrity(t *testing.T) {
 
 		// Repeatedly thrash client
 		for j := 0; j < 100; j++ {
-
 			// Make sure my values are still mine
 			for i := 0; i < len(keys); i++ {
 				v, err := c.Get(ctx, keys[i])
@@ -136,7 +135,6 @@ func TestClientHandlesSimpleCases(t *testing.T) {
 	data, err = client.Get(ctx, "key")
 	require.NoError(t, err)
 	require.Nil(t, data)
-
 }
 
 func TestTwoClientsWithDifferentNames(t *testing.T) {

--- a/extension/sumologicextension/extension.go
+++ b/extension/sumologicextension/extension.go
@@ -604,7 +604,6 @@ func (se *SumologicExtension) heartbeatLoop() {
 						zap.String(collectorNameField, colCreds.Credentials.CollectorName),
 						zap.String(collectorIDField, colCreds.Credentials.CollectorID),
 					)
-
 				} else {
 					se.logger.Error("Heartbeat error", zap.Error(err))
 				}
@@ -618,7 +617,6 @@ func (se *SumologicExtension) heartbeatLoop() {
 				timer.Reset(se.conf.HeartBeatInterval)
 			case <-se.closeChan:
 			}
-
 		}
 	}
 }

--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -97,7 +97,6 @@ func TestBasicStart(t *testing.T) {
 			reqNum := atomic.AddInt32(&reqCount, 1)
 
 			switch reqNum {
-
 			// register
 			case 1:
 				assert.Equal(t, registerURL, req.URL.Path)
@@ -159,7 +158,6 @@ func TestStoreCredentials(t *testing.T) {
 				reqNum := atomic.AddInt32(&reqCount, 1)
 
 				switch reqNum {
-
 				// register
 				case 1:
 					assert.Equal(t, registerURL, req.URL.Path)
@@ -402,7 +400,6 @@ func TestLocalFSCredentialsStore_WorkCorrectlyForMultipleExtensions(t *testing.T
 				reqNum := atomic.AddInt32(&reqCount, 1)
 
 				switch reqNum {
-
 				// register
 				case 1:
 					assert.Equal(t, registerURL, req.URL.Path)
@@ -506,7 +503,6 @@ func TestRegisterEmptyCollectorName(t *testing.T) {
 			reqNum := atomic.AddInt32(&reqCount, 1)
 
 			switch reqNum {
-
 			// register
 			case 1:
 				assert.Equal(t, registerURL, req.URL.Path)
@@ -575,7 +571,6 @@ func TestRegisterEmptyCollectorNameForceRegistration(t *testing.T) {
 			reqNum := atomic.AddInt32(&reqCount, 1)
 
 			switch reqNum {
-
 			// register
 			case 1:
 				assert.Equal(t, registerURL, req.URL.Path)
@@ -669,7 +664,6 @@ func TestCollectorSendsBasicAuthHeadersOnRegistration(t *testing.T) {
 			reqNum := atomic.AddInt32(&reqCount, 1)
 
 			switch reqNum {
-
 			// register
 			case 1:
 				assert.Equal(t, registerURL, req.URL.Path)
@@ -773,7 +767,6 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 						reqNum := atomic.AddInt32(&reqCount, 1)
 
 						switch reqNum {
-
 						// heatbeat
 						case 1:
 							assert.NotEqual(t, registerURL, req.URL.Path,
@@ -821,7 +814,6 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 						reqNum := atomic.AddInt32(&reqCount, 1)
 
 						switch reqNum {
-
 						// failing heatbeat
 						case 1:
 							assert.NotEqual(t, registerURL, req.URL.Path,
@@ -885,7 +877,6 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 						reqNum := atomic.AddInt32(&reqCount, 1)
 
 						switch reqNum {
-
 						// failing heatbeat
 						case 1:
 							assert.NotEqual(t, registerURL, req.URL.Path,
@@ -953,7 +944,6 @@ func TestCollectorCheckingCredentialsFoundInLocalStorage(t *testing.T) {
 						reqNum := atomic.AddInt32(&reqCount, 1)
 
 						switch reqNum {
-
 						// register
 						case 1:
 							assert.Equal(t, registerURL, req.URL.Path)
@@ -1044,7 +1034,6 @@ func TestRegisterEmptyCollectorNameWithBackoff(t *testing.T) {
 			reqNum := atomic.AddInt32(&reqCount, 1)
 
 			switch {
-
 			// register
 			case reqNum <= retriesLimit:
 				assert.Equal(t, registerURL, req.URL.Path)
@@ -1056,7 +1045,6 @@ func TestRegisterEmptyCollectorNameWithBackoff(t *testing.T) {
 				if reqCount < retriesLimit {
 					w.WriteHeader(http.StatusTooManyRequests)
 				} else {
-
 					_, err = w.Write([]byte(`{
 						"collectorCredentialID": "aaaaaaaaaaaaaaaaaaaa",
 						"collectorCredentialKey": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
@@ -1163,7 +1151,6 @@ func TestRegistrationRedirect(t *testing.T) {
 	destSrv := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, req *http.Request) {
 			switch atomic.AddInt32(&destReqCount, 1) {
-
 			// register
 			case 1:
 				assert.Equal(t, registerURL, req.URL.Path)
@@ -1221,7 +1208,6 @@ func TestRegistrationRedirect(t *testing.T) {
 	origSrv := httptest.NewServer(http.HandlerFunc(
 		func(w http.ResponseWriter, req *http.Request) {
 			switch atomic.AddInt32(&origReqCount, 1) {
-
 			// register
 			case 1:
 				assert.Equal(t, registerURL, req.URL.Path)
@@ -1431,7 +1417,6 @@ func TestRegistrationRequestPayload(t *testing.T) {
 				assert.Equal(t, metadataURL, req.URL.Path)
 				w.WriteHeader(http.StatusOK)
 			}
-
 		})
 	}())
 


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
