### PR TITLE
[chore]: enable whitespace linter for connector

### DIFF
--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -197,7 +197,6 @@ func (c *traceToMetricConnector) enrichStatsPayload(stats *pb.StatsPayload) {
 	for _, stat := range stats.Stats {
 		if stat.ContainerID != "" {
 			if tags, ok := c.containerTagCache.Get(stat.ContainerID); ok {
-
 				tagList := tags.(*sync.Map)
 				for _, tag := range stat.Tags {
 					tagList.Store(tag, struct{}{})

--- a/connector/exceptionsconnector/connector_metrics_test.go
+++ b/connector/exceptionsconnector/connector_metrics_test.go
@@ -108,7 +108,6 @@ func TestConnectorConsumeTraces(t *testing.T) {
 		assert.NotEmpty(t, metrics)
 		verifyBadMetricsOkay(t, metrics[len(metrics)-1])
 	})
-
 }
 
 func BenchmarkConnectorConsumeTraces(b *testing.B) {
@@ -205,7 +204,6 @@ func verifyConsumeMetricsInput(t testing.TB, input pmetric.Metrics, numCumulativ
 		assert.NotZero(t, exemplar.Timestamp())
 		assert.NotZero(t, exemplar.TraceID())
 		assert.NotZero(t, exemplar.SpanID())
-
 	}
 	return true
 }

--- a/connector/failoverconnector/failover_test.go
+++ b/connector/failoverconnector/failover_test.go
@@ -214,12 +214,10 @@ func TestFailoverRecovery_MaxRetries(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return consumeTracesAndCheckStable(failoverConnector, 1, tr)
 	}, 3*time.Second, 5*time.Millisecond)
-
 }
 
 func resetConsumers(conn *tracesFailover, consumers ...consumer.Traces) {
 	for i, sink := range consumers {
-
 		conn.failover.ModifyConsumerAtIndex(i, sink)
 	}
 	conn.failover.pS.TestSetStableIndex(0)

--- a/connector/failoverconnector/internal/state/pipeline_selector.go
+++ b/connector/failoverconnector/internal/state/pipeline_selector.go
@@ -87,7 +87,6 @@ func (p *PipelineSelector) setToNextPriorityPipeline(idx int) {
 
 // RetryHighPriorityPipelines responsible for single iteration through all higher priority pipelines
 func (p *PipelineSelector) retryHighPriorityPipelines(ctx context.Context, retryGap time.Duration) {
-
 	ticker := time.NewTicker(retryGap)
 
 	defer ticker.Stop()

--- a/connector/otlpjsonconnector/logs.go
+++ b/connector/otlpjsonconnector/logs.go
@@ -72,7 +72,6 @@ func (c *connectorLogs) ConsumeLogs(ctx context.Context, pl plog.Logs) error {
 					// If no regex matches, log the invalid payload
 					c.logger.Error("Invalid otlp payload")
 				}
-
 			}
 		}
 	}

--- a/connector/otlpjsonconnector/metrics.go
+++ b/connector/otlpjsonconnector/metrics.go
@@ -72,7 +72,6 @@ func (c *connectorMetrics) ConsumeLogs(ctx context.Context, pl plog.Logs) error 
 					// If no regex matches, log the invalid payload
 					c.logger.Error("Invalid otlp payload")
 				}
-
 			}
 		}
 	}

--- a/connector/routingconnector/internal/plogutiltest/logs_test.go
+++ b/connector/routingconnector/internal/plogutiltest/logs_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestNewLogs(t *testing.T) {
-
 	t.Run("empty", func(t *testing.T) {
 		expected := plog.NewLogs()
 		assert.NoError(t, plogtest.CompareLogs(expected, plogutiltest.NewLogs("", "", "")))

--- a/connector/routingconnector/internal/pmetricutiltest/metrics_test.go
+++ b/connector/routingconnector/internal/pmetricutiltest/metrics_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestNewMetrics(t *testing.T) {
-
 	t.Run("empty", func(t *testing.T) {
 		expected := pmetric.NewMetrics()
 		assert.NoError(t, pmetrictest.CompareMetrics(expected, pmetricutiltest.NewMetrics("", "", "", "")))

--- a/connector/routingconnector/internal/ptraceutiltest/traces_test.go
+++ b/connector/routingconnector/internal/ptraceutiltest/traces_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestNewTraces(t *testing.T) {
-
 	t.Run("empty", func(t *testing.T) {
 		expected := ptrace.NewTraces()
 		assert.NoError(t, ptracetest.CompareTraces(expected, ptraceutiltest.NewTraces("", "", "", "")))

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -140,7 +140,6 @@ func (c *metricsConnector) matchAllMetrics(ctx context.Context, md pmetric.Metri
 				noRoutesMatch = false
 				groupMetrics(groups, route.consumer, rmetrics)
 			}
-
 		}
 		if noRoutesMatch {
 			// no route conditions are matched, add resource metrics to default exporters group

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -139,7 +139,6 @@ func (c *tracesConnector) matchAllTraces(ctx context.Context, td ptrace.Traces) 
 				noRoutesMatch = false
 				groupTraces(groups, route.consumer, rspans)
 			}
-
 		}
 		if noRoutesMatch {
 			// no route conditions are matched, add resource spans to default pipelines group

--- a/connector/servicegraphconnector/config_test.go
+++ b/connector/servicegraphconnector/config_test.go
@@ -43,5 +43,4 @@ func TestLoadConfig(t *testing.T) {
 		},
 		cfg.Connectors[component.NewID(metadata.Type)],
 	)
-
 }

--- a/connector/servicegraphconnector/connector.go
+++ b/connector/servicegraphconnector/connector.go
@@ -581,7 +581,6 @@ func (p *serviceGraphConnector) collectServerLatencyMetrics(ilm pmetric.ScopeMet
 		timestamp := pcommon.NewTimestampFromTime(time.Now())
 
 		for key := range p.reqServerDurationSecondsCount {
-
 			dpDuration := mDuration.Histogram().DataPoints().AppendEmpty()
 			dpDuration.SetStartTimestamp(pcommon.NewTimestampFromTime(p.startTime))
 			dpDuration.SetTimestamp(timestamp)
@@ -652,7 +651,6 @@ func (p *serviceGraphConnector) cacheLoop(d time.Duration) {
 			return
 		}
 	}
-
 }
 
 // cleanCache removes series that have not been updated in 15 minutes

--- a/connector/spanmetricsconnector/connector.go
+++ b/connector/spanmetricsconnector/connector.go
@@ -358,7 +358,6 @@ func (p *connectorImp) resetState() {
 				}
 			}
 		})
-
 	}
 }
 
@@ -410,7 +409,6 @@ func (p *connectorImp) aggregateMetrics(traces ptrace.Traces) {
 					h := histograms.GetOrCreate(key, attributes)
 					p.addExemplar(span, duration, h)
 					h.Observe(duration)
-
 				}
 				// aggregate sums metrics
 				s := sums.GetOrCreate(key, attributes)

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -102,7 +102,6 @@ func verifyExemplarsExist(t testing.TB, input pmetric.Metrics) bool {
 
 		// Checking all metrics, naming notice: ismC/mC - C here is for Counter.
 		for ismC := 0; ismC < ism.Len(); ismC++ {
-
 			m := ism.At(ismC).Metrics()
 
 			for mC := 0; mC < m.Len(); mC++ {
@@ -1055,7 +1054,6 @@ func BenchmarkConnectorConsumeTraces(b *testing.B) {
 }
 
 func TestExcludeDimensionsConsumeTraces(t *testing.T) {
-
 	testcases := []struct {
 		dsc                string
 		featureGateEnabled bool
@@ -1109,7 +1107,6 @@ func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 									for attributeKey := range dp.At(dpi).Attributes().AsRaw() {
 										assert.NotContains(t, excludeDimensions, attributeKey)
 									}
-
 								}
 							}
 						case pmetric.MetricTypeEmpty, pmetric.MetricTypeGauge, pmetric.MetricTypeSum, pmetric.MetricTypeSummary:
@@ -1121,16 +1118,12 @@ func TestExcludeDimensionsConsumeTraces(t *testing.T) {
 									}
 								}
 							}
-
 						}
-
 					}
 				}
 			}
-
 		})
 	}
-
 }
 
 func TestConnectorConsumeTracesEvictedCacheKey(t *testing.T) {

--- a/connector/spanmetricsconnector/internal/metrics/metrics.go
+++ b/connector/spanmetricsconnector/internal/metrics/metrics.go
@@ -139,7 +139,6 @@ func (m *exponentialHistogramMetrics) GetOrCreate(key Key, attributes pcommon.Ma
 			maxExemplarCount: m.maxExemplarCount,
 		}
 		m.metrics[key] = h
-
 	}
 
 	return h


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
