### PR TITLE
[chore]: enable whitespace linter for exporter

### DIFF
--- a/exporter/alertmanagerexporter/alertmanager_exporter.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter.go
@@ -67,7 +67,6 @@ func (s *alertmanagerExporter) convertEventSliceToArray(eventSlice ptrace.SpanEv
 }
 
 func (s *alertmanagerExporter) extractEvents(td ptrace.Traces) []*alertmanagerEvent {
-
 	// Stitch parent trace ID and span ID
 	rss := td.ResourceSpans()
 	var events []*alertmanagerEvent
@@ -107,7 +106,6 @@ func createAnnotations(event *alertmanagerEvent) model.LabelSet {
 }
 
 func (s *alertmanagerExporter) convertEventsToAlertPayload(events []*alertmanagerEvent) []model.Alert {
-
 	payload := make([]model.Alert, len(events))
 
 	for i, event := range events {
@@ -126,7 +124,6 @@ func (s *alertmanagerExporter) convertEventsToAlertPayload(events []*alertmanage
 }
 
 func (s *alertmanagerExporter) postAlert(ctx context.Context, payload []model.Alert) error {
-
 	msg, err := json.Marshal(payload)
 	if err != nil {
 		return fmt.Errorf("error marshaling alert to JSON: %w", err)
@@ -162,7 +159,6 @@ func (s *alertmanagerExporter) postAlert(ctx context.Context, payload []model.Al
 }
 
 func (s *alertmanagerExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
-
 	events := s.extractEvents(td)
 
 	if len(events) == 0 {
@@ -180,7 +176,6 @@ func (s *alertmanagerExporter) pushTraces(ctx context.Context, td ptrace.Traces)
 }
 
 func (s *alertmanagerExporter) start(ctx context.Context, host component.Host) error {
-
 	client, err := s.config.ClientConfig.ToClient(ctx, host, s.settings)
 	if err != nil {
 		return fmt.Errorf("failed to create HTTP Client: %w", err)
@@ -190,7 +185,6 @@ func (s *alertmanagerExporter) start(ctx context.Context, host component.Host) e
 }
 
 func (s *alertmanagerExporter) shutdown(context.Context) error {
-
 	if s.client != nil {
 		s.client.CloseIdleConnections()
 	}
@@ -198,7 +192,6 @@ func (s *alertmanagerExporter) shutdown(context.Context) error {
 }
 
 func newAlertManagerExporter(cfg *Config, set component.TelemetrySettings) *alertmanagerExporter {
-
 	return &alertmanagerExporter{
 		config:            cfg,
 		settings:          set,
@@ -211,7 +204,6 @@ func newAlertManagerExporter(cfg *Config, set component.TelemetrySettings) *aler
 }
 
 func newTracesExporter(ctx context.Context, cfg component.Config, set exporter.Settings) (exporter.Traces, error) {
-
 	config := cfg.(*Config)
 
 	s := newAlertManagerExporter(config, set.TelemetrySettings)

--- a/exporter/alertmanagerexporter/alertmanager_exporter_test.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter_test.go
@@ -190,7 +190,6 @@ func TestAlertManagerExporterSeverity(t *testing.T) {
 
 	ls = model.LabelSet{"event_name": "unittest-event", "severity": "info"}
 	assert.Equal(t, ls, alerts[1].Labels)
-
 }
 
 func TestAlertManagerExporterNoDefaultSeverity(t *testing.T) {
@@ -221,7 +220,6 @@ func TestAlertManagerExporterNoDefaultSeverity(t *testing.T) {
 
 	ls := model.LabelSet{"event_name": "unittest-event", "severity": "info"}
 	assert.Equal(t, ls, alerts[0].Labels)
-
 }
 
 func TestAlertManagerExporterAlertPayload(t *testing.T) {
@@ -267,7 +265,6 @@ func TestAlertManagerExporterAlertPayload(t *testing.T) {
 	assert.Equal(t, expect.Labels, got[0].Labels)
 	assert.Equal(t, expect.Annotations, got[0].Annotations)
 	assert.Equal(t, expect.GeneratorURL, got[0].GeneratorURL)
-
 }
 
 func TestAlertManagerTracesExporterNoErrors(t *testing.T) {

--- a/exporter/alertmanagerexporter/config.go
+++ b/exporter/alertmanagerexporter/config.go
@@ -28,7 +28,6 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
-
 	if cfg.ClientConfig.Endpoint == "" {
 		return errors.New("endpoint must be non-empty")
 	}

--- a/exporter/alibabacloudlogserviceexporter/logs_exporter.go
+++ b/exporter/alibabacloudlogserviceexporter/logs_exporter.go
@@ -15,7 +15,6 @@ import (
 
 // newLogsExporter return a new LogService logs exporter.
 func newLogsExporter(set exporter.Settings, cfg component.Config) (exporter.Logs, error) {
-
 	l := &logServiceLogsSender{
 		logger: set.Logger,
 	}

--- a/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice_test.go
+++ b/exporter/alibabacloudlogserviceexporter/logsdata_to_logservice_test.go
@@ -88,7 +88,6 @@ func TestLogsDataToLogService(t *testing.T) {
 			})
 		}
 		gotLogPairs = append(gotLogPairs, pairs)
-
 	}
 
 	wantLogs := make([][]logKeyValuePair, 0, validLogCount)
@@ -98,7 +97,6 @@ func TestLogsDataToLogService(t *testing.T) {
 		return
 	}
 	for j := 0; j < validLogCount; j++ {
-
 		sort.Sort(logKeyValuePairs(gotLogPairs[j]))
 		sort.Sort(logKeyValuePairs(wantLogs[j]))
 		assert.Equal(t, wantLogs[j], gotLogPairs[j])

--- a/exporter/alibabacloudlogserviceexporter/metrics_exporter.go
+++ b/exporter/alibabacloudlogserviceexporter/metrics_exporter.go
@@ -15,7 +15,6 @@ import (
 
 // newMetricsExporter return a new LogSerice metrics exporter.
 func newMetricsExporter(set exporter.Settings, cfg component.Config) (exporter.Metrics, error) {
-
 	l := &logServiceMetricsSender{
 		logger: set.Logger,
 	}

--- a/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice.go
+++ b/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice.go
@@ -227,7 +227,6 @@ func doubleHistogramMetricsToLogs(name string, data pmetric.HistogramDataPointSl
 					float64(bucket),
 				))
 		}
-
 	}
 	return logs
 }
@@ -289,7 +288,6 @@ func metricsDataToLogServiceData(
 	_ *zap.Logger,
 	md pmetric.Metrics,
 ) (logs []*sls.Log) {
-
 	resMetrics := md.ResourceMetrics()
 	for i := 0; i < resMetrics.Len(); i++ {
 		resMetricSlice := resMetrics.At(i)

--- a/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice_test.go
+++ b/exporter/alibabacloudlogserviceexporter/metricsdata_to_logservice_test.go
@@ -112,7 +112,6 @@ func TestMetricDataToLogService(t *testing.T) {
 			})
 		}
 		gotLogPairs = append(gotLogPairs, pairs)
-
 	}
 
 	wantLogs := make([][]logKeyValuePair, 0, len(gotLogs))

--- a/exporter/alibabacloudlogserviceexporter/trace_exporter.go
+++ b/exporter/alibabacloudlogserviceexporter/trace_exporter.go
@@ -15,7 +15,6 @@ import (
 
 // newTracesExporter return a new LogSerice trace exporter.
 func newTracesExporter(set exporter.Settings, cfg component.Config) (exporter.Traces, error) {
-
 	l := &logServiceTraceSender{
 		logger: set.Logger,
 	}

--- a/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
+++ b/exporter/alibabacloudlogserviceexporter/trace_exporter_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestNewTracesExporter(t *testing.T) {
-
 	got, err := newTracesExporter(exportertest.NewNopSettings(), &Config{
 		Endpoint: "cn-hangzhou.log.aliyuncs.com",
 		Project:  "demo-project",
@@ -35,7 +34,6 @@ func TestNewTracesExporter(t *testing.T) {
 }
 
 func TestNewFailsWithEmptyTracesExporterName(t *testing.T) {
-
 	got, err := newTracesExporter(exportertest.NewNopSettings(), &Config{})
 	assert.Error(t, err)
 	require.Nil(t, got)

--- a/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice.go
+++ b/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice.go
@@ -188,7 +188,6 @@ func eventsToString(events ptrace.SpanEventSlice) string {
 	}
 	eventArrayBytes, _ := json.Marshal(&eventArray)
 	return string(eventArrayBytes)
-
 }
 
 func spanLinksToString(spanLinkSlice ptrace.SpanLinkSlice) string {

--- a/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice_test.go
+++ b/exporter/alibabacloudlogserviceexporter/tracedata_to_logservice_test.go
@@ -43,7 +43,6 @@ func TestTraceDataToLogService(t *testing.T) {
 			})
 		}
 		gotLogPairs = append(gotLogPairs, pairs)
-
 	}
 
 	wantLogs := make([][]logKeyValuePair, 0, len(gotLogs))

--- a/exporter/awscloudwatchlogsexporter/config.go
+++ b/exporter/awscloudwatchlogsexporter/config.go
@@ -73,7 +73,6 @@ func (config *Config) Validate() error {
 		return retErr
 	}
 	return cwlogs.ValidateTagsInput(config.Tags)
-
 }
 
 // TODO(jbd): Add ARN role to config.

--- a/exporter/awscloudwatchlogsexporter/config_test.go
+++ b/exporter/awscloudwatchlogsexporter/config_test.go
@@ -125,7 +125,6 @@ func TestRetentionValidateCorrect(t *testing.T) {
 		},
 	}
 	assert.NoError(t, component.ValidateConfig(cfg))
-
 }
 
 func TestRetentionValidateWrong(t *testing.T) {
@@ -143,7 +142,6 @@ func TestRetentionValidateWrong(t *testing.T) {
 		},
 	}
 	assert.Error(t, component.ValidateConfig(wrongcfg))
-
 }
 
 func TestValidateTags(t *testing.T) {

--- a/exporter/awscloudwatchlogsexporter/factory.go
+++ b/exporter/awscloudwatchlogsexporter/factory.go
@@ -45,5 +45,4 @@ func createLogsExporter(_ context.Context, params exporter.Settings, config comp
 		return nil, errors.New("invalid configuration type; can't cast to awscloudwatchlogsexporter.Config")
 	}
 	return newCwLogsExporter(expConfig, params)
-
 }

--- a/exporter/awsemfexporter/config_test.go
+++ b/exporter/awsemfexporter/config_test.go
@@ -159,7 +159,6 @@ func TestRetentionValidateCorrect(t *testing.T) {
 		logger:                      zap.NewNop(),
 	}
 	assert.NoError(t, component.ValidateConfig(cfg))
-
 }
 
 func TestRetentionValidateWrong(t *testing.T) {
@@ -174,7 +173,6 @@ func TestRetentionValidateWrong(t *testing.T) {
 		logger:                      zap.NewNop(),
 	}
 	assert.Error(t, component.ValidateConfig(wrongcfg))
-
 }
 
 func TestValidateTags(t *testing.T) {

--- a/exporter/awsemfexporter/datapoint.go
+++ b/exporter/awsemfexporter/datapoint.go
@@ -334,7 +334,6 @@ func (dps summaryDataPointSlice) CalculateDeltaDatapoints(i int, instrumentation
 			quantile := values.At(i)
 			cLabels["quantile"] = strconv.FormatFloat(quantile.Quantile(), 'g', -1, 64)
 			datapoints = append(datapoints, dataPoint{name: dps.metricName, value: quantile.Value(), labels: cLabels, timestampMs: timestampMs})
-
 		}
 	} else {
 		metricVal := &cWMetricStats{Count: count, Sum: sum}

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -355,7 +355,6 @@ func shutdownEmfCalculators(c *emfCalculators) error {
 	var errs error
 	errs = multierr.Append(errs, c.delta.Shutdown())
 	return multierr.Append(errs, c.summary.Shutdown())
-
 }
 
 func TestIsStaleNaNInf_NumberDataPointSlice(t *testing.T) {
@@ -398,7 +397,6 @@ func TestIsStaleNaNInf_NumberDataPointSlice(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			// Given the number datapoint (including Sum and Gauge OTEL metric type) with data type as int or double
 			numberDPS := pmetric.NewNumberDataPointSlice()
 
@@ -425,7 +423,6 @@ func TestCalculateDeltaDatapoints_NumberDataPointSlice(t *testing.T) {
 	emfCalcs := setupEmfCalculators()
 	defer require.NoError(t, shutdownEmfCalculators(emfCalcs))
 	for _, retainInitialValueOfDeltaMetric := range []bool{true, false} {
-
 		testCases := []struct {
 			name              string
 			adjustToDelta     bool
@@ -511,7 +508,6 @@ func TestCalculateDeltaDatapoints_NumberDataPointSlice(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-
 				// Given the number datapoint (including Sum and Gauge OTEL metric type) with data type as int or double
 				numberDPS := pmetric.NewNumberDataPointSlice()
 				numberDP := numberDPS.AppendEmpty()
@@ -579,7 +575,6 @@ func TestCalculateDeltaDatapoints_HistogramDataPointSlice(t *testing.T) {
 				histogramDP.SetSum(17.13)
 				histogramDP.Attributes().PutStr("label1", "value1")
 				return histogramDPS
-
 			}(),
 			expectedDatapoint: dataPoint{
 				name:   "foo",
@@ -620,14 +615,11 @@ func TestCalculateDeltaDatapoints_HistogramDataPointSlice(t *testing.T) {
 			assert.True(t, retained)
 			assert.Equal(t, 1, histogramDatapointSlice.Len())
 			assert.Equal(t, tc.expectedDatapoint, dps[0])
-
 		})
 	}
-
 }
 
 func TestIsStaleNaNInf_HistogramDataPointSlice(t *testing.T) {
-
 	testCases := []struct {
 		name           string
 		histogramDPS   pmetric.HistogramDataPointSlice
@@ -791,7 +783,6 @@ func TestIsStaleNaNInf_HistogramDataPointSlice(t *testing.T) {
 			tc.boolAssertFunc(t, isStaleNanInf)
 		})
 	}
-
 }
 
 func TestCalculateDeltaDatapoints_ExponentialHistogramDataPointSlice(t *testing.T) {
@@ -829,7 +820,6 @@ func TestCalculateDeltaDatapoints_ExponentialHistogramDataPointSlice(t *testing.
 				histogramDP.SetSum(17.13)
 				histogramDP.Attributes().PutStr("label1", "value1")
 				return histogramDPS
-
 			}(),
 			expectedDatapoint: dataPoint{
 				name:   "foo",
@@ -892,11 +882,9 @@ func TestCalculateDeltaDatapoints_ExponentialHistogramDataPointSlice(t *testing.
 			assert.Equal(t, tc.expectedDatapoint, dps[0])
 		})
 	}
-
 }
 
 func TestIsStaleNaNInf_ExponentialHistogramDataPointSlice(t *testing.T) {
-
 	testCases := []struct {
 		name           string
 		histogramDPS   pmetric.ExponentialHistogramDataPointSlice
@@ -1089,7 +1077,6 @@ func TestIsStaleNaNInf_ExponentialHistogramDataPointSlice(t *testing.T) {
 			tc.boolAssertFunc(t, isStaleNaNInf)
 		})
 	}
-
 }
 
 func TestCalculateDeltaDatapoints_SummaryDataPointSlice(t *testing.T) {
@@ -1170,7 +1157,6 @@ func TestCalculateDeltaDatapoints_SummaryDataPointSlice(t *testing.T) {
 						assert.Equal(t, tc.expectedDatapoint[i].labels, dp.labels)
 						assert.InDelta(t, tc.expectedDatapoint[i].value, dp.value, 0.002)
 					}
-
 				}
 			})
 		}
@@ -1366,7 +1352,6 @@ func TestIsStaleNaNInf_SummaryDataPointSlice(t *testing.T) {
 			tc.expectedBoolAssert(t, isStaleNaNInf)
 		})
 	}
-
 }
 
 func TestCreateLabels(t *testing.T) {
@@ -1455,7 +1440,6 @@ func TestGetDataPoints(t *testing.T) {
 		metadata := generateTestMetricMetadata("namespace", time.Now().UnixNano()/int64(time.Millisecond), "log-group", "log-stream", "cloudwatch-otel", metric.Type())
 
 		t.Run(tc.name, func(t *testing.T) {
-
 			if tc.isPrometheusMetrics {
 				metadata.receiver = prometheusReceiver
 			} else {

--- a/exporter/awsemfexporter/emf_exporter.go
+++ b/exporter/awsemfexporter/emf_exporter.go
@@ -136,7 +136,6 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pmetric.Metrics) e
 				fmt.Println(*putLogEvent.InputLogEvent.Message)
 			}
 		} else if strings.EqualFold(outputDestination, outputDestinationCloudWatch) {
-
 			emfPusher := emf.getPusher(putLogEvent.StreamKey)
 			if emfPusher != nil {
 				returnError := emfPusher.AddLogEntry(putLogEvent)
@@ -167,7 +166,6 @@ func (emf *emfExporter) pushMetricsData(_ context.Context, md pmetric.Metrics) e
 }
 
 func (emf *emfExporter) getPusher(key cwlogs.StreamKey) cwlogs.Pusher {
-
 	var ok bool
 	if _, ok = emf.pusherMap[key]; !ok {
 		emf.pusherMap[key] = cwlogs.NewPusher(key, emf.retryCnt, *emf.svcStructuredLog, emf.config.logger)

--- a/exporter/awsemfexporter/emf_exporter_test.go
+++ b/exporter/awsemfexporter/emf_exporter_test.go
@@ -102,7 +102,6 @@ func TestConsumeMetricsWithNaNValues(t *testing.T) {
 			require.NoError(t, exp.shutdown(ctx))
 		})
 	}
-
 }
 
 func TestConsumeMetricsWithInfValues(t *testing.T) {
@@ -142,7 +141,6 @@ func TestConsumeMetricsWithInfValues(t *testing.T) {
 			require.NoError(t, exp.shutdown(ctx))
 		})
 	}
-
 }
 
 func TestConsumeMetricsWithOutputDestination(t *testing.T) {

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -36,7 +36,6 @@ func addToGroupedMetric(
 	config *Config,
 	calculators *emfCalculators,
 ) error {
-
 	dps := getDataPoints(pmd, metadata, config.logger)
 	if dps == nil || dps.Len() == 0 {
 		return nil
@@ -107,7 +106,6 @@ func addToGroupedMetric(
 				}
 			}
 		}
-
 	}
 	return nil
 }

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -405,7 +405,6 @@ func TestAddToGroupedMetric(t *testing.T) {
 		assert.Equal(t, 1, logs.Len())
 		assert.Equal(t, expectedLogs, logs.AllUntimed())
 	})
-
 }
 
 func TestAddKubernetesWrapper(t *testing.T) {

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -406,7 +406,6 @@ func translateCWMetricToEMF(cWMetric *cWMetrics, config *Config) (*cwlogs.Event,
 				"CloudWatchMetrics": cWMetric.measurements,
 				"Timestamp":         cWMetric.timestampMs,
 			}
-
 		}
 	}
 

--- a/exporter/awsemfexporter/metric_translator_test.go
+++ b/exporter/awsemfexporter/metric_translator_test.go
@@ -347,7 +347,6 @@ func TestTranslateOtToGroupedMetric(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.testName, func(t *testing.T) {
-
 			groupedMetrics := make(map[any]*groupedMetric)
 			err := translator.translateOTelToGroupedMetric(tc.metric, groupedMetrics, config)
 			assert.NoError(t, err)
@@ -459,7 +458,6 @@ func TestTranslateCWMetricToEMF(t *testing.T) {
 			assert.Equal(t, tc.expectedEMFLogEvent, *emfLogEvent.InputLogEvent.Message)
 		})
 	}
-
 }
 
 func TestTranslateGroupedMetricToCWMetric(t *testing.T) {

--- a/exporter/awsemfexporter/util_test.go
+++ b/exporter/awsemfexporter/util_test.go
@@ -341,5 +341,4 @@ func TestGetLogInfo(t *testing.T) {
 			})
 		}
 	}
-
 }

--- a/exporter/awskinesisexporter/internal/batch/batch.go
+++ b/exporter/awskinesisexporter/internal/batch/batch.go
@@ -76,7 +76,6 @@ func New(opts ...Option) *Batch {
 }
 
 func (b *Batch) AddRecord(raw []byte, key string) error {
-
 	compressor, err := compress.NewCompressor(b.compressionType)
 	if err != nil {
 		return err

--- a/exporter/awskinesisexporter/internal/compress/compresser.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser.go
@@ -63,7 +63,6 @@ func gzipCompressor(in []byte) ([]byte, error) {
 
 	err = w.Flush()
 	if err != nil {
-
 		return nil, err
 	}
 

--- a/exporter/awskinesisexporter/internal/compress/compresser_test.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser_test.go
@@ -143,7 +143,6 @@ func benchmarkCompressor(b *testing.B, format string, length int) {
 // current implementation creates a new context on each compression request
 // this is a test to check no exceptions are raised for executing concurrent compressions
 func TestCompressorConcurrent(t *testing.T) {
-
 	timeout := time.After(15 * time.Second)
 	done := make(chan bool)
 	go func() {
@@ -157,7 +156,6 @@ func TestCompressorConcurrent(t *testing.T) {
 		t.Fatal("Test didn't finish in time")
 	case <-done:
 	}
-
 }
 
 func concurrentCompressFunc(t *testing.T) {
@@ -250,7 +248,6 @@ func decompressZlib(input []byte) ([]byte, error) {
 }
 
 func decompressFlate(input []byte) ([]byte, error) {
-
 	r := flate.NewReader(bytes.NewReader(input))
 	defer r.Close()
 

--- a/exporter/awss3exporter/config_test.go
+++ b/exporter/awss3exporter/config_test.go
@@ -223,7 +223,6 @@ func TestMarshallerName(t *testing.T) {
 		MarshalerName: "otlp_proto",
 	}, e,
 	)
-
 }
 
 func TestCompressionName(t *testing.T) {
@@ -265,5 +264,4 @@ func TestCompressionName(t *testing.T) {
 		MarshalerName: "otlp_proto",
 	}, e,
 	)
-
 }

--- a/exporter/awss3exporter/exporter.go
+++ b/exporter/awss3exporter/exporter.go
@@ -25,7 +25,6 @@ type s3Exporter struct {
 
 func newS3Exporter(config *Config,
 	params exporter.Settings) *s3Exporter {
-
 	s3Exporter := &s3Exporter{
 		config:     config,
 		dataWriter: &s3Writer{},
@@ -35,7 +34,6 @@ func newS3Exporter(config *Config,
 }
 
 func (e *s3Exporter) start(_ context.Context, host component.Host) error {
-
 	var m marshaler
 	var err error
 	if e.config.Encoding != nil {

--- a/exporter/awss3exporter/factory.go
+++ b/exporter/awss3exporter/factory.go
@@ -38,7 +38,6 @@ func createDefaultConfig() component.Config {
 func createLogsExporter(ctx context.Context,
 	params exporter.Settings,
 	config component.Config) (exporter.Logs, error) {
-
 	s3Exporter := newS3Exporter(config.(*Config), params)
 
 	return exporterhelper.NewLogs(ctx, params,
@@ -50,7 +49,6 @@ func createLogsExporter(ctx context.Context,
 func createMetricsExporter(ctx context.Context,
 	params exporter.Settings,
 	config component.Config) (exporter.Metrics, error) {
-
 	s3Exporter := newS3Exporter(config.(*Config), params)
 
 	if config.(*Config).MarshalerName == SumoIC {
@@ -66,7 +64,6 @@ func createMetricsExporter(ctx context.Context,
 func createTracesExporter(ctx context.Context,
 	params exporter.Settings,
 	config component.Config) (exporter.Traces, error) {
-
 	s3Exporter := newS3Exporter(config.(*Config), params)
 
 	if config.(*Config).MarshalerName == SumoIC {

--- a/exporter/azuredataexplorerexporter/adx_exporter.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter.go
@@ -61,7 +61,6 @@ func (e *adxDataProducer) metricsDataPusher(ctx context.Context, metrics pmetric
 }
 
 func (e *adxDataProducer) ingestData(b []string) error {
-
 	ingestReader := strings.NewReader(strings.Join(b, nextline))
 
 	if _, err := e.ingestor.FromReader(context.Background(), ingestReader, e.ingestOptions...); err != nil {
@@ -128,7 +127,6 @@ func (e *adxDataProducer) tracesDataPusher(_ context.Context, traceData ptrace.T
 }
 
 func (e *adxDataProducer) Close(context.Context) error {
-
 	var err error
 
 	err = e.ingestor.Close()

--- a/exporter/azuredataexplorerexporter/adx_exporter_test.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter_test.go
@@ -310,7 +310,6 @@ func createLogsData() plog.Logs {
 	log.SetSeverityNumber(plog.SeverityNumberDebug)
 	log.SetSeverityText("DEBUG")
 	return logs
-
 }
 
 func createTracesData() ptrace.Traces {

--- a/exporter/azuredataexplorerexporter/logsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/logsdata_to_adx.go
@@ -27,7 +27,6 @@ type AdxLog struct {
 
 // Convert the plog to the type ADXLog, this matches the scheme in the Log table in the database
 func mapToAdxLog(resource pcommon.Resource, scope pcommon.InstrumentationScope, logData plog.LogRecord, _ *zap.Logger) *AdxLog {
-
 	logAttrib := logData.Attributes().AsRaw()
 	clonedLogAttrib := cloneMap(logAttrib)
 	copyMap(clonedLogAttrib, getScopeMap(scope))

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx.go
@@ -183,7 +183,6 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 				}
 				return metricValue
 			}, "", "", pmetric.MetricTypeSum)
-
 		}
 		return adxMetrics
 	case pmetric.MetricTypeSummary:
@@ -208,7 +207,6 @@ func mapToAdxMetric(res pcommon.Resource, md pmetric.Metric, scopeattrs map[stri
 					fmt.Sprintf("%s_%s", md.Name(), countsuffix),
 					fmt.Sprintf("%s%s", md.Description(), countdescription),
 					pmetric.MetricTypeSummary))
-
 			}
 			// now create values for each quantile.
 			for bi := 0; bi < dataPoint.QuantileValues().Len(); bi++ {

--- a/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/metricsdata_to_adx_test.go
@@ -169,7 +169,6 @@ func Test_rawMetricsToAdxMetrics(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func Test_mapToAdxMetric(t *testing.T) {

--- a/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
+++ b/exporter/azuredataexplorerexporter/tracesdata_to_adx.go
@@ -47,7 +47,6 @@ type Status struct {
 }
 
 func mapToAdxTrace(resource pcommon.Resource, scope pcommon.InstrumentationScope, spanData ptrace.Span) *AdxTrace {
-
 	traceAttrib := spanData.Attributes().AsRaw()
 	clonedTraceAttrib := cloneMap(traceAttrib)
 	copyMap(clonedTraceAttrib, getScopeMap(scope))

--- a/exporter/azuredataexplorerexporter/tracesdata_to_adx_test.go
+++ b/exporter/azuredataexplorerexporter/tracesdata_to_adx_test.go
@@ -64,7 +64,6 @@ func Test_mapToAdxTrace(t *testing.T) {
 		}, {
 			name: "No data",
 			spanDatafn: func() ptrace.Span {
-
 				span := ptrace.NewSpan()
 				return span
 			},
@@ -192,15 +191,12 @@ func Test_mapToAdxTrace(t *testing.T) {
 			got := mapToAdxTrace(tt.resourceFn(), tt.insScopeFn(), tt.spanDatafn())
 			require.NotNil(t, got)
 			assert.Equal(t, want, got)
-
 		})
 	}
-
 }
 
 func getEmptyEvents() []*Event {
 	return []*Event{}
-
 }
 
 func getEmptyLinks() []*Link {

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -114,7 +114,6 @@ func (f *factory) createMetricsExporter(
 // Configures the transport channel.
 // This method is not thread-safe
 func (f *factory) getTransportChannel(exporterConfig *Config, logger *zap.Logger) (transportChannel, error) {
-
 	// The default transport channel uses the default send mechanism from the AppInsights telemetry client.
 	// This default channel handles batching, appropriate retries, and is backed by memory.
 	if f.tChannel == nil {

--- a/exporter/azuremonitorexporter/metric_to_envelopes.go
+++ b/exporter/azuremonitorexporter/metric_to_envelopes.go
@@ -33,9 +33,7 @@ func (packer *metricPacker) MetricToEnvelopes(metric pmetric.Metric, resource pc
 	mtd := packer.getMetricTimedData(metric)
 
 	if mtd != nil {
-
 		for _, timedDataPoint := range mtd.getTimedDataPoints() {
-
 			envelope := contracts.NewEnvelope()
 			envelope.Tags = make(map[string]string)
 			envelope.Time = toTime(timedDataPoint.timestamp).Format(time.RFC3339Nano)
@@ -67,7 +65,6 @@ func (packer *metricPacker) MetricToEnvelopes(metric pmetric.Metric, resource pc
 			packer.logger.Debug("Metric is packed", zap.String("name", dataPoint.Name), zap.Any("value", dataPoint.Value))
 
 			envelopes = append(envelopes, envelope)
-
 		}
 	}
 
@@ -172,7 +169,6 @@ func (m histogramMetric) getTimedDataPoints() []*timedMetricDataPoint {
 			timestamp:  histogramDataPoint.Timestamp(),
 			attributes: histogramDataPoint.Attributes(),
 		}
-
 	}
 	return timedDataPoints
 }
@@ -237,7 +233,6 @@ func (m summaryMetric) getTimedDataPoints() []*timedMetricDataPoint {
 			timestamp:  summaryDataPoint.Timestamp(),
 			attributes: summaryDataPoint.Attributes(),
 		}
-
 	}
 	return timedDataPoints
 }

--- a/exporter/azuremonitorexporter/trace_to_envelope.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope.go
@@ -48,7 +48,6 @@ func spanToEnvelopes(
 	span ptrace.Span,
 	spanEventsEnabled bool,
 	logger *zap.Logger) ([]*contracts.Envelope, error) {
-
 	spanKind := span.Kind()
 
 	// According to the SpanKind documentation, we can assume it to be INTERNAL
@@ -552,7 +551,6 @@ func copyAndMapAttributes(
 	attributeMap pcommon.Map,
 	properties map[string]string,
 	mappingFunc func(k string, v pcommon.Value)) {
-
 	attributeMap.Range(func(k string, v pcommon.Value) bool {
 		setAttributeValueAsProperty(k, v, properties)
 		if mappingFunc != nil {
@@ -566,7 +564,6 @@ func copyAndMapAttributes(
 func copyAttributesWithoutMapping(
 	attributeMap pcommon.Map,
 	properties map[string]string) {
-
 	copyAndMapAttributes(attributeMap, properties, nil)
 }
 
@@ -574,7 +571,6 @@ func copyAttributesWithoutMapping(
 func copyAndExtractHTTPAttributes(
 	attributeMap pcommon.Map,
 	properties map[string]string) *HTTPAttributes {
-
 	attrs := &HTTPAttributes{}
 	copyAndMapAttributes(
 		attributeMap,
@@ -588,7 +584,6 @@ func copyAndExtractHTTPAttributes(
 func copyAndExtractRPCAttributes(
 	attributeMap pcommon.Map,
 	properties map[string]string) *RPCAttributes {
-
 	attrs := &RPCAttributes{}
 	copyAndMapAttributes(
 		attributeMap,
@@ -602,7 +597,6 @@ func copyAndExtractRPCAttributes(
 func copyAndExtractDatabaseAttributes(
 	attributeMap pcommon.Map,
 	properties map[string]string) *DatabaseAttributes {
-
 	attrs := &DatabaseAttributes{}
 	copyAndMapAttributes(
 		attributeMap,
@@ -616,7 +610,6 @@ func copyAndExtractDatabaseAttributes(
 func copyAndExtractMessagingAttributes(
 	attributeMap pcommon.Map,
 	properties map[string]string) *MessagingAttributes {
-
 	attrs := &MessagingAttributes{}
 	copyAndMapAttributes(
 		attributeMap,
@@ -630,7 +623,6 @@ func copyAndExtractMessagingAttributes(
 func copyAndExtractExceptionAttributes(
 	attributeMap pcommon.Map,
 	properties map[string]string) *ExceptionAttributes {
-
 	attrs := &ExceptionAttributes{}
 	copyAndMapAttributes(
 		attributeMap,
@@ -705,7 +697,6 @@ func setAttributeValueAsProperty(
 	key string,
 	attributeValue pcommon.Value,
 	properties map[string]string) {
-
 	switch attributeValue.Type() {
 	case pcommon.ValueTypeBool:
 		properties[key] = strconv.FormatBool(attributeValue.Bool())

--- a/exporter/azuremonitorexporter/trace_to_envelope_test.go
+++ b/exporter/azuremonitorexporter/trace_to_envelope_test.go
@@ -566,7 +566,6 @@ func commonEnvelopeValidations(
 	span ptrace.Span,
 	envelope *contracts.Envelope,
 	expectedEnvelopeName string) {
-
 	assert.NotNil(t, envelope)
 	assert.Equal(t, expectedEnvelopeName, envelope.Name)
 	assert.Equal(t, toTime(span.StartTimestamp()).Format(time.RFC3339Nano), envelope.Time)
@@ -588,7 +587,6 @@ func commonRequestDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RequestData) {
-
 	assertAttributesCopiedToProperties(t, span.Attributes(), data.Properties)
 	assert.Equal(t, defaultSpanIDAsHex, data.Id)
 	assert.Equal(t, defaultSpanDuration, data.Duration)
@@ -602,7 +600,6 @@ func defaultHTTPRequestDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RequestData) {
-
 	commonRequestDataValidations(t, span, data)
 
 	assert.Equal(t, defaultHTTPStatusCodeAsString, data.ResponseCode)
@@ -615,7 +612,6 @@ func commonRemoteDependencyDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RemoteDependencyData) {
-
 	assertAttributesCopiedToProperties(t, span.Attributes(), data.Properties)
 	assert.Equal(t, defaultSpanIDAsHex, data.Id)
 	assert.Equal(t, defaultSpanDuration, data.Duration)
@@ -626,7 +622,6 @@ func defaultHTTPRemoteDependencyDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RemoteDependencyData) {
-
 	commonRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, defaultHTTPStatusCodeAsString, data.ResultCode)
@@ -640,7 +635,6 @@ func defaultRPCRequestDataValidations(
 	span ptrace.Span,
 	data *contracts.RequestData,
 	expectedDataSource string) {
-
 	commonRequestDataValidations(t, span, data)
 
 	assert.Equal(t, defaultRPCStatusCodeAsString, data.ResponseCode)
@@ -655,7 +649,6 @@ func defaultRPCRemoteDependencyDataValidations(
 	span ptrace.Span,
 	data *contracts.RemoteDependencyData,
 	expectedDataTarget string) {
-
 	commonRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, defaultRPCStatusCodeAsString, data.ResultCode)
@@ -672,7 +665,6 @@ func defaultDatabaseRemoteDependencyDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RemoteDependencyData) {
-
 	commonRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, defaultDatabaseStatusCodeAsString, data.ResultCode)
@@ -685,7 +677,6 @@ func defaultMessagingRequestDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RequestData) {
-
 	commonRequestDataValidations(t, span, data)
 
 	assert.Equal(t, defaultMessagingStatusCodeAsString, data.ResponseCode)
@@ -697,7 +688,6 @@ func defaultMessagingRemoteDependencyDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RemoteDependencyData) {
-
 	commonRemoteDependencyDataValidations(t, span, data)
 
 	assert.Equal(t, defaultMessagingStatusCodeAsString, data.ResultCode)
@@ -710,7 +700,6 @@ func defaultInternalRemoteDependencyDataValidations(
 	t *testing.T,
 	span ptrace.Span,
 	data *contracts.RemoteDependencyData) {
-
 	assertAttributesCopiedToProperties(t, span.Attributes(), data.Properties)
 	assert.Equal(t, "InProc", data.Type)
 }
@@ -720,7 +709,6 @@ func assertAttributesCopiedToProperties(
 	t *testing.T,
 	attributeMap pcommon.Map,
 	properties map[string]string) {
-
 	attributeMap.Range(func(k string, v pcommon.Value) bool {
 		p, exists := properties[k]
 		assert.True(t, exists)

--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -31,7 +31,6 @@ func (v *traceVisitor) visit(
 	resource pcommon.Resource,
 	scope pcommon.InstrumentationScope,
 	span ptrace.Span) (ok bool) {
-
 	envelopes, err := spanToEnvelopes(resource, scope, span, v.exporter.config.SpanEventsEnabled, v.exporter.logger)
 	if err != nil {
 		// record the error and short-circuit

--- a/exporter/carbonexporter/exporter_test.go
+++ b/exporter/carbonexporter/exporter_test.go
@@ -247,7 +247,6 @@ func TestConnPoolWithIdleMaxConnections(t *testing.T) {
 		if i != 0 {
 			assert.NotSame(t, conn, conns[i-1])
 		}
-
 	}
 	for _, conn := range conns {
 		cp.put(conn)

--- a/exporter/cassandraexporter/exporter_logs.go
+++ b/exporter/cassandraexporter/exporter_logs.go
@@ -25,7 +25,6 @@ type logsExporter struct {
 }
 
 func newLogsExporter(logger *zap.Logger, cfg *Config) *logsExporter {
-
 	return &logsExporter{logger: logger, cfg: cfg}
 }
 

--- a/exporter/clickhouseexporter/config_test.go
+++ b/exporter/clickhouseexporter/config_test.go
@@ -506,7 +506,6 @@ func TestConfig_buildDSN(t *testing.T) {
 				}
 				assert.Equalf(t, tt.want, dsn, "buildDSN()")
 			}
-
 		})
 	}
 }

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -56,7 +56,6 @@ func TestLogsExporter_New(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-
 			var err error
 			exporter, err := newLogsExporter(zap.NewNop(), test.config)
 			err = errors.Join(err, err)

--- a/exporter/clickhouseexporter/internal/metrics_model_test.go
+++ b/exporter/clickhouseexporter/internal/metrics_model_test.go
@@ -50,7 +50,6 @@ func Test_convertExemplars(t *testing.T) {
 		require.Equal(t, expectValues, values)
 		require.Equal(t, expectTraceIDs, traceIDs)
 		require.Equal(t, expectSpanIDs, spanIDs)
-
 	})
 	t.Run("one exemplar with only FilteredAttributes", func(t *testing.T) {
 		exemplars := pmetric.NewExemplarSlice()
@@ -200,7 +199,6 @@ func Test_convertValueAtQuantile(t *testing.T) {
 		require.Equal(t, clickhouse.ArraySet{1.0, 2.0}, quantiles)
 		require.Equal(t, clickhouse.ArraySet{1.0, 2.0}, values)
 	})
-
 }
 
 func Test_getValue(t *testing.T) {

--- a/exporter/coralogixexporter/factory_test.go
+++ b/exporter/coralogixexporter/factory_test.go
@@ -242,5 +242,4 @@ func TestCreateLogsWithDomainAndEndpoint(t *testing.T) {
 		// exporter may already stop because it cannot connect.
 		assert.Equal(t, "rpc error: code = Canceled desc = grpc: the client connection is closing", err.Error())
 	}
-
 }

--- a/exporter/coralogixexporter/logs_client.go
+++ b/exporter/coralogixexporter/logs_client.go
@@ -79,7 +79,6 @@ func (e *logsExporter) shutdown(context.Context) error {
 }
 
 func (e *logsExporter) pushLogs(ctx context.Context, ld plog.Logs) error {
-
 	rss := ld.ResourceLogs()
 	for i := 0; i < rss.Len(); i++ {
 		resourceLog := rss.At(i)

--- a/exporter/coralogixexporter/metrics_client.go
+++ b/exporter/coralogixexporter/metrics_client.go
@@ -52,7 +52,6 @@ type metricsExporter struct {
 }
 
 func (e *metricsExporter) start(ctx context.Context, host component.Host) (err error) {
-
 	switch {
 	case !isEmpty(e.config.Metrics.Endpoint):
 		if e.clientConn, err = e.config.Metrics.ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
@@ -78,7 +77,6 @@ func (e *metricsExporter) start(ctx context.Context, host component.Host) (err e
 }
 
 func (e *metricsExporter) pushMetrics(ctx context.Context, md pmetric.Metrics) error {
-
 	rss := md.ResourceMetrics()
 	for i := 0; i < rss.Len(); i++ {
 		resourceMetric := rss.At(i)

--- a/exporter/coralogixexporter/traces_client.go
+++ b/exporter/coralogixexporter/traces_client.go
@@ -49,7 +49,6 @@ func newTracesExporter(cfg component.Config, set exporter.Settings) (*tracesExpo
 }
 
 func (e *tracesExporter) start(ctx context.Context, host component.Host) (err error) {
-
 	switch {
 	case !isEmpty(e.config.Traces.Endpoint):
 		if e.clientConn, err = e.config.Traces.ToClientConn(ctx, host, e.settings, configgrpc.WithGrpcDialOption(grpc.WithUserAgent(e.userAgent))); err != nil {
@@ -75,14 +74,12 @@ func (e *tracesExporter) start(ctx context.Context, host component.Host) (err er
 }
 
 func (e *tracesExporter) pushTraces(ctx context.Context, td ptrace.Traces) error {
-
 	rss := td.ResourceSpans()
 	for i := 0; i < rss.Len(); i++ {
 		resourceSpan := rss.At(i)
 		appName, subsystem := e.config.getMetadataFromResource(resourceSpan.Resource())
 		resourceSpan.Resource().Attributes().PutStr(cxAppNameAttrName, appName)
 		resourceSpan.Resource().Attributes().PutStr(cxSubsystemNameAttrName, subsystem)
-
 	}
 
 	_, err := e.traceExporter.Export(e.enhanceContext(ctx), ptraceotlp.NewExportRequestFromTraces(td), e.callOptions...)

--- a/exporter/datadogexporter/internal/clientutil/http_test.go
+++ b/exporter/datadogexporter/internal/clientutil/http_test.go
@@ -160,7 +160,6 @@ func TestNewHTTPClient(t *testing.T) {
 }
 
 func TestUserAgent(t *testing.T) {
-
 	assert.Equal(t, "otelcontribcol/1.0", UserAgent(buildInfo))
 }
 
@@ -170,5 +169,4 @@ func TestDDHeaders(t *testing.T) {
 	SetDDHeaders(header, buildInfo, apiKey)
 	assert.Equal(t, header.Get("DD-Api-Key"), apiKey)
 	assert.Equal(t, "otelcontribcol/1.0", header.Get("USer-Agent"))
-
 }

--- a/exporter/datadogexporter/internal/hostmetadata/internal/system/host_test.go
+++ b/exporter/datadogexporter/internal/hostmetadata/internal/system/host_test.go
@@ -42,5 +42,4 @@ func TestGetHostname(t *testing.T) {
 		OS: "os",
 	}
 	assert.Equal(t, "os", hostInfoMissingFQDN.GetHostname(logger))
-
 }

--- a/exporter/datadogexporter/internal/metrics/consumer_deprecated_test.go
+++ b/exporter/datadogexporter/internal/metrics/consumer_deprecated_test.go
@@ -53,7 +53,6 @@ func TestZorkianRunningMetrics(t *testing.T) {
 		runningHostnames,
 		[]string{"fallbackHostname", "resource-hostname-1", "resource-hostname-2"},
 	)
-
 }
 
 func TestZorkianTagsMetrics(t *testing.T) {

--- a/exporter/datadogexporter/internal/metrics/series_deprecated_test.go
+++ b/exporter/datadogexporter/internal/metrics/series_deprecated_test.go
@@ -38,7 +38,6 @@ func TestNewZorkianType(t *testing.T) {
 
 	count := NewZorkianCount(name, ts, value, tags)
 	assert.Equal(t, count.GetType(), string(Count))
-
 }
 
 func TestDefaultZorkianMetrics(t *testing.T) {

--- a/exporter/datadogexporter/internal/metrics/sketches/sketches_test.go
+++ b/exporter/datadogexporter/internal/metrics/sketches/sketches_test.go
@@ -96,7 +96,6 @@ func TestSketchSeriesListMarshal(t *testing.T) {
 
 		require.Len(t, pb.Dogsketches, len(in.Points))
 		for j, pointPb := range pb.Dogsketches {
-
 			check(t, in.Points[j], pointPb)
 		}
 	}

--- a/exporter/datasetexporter/logs_exporter_test.go
+++ b/exporter/datasetexporter/logs_exporter_test.go
@@ -604,7 +604,6 @@ func TestBuildEventFromLog(t *testing.T) {
 			assert.Equal(t, expected, was)
 		})
 	}
-
 }
 
 func TestBuildEventFromLogExportResources(t *testing.T) {
@@ -1090,7 +1089,6 @@ func TestOtelSeverityToDataSetSeverityWithSeverityNumberNoSeverityTextInvalidVal
 
 	ld = makeLogRecordWithSeverityNumberAndSeverityText(100, "")
 	assert.Equal(t, defaultDataSetSeverityLevel, mapOtelSeverityToDataSetSeverity(ld))
-
 }
 
 func TestOtelSeverityToDataSetSeverityWithSeverityNumberNoSeverityTextDataSetTraceLogLevel(t *testing.T) {

--- a/exporter/dorisexporter/exporter_logs.go
+++ b/exporter/dorisexporter/exporter_logs.go
@@ -115,9 +115,7 @@ func (e *logsExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 
 				logs = append(logs, log)
 			}
-
 		}
-
 	}
 
 	return e.pushLogDataInternal(ctx, logs)

--- a/exporter/dorisexporter/exporter_metrics.go
+++ b/exporter/dorisexporter/exporter_metrics.go
@@ -135,7 +135,6 @@ func (e *metricsExporter) pushMetricData(ctx context.Context, md pmetric.Metrics
 				}
 			}
 		}
-
 	}
 
 	return e.pushMetricDataParallel(ctx, metricMap)

--- a/exporter/dorisexporter/exporter_metrics_test.go
+++ b/exporter/dorisexporter/exporter_metrics_test.go
@@ -250,7 +250,6 @@ func simpleMetrics(count int, typeSet map[pmetric.MetricType]struct{}) pmetric.M
 			exemplars.FilteredAttributes().PutStr("key2", "value2")
 			exemplars.SetSpanID([8]byte{1, 2, 3, byte(i)})
 			exemplars.SetTraceID([16]byte{1, 2, 3, byte(i)})
-
 		}
 
 		// histogram
@@ -276,7 +275,6 @@ func simpleMetrics(count int, typeSet map[pmetric.MetricType]struct{}) pmetric.M
 			exemplars.FilteredAttributes().PutStr("key2", "value2")
 			exemplars.SetSpanID([8]byte{1, 2, 3, byte(i)})
 			exemplars.SetTraceID([16]byte{1, 2, 3, byte(i)})
-
 		}
 
 		// exp histogram
@@ -394,7 +392,6 @@ func simpleMetrics(count int, typeSet map[pmetric.MetricType]struct{}) pmetric.M
 			exemplars.FilteredAttributes().PutStr("key2", "value2")
 			exemplars.SetSpanID([8]byte{1, 2, 3, byte(i)})
 			exemplars.SetTraceID([16]byte{1, 2, 3, byte(i)})
-
 		}
 
 		// exp histogram
@@ -424,7 +421,6 @@ func simpleMetrics(count int, typeSet map[pmetric.MetricType]struct{}) pmetric.M
 			exemplars.FilteredAttributes().PutStr("key2", "value2")
 			exemplars.SetSpanID([8]byte{1, 2, 3, byte(i)})
 			exemplars.SetTraceID([16]byte{1, 2, 3, byte(i)})
-
 		}
 
 		// summary

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -298,7 +298,6 @@ func TestExporterLogs(t *testing.T) {
 	})
 
 	t.Run("publish with dynamic index, prefix_suffix", func(t *testing.T) {
-
 		rec := newBulkRecorder()
 		var (
 			prefix = "resprefix-"
@@ -515,7 +514,6 @@ func TestExporterLogs(t *testing.T) {
 
 			assertRecordedItems(t, expected, rec, false)
 		}
-
 	})
 
 	t.Run("retry http request", func(t *testing.T) {
@@ -1439,7 +1437,6 @@ func TestExporterTraces(t *testing.T) {
 	})
 
 	t.Run("publish with dynamic index, prefix_suffix", func(t *testing.T) {
-
 		rec := newBulkRecorder()
 		var (
 			prefix = "resprefix-"
@@ -1485,7 +1482,6 @@ func TestExporterTraces(t *testing.T) {
 	})
 
 	t.Run("publish with dynamic index, data_stream", func(t *testing.T) {
-
 		rec := newBulkRecorder()
 
 		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -372,7 +372,6 @@ func (doc *Document) iterJSONDedot(w *json.Visitor, otel bool) error {
 
 		// increase object level up to current field
 		for {
-
 			// Otel mode serialization
 			if otel {
 				// Check the prefix

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -338,7 +338,6 @@ func TestEncodeLogECSModeDuplication(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, want, string(doc))
-
 }
 
 func TestEncodeLogECSMode(t *testing.T) {
@@ -1136,7 +1135,6 @@ func createTestOTelLogRecord(t *testing.T, rec OTelRecord) (plog.LogRecord, pcom
 }
 
 func buildOTelRecordTestData(t *testing.T, fn func(OTelRecord) OTelRecord) OTelRecord {
-
 	s := `{
     "@timestamp": "2024-03-12T20:00:41.123456780Z",
     "attributes": {
@@ -1176,7 +1174,6 @@ func buildOTelRecordTestData(t *testing.T, fn func(OTelRecord) OTelRecord) OTelR
 		record = fn(record)
 	}
 	return record
-
 }
 
 func deleteDatasetAttributes(or OTelRecord) {

--- a/exporter/fileexporter/buffered_writer_test.go
+++ b/exporter/fileexporter/buffered_writer_test.go
@@ -87,5 +87,4 @@ func BenchmarkWriter(b *testing.B) {
 			})
 		}
 	}
-
 }

--- a/exporter/fileexporter/factory.go
+++ b/exporter/fileexporter/factory.go
@@ -143,7 +143,6 @@ func newFileExporter(conf *Config, logger *zap.Logger) FileExporter {
 		conf:   conf,
 		logger: logger,
 	}
-
 }
 
 func newFileWriter(path string, shouldAppend bool, rotation *Rotation, flushInterval time.Duration, export exportFunc) (*fileWriter, error) {

--- a/exporter/fileexporter/file_exporter_test.go
+++ b/exporter/fileexporter/file_exporter_test.go
@@ -297,7 +297,6 @@ func TestFileMetricsExporter(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestFileMetricsExporterError(t *testing.T) {

--- a/exporter/fileexporter/file_writer.go
+++ b/exporter/fileexporter/file_writer.go
@@ -95,7 +95,6 @@ func (w *fileWriter) start() {
 // Shutdown stops the exporter and is invoked during shutdown.
 // It stops the flush ticker if set.
 func (w *fileWriter) shutdown() error {
-
 	// Stop the flush ticker.
 	if w.flushTicker != nil {
 		// Stop the go routine.

--- a/exporter/googlecloudpubsubexporter/factory.go
+++ b/exporter/googlecloudpubsubexporter/factory.go
@@ -85,7 +85,6 @@ func createTracesExporter(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config) (exporter.Traces, error) {
-
 	pCfg := cfg.(*Config)
 	pubsubExporter := ensureExporter(set, pCfg)
 
@@ -107,7 +106,6 @@ func createMetricsExporter(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config) (exporter.Metrics, error) {
-
 	pCfg := cfg.(*Config)
 	pubsubExporter := ensureExporter(set, pCfg)
 	return exporterhelper.NewMetrics(
@@ -128,7 +126,6 @@ func createLogsExporter(
 	ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config) (exporter.Logs, error) {
-
 	pCfg := cfg.(*Config)
 	pubsubExporter := ensureExporter(set, pCfg)
 

--- a/exporter/honeycombmarkerexporter/logs_exporter.go
+++ b/exporter/honeycombmarkerexporter/logs_exporter.go
@@ -95,7 +95,6 @@ func (e *honeycombLogsExporter) exportMarkers(ctx context.Context, ld plog.Logs)
 						}
 					}
 				}
-
 			}
 		}
 	}

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -140,7 +140,6 @@ func TestNewExporter_err_auth_type(t *testing.T) {
 	require.NotNil(t, lexp)
 	err = lexp.start(context.Background(), componenttest.NewNopHost())
 	assert.ErrorContains(t, err, "failed to load TLS config")
-
 }
 
 func TestNewExporter_err_compression(t *testing.T) {

--- a/exporter/kafkaexporter/marshaler.go
+++ b/exporter/kafkaexporter/marshaler.go
@@ -65,7 +65,6 @@ func createTracesMarshaler(config Config) (TracesMarshaler, error) {
 	default:
 		return nil, errUnrecognizedEncoding
 	}
-
 }
 
 // creates MetricsMarshaler based on the provided config

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -456,7 +456,6 @@ func TestOTLPTracesJsonMarshaling(t *testing.T) {
 	}
 
 	for _, test := range tests {
-
 		marshaler, err := createTracesMarshaler(Config{
 			Encoding:            test.encoding,
 			PartitionTracesByID: test.partitionTracesByID,

--- a/exporter/kafkaexporter/pdata_marshaler.go
+++ b/exporter/kafkaexporter/pdata_marshaler.go
@@ -140,7 +140,6 @@ func (p *pdataTracesMarshaler) Marshal(td ptrace.Traces, topic string) ([]*saram
 				Value: sarama.ByteEncoder(bts),
 				Key:   sarama.ByteEncoder(traceutil.TraceIDToHexOrEmptyString(trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID())),
 			})
-
 		}
 	} else {
 		bts, err := p.marshaler.MarshalTraces(td)

--- a/exporter/kineticaexporter/common.go
+++ b/exporter/kineticaexporter/common.go
@@ -733,7 +733,6 @@ func getAttributeValue(vtPair ValueTypePair) (*AttributeValue, error) {
 	}
 
 	return av, nil
-
 }
 
 // chunkBySize - Splits a slice into multiple slices of the given size

--- a/exporter/kineticaexporter/exporter_metric_test.go
+++ b/exporter/kineticaexporter/exporter_metric_test.go
@@ -466,7 +466,6 @@ func handleShowTable(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Error wrting reesponse", http.StatusInternalServerError)
 		return
 	}
-
 }
 
 func getShowTableResponse(requestBody string) []byte {
@@ -486,7 +485,6 @@ func getShowTableResponse(requestBody string) []byte {
 	default:
 		return []byte("")
 	}
-
 }
 
 // setupTestMain function (runs before tests start)

--- a/exporter/kineticaexporter/factory.go
+++ b/exporter/kineticaexporter/factory.go
@@ -75,7 +75,6 @@ func createLogsExporter(
 func createTracesExporter(ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config) (exporter.Traces, error) {
-
 	cf := cfg.(*Config)
 	exporter := newTracesExporter(set.Logger, cf)
 
@@ -99,7 +98,6 @@ func createTracesExporter(ctx context.Context,
 func createMetricsExporter(ctx context.Context,
 	set exporter.Settings,
 	cfg component.Config) (exporter.Metrics, error) {
-
 	cf := cfg.(*Config)
 	exporter := newMetricsExporter(set.Logger, cf)
 	return exporterhelper.NewMetrics(

--- a/exporter/kineticaexporter/logs_exporter.go
+++ b/exporter/kineticaexporter/logs_exporter.go
@@ -29,7 +29,6 @@ func newLogsExporter(logger *zap.Logger, _ *Config) *kineticaLogsExporter {
 }
 
 func (e *kineticaLogsExporter) start(_ context.Context, _ component.Host) error {
-
 	return nil
 }
 

--- a/exporter/kineticaexporter/metrics_exporter.go
+++ b/exporter/kineticaexporter/metrics_exporter.go
@@ -143,7 +143,6 @@ func newMetricsExporter(logger *zap.Logger, cfg *Config) *kineticaMetricsExporte
 }
 
 func (e *kineticaMetricsExporter) start(ctx context.Context, _ component.Host) error {
-
 	fmt.Println("SCHEMA NAME - ", e.writer.cfg.Schema)
 
 	if e.writer.cfg.Schema != "" && len(e.writer.cfg.Schema) != 0 {
@@ -209,7 +208,6 @@ func createTablesForMetricType(ctx context.Context, metricTypeDDLs []string, kiW
 	}
 
 	lo.ForEach(metricTypeDDLs, func(ddl string, _ int) {
-
 		stmt := strings.ReplaceAll(ddl, "%s", schema)
 		kiWriter.logger.Debug("Creating Table - ", zap.String("DDL", stmt))
 
@@ -251,7 +249,6 @@ func (e *kineticaMetricsExporter) shutdown(_ context.Context) error {
 //	@param md
 //	@return error
 func (e *kineticaMetricsExporter) pushMetricsData(_ context.Context, md pmetric.Metrics) error {
-
 	var metricType pmetric.MetricType
 	var errs []error
 
@@ -277,7 +274,6 @@ func (e *kineticaMetricsExporter) pushMetricsData(_ context.Context, md pmetric.
 			e.logger.Debug("metrics ", zap.Int("count = ", metricSlice.Len()))
 
 			for k := 0; k < metricSlice.Len(); k++ {
-
 				metric := metricSlice.At(k)
 				metricType = metric.Type()
 				switch metric.Type() {
@@ -374,7 +370,6 @@ func (e *kineticaMetricsExporter) pushMetricsData(_ context.Context, md pmetric.
 		}
 	default:
 		return fmt.Errorf("Unsupported metrics type")
-
 	}
 	return multierr.Combine(errs...)
 }
@@ -464,7 +459,6 @@ func (e *kineticaMetricsExporter) createSummaryRecord(resAttr pcommon.Map, _ str
 			}
 			kiSummaryRecord.summaryDatapointQuantileValues = append(kiSummaryRecord.summaryDatapointQuantileValues, *summaryQV)
 		}
-
 	}
 
 	// Handle Resource attribute
@@ -658,7 +652,6 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 			for k := range exemplarAttributes {
 				delete(exemplarAttributes, k)
 			}
-
 		}
 
 		// Handle positive and negative bucket counts
@@ -683,7 +676,6 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 			})
 		}
 		kiExpHistogramRecord.histogramBucketNegativeCount = append(kiExpHistogramRecord.histogramBucketNegativeCount, datapointBucketNegativeCount...)
-
 	}
 
 	// Handle Resource attribute
@@ -761,7 +753,6 @@ func (e *kineticaMetricsExporter) createExponentialHistogramRecord(resAttr pcomm
 //	@return *kineticaHistogramRecord
 //	@return error
 func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ string, scopeInstr pcommon.InstrumentationScope, _ string, histogramRecord pmetric.Histogram, name, description, unit string) (*kineticaHistogramRecord, error) {
-
 	e.logger.Debug("In createHistogramRecord ...")
 
 	var errs []error
@@ -928,7 +919,6 @@ func (e *kineticaMetricsExporter) createHistogramRecord(resAttr pcommon.Map, _ s
 
 		kiHistogramRecord.histogramResourceAttribute = make([]HistogramResourceAttribute, len(resourceAttribute))
 		copy(kiHistogramRecord.histogramResourceAttribute, resourceAttribute)
-
 	}
 
 	// Handle Scope attribute
@@ -1092,9 +1082,7 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 			for k := range exemplarAttributes {
 				delete(exemplarAttributes, k)
 			}
-
 		}
-
 	}
 
 	// Handle Resource attribute
@@ -1167,7 +1155,6 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 			Key:            "",
 			AttributeValue: AttributeValue{},
 		})
-
 	}
 
 	return kiSumRecord, multierr.Combine(errs...)
@@ -1187,7 +1174,6 @@ func (e *kineticaMetricsExporter) createSumRecord(resAttr pcommon.Map, _ string,
 //	@return *kineticaGaugeRecord
 //	@return error
 func (e *kineticaMetricsExporter) createGaugeRecord(resAttr pcommon.Map, _ string, scopeInstr pcommon.InstrumentationScope, _ string, gaugeRecord pmetric.Gauge, name, description, unit string) (*kineticaGaugeRecord, error) {
-
 	var errs []error
 
 	kiGaugeRecord := new(kineticaGaugeRecord)
@@ -1605,7 +1591,6 @@ func (e *kineticaMetricsExporter) newSummaryScopeAttributeValue(summaryID string
 
 	sa := &SummaryScopeAttribute{summaryID, key, scopeName, scopeVersion, *av}
 	return sa, nil
-
 }
 
 func (e *kineticaMetricsExporter) newSummaryDatapointAttributeValue(summaryID string, summaryDatapointID string, key string, vtPair ValueTypePair) (*SummaryDataPointAttribute, error) {

--- a/exporter/kineticaexporter/writer.go
+++ b/exporter/kineticaexporter/writer.go
@@ -459,7 +459,6 @@ type SummaryScopeAttribute struct {
 //	@param tableDataMap - a map from table name to the relevant data
 //	@return error
 func (kiwriter *KiWriter) writeMetric(metricType string, tableDataMap *orderedmap.OrderedMap[string, []any]) error {
-
 	kiwriter.logger.Debug("Writing metric", zap.String("Type", metricType))
 
 	var errs []error
@@ -479,7 +478,6 @@ func (kiwriter *KiWriter) writeMetric(metricType string, tableDataMap *orderedma
 			}
 			wg.Done()
 		}(tableName, data, wg)
-
 	}
 	wg.Wait()
 
@@ -506,7 +504,6 @@ func (kiwriter *KiWriter) persistGaugeRecord(gaugeRecords []kineticaGaugeRecord)
 	var exemplarAttributes []any
 
 	for _, gaugerecord := range gaugeRecords {
-
 		gauges = append(gauges, *gaugerecord.gauge)
 
 		for _, gr := range gaugerecord.resourceAttribute {
@@ -532,7 +529,6 @@ func (kiwriter *KiWriter) persistGaugeRecord(gaugeRecords []kineticaGaugeRecord)
 		for _, geattr := range gaugerecord.exemplarAttribute {
 			exemplarAttributes = append(exemplarAttributes, geattr)
 		}
-
 	}
 
 	tableDataMap := orderedmap.New[string, []any]()
@@ -564,7 +560,6 @@ func (kiwriter *KiWriter) persistSumRecord(sumRecords []kineticaSumRecord) error
 	var exemplarAttributes []any
 
 	for _, sumrecord := range sumRecords {
-
 		sums = append(sums, *sumrecord.sum)
 
 		for _, sr := range sumrecord.sumResourceAttribute {
@@ -590,7 +585,6 @@ func (kiwriter *KiWriter) persistSumRecord(sumRecords []kineticaSumRecord) error
 		for _, seattr := range sumrecord.exemplarAttribute {
 			exemplarAttributes = append(exemplarAttributes, seattr)
 		}
-
 	}
 
 	tableDataMap := orderedmap.New[string, []any]()
@@ -624,7 +618,6 @@ func (kiwriter *KiWriter) persistHistogramRecord(histogramRecords []kineticaHist
 	var exemplarAttributes []any
 
 	for _, histogramrecord := range histogramRecords {
-
 		histograms = append(histograms, *histogramrecord.histogram)
 
 		for _, ra := range histogramrecord.histogramResourceAttribute {
@@ -693,7 +686,6 @@ func (kiwriter *KiWriter) persistExponentialHistogramRecord(exponentialHistogram
 	var exemplarAttributes []any
 
 	for _, histogramrecord := range exponentialHistogramRecords {
-
 		histograms = append(histograms, *histogramrecord.histogram)
 
 		for _, ra := range histogramrecord.histogramResourceAttribute {
@@ -759,7 +751,6 @@ func (kiwriter *KiWriter) persistSummaryRecord(summaryRecords []kineticaSummaryR
 	var datapointQuantiles []any
 
 	for _, summaryrecord := range summaryRecords {
-
 		summaries = append(summaries, *summaryrecord.summary)
 
 		for _, ra := range summaryrecord.summaryResourceAttribute {
@@ -795,11 +786,9 @@ func (kiwriter *KiWriter) persistSummaryRecord(summaryRecords []kineticaSummaryR
 	errs = append(errs, kiwriter.writeMetric(pmetric.MetricTypeSummary.String(), tableDataMap))
 
 	return multierr.Combine(errs...)
-
 }
 
 func (kiwriter *KiWriter) doChunkedInsert(_ context.Context, tableName string, records []any) error {
-
 	// Build the final table name with the schema prepended
 	var finalTable string
 	if len(kiwriter.cfg.Schema) != 0 {

--- a/exporter/loadbalancingexporter/consistent_hashing_test.go
+++ b/exporter/loadbalancingexporter/consistent_hashing_test.go
@@ -42,7 +42,6 @@ func TestEndpointFor(t *testing.T) {
 
 			// verify
 			assert.Equal(t, tt.expected, endpoint)
-
 		})
 	}
 }

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -71,7 +71,6 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 		return nil, fmt.Errorf("unsupported routing_key: %q", cfg.(*Config).RoutingKey)
 	}
 	return &metricExporter, nil
-
 }
 
 func (e *metricExporterImp) Capabilities() consumer.Capabilities {

--- a/exporter/loadbalancingexporter/resolver_aws_cloudmap_test.go
+++ b/exporter/loadbalancingexporter/resolver_aws_cloudmap_test.go
@@ -103,7 +103,6 @@ func makeSummary(i int) types.HttpInstanceSummary {
 	}
 }
 func mockDiscovery(*servicediscovery.DiscoverInstancesInput) (*servicediscovery.DiscoverInstancesOutput, error) {
-
 	s := &servicediscovery.DiscoverInstancesOutput{
 		Instances: []types.HttpInstanceSummary{
 			makeSummary(1),

--- a/exporter/loadbalancingexporter/resolver_k8s.go
+++ b/exporter/loadbalancingexporter/resolver_k8s.go
@@ -77,7 +77,6 @@ func newK8sResolver(clt kubernetes.Interface,
 	timeout time.Duration,
 	tb *metadata.TelemetryBuilder,
 ) (*k8sResolver, error) {
-
 	if len(service) == 0 {
 		return nil, errNoSvc
 	}

--- a/exporter/loadbalancingexporter/resolver_k8s_test.go
+++ b/exporter/loadbalancingexporter/resolver_k8s_test.go
@@ -100,7 +100,6 @@ func TestK8sResolve(t *testing.T) {
 				_, err = suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
 					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
 				return err
-
 			},
 			verifyFn: func(ctx *suiteContext, _ args) error {
 				if _, err := ctx.resolver.resolve(context.Background()); err != nil {
@@ -138,7 +137,6 @@ func TestK8sResolve(t *testing.T) {
 				_, err = suiteCtx.clientset.CoreV1().Endpoints(args.namespace).
 					Patch(context.TODO(), args.service, types.MergePatchType, data, metav1.PatchOptions{})
 				return err
-
 			},
 			verifyFn: func(ctx *suiteContext, _ args) error {
 				if _, err := ctx.resolver.resolve(context.Background()); err != nil {

--- a/exporter/logicmonitorexporter/internal/logs/sender_test.go
+++ b/exporter/logicmonitorexporter/internal/logs/sender_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestSendLogs(t *testing.T) {
-
 	t.Run("should not return error", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			response := lmsdklogs.LMLogIngestResponse{

--- a/exporter/logzioexporter/exporter_test.go
+++ b/exporter/logzioexporter/exporter_test.go
@@ -204,7 +204,6 @@ func TestExportErrors(tester *testing.T) {
 		server.Close()
 		require.Error(tester, err)
 	}
-
 }
 
 func TestNullTracesExporterConfig(tester *testing.T) {

--- a/exporter/logzioexporter/factory.go
+++ b/exporter/logzioexporter/factory.go
@@ -29,7 +29,6 @@ func NewFactory() exporter.Factory {
 		createDefaultConfig,
 		exporter.WithTraces(createTracesExporter, metadata.TracesStability),
 		exporter.WithLogs(createLogsExporter, metadata.LogsStability))
-
 }
 
 func createDefaultConfig() component.Config {

--- a/exporter/logzioexporter/factory_test.go
+++ b/exporter/logzioexporter/factory_test.go
@@ -26,7 +26,6 @@ func TestCreateDefaultConfig(t *testing.T) {
 }
 
 func TestCreateTraces(t *testing.T) {
-
 	cm, err := confmaptest.LoadConf(filepath.Join("testdata", "config.yaml"))
 	require.NoError(t, err)
 	factory := NewFactory()

--- a/exporter/opensearchexporter/internal/objmodel/objmodel_test.go
+++ b/exporter/opensearchexporter/internal/objmodel/objmodel_test.go
@@ -117,7 +117,6 @@ func TestDocument_Sort(t *testing.T) {
 			assert.Equal(t, test.want, doc)
 		})
 	}
-
 }
 
 func TestObjectModel_Dedup(t *testing.T) {

--- a/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -362,7 +362,6 @@ func (e *Exporter) SendAndWait(ctx context.Context, data any) (bool, error) {
 		err := writer.sendAndWait(ctx, errCh, wri)
 		if err != nil && errors.Is(err, ErrStreamRestarting) {
 			continue // an internal retry
-
 		}
 		// result from arrow server (may be nil, may be
 		// permanent, etc.)

--- a/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -579,7 +579,6 @@ func TestArrowExporterStreaming(t *testing.T) {
 func TestArrowExporterHeaders(t *testing.T) {
 	for _, withDeadline := range []bool{true, false} {
 		t.Run(fmt.Sprint("with_deadline=", withDeadline), func(t *testing.T) {
-
 			tc := newSingleStreamMetadataTestCase(t)
 			channel := newHealthyTestChannel()
 

--- a/exporter/otelarrowexporter/internal/arrow/stream_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/stream_test.go
@@ -141,7 +141,6 @@ func (tc *streamTestCase) mustSendAndWait() error {
 func TestStreamNoMaxLifetime(t *testing.T) {
 	for _, pname := range AllPrioritizers {
 		t.Run(string(pname), func(t *testing.T) {
-
 			tc := newStreamTestCase(t, pname)
 
 			tc.fromTracesCall.Times(1).Return(oneBatch, nil)

--- a/exporter/otelarrowexporter/otelarrow_test.go
+++ b/exporter/otelarrowexporter/otelarrow_test.go
@@ -1082,7 +1082,6 @@ func (r *mockTracesReceiver) startStreamMockArrowTraces(t *testing.T, statusFor 
 		MockArrowTracesServiceServer: svc,
 	})
 	svc.EXPECT().ArrowTraces(gomock.Any()).Times(1).DoAndReturn(doer)
-
 }
 
 func TestSendArrowFailedTraces(t *testing.T) {

--- a/exporter/prometheusexporter/accumulator.go
+++ b/exporter/prometheusexporter/accumulator.go
@@ -365,7 +365,6 @@ func accumulateHistogramValues(prev, current, dest pmetric.HistogramDataPoint) {
 	}
 
 	if match {
-
 		dest.SetCount(newer.Count() + older.Count())
 		dest.SetSum(newer.Sum() + older.Sum())
 

--- a/exporter/prometheusexporter/accumulator_test.go
+++ b/exporter/prometheusexporter/accumulator_test.go
@@ -218,7 +218,6 @@ func TestAccumulateMetrics(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			ts1 := time.Now().Add(-3 * time.Second)
 			ts2 := time.Now().Add(-2 * time.Second)
 			ts3 := time.Now().Add(-1 * time.Second)
@@ -327,7 +326,6 @@ func TestAccumulateDeltaToCumulative(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			ts1 := time.Now().Add(-3 * time.Second)
 			ts2 := time.Now().Add(-2 * time.Second)
 			ts3 := time.Now().Add(-1 * time.Second)

--- a/exporter/prometheusexporter/collector.go
+++ b/exporter/prometheusexporter/collector.go
@@ -72,7 +72,6 @@ func convertExemplars(exemplars pmetric.ExemplarSlice) []prometheus.Exemplar {
 			Labels:    exemplarLabels,
 			Timestamp: e.Timestamp().AsTime(),
 		}
-
 	}
 	return result
 }

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -174,7 +174,6 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	if len(prometheusExporterScrape) != 0 {
 		t.Fatalf("Left-over unmatched Prometheus scrape content: %q\n", prometheusExporterScrape)
 	}
-
 }
 
 // the following triggers G101: Potential hardcoded credentials

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -384,7 +384,6 @@ func runExportPipeline(ts *prompb.TimeSeries, endpoint *url.URL) error {
 // Test_PushMetrics checks the number of TimeSeries received by server and the number of metrics dropped is the same as
 // expected
 func Test_PushMetrics(t *testing.T) {
-
 	invalidTypeBatch := testdata.GenerateMetricsMetricTypeInvalid()
 
 	// success cases
@@ -1080,7 +1079,6 @@ func assertPermanentConsumerError(t assert.TestingT, err error, _ ...any) bool {
 }
 
 func TestRetries(t *testing.T) {
-
 	tts := []struct {
 		name             string
 		serverErrorCount int // number of times server should return error

--- a/exporter/prometheusremotewriteexporter/factory.go
+++ b/exporter/prometheusremotewriteexporter/factory.go
@@ -36,7 +36,6 @@ func NewFactory() exporter.Factory {
 
 func createMetricsExporter(ctx context.Context, set exporter.Settings,
 	cfg component.Config) (exporter.Metrics, error) {
-
 	prwCfg, ok := cfg.(*Config)
 	if !ok {
 		return nil, errors.New("invalid configuration")

--- a/exporter/prometheusremotewriteexporter/factory_test.go
+++ b/exporter/prometheusremotewriteexporter/factory_test.go
@@ -25,7 +25,6 @@ func Test_createDefaultConfig(t *testing.T) {
 
 // Tests whether or not a correct Metrics Exporter from the default Config parameters
 func Test_createMetricsExporter(t *testing.T) {
-
 	invalidConfig := createDefaultConfig().(*Config)
 	invalidConfig.ClientConfig = confighttp.NewDefaultClientConfig()
 	invalidTLSConfig := createDefaultConfig().(*Config)

--- a/exporter/pulsarexporter/config.go
+++ b/exporter/pulsarexporter/config.go
@@ -90,7 +90,6 @@ var _ component.Config = (*Config)(nil)
 
 // Validate checks if the exporter configuration is valid
 func (cfg *Config) Validate() error {
-
 	return nil
 }
 

--- a/exporter/pulsarexporter/config_test.go
+++ b/exporter/pulsarexporter/config_test.go
@@ -110,5 +110,4 @@ func TestClientOptions(t *testing.T) {
 		OperationTimeout:        30 * time.Second,
 		MaxConnectionsPerBroker: 1,
 	}, &options)
-
 }

--- a/exporter/pulsarexporter/pulsar_exporter.go
+++ b/exporter/pulsarexporter/pulsar_exporter.go
@@ -37,13 +37,11 @@ func (e *PulsarTracesProducer) tracesPusher(ctx context.Context, td ptrace.Trace
 
 	var errs error
 	for _, message := range messages {
-
 		e.producer.SendAsync(ctx, message, func(_ pulsar.MessageID, _ *pulsar.ProducerMessage, err error) {
 			if err != nil {
 				errs = multierr.Append(errs, err)
 			}
 		})
-
 	}
 
 	return errs
@@ -85,13 +83,11 @@ func (e *PulsarMetricsProducer) metricsDataPusher(ctx context.Context, md pmetri
 
 	var errs error
 	for _, message := range messages {
-
 		e.producer.SendAsync(ctx, message, func(_ pulsar.MessageID, _ *pulsar.ProducerMessage, err error) {
 			if err != nil {
 				errs = multierr.Append(errs, err)
 			}
 		})
-
 	}
 
 	return errs
@@ -133,13 +129,11 @@ func (e *PulsarLogsProducer) logsDataPusher(ctx context.Context, ld plog.Logs) e
 
 	var errs error
 	for _, message := range messages {
-
 		e.producer.SendAsync(ctx, message, func(_ pulsar.MessageID, _ *pulsar.ProducerMessage, err error) {
 			if err != nil {
 				errs = multierr.Append(errs, err)
 			}
 		})
-
 	}
 
 	return errs
@@ -196,7 +190,6 @@ func newMetricsExporter(config Config, set exporter.Settings, marshalers map[str
 		marshaler: marshaler,
 		logger:    set.Logger,
 	}, nil
-
 }
 
 func newTracesExporter(config Config, set exporter.Settings, marshalers map[string]TracesMarshaler) (*PulsarTracesProducer, error) {
@@ -224,5 +217,4 @@ func newLogsExporter(config Config, set exporter.Settings, marshalers map[string
 		marshaler: marshaler,
 		logger:    set.Logger,
 	}, nil
-
 }

--- a/exporter/pulsarexporter/pulsar_exporter_test.go
+++ b/exporter/pulsarexporter/pulsar_exporter_test.go
@@ -29,7 +29,6 @@ func TestNewMetricsExporter_err_traces_encoding(t *testing.T) {
 	mexp, err := newMetricsExporter(c, exportertest.NewNopSettings(), metricsMarshalers())
 	assert.EqualError(t, err, errUnrecognizedEncoding.Error())
 	assert.Nil(t, mexp)
-
 }
 
 func TestNewLogsExporter_err_encoding(t *testing.T) {

--- a/exporter/signalfxexporter/dpclient.go
+++ b/exporter/signalfxexporter/dpclient.go
@@ -111,7 +111,6 @@ func (s *sfxDPClient) pushMetricsData(
 	}
 
 	return 0, nil
-
 }
 
 func (s *sfxDPClient) postData(ctx context.Context, body io.Reader, headers map[string]string) error {
@@ -154,7 +153,6 @@ func (s *sfxDPClient) postData(ctx context.Context, body io.Reader, headers map[
 }
 
 func (s *sfxDPClient) pushMetricsDataForToken(ctx context.Context, sfxDataPoints []*sfxpb.DataPoint, accessToken string) (int, error) {
-
 	if s.logDataPoints {
 		for _, dp := range sfxDataPoints {
 			s.logger.Debug("Dispatching SFx datapoint", zap.Stringer("dp", dp))
@@ -210,7 +208,6 @@ func (s *sfxDPClient) retrieveAccessToken(md pmetric.ResourceMetrics) string {
 }
 
 func (s *sfxDPClient) pushOTLPMetricsDataForToken(ctx context.Context, mh pmetric.Metrics, accessToken string) (int, error) {
-
 	dataPointCount := mh.DataPointCount()
 	if s.logDataPoints {
 		s.logger.Debug("Count of metrics to send in OTLP format",
@@ -256,7 +253,6 @@ func (s *sfxDPClient) pushOTLPMetricsDataForToken(ctx context.Context, mh pmetri
 }
 
 func (s *sfxDPClient) encodeOTLPBody(md pmetric.Metrics) (bodyReader io.Reader, compressed bool, err error) {
-
 	tr := pmetricotlp.NewExportRequestFromMetrics(md)
 
 	body, err := tr.MarshalProto()

--- a/exporter/signalfxexporter/exporter.go
+++ b/exporter/signalfxexporter/exporter.go
@@ -184,7 +184,6 @@ func newEventExporter(config *Config, createSettings exporter.Settings) (*signal
 		logger:            createSettings.Logger,
 		telemetrySettings: createSettings.TelemetrySettings,
 	}, nil
-
 }
 
 func (se *signalfxExporter) startLogs(ctx context.Context, host component.Host) error {

--- a/exporter/signalfxexporter/factory_test.go
+++ b/exporter/signalfxexporter/factory_test.go
@@ -584,7 +584,6 @@ func TestDefaultExcludesTranslated(t *testing.T) {
 	// (because cpu.utilization_per_core is supplied) and should not be excluded
 	require.Len(t, dps, 1)
 	require.Equal(t, "cpu.utilization", dps[0].Metric)
-
 }
 
 func TestDefaultExcludes_not_translated(t *testing.T) {

--- a/exporter/signalfxexporter/internal/apm/correlations/dedup.go
+++ b/exporter/signalfxexporter/internal/apm/correlations/dedup.go
@@ -79,7 +79,6 @@ func (d *deduplicator) evictPendingCreate() {
 			req.cancel()
 			d.pendingCreates.Remove(elem)
 			delete(d.pendingCreateKeys, *req.Correlation)
-
 		}
 	}
 }

--- a/exporter/signalfxexporter/internal/correlation/correlation_test.go
+++ b/exporter/signalfxexporter/internal/correlation/correlation_test.go
@@ -44,7 +44,6 @@ func TestTrackerAddSpans(t *testing.T) {
 }
 
 func TestTrackerStart(t *testing.T) {
-
 	tests := []struct {
 		name    string
 		config  *Config

--- a/exporter/signalfxexporter/internal/dimensions/metadata_test.go
+++ b/exporter/signalfxexporter/internal/dimensions/metadata_test.go
@@ -197,7 +197,6 @@ func TestGetDimensionUpdateFromMetadata(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
 			converter, err := translation.NewMetricsConverter(
 				zap.NewNop(),
 				tt.args.metricTranslator,

--- a/exporter/signalfxexporter/internal/hostmetadata/host_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/host_test.go
@@ -274,5 +274,4 @@ func TestEtcPath(t *testing.T) {
 			assert.Equal(t, tt.want, etcPath())
 		})
 	}
-
 }

--- a/exporter/signalfxexporter/internal/hostmetadata/metadata_test.go
+++ b/exporter/signalfxexporter/internal/hostmetadata/metadata_test.go
@@ -265,7 +265,6 @@ func TestSyncMetadata(t *testing.T) {
 			for i, log := range logs.All() {
 				assert.Equal(t, tt.wantLogs[i], log.Message)
 			}
-
 		})
 	}
 }

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -1176,7 +1176,6 @@ func TestDimensionKeyCharsWithPeriod(t *testing.T) {
 	c, err := NewMetricsConverter(zap.NewNop(), translator, nil, nil, "_-.", false, true)
 	require.NoError(t, err)
 	assert.EqualValues(t, expected, c.MetricsToSignalFxV2(md))
-
 }
 
 func TestInvalidNumberOfDimensions(t *testing.T) {

--- a/exporter/signalfxexporter/internal/translation/dpfilters/datapoint.go
+++ b/exporter/signalfxexporter/internal/translation/dpfilters/datapoint.go
@@ -51,5 +51,4 @@ func (f *dataPointFilter) Matches(dp *sfxpb.DataPoint) bool {
 		return f.dimensionsFilter == nil || f.dimensionsFilter.Matches(dp.Dimensions)
 	}
 	return false
-
 }

--- a/exporter/signalfxexporter/internal/translation/translator.go
+++ b/exporter/signalfxexporter/internal/translation/translator.go
@@ -430,7 +430,6 @@ func (mp *MetricTranslator) TranslateDataPoints(logger *zap.Logger, sfxDataPoint
 						for _, d := range dp.Dimensions {
 							if k, ok := tr.CopyDimensions[d.Key]; ok {
 								dp.Dimensions = append(dp.Dimensions, &sfxpb.Dimension{Key: k, Value: d.Value})
-
 							}
 						}
 					}

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -611,7 +611,6 @@ func (c *client) stop(context.Context) error {
 }
 
 func (c *client) start(ctx context.Context, host component.Host) (err error) {
-
 	httpClient, err := buildHTTPClient(ctx, c.config, host, c.telemetrySettings)
 	if err != nil {
 		return err
@@ -636,7 +635,6 @@ func (c *client) start(ctx context.Context, host component.Host) (err error) {
 }
 
 func checkHecHealth(ctx context.Context, client *http.Client, healthCheckURL *url.URL) error {
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, healthCheckURL.String(), nil)
 	if err != nil {
 		return consumererror.NewPermanent(err)

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -1211,7 +1211,6 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 		}
 		t.Run(test.name, testFn(false))
 		t.Run(test.name+"_MultiMetric", testFn(true))
-
 	}
 }
 
@@ -1541,7 +1540,6 @@ func Test_pushLogData_nil_Logs(t *testing.T) {
 			})
 		}
 	}
-
 }
 
 func Test_pushLogData_InvalidLog(t *testing.T) {
@@ -2105,5 +2103,4 @@ func validateCompressedContains(t *testing.T, expected []string, got []byte) {
 	for _, e := range expected {
 		assert.Contains(t, string(p), e)
 	}
-
 }

--- a/exporter/splunkhecexporter/config.go
+++ b/exporter/splunkhecexporter/config.go
@@ -141,7 +141,6 @@ type Config struct {
 }
 
 func (cfg *Config) getURL() (out *url.URL, err error) {
-
 	out, err = url.Parse(cfg.ClientConfig.Endpoint)
 	if err != nil {
 		return out, err

--- a/exporter/splunkhecexporter/heartbeat.go
+++ b/exporter/splunkhecexporter/heartbeat.go
@@ -107,7 +107,6 @@ func observe(heartbeatsSent, heartbeatsFailed metric.Int64Counter, attrs attribu
 	} else {
 		heartbeatsFailed.Add(context.Background(), 1, metric.WithAttributeSet(attrs))
 	}
-
 }
 
 func generateHeartbeatLog(hecToOtelAttrs splunk.HecToOtelAttrs, buildInfo component.BuildInfo) plog.Logs {

--- a/exporter/splunkhecexporter/internal/integrationtestutils/config_helper.go
+++ b/exporter/splunkhecexporter/internal/integrationtestutils/config_helper.go
@@ -109,5 +109,4 @@ func SetConfigVariable(key string, value string) {
 	}
 
 	fmt.Println("Host value updated successfully!")
-
 }

--- a/exporter/splunkhecexporter/logdata_to_splunk.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk.go
@@ -119,7 +119,6 @@ func mergeValue(dst map[string]any, k string, v any) {
 	default:
 		dst[k] = v
 	}
-
 }
 
 func isArrayFlat(array []any) bool {

--- a/exporter/splunkhecexporter/logdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/logdata_to_splunk_test.go
@@ -521,5 +521,4 @@ func Test_mergeValue(t *testing.T) {
 			assert.Equal(t, tt.expected, fields)
 		})
 	}
-
 }

--- a/exporter/splunkhecexporter/metricdata_to_splunk_test.go
+++ b/exporter/splunkhecexporter/metricdata_to_splunk_test.go
@@ -215,7 +215,6 @@ func Test_metricDataToSplunk(t *testing.T) {
 				return res
 			},
 			metricsDataFn: func() pmetric.Metric {
-
 				doubleGauge := pmetric.NewMetric()
 				doubleGauge.SetName("gauge_double_with_dims")
 				doubleDataPt := doubleGauge.SetEmptyGauge().DataPoints().AppendEmpty()

--- a/exporter/sumologicexporter/config.go
+++ b/exporter/sumologicexporter/config.go
@@ -73,7 +73,6 @@ func createDefaultClientConfig() confighttp.ClientConfig {
 }
 
 func (cfg *Config) Validate() error {
-
 	if cfg.CompressEncoding != nil {
 		return errors.New("support for compress_encoding configuration has been removed, in favor of compression")
 	}

--- a/exporter/sumologicexporter/otlp_test.go
+++ b/exporter/sumologicexporter/otlp_test.go
@@ -166,5 +166,4 @@ func addExpectedHistogramBuckets(metrics pmetric.MetricSlice) {
 		dataPoint.SetTimestamp(timestamp2)
 		dataPoint.SetIntValue(bucketCount)
 	}
-
 }

--- a/exporter/sumologicexporter/sender.go
+++ b/exporter/sumologicexporter/sender.go
@@ -485,7 +485,6 @@ func (s *sender) sendNonOTLPMetrics(ctx context.Context, md pmetric.Metrics) (pm
 			previousFields := newFields(rms.At(i - 1).Resource().Attributes())
 			previousSourceHeaders := getSourcesHeaders(previousFields)
 			if !reflect.DeepEqual(previousSourceHeaders, currentSourceHeaders) && body.Len() > 0 {
-
 				if err := s.send(ctx, MetricsPipeline, body.toCountingReader(), previousFields); err != nil {
 					errs = append(errs, err)
 					for _, resource := range currentResources {
@@ -537,7 +536,6 @@ func (s *sender) sendNonOTLPMetrics(ctx context.Context, md pmetric.Metrics) (pm
 		}
 
 		currentResources = append(currentResources, rm)
-
 	}
 
 	if body.Len() > 0 {
@@ -580,7 +578,6 @@ func (s *sender) appendAndMaybeSend(
 	body *bodyBuilder,
 	flds fields,
 ) (sent bool, err error) {
-
 	linesTotalLength := 0
 	for _, line := range lines {
 		linesTotalLength += len(line) + 1 // count the newline as well

--- a/exporter/syslogexporter/config_test.go
+++ b/exporter/syslogexporter/config_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestValidate(t *testing.T) {
-
 	tests := []struct {
 		name string
 		cfg  *Config

--- a/exporter/syslogexporter/exporter_test.go
+++ b/exporter/syslogexporter/exporter_test.go
@@ -130,7 +130,6 @@ func prepareExporterTest(t *testing.T, cfg *Config, invalidExporter bool) *expor
 		srv: testServer,
 		exp: exp,
 	}
-
 }
 
 func createTestConfig() *Config {
@@ -187,7 +186,6 @@ func TestSyslogExportFail(t *testing.T) {
 }
 
 func TestTLSConfig(t *testing.T) {
-
 	tests := []struct {
 		name        string
 		network     string
@@ -218,7 +216,6 @@ func TestTLSConfig(t *testing.T) {
 
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
-
 			exporter, err := initExporter(
 				&Config{Endpoint: "test.com",
 					Network:    testInstance.network,
@@ -233,7 +230,6 @@ func TestTLSConfig(t *testing.T) {
 			} else {
 				assert.Nil(t, exporter.tlsConfig)
 			}
-
 		})
 	}
 }

--- a/exporter/syslogexporter/rfc5424_formatter.go
+++ b/exporter/syslogexporter/rfc5424_formatter.go
@@ -94,7 +94,6 @@ func (f *rfc5424Formatter) formatStructuredData(logRecord plog.LogRecord) string
 		}
 	}
 	return fmt.Sprint(sdElements)
-
 }
 
 func (f *rfc5424Formatter) formatMessage(logRecord plog.LogRecord) string {

--- a/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice_test.go
+++ b/exporter/tencentcloudlogserviceexporter/logsdata_to_logservice_test.go
@@ -102,7 +102,6 @@ func TestConvertLogs(t *testing.T) {
 			})
 		}
 		gotLogPairs = append(gotLogPairs, pairs)
-
 	}
 
 	wantLogs := make([][]logKeyValuePair, 0, validLogCount)


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
