### PR TITLE
[chore] Ignore datadog-api-client-go in renov updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -108,7 +108,8 @@
       }
     ],
     "ignoreDeps": [
-      "github.com/DataDog/datadog-agent/pkg/trace/exportable"
+      "github.com/DataDog/datadog-agent/pkg/trace/exportable",
+      "github.com/datadog/datadog-api-client-go/v2"
     ],
     "prConcurrentLimit": 200,
     "suppressNotifications": ["prEditedNotification"]


### PR DESCRIPTION
#### Description
There is breaking change in github.com/DataDog/datadog-api-client-go/v2 v2.32.0. This dependency should be removed soon, for now we skip auto-update and will do manual dependency bump when needed.