### PR TITLE
[processor/tailsampling] record sampling policy

### DIFF
--- a/.chloggen/tailsampling-record-policy.yaml
+++ b/.chloggen/tailsampling-record-policy.yaml
@@ -1,0 +1,15 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/tailsampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Adds support for optionally recording the policy (and any composite policy) associated with an inclusive tail processor sampling decision. 
+  This functionality is disabled by default, you can enable it by passing the following feature flag to the collector: `+processor.tailsamplingprocessor.recordpolicy`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35180]

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -531,7 +531,7 @@ As a reminder, a policy voting to sample the trace does not guarantee sampling; 
 ### Tracking sampling policy
 To better understand _which_ sampling policy made the decision to include a trace, you can enable tracking the policy responsible for sampling a trace via the `processor.tailsamplingprocessor.recordpolicy` feature gate.
 
-When this feature gate is set, this will add additional attributes on each sampled span scope:
+When this feature gate is set, this will add additional attributes on each sampled span:
 
 | Attribute                       | Description                                                               | Present?                   |
 |---------------------------------|---------------------------------------------------------------------------|----------------------------|

--- a/processor/tailsamplingprocessor/README.md
+++ b/processor/tailsamplingprocessor/README.md
@@ -528,6 +528,16 @@ sum (otelcol_processor_tail_sampling_count_traces_sampled) by (policy)
 
 As a reminder, a policy voting to sample the trace does not guarantee sampling; an "inverted not" decision from another policy would still discard the trace.
 
+### Tracking sampling policy
+To better understand _which_ sampling policy made the decision to include a trace, you can enable tracking the policy responsible for sampling a trace via the `processor.tailsamplingprocessor.recordpolicy` feature gate.
+
+When this feature gate is set, this will add additional attributes on each sampled span scope:
+
+| Attribute                       | Description                                                               | Present?                   |
+|---------------------------------|---------------------------------------------------------------------------|----------------------------|
+| `tailsampling.policy`           | Records the configured name of the policy that sampled a trace            | Always                     |
+| `tailsampling.composite_policy` | Records the configured name of a composite subpolicy that sampled a trace | When composite policy used |
+
 ### Policy Evaluation Errors
 
 ```

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -4,8 +4,9 @@
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"go.opentelemetry.io/collector/component"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
 )

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -4,6 +4,7 @@
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
@@ -22,10 +23,11 @@ func getNewCompositePolicy(settings component.TelemetrySettings, config *Composi
 		evalParams := sampling.SubPolicyEvalParams{
 			Evaluator:         policy,
 			MaxSpansPerSecond: int64(rateAllocationsMap[policyCfg.Name]),
+			Name:              policyCfg.Name,
 		}
 		subPolicyEvalParams[i] = evalParams
 	}
-	return sampling.NewComposite(settings.Logger, config.MaxTotalSpansPerSecond, subPolicyEvalParams, sampling.MonotonicClock{}), nil
+	return sampling.NewComposite(settings.Logger, config.MaxTotalSpansPerSecond, subPolicyEvalParams, sampling.MonotonicClock{}, telemetry.IsRecordPolicyEnabled()), nil
 }
 
 // Apply rate allocations to the sub-policies

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -6,9 +6,8 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 import (
 	"go.opentelemetry.io/collector/component"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
-
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/sampling"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 )
 
 func getNewCompositePolicy(settings component.TelemetrySettings, config *CompositeCfg) (sampling.PolicyEvaluator, error) {

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -4,7 +4,6 @@
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"

--- a/processor/tailsamplingprocessor/composite_helper.go
+++ b/processor/tailsamplingprocessor/composite_helper.go
@@ -4,6 +4,7 @@
 package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 
 import (
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"go.opentelemetry.io/collector/component"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"

--- a/processor/tailsamplingprocessor/composite_helper_test.go
+++ b/processor/tailsamplingprocessor/composite_helper_test.go
@@ -52,12 +52,14 @@ func TestCompositeHelper(t *testing.T) {
 			{
 				Evaluator:         sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 100, 0),
 				MaxSpansPerSecond: 250,
+				Name:              "test-composite-policy-1",
 			},
 			{
 				Evaluator:         sampling.NewLatency(componenttest.NewNopTelemetrySettings(), 200, 0),
 				MaxSpansPerSecond: 500,
+				Name:              "test-composite-policy-2",
 			},
-		}, sampling.MonotonicClock{})
+		}, sampling.MonotonicClock{}, false)
 		assert.Equal(t, expected, actual)
 	})
 

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -7,6 +7,7 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -7,6 +7,7 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"time"
 
 	"go.opentelemetry.io/collector/component"
@@ -38,5 +39,10 @@ func createTracesProcessor(
 	nextConsumer consumer.Traces,
 ) (processor.Traces, error) {
 	tCfg := cfg.(*Config)
-	return newTracesProcessor(ctx, params, nextConsumer, *tCfg)
+	opts := []Option{}
+
+	if telemetry.IsRecordPolicyEnabled() {
+		opts = append(opts, withRecordPolicy())
+	}
+	return newTracesProcessor(ctx, params, nextConsumer, *tCfg, opts...)
 }

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -7,7 +7,6 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"time"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -9,13 +9,12 @@ import (
 	"context"
 	"time"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/processor"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/metadata"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 )
 
 // NewFactory returns a new factory for the Tail Sampling processor.

--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -7,8 +7,9 @@ package tailsamplingprocessor // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 	"time"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor/internal/telemetry"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"

--- a/processor/tailsamplingprocessor/generated_component_telemetry_test.go
+++ b/processor/tailsamplingprocessor/generated_component_telemetry_test.go
@@ -7,15 +7,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/collector/processor"
 	"go.opentelemetry.io/collector/processor/processortest"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata/metricdatatest"
 )
 
 type componentTestTelemetry struct {

--- a/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
+++ b/processor/tailsamplingprocessor/internal/metadata/generated_telemetry.go
@@ -5,12 +5,11 @@ package metadata
 import (
 	"errors"
 
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config/configtelemetry"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/config/configtelemetry"
 )
 
 func Meter(settings component.TelemetrySettings) metric.Meter {

--- a/processor/tailsamplingprocessor/internal/metadata/generated_telemetry_test.go
+++ b/processor/tailsamplingprocessor/internal/metadata/generated_telemetry_test.go
@@ -6,15 +6,14 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/otel/metric"
 	embeddedmetric "go.opentelemetry.io/otel/metric/embedded"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
 	"go.opentelemetry.io/otel/trace"
 	embeddedtrace "go.opentelemetry.io/otel/trace/embedded"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
-
-	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 type mockMeter struct {

--- a/processor/tailsamplingprocessor/internal/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite_test.go
@@ -104,9 +104,7 @@ func TestCompositeEvaluatorSampled_RecordSubPolicy(t *testing.T) {
 	expected := Sampled
 	assert.Equal(t, expected, decision)
 	val, ok := trace.ReceivedBatches.ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.composite_policy")
-	if !ok {
-		assert.FailNow(t, "Did not find expected key")
-	}
+	assert.True(t, ok, "Did not find expected key")
 	assert.Equal(t, "eval-2", val.AsString())
 }
 
@@ -197,9 +195,7 @@ func TestCompositeEvaluatorInverseSampled_AlwaysSampled_RecordSubPolicy(t *testi
 		expected := Sampled
 		assert.Equal(t, expected, decision)
 		val, ok := trace.ReceivedBatches.ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.composite_policy")
-		if !ok {
-			assert.FailNow(t, "Did not find expected key")
-		}
+		assert.True(t, ok, "Did not find expected key")
 		assert.Equal(t, "eval-2", val.AsString())
 	}
 }

--- a/processor/tailsamplingprocessor/internal/sampling/composite_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/composite_test.go
@@ -90,7 +90,6 @@ func TestCompositeEvaluatorSampled(t *testing.T) {
 }
 
 func TestCompositeEvaluatorSampled_RecordSubPolicy(t *testing.T) {
-
 	// Create 2 subpolicies. First results in 100% NotSampled, the second in 100% Sampled.
 	n1 := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", 0, 100, false)
 	n2 := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
@@ -183,7 +182,6 @@ func TestCompositeEvaluatorInverseSampled_AlwaysSampled(t *testing.T) {
 }
 
 func TestCompositeEvaluatorInverseSampled_AlwaysSampled_RecordSubPolicy(t *testing.T) {
-
 	// The first policy does not match, the second matches through invert
 	n1 := NewStringAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", []string{"foo"}, false, 0, false)
 	n2 := NewStringAttributeFilter(componenttest.NewNopTelemetrySettings(), "tag", []string{"foo"}, false, 0, true)

--- a/processor/tailsamplingprocessor/internal/sampling/util.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util.go
@@ -95,9 +95,10 @@ func invertHasInstrumentationLibrarySpanWithCondition(ilss ptrace.ScopeSpansSlic
 }
 
 func SetAttrOnScopeSpans(data *TraceData, attrName string, attrKey string) {
+	data.Mutex.Lock()
+	defer data.Mutex.Unlock()
 
 	rs := data.ReceivedBatches.ResourceSpans()
-
 	for i := 0; i < rs.Len(); i++ {
 		rss := rs.At(i)
 		for j := 0; j < rss.ScopeSpans().Len(); j++ {

--- a/processor/tailsamplingprocessor/internal/sampling/util.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util.go
@@ -93,3 +93,16 @@ func invertHasInstrumentationLibrarySpanWithCondition(ilss ptrace.ScopeSpansSlic
 	}
 	return true
 }
+
+func SetAttrOnScopeSpans(data *TraceData, attrName string, attrKey string) {
+
+	rs := data.ReceivedBatches.ResourceSpans()
+
+	for i := 0; i < rs.Len(); i++ {
+		rss := rs.At(i)
+		for j := 0; j < rss.ScopeSpans().Len(); j++ {
+			ss := rss.ScopeSpans().At(j)
+			ss.Scope().Attributes().PutStr(attrName, attrKey)
+		}
+	}
+}

--- a/processor/tailsamplingprocessor/internal/sampling/util_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util_test.go
@@ -1,10 +1,14 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
 package sampling
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	"testing"
 )
 
 func TestSetAttrOnScopeSpans_Empty(t *testing.T) {
@@ -17,7 +21,6 @@ func TestSetAttrOnScopeSpans_Empty(t *testing.T) {
 }
 
 func TestSetAttrOnScopeSpans_Many(t *testing.T) {
-
 	assertAttrExists := func(t *testing.T, attrs pcommon.Map, key string, value string) {
 		v, ok := attrs.Get(key)
 		assert.True(t, ok)

--- a/processor/tailsamplingprocessor/internal/sampling/util_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util_test.go
@@ -11,7 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
-func TestSetAttrOnScopeSpans_Empty(t *testing.T) {
+func TestSetAttrOnScopeSpans_Empty(_ *testing.T) {
 	traces := ptrace.NewTraces()
 	traceData := &TraceData{
 		ReceivedBatches: traces,
@@ -61,7 +61,6 @@ func TestSetAttrOnScopeSpans_Many(t *testing.T) {
 
 func BenchmarkSetAttrOnScopeSpans(b *testing.B) {
 	for n := 0; n < b.N; n++ {
-
 		traces := ptrace.NewTraces()
 
 		for i := 0; i < 5; i++ {

--- a/processor/tailsamplingprocessor/internal/sampling/util_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/util_test.go
@@ -1,0 +1,87 @@
+package sampling
+
+import (
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+	"testing"
+)
+
+func TestSetAttrOnScopeSpans_Empty(t *testing.T) {
+	traces := ptrace.NewTraces()
+	traceData := &TraceData{
+		ReceivedBatches: traces,
+	}
+
+	SetAttrOnScopeSpans(traceData, "test.attr", "value")
+}
+
+func TestSetAttrOnScopeSpans_Many(t *testing.T) {
+
+	assertAttrExists := func(t *testing.T, attrs pcommon.Map, key string, value string) {
+		v, ok := attrs.Get(key)
+		assert.True(t, ok)
+		assert.Equal(t, value, v.AsString())
+	}
+
+	traces := ptrace.NewTraces()
+
+	rs1 := traces.ResourceSpans().AppendEmpty()
+	ss1 := rs1.ScopeSpans().AppendEmpty()
+	span1 := ss1.Spans().AppendEmpty()
+	span2 := ss1.Spans().AppendEmpty()
+	ss2 := rs1.ScopeSpans().AppendEmpty()
+	span3 := ss2.Spans().AppendEmpty()
+	rs2 := traces.ResourceSpans().AppendEmpty()
+	ss3 := rs2.ScopeSpans().AppendEmpty()
+	span4 := ss3.Spans().AppendEmpty()
+
+	traceData := &TraceData{
+		ReceivedBatches: traces,
+	}
+
+	SetAttrOnScopeSpans(traceData, "test.attr", "value")
+
+	assertAttrExists(t, ss1.Scope().Attributes(), "test.attr", "value")
+	assertAttrExists(t, ss2.Scope().Attributes(), "test.attr", "value")
+	assertAttrExists(t, ss3.Scope().Attributes(), "test.attr", "value")
+
+	_, ok := span1.Attributes().Get("test.attr")
+	assert.False(t, ok)
+	_, ok = span2.Attributes().Get("test.attr")
+	assert.False(t, ok)
+	_, ok = span3.Attributes().Get("test.attr")
+	assert.False(t, ok)
+	_, ok = span4.Attributes().Get("test.attr")
+	assert.False(t, ok)
+}
+
+func BenchmarkSetAttrOnScopeSpans(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+
+		traces := ptrace.NewTraces()
+
+		for i := 0; i < 5; i++ {
+			rs := traces.ResourceSpans().AppendEmpty()
+			ss1 := rs.ScopeSpans().AppendEmpty()
+			ss1.Spans().AppendEmpty()
+			ss1.Spans().AppendEmpty()
+			ss1.Spans().AppendEmpty()
+
+			ss2 := rs.ScopeSpans().AppendEmpty()
+			ss2.Spans().AppendEmpty()
+			ss2.Spans().AppendEmpty()
+
+			ss3 := rs.ScopeSpans().AppendEmpty()
+			ss3.Spans().AppendEmpty()
+		}
+
+		traceData := &TraceData{
+			ReceivedBatches: traces,
+		}
+
+		b.StartTimer()
+		SetAttrOnScopeSpans(traceData, "test.attr", "value")
+		b.StopTimer()
+	}
+}

--- a/processor/tailsamplingprocessor/internal/telemetry/featureflag.go
+++ b/processor/tailsamplingprocessor/internal/telemetry/featureflag.go
@@ -14,3 +14,13 @@ var metricStatCountSpansSampledFeatureGate = featuregate.GlobalRegistry().MustRe
 func IsMetricStatCountSpansSampledEnabled() bool {
 	return metricStatCountSpansSampledFeatureGate.IsEnabled()
 }
+
+var recordPolicyFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"processor.tailsamplingprocessor.recordpolicy",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled, attaches the name of the policy (and if applicable, composite policy) responsible for sampling a trace in the 'tailsampling.policy'/ 'tailsampling.composite_policy' attributes."),
+)
+
+func IsRecordPolicyEnabled() bool {
+	return recordPolicyFeatureGate.IsEnabled()
+}

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -59,7 +59,7 @@ type tailSamplingSpanProcessor struct {
 	nonSampledIDCache cache.Cache[bool]
 	deleteChan        chan pcommon.TraceID
 	numTracesOnMap    *atomic.Uint64
-	recordPolicy    bool
+	recordPolicy      bool
 }
 
 // spanAndScope a structure for holding information about span and its instrumentation scope.

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -5,7 +5,6 @@ package tailsamplingprocessor
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -5,6 +5,7 @@ package tailsamplingprocessor
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -160,6 +161,57 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 	require.NoError(t, tel.Shutdown(context.Background()))
 }
 
+func TestSamplingMultiplePolicies_WithRecordPolicy(t *testing.T) {
+	cfg := Config{
+		DecisionWait: defaultTestDecisionWait,
+		NumTraces:    defaultNumTraces,
+	}
+	nextConsumer := new(consumertest.TracesSink)
+	s := setupTestTelemetry()
+	ct := s.NewSettings()
+	idb := newSyncIDBatcher()
+
+	mpe1 := &mockPolicyEvaluator{}
+	mpe2 := &mockPolicyEvaluator{}
+
+	policies := []*policy{
+		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+	}
+
+	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg, withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy())
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(context.Background()))
+	}()
+
+	// First policy takes precedence
+	mpe1.NextDecision = sampling.Sampled
+	mpe2.NextDecision = sampling.Sampled
+
+	// Generate and deliver first span
+	require.NoError(t, p.ConsumeTraces(context.Background(), simpleTraces()))
+
+	tsp := p.(*tailSamplingSpanProcessor)
+
+	// The first tick won't do anything
+	tsp.policyTicker.OnTick()
+	// This will cause policy evaluations on the first span
+	tsp.policyTicker.OnTick()
+
+	// The final decision SHOULD be Sampled.
+	require.EqualValues(t, 1, nextConsumer.SpanCount())
+
+	// First span should have an attribute that records the policy that sampled it
+	policy, ok := nextConsumer.AllTraces()[0].ResourceSpans().At(0).ScopeSpans().At(0).Scope().Attributes().Get("tailsampling.policy")
+	if !ok {
+		assert.FailNow(t, "Did not find expected attribute")
+	}
+	require.EqualValues(t, "mock-policy-1", policy.AsString())
+}
+
 func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 	cfg := Config{
 		DecisionWait: defaultTestDecisionWait,
@@ -204,6 +256,47 @@ func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 	// The final decision SHOULD be NotSampled.
 	require.EqualValues(t, 0, nextConsumer.SpanCount())
 	require.NoError(t, tel.Shutdown(context.Background()))
+}
+
+func TestSamplingPolicyDecisionNotSampled_WithRecordPolicy(t *testing.T) {
+	cfg := Config{
+		DecisionWait: defaultTestDecisionWait,
+		NumTraces:    defaultNumTraces,
+	}
+	nextConsumer := new(consumertest.TracesSink)
+	s := setupTestTelemetry()
+	ct := s.NewSettings()
+	idb := newSyncIDBatcher()
+
+	mpe1 := &mockPolicyEvaluator{}
+
+	policies := []*policy{
+		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+	}
+
+	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg, withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy())
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(context.Background()))
+	}()
+
+	// InvertNotSampled takes precedence
+	mpe1.NextDecision = sampling.NotSampled
+
+	// Generate and deliver first span
+	require.NoError(t, p.ConsumeTraces(context.Background(), simpleTraces()))
+
+	tsp := p.(*tailSamplingSpanProcessor)
+
+	// The first tick won't do anything
+	tsp.policyTicker.OnTick()
+	// This will cause policy evaluations on the first span
+	tsp.policyTicker.OnTick()
+
+	// The final decision SHOULD be NotSampled.
+	require.EqualValues(t, 0, nextConsumer.SpanCount())
 }
 
 func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
@@ -255,6 +348,50 @@ func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
 	// The final decision SHOULD be NotSampled.
 	require.EqualValues(t, 0, nextConsumer.SpanCount())
 	require.NoError(t, tel.Shutdown(context.Background()))
+}
+
+func TestSamplingPolicyDecisionInvertNotSampled_WithRecordPolicy(t *testing.T) {
+	cfg := Config{
+		DecisionWait: defaultTestDecisionWait,
+		NumTraces:    defaultNumTraces,
+	}
+	nextConsumer := new(consumertest.TracesSink)
+	s := setupTestTelemetry()
+	ct := s.NewSettings()
+	idb := newSyncIDBatcher()
+
+	mpe1 := &mockPolicyEvaluator{}
+	mpe2 := &mockPolicyEvaluator{}
+
+	policies := []*policy{
+		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
+		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
+	}
+
+	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg, withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy())
+	require.NoError(t, err)
+
+	require.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
+	defer func() {
+		require.NoError(t, p.Shutdown(context.Background()))
+	}()
+
+	// InvertNotSampled takes precedence
+	mpe1.NextDecision = sampling.InvertNotSampled
+	mpe2.NextDecision = sampling.Sampled
+
+	// Generate and deliver first span
+	require.NoError(t, p.ConsumeTraces(context.Background(), simpleTraces()))
+
+	tsp := p.(*tailSamplingSpanProcessor)
+
+	// The first tick won't do anything
+	tsp.policyTicker.OnTick()
+	// This will cause policy evaluations on the first span
+	tsp.policyTicker.OnTick()
+
+	// The final decision SHOULD be NotSampled.
+	require.EqualValues(t, 0, nextConsumer.SpanCount())
 }
 
 func TestLateArrivingSpansAssignedOriginalDecision(t *testing.T) {

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -5,9 +5,10 @@ package tailsamplingprocessor
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -5,6 +5,7 @@ package tailsamplingprocessor
 
 import (
 	"context"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 


### PR DESCRIPTION
#### Description
Adds support for optionally recording the policy (and any composite policy) associated with an inclusive tail processor sampling decision:

![image](https://github.com/user-attachments/assets/29b5ac62-23fa-4226-9130-1717c1023319)


#### Link to tracking issue
Fixes
Resolves #35180.

#### Implementation notes
- This functionality lives behind a feature flag that is disabled by default
- The original issue described a solution where we might attach the attribute solely to the root span. I'm not sure I agree with the commenter that we can rely on this (e.g. we might decide to sample halfway through a long-running trace) so I have attached the attributes to all present scope spans. This feels like a decent trade off between complexity + network cost, as finding the highest non-root parent would require multiple passes of the spans and keeping all span ids in a set

#### Testing
- Added automated tests to verify enabling the flag both records the expected decision while not impacting existing logic
- Built a custom version and ran it in our preprod environment to ensure it was stable over a 1h period (still evaluating, will update PR with any further observations)

#### TODO
Does this require a CHANGELOG entry?



<!--Please delete paragraphs that you did not use before submitting.-->
