### PR TITLE
[extension/opamp] Add Opampextension content type

### DIFF
--- a/.chloggen/opampextension-content-type.yaml
+++ b/.chloggen/opampextension-content-type.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add content type to opamp extension when reporting EffectiveConfig
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Add EffectiveConfig.ConfigMap.ConfigMap[*].ContentType as "text/yaml" to the opamp extension when reporting EffectiveConfig.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/opampextension-content-type.yaml
+++ b/.chloggen/opampextension-content-type.yaml
@@ -10,7 +10,7 @@ component: opampextension
 note: Add content type to opamp extension when reporting EffectiveConfig
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [36327]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -344,7 +344,10 @@ func (o *opampAgent) composeEffectiveConfig() *protobufs.EffectiveConfig {
 	return &protobufs.EffectiveConfig{
 		ConfigMap: &protobufs.AgentConfigMap{
 			ConfigMap: map[string]*protobufs.AgentConfigFile{
-				"": {Body: conf},
+				"": {
+					Body:        conf,
+					ContentType: "text/yaml",
+				},
 			},
 		},
 	}

--- a/extension/opampextension/opamp_agent_test.go
+++ b/extension/opampextension/opamp_agent_test.go
@@ -188,6 +188,7 @@ func TestComposeEffectiveConfig(t *testing.T) {
 	ec = o.composeEffectiveConfig()
 	assert.NotNil(t, ec)
 	assert.YAMLEq(t, string(expected), string(ec.ConfigMap.ConfigMap[""].Body))
+	assert.Equal(t, "text/yaml", ec.ConfigMap.ConfigMap[""].ContentType)
 }
 
 func TestShutdown(t *testing.T) {


### PR DESCRIPTION
- from https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36157

#### Description
- [extension/opampextension] Add "text/yaml" toEffectiveConfig.ConfigMap.ConfigMap[*].ContentType:

ref. https://opentelemetry.io/docs/specs/opamp/#configuration
> content_type is an optional field. It is a MIME Content-Type that describes what’s contained in the body field, for example “text/yaml”. The content_type reported in the Effective Configuration in the Agent’s status report may be used for example by the Server to visualize the reported configuration nicely in a UI.

