### PR TITLE
[processor/interval]Fix incorrect exponential histogram test

### DIFF
--- a/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/input.yaml
+++ b/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/input.yaml
@@ -16,7 +16,7 @@ resourceMetrics:
                 stringValue: bar
         metrics:
           - name: cumulative.exphistogram.test
-            histogram:
+            exponentialHistogram:
               aggregationTemporality: 2
               dataPoints:
                 - timeUnixNano: 50

--- a/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
+++ b/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
@@ -1,34 +1,34 @@
 resourceMetrics:
-  - resource:
+  - schemaUrl: https://test-res-schema.com/schema
+    resource:
       attributes:
         - key: asdf
           value:
             stringValue: foo
-    schemaUrl: https://test-res-schema.com/schema
     scopeMetrics:
-      - scope:
+      - schemaUrl: https://test-scope-schema.com/schema
+        scope:
+          name: MyTestInstrument
+          version: 1.2.3
           attributes:
             - key: foo
               value:
                 stringValue: bar
-          name: MyTestInstrument
-          version: 1.2.3
-        schemaUrl: https://test-scope-schema.com/schema
         metrics:
-          - exponentialHistogram:
+          - name: cumulative.exphistogram.test
+            exponentialHistogram:
               aggregationTemporality: 2
               dataPoints:
-                - attributes:
+                - timeUnixNano: 80
+                  scale: 4
+                  zeroCount: 5
+                  attributes:
                     - key: aaa
                       value:
                         stringValue: bbb
-                  negative:
-                    bucketCounts: [6, 21, 9, 19, 7]
-                    offset: 6
                   positive:
                     bucketCounts: [9, 12, 17, 8, 34]
                     offset: 2
-                  scale: 4
-                  timeUnixNano: 80
-                  zeroCount: 5
-            name: cumulative.exphistogram.test
+                  negative:
+                    bucketCounts: [6, 21, 9, 19, 7]
+                    offset: 6

--- a/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
+++ b/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
@@ -9,7 +9,7 @@ resourceMetrics:
       - schemaUrl: https://test-scope-schema.com/schema
         scope:
           name: MyTestInstrument
-          version: 1.2.3
+          version: "1.2.3"
           attributes:
             - key: foo
               value:
@@ -22,13 +22,13 @@ resourceMetrics:
                 - timeUnixNano: 80
                   scale: 4
                   zeroCount: 5
-                  attributes:
-                    - key: aaa
-                      value:
-                        stringValue: bbb
                   positive:
                     bucketCounts: [9, 12, 17, 8, 34]
                     offset: 2
                   negative:
                     bucketCounts: [6, 21, 9, 19, 7]
                     offset: 6
+                  attributes:
+                    - key: aaa
+                      value:
+                        stringValue: bbb

--- a/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
+++ b/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
@@ -23,20 +23,10 @@ resourceMetrics:
                       value:
                         stringValue: bbb
                   negative:
-                    bucketCounts:
-                      - 6
-                      - 21
-                      - 9
-                      - 19
-                      - 7
+                    bucketCounts: [6, 21, 9, 19, 7]
                     offset: 6
                   positive:
-                    bucketCounts:
-                      - 9
-                      - 12
-                      - 17
-                      - 8
-                      - 34
+                    bucketCounts: [9, 12, 17, 8, 34]
                     offset: 2
                   scale: 4
                   timeUnixNano: 80

--- a/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
+++ b/processor/intervalprocessor/testdata/exp_histograms_are_aggregated/output.yaml
@@ -1,34 +1,44 @@
 resourceMetrics:
-  - schemaUrl: https://test-res-schema.com/schema
-    resource:
+  - resource:
       attributes:
         - key: asdf
           value:
             stringValue: foo
+    schemaUrl: https://test-res-schema.com/schema
     scopeMetrics:
-      - schemaUrl: https://test-scope-schema.com/schema
-        scope:
-          name: MyTestInstrument
-          version: "1.2.3"
+      - scope:
           attributes:
             - key: foo
               value:
                 stringValue: bar
+          name: MyTestInstrument
+          version: 1.2.3
+        schemaUrl: https://test-scope-schema.com/schema
         metrics:
-          - name: cumulative.exphistogram.test
-            histogram:
+          - exponentialHistogram:
               aggregationTemporality: 2
               dataPoints:
-                - timeUnixNano: 80
-                  scale: 4
-                  zeroCount: 5
-                  positive:
-                    offset: 2
-                    bucketCounts: [9, 12, 17, 8, 34]
-                  negative:
-                    offset: 6
-                    bucketCounts: [6, 21, 9, 19, 7]
-                  attributes:
+                - attributes:
                     - key: aaa
                       value:
                         stringValue: bbb
+                  negative:
+                    bucketCounts:
+                      - 6
+                      - 21
+                      - 9
+                      - 19
+                      - 7
+                    offset: 6
+                  positive:
+                    bucketCounts:
+                      - 9
+                      - 12
+                      - 17
+                      - 8
+                      - 34
+                    offset: 2
+                  scale: 4
+                  timeUnixNano: 80
+                  zeroCount: 5
+            name: cumulative.exphistogram.test


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes the exponential histogram test to use exponential histogram as input rather than histogram.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Run the unit tests using `make test`
<!--Describe the documentation added.-->
#### Documentation
N/A
<!--Please delete paragraphs that you did not use before submitting.-->
