### PR TITLE
[chore]: enable gofumpt linter for processor

### DIFF
--- a/processor/attributesprocessor/attributes_log_test.go
+++ b/processor/attributesprocessor/attributes_log_test.go
@@ -136,7 +136,7 @@ func TestAttributes_FilterLogs(t *testing.T) {
 	}
 	oCfg.Include = &filterconfig.MatchProperties{
 		Resources: []filterconfig.Attribute{{Key: "name", Value: "^[^i].*"}},
-		//Libraries: []filterconfig.InstrumentationLibrary{{Name: "^[^i].*"}},
+		// Libraries: []filterconfig.InstrumentationLibrary{{Name: "^[^i].*"}},
 		Config: *createConfig(filterset.Regexp),
 	}
 	oCfg.Exclude = &filterconfig.MatchProperties{

--- a/processor/attributesprocessor/attributes_metric_test.go
+++ b/processor/attributesprocessor/attributes_metric_test.go
@@ -347,6 +347,7 @@ func TestMetricAttributes_Hash(t *testing.T) {
 		runIndividualMetricTestCase(t, tc, mp)
 	}
 }
+
 func TestMetricAttributes_Convert(t *testing.T) {
 	testCases := []metricTestCase{
 		{

--- a/processor/cumulativetodeltaprocessor/internal/tracking/identity.go
+++ b/processor/cumulativetodeltaprocessor/internal/tracking/identity.go
@@ -25,9 +25,11 @@ type MetricIdentity struct {
 	MetricValueType        pmetric.NumberDataPointValueType
 }
 
-const A = int32('A')
-const SEP = byte(0x1E)
-const SEPSTR = string(SEP)
+const (
+	A      = int32('A')
+	SEP    = byte(0x1E)
+	SEPSTR = string(SEP)
+)
 
 func (mi *MetricIdentity) Write(b *bytes.Buffer) {
 	b.WriteRune(A + int32(mi.MetricType))

--- a/processor/deltatocumulativeprocessor/internal/data/expo_test.go
+++ b/processor/deltatocumulativeprocessor/internal/data/expo_test.go
@@ -20,7 +20,7 @@ const ø = math.MaxUint64
 func TestExpoAdd(t *testing.T) {
 	type expdp = expotest.Histogram
 	type bins = expotest.Bins
-	var obs0 = expotest.Observe0
+	obs0 := expotest.Observe0
 
 	cases := []struct {
 		name   string

--- a/processor/deltatocumulativeprocessor/internal/data/histo_test.go
+++ b/processor/deltatocumulativeprocessor/internal/data/histo_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestHistoAdd(t *testing.T) {
 	type histdp = histotest.Histogram
-	var obs = histotest.Bounds(histo.DefaultBounds).Observe
+	obs := histotest.Bounds(histo.DefaultBounds).Observe
 
 	cases := []struct {
 		name   string

--- a/processor/deltatocumulativeprocessor/internal/streams/data_test.go
+++ b/processor/deltatocumulativeprocessor/internal/streams/data_test.go
@@ -16,8 +16,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testdata/random"
 )
 
-var rdp data.Number
-var rid streams.Ident
+var (
+	rdp data.Number
+	rid streams.Ident
+)
 
 func BenchmarkSamples(b *testing.B) {
 	b.Run("iterfn", func(b *testing.B) {

--- a/processor/deltatocumulativeprocessor/linear.go
+++ b/processor/deltatocumulativeprocessor/linear.go
@@ -115,7 +115,6 @@ func (p *Linear) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {
 				// tracked stream: add incoming delta dp to existing cumulative aggregation
 				return acc, delta.AccumulateInto(acc, dp)
 			}()
-
 			// aggregation failed, record as metric and drop datapoint
 			if err != nil {
 				p.tel.Datapoints().Inc(ctx, telemetry.Cause(err))

--- a/processor/deltatorateprocessor/config.go
+++ b/processor/deltatorateprocessor/config.go
@@ -9,7 +9,6 @@ import (
 
 // Config defines the configuration for the processor.
 type Config struct {
-
 	// List of delta sum metrics to convert to rates
 	Metrics []string `mapstructure:"metrics"`
 }

--- a/processor/deltatorateprocessor/processor_test.go
+++ b/processor/deltatorateprocessor/processor_test.go
@@ -31,84 +31,82 @@ type deltaToRateTest struct {
 	outMetrics pmetric.Metrics
 }
 
-var (
-	testCases = []deltaToRateTest{
-		{
-			name:    "delta_to_rate_expect_same",
-			metrics: nil,
-			inMetrics: generateSumMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-				isDelta:      []bool{true, true},
-				deltaSecond:  120,
-			}),
-			outMetrics: generateSumMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-				isDelta:      []bool{true, true},
-				deltaSecond:  120,
-			}),
-		},
-		{
-			name:    "delta_to_rate_one_positive",
-			metrics: []string{"metric_1", "metric_2"},
-			inMetrics: generateSumMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{120, 240, 360}, {360}},
-				isDelta:      []bool{true, true},
-				deltaSecond:  120,
-			}),
-			outMetrics: generateGaugeMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{1, 2, 3}, {3}},
-			}),
-		},
-		{
-			name:    "delta_to_rate_with_cumulative",
-			metrics: []string{"metric_1", "metric_2"},
-			inMetrics: generateSumMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-				isDelta:      []bool{false, false},
-				deltaSecond:  120,
-			}),
-			outMetrics: generateSumMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-				isDelta:      []bool{false, false},
-				deltaSecond:  120,
-			}),
-		},
-		{
-			name:    "delta_to_rate_expect_zero",
-			metrics: []string{"metric_1", "metric_2"},
-			inMetrics: generateSumMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{120, 240, 360}, {360}},
-				isDelta:      []bool{true, true},
-				deltaSecond:  0,
-			}),
-			outMetrics: generateGaugeMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{0, 0, 0}, {0}},
-			}),
-		},
-		{
-			name:    "int64-delta_to_rate_one_positive",
-			metrics: []string{"metric_1", "metric_2"},
-			inMetrics: generateSumMetrics(testMetric{
-				metricNames:     []string{"metric_1", "metric_2"},
-				metricIntValues: [][]int64{{120, 240, 360}, {360}},
-				isDelta:         []bool{true, true},
-				deltaSecond:     120,
-			}),
-			outMetrics: generateGaugeMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{1, 2, 3}, {3}},
-			}),
-		},
-	}
-)
+var testCases = []deltaToRateTest{
+	{
+		name:    "delta_to_rate_expect_same",
+		metrics: nil,
+		inMetrics: generateSumMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+			isDelta:      []bool{true, true},
+			deltaSecond:  120,
+		}),
+		outMetrics: generateSumMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+			isDelta:      []bool{true, true},
+			deltaSecond:  120,
+		}),
+	},
+	{
+		name:    "delta_to_rate_one_positive",
+		metrics: []string{"metric_1", "metric_2"},
+		inMetrics: generateSumMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{120, 240, 360}, {360}},
+			isDelta:      []bool{true, true},
+			deltaSecond:  120,
+		}),
+		outMetrics: generateGaugeMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{1, 2, 3}, {3}},
+		}),
+	},
+	{
+		name:    "delta_to_rate_with_cumulative",
+		metrics: []string{"metric_1", "metric_2"},
+		inMetrics: generateSumMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+			isDelta:      []bool{false, false},
+			deltaSecond:  120,
+		}),
+		outMetrics: generateSumMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+			isDelta:      []bool{false, false},
+			deltaSecond:  120,
+		}),
+	},
+	{
+		name:    "delta_to_rate_expect_zero",
+		metrics: []string{"metric_1", "metric_2"},
+		inMetrics: generateSumMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{120, 240, 360}, {360}},
+			isDelta:      []bool{true, true},
+			deltaSecond:  0,
+		}),
+		outMetrics: generateGaugeMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{0, 0, 0}, {0}},
+		}),
+	},
+	{
+		name:    "int64-delta_to_rate_one_positive",
+		metrics: []string{"metric_1", "metric_2"},
+		inMetrics: generateSumMetrics(testMetric{
+			metricNames:     []string{"metric_1", "metric_2"},
+			metricIntValues: [][]int64{{120, 240, 360}, {360}},
+			isDelta:         []bool{true, true},
+			deltaSecond:     120,
+		}),
+		outMetrics: generateGaugeMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{1, 2, 3}, {3}},
+		}),
+	},
+}
 
 func TestCumulativeToDeltaProcessor(t *testing.T) {
 	for _, test := range testCases {

--- a/processor/filterprocessor/expr_test.go
+++ b/processor/filterprocessor/expr_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter/filterconfig"
 )
 
-const filteredMetric = "p0_metric_1"
-const filteredAttrKey = "pt-label-key-1"
+const (
+	filteredMetric  = "p0_metric_1"
+	filteredAttrKey = "pt-label-key-1"
+)
 
 var filteredAttrVal = pcommon.NewValueStr("pt-label-val-1")
 

--- a/processor/groupbyattrsprocessor/config.go
+++ b/processor/groupbyattrsprocessor/config.go
@@ -5,7 +5,6 @@ package groupbyattrsprocessor // import "github.com/open-telemetry/opentelemetry
 
 // Config is the configuration for the processor.
 type Config struct {
-
 	// GroupByKeys describes the attribute names that are going to be used for grouping.
 	// Empty value is allowed, since processor in such case can compact data
 	GroupByKeys []string `mapstructure:"keys"`

--- a/processor/groupbyattrsprocessor/factory.go
+++ b/processor/groupbyattrsprocessor/factory.go
@@ -15,9 +15,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/groupbyattrsprocessor/internal/metadata"
 )
 
-var (
-	consumerCapabilities = consumer.Capabilities{MutatesData: true}
-)
+var consumerCapabilities = consumer.Capabilities{MutatesData: true}
 
 // NewFactory returns a new factory for the Filter processor.
 func NewFactory() processor.Factory {
@@ -64,7 +62,8 @@ func createTracesProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Traces) (processor.Traces, error) {
+	nextConsumer consumer.Traces,
+) (processor.Traces, error) {
 	oCfg := cfg.(*Config)
 	gap, err := createGroupByAttrsProcessor(set, oCfg.GroupByKeys)
 	if err != nil {
@@ -85,7 +84,8 @@ func createLogsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Logs) (processor.Logs, error) {
+	nextConsumer consumer.Logs,
+) (processor.Logs, error) {
 	oCfg := cfg.(*Config)
 	gap, err := createGroupByAttrsProcessor(set, oCfg.GroupByKeys)
 	if err != nil {
@@ -106,7 +106,8 @@ func createMetricsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Metrics) (processor.Metrics, error) {
+	nextConsumer consumer.Metrics,
+) (processor.Metrics, error) {
 	oCfg := cfg.(*Config)
 	gap, err := createGroupByAttrsProcessor(set, oCfg.GroupByKeys)
 	if err != nil {

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -22,9 +22,7 @@ import (
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
 
-var (
-	attrMap = prepareAttributeMap()
-)
+var attrMap = prepareAttributeMap()
 
 func prepareAttributeMap() pcommon.Map {
 	am := pcommon.NewMap()

--- a/processor/groupbytraceprocessor/config.go
+++ b/processor/groupbytraceprocessor/config.go
@@ -9,7 +9,6 @@ import (
 
 // Config is the configuration for the processor.
 type Config struct {
-
 	// NumTraces is the max number of traces to keep in memory waiting for the duration.
 	// Default: 1_000_000.
 	NumTraces int `mapstructure:"num_traces"`

--- a/processor/groupbytraceprocessor/event.go
+++ b/processor/groupbytraceprocessor/event.go
@@ -48,11 +48,13 @@ var (
 	}
 )
 
-type eventType int
-type event struct {
-	typ     eventType
-	payload any
-}
+type (
+	eventType int
+	event     struct {
+		typ     eventType
+		payload any
+	}
+)
 
 type tracesWithID struct {
 	id pcommon.TraceID

--- a/processor/groupbytraceprocessor/factory.go
+++ b/processor/groupbytraceprocessor/factory.go
@@ -54,7 +54,8 @@ func createTracesProcessor(
 	_ context.Context,
 	params processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Traces) (processor.Traces, error) {
+	nextConsumer consumer.Traces,
+) (processor.Traces, error) {
 	oCfg := cfg.(*Config)
 
 	var st storage

--- a/processor/groupbytraceprocessor/processor_test.go
+++ b/processor/groupbytraceprocessor/processor_test.go
@@ -599,12 +599,15 @@ func (m *mockProcessor) ConsumeTraces(ctx context.Context, td ptrace.Traces) err
 	}
 	return nil
 }
+
 func (m *mockProcessor) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: true}
 }
+
 func (m *mockProcessor) Shutdown(context.Context) error {
 	return nil
 }
+
 func (m *mockProcessor) Start(_ context.Context, _ component.Host) error {
 	return nil
 }
@@ -625,24 +628,28 @@ func (st *mockStorage) createOrAppend(traceID pcommon.TraceID, trace ptrace.Trac
 	}
 	return nil
 }
+
 func (st *mockStorage) get(traceID pcommon.TraceID) ([]ptrace.ResourceSpans, error) {
 	if st.onGet != nil {
 		return st.onGet(traceID)
 	}
 	return nil, nil
 }
+
 func (st *mockStorage) delete(traceID pcommon.TraceID) ([]ptrace.ResourceSpans, error) {
 	if st.onDelete != nil {
 		return st.onDelete(traceID)
 	}
 	return nil, nil
 }
+
 func (st *mockStorage) start() error {
 	if st.onStart != nil {
 		return st.onStart()
 	}
 	return nil
 }
+
 func (st *mockStorage) shutdown() error {
 	if st.onShutdown != nil {
 		return st.onShutdown()
@@ -659,6 +666,7 @@ var _ consumer.Traces = (*blockingConsumer)(nil)
 func (b *blockingConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{MutatesData: false}
 }
+
 func (b *blockingConsumer) ConsumeTraces(context.Context, ptrace.Traces) error {
 	<-b.blockCh
 	return nil

--- a/processor/groupbytraceprocessor/storage_memory.go
+++ b/processor/groupbytraceprocessor/storage_memory.go
@@ -49,6 +49,7 @@ func (st *memoryStorage) createOrAppend(traceID pcommon.TraceID, td ptrace.Trace
 
 	return nil
 }
+
 func (st *memoryStorage) get(traceID pcommon.TraceID) ([]ptrace.ResourceSpans, error) {
 	st.RLock()
 	rss, ok := st.content[traceID]

--- a/processor/intervalprocessor/config.go
+++ b/processor/intervalprocessor/config.go
@@ -10,9 +10,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-var (
-	ErrInvalidIntervalValue = errors.New("invalid interval value")
-)
+var ErrInvalidIntervalValue = errors.New("invalid interval value")
 
 var _ component.Config = (*Config)(nil)
 

--- a/processor/k8sattributesprocessor/e2e_test.go
+++ b/processor/k8sattributesprocessor/e2e_test.go
@@ -62,7 +62,6 @@ func newExpectedValue(mode int, value string) *expectedValue {
 //	make docker-otelcontribcol
 //	KUBECONFIG=/tmp/kube-config-otelcol-e2e-testing kind load docker-image otelcontribcol:latest
 func TestE2E_ClusterRBAC(t *testing.T) {
-
 	testDir := filepath.Join("testdata", "e2e", "clusterrbac")
 
 	k8sClient, err := k8stest.NewK8sClient(testKubeConfig)
@@ -543,7 +542,6 @@ func TestE2E_ClusterRBAC(t *testing.T) {
 
 // Test with `filter::namespace` set and only role binding to collector's SA. We can't get node and namespace labels/annotations.
 func TestE2E_NamespacedRBAC(t *testing.T) {
-
 	testDir := filepath.Join("testdata", "e2e", "namespacedrbac")
 
 	k8sClient, err := k8stest.NewK8sClient(testKubeConfig)
@@ -716,7 +714,6 @@ func TestE2E_NamespacedRBAC(t *testing.T) {
 // Test with `filter::namespace` set, role binding for namespace-scoped objects (pod, replicaset) and clusterrole
 // binding for node and namespace objects.
 func TestE2E_MixRBAC(t *testing.T) {
-
 	testDir := filepath.Join("testdata", "e2e", "mixrbac")
 
 	k8sClient, err := k8stest.NewK8sClient(testKubeConfig)
@@ -1089,7 +1086,8 @@ func TestE2E_NamespacedRBACNoPodIP(t *testing.T) {
 }
 
 func scanTracesForAttributes(t *testing.T, ts *consumertest.TracesSink, expectedService string,
-	kvs map[string]*expectedValue) {
+	kvs map[string]*expectedValue,
+) {
 	// Iterate over the received set of traces starting from the most recent entries due to a bug in the processor:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892
 	// TODO: Remove the reverse loop once it's fixed. All the metrics should be properly annotated.
@@ -1110,7 +1108,8 @@ func scanTracesForAttributes(t *testing.T, ts *consumertest.TracesSink, expected
 }
 
 func scanMetricsForAttributes(t *testing.T, ms *consumertest.MetricsSink, expectedService string,
-	kvs map[string]*expectedValue) {
+	kvs map[string]*expectedValue,
+) {
 	// Iterate over the received set of metrics starting from the most recent entries due to a bug in the processor:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892
 	// TODO: Remove the reverse loop once it's fixed. All the metrics should be properly annotated.
@@ -1131,7 +1130,8 @@ func scanMetricsForAttributes(t *testing.T, ms *consumertest.MetricsSink, expect
 }
 
 func scanLogsForAttributes(t *testing.T, ls *consumertest.LogsSink, expectedService string,
-	kvs map[string]*expectedValue) {
+	kvs map[string]*expectedValue,
+) {
 	// Iterate over the received set of logs starting from the most recent entries due to a bug in the processor:
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/18892
 	// TODO: Remove the reverse loop once it's fixed. All the metrics should be properly annotated.
@@ -1152,8 +1152,8 @@ func scanLogsForAttributes(t *testing.T, ls *consumertest.LogsSink, expectedServ
 }
 
 func scanProfilesForAttributes(t *testing.T, ps *consumertest.ProfilesSink, expectedService string,
-	kvs map[string]*expectedValue) {
-
+	kvs map[string]*expectedValue,
+) {
 	// `telemetrygen` doesn't support profiles
 	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36127
 	// TODO: Remove `t.Skip()` once #36127 is resolved
@@ -1207,7 +1207,6 @@ func resourceHasAttributes(resource pcommon.Resource, kvs map[string]*expectedVa
 				case shouldnotexist:
 					shouldNotFoundAttrs[k] = true
 				}
-
 			}
 			return true
 		},

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -19,9 +19,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/metadata"
 )
 
-var kubeClientProvider = kube.ClientProvider(nil)
-var consumerCapabilities = consumer.Capabilities{MutatesData: true}
-var defaultExcludes = ExcludeConfig{Pods: []ExcludePodConfig{{Name: "jaeger-agent"}, {Name: "jaeger-collector"}}}
+var (
+	kubeClientProvider   = kube.ClientProvider(nil)
+	consumerCapabilities = consumer.Capabilities{MutatesData: true}
+	defaultExcludes      = ExcludeConfig{Pods: []ExcludePodConfig{{Name: "jaeger-agent"}, {Name: "jaeger-collector"}}}
+)
 
 // NewFactory returns a new factory for the k8s processor.
 func NewFactory() processor.Factory {
@@ -167,7 +169,8 @@ func createKubernetesProcessor(
 	cfg component.Config,
 	options ...option,
 ) *kubernetesprocessor {
-	kp := &kubernetesprocessor{logger: params.Logger,
+	kp := &kubernetesprocessor{
+		logger:            params.Logger,
 		cfg:               cfg,
 		options:           options,
 		telemetrySettings: params.TelemetrySettings,

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -717,178 +717,197 @@ func TestExtractionRules(t *testing.T) {
 		name       string
 		rules      ExtractionRules
 		attributes map[string]string
-	}{{
-		name:       "no-rules",
-		rules:      ExtractionRules{},
-		attributes: nil,
-	}, {
-		name: "deployment",
-		rules: ExtractionRules{
-			DeploymentName: true,
-			DeploymentUID:  true,
+	}{
+		{
+			name:       "no-rules",
+			rules:      ExtractionRules{},
+			attributes: nil,
 		},
-		attributes: map[string]string{
-			"k8s.deployment.name": "auth-service",
-			"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
-		},
-	}, {
-		name: "replicasetId",
-		rules: ExtractionRules{
-			ReplicaSetID: true,
-		},
-		attributes: map[string]string{
-			"k8s.replicaset.uid": "207ea729-c779-401d-8347-008ecbc137e3",
-		},
-	}, {
-		name: "replicasetName",
-		rules: ExtractionRules{
-			ReplicaSetName: true,
-		},
-		attributes: map[string]string{
-			"k8s.replicaset.name": "auth-service-66f5996c7c",
-		},
-	}, {
-		name: "daemonsetUID",
-		rules: ExtractionRules{
-			DaemonSetUID: true,
-		},
-		attributes: map[string]string{
-			"k8s.daemonset.uid": "c94d3814-2253-427a-ab13-2cf609e4dafa",
-		},
-	}, {
-		name: "daemonsetName",
-		rules: ExtractionRules{
-			DaemonSetName: true,
-		},
-		attributes: map[string]string{
-			"k8s.daemonset.name": "auth-daemonset",
-		},
-	}, {
-		name: "jobUID",
-		rules: ExtractionRules{
-			JobUID: true,
-		},
-		attributes: map[string]string{
-			"k8s.job.uid": "59f27ac1-5c71-42e5-abe9-2c499d603706",
-		},
-	}, {
-		name: "jobName",
-		rules: ExtractionRules{
-			JobName: true,
-		},
-		attributes: map[string]string{
-			"k8s.job.name": "auth-cronjob-27667920",
-		},
-	}, {
-		name: "cronJob",
-		rules: ExtractionRules{
-			CronJobName: true,
-		},
-		attributes: map[string]string{
-			"k8s.cronjob.name": "auth-cronjob",
-		},
-	}, {
-		name: "statefulsetUID",
-		rules: ExtractionRules{
-			StatefulSetUID: true,
-		},
-		attributes: map[string]string{
-			"k8s.statefulset.uid": "03755eb1-6175-47d5-afd5-05cfc30244d7",
-		},
-	}, {
-		name: "jobName",
-		rules: ExtractionRules{
-			StatefulSetName: true,
-		},
-		attributes: map[string]string{
-			"k8s.statefulset.name": "pi-statefulset",
-		},
-	}, {
-		name: "metadata",
-		rules: ExtractionRules{
-			DeploymentName: true,
-			DeploymentUID:  true,
-			Namespace:      true,
-			PodName:        true,
-			PodUID:         true,
-			PodHostName:    true,
-			PodIP:          true,
-			Node:           true,
-			StartTime:      true,
-		},
-		attributes: map[string]string{
-			"k8s.deployment.name": "auth-service",
-			"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
-			"k8s.namespace.name":  "ns1",
-			"k8s.node.name":       "node1",
-			"k8s.pod.name":        "auth-service-abc12-xyz3",
-			"k8s.pod.hostname":    "host1",
-			"k8s.pod.uid":         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
-			"k8s.pod.ip":          "1.1.1.1",
-			"k8s.pod.start_time": func() string {
-				b, err := pod.GetCreationTimestamp().MarshalText()
-				require.NoError(t, err)
-				return string(b)
-			}(),
-		},
-	}, {
-		name: "labels",
-		rules: ExtractionRules{
-			Annotations: []FieldExtractionRule{{
-				Name: "a1",
-				Key:  "annotation1",
-				From: MetadataFromPod,
+		{
+			name: "deployment",
+			rules: ExtractionRules{
+				DeploymentName: true,
+				DeploymentUID:  true,
 			},
-			},
-			Labels: []FieldExtractionRule{{
-				Name: "l1",
-				Key:  "label1",
-				From: MetadataFromPod,
-			}, {
-				Name:  "l2",
-				Key:   "label2",
-				Regex: regexp.MustCompile(`k5=(?P<value>[^\s]+)`),
-				From:  MetadataFromPod,
-			},
+			attributes: map[string]string{
+				"k8s.deployment.name": "auth-service",
+				"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
 			},
 		},
-		attributes: map[string]string{
-			"l1": "lv1",
-			"l2": "v5",
-			"a1": "av1",
-		},
-	}, {
-		// By default if the From field is not set for labels and annotations we want to extract them from pod
-		name: "labels-annotations-default-pod",
-		rules: ExtractionRules{
-			Annotations: []FieldExtractionRule{{
-				Name: "a1",
-				Key:  "annotation1",
+		{
+			name: "replicasetId",
+			rules: ExtractionRules{
+				ReplicaSetID: true,
 			},
-			},
-			Labels: []FieldExtractionRule{{
-				Name: "l1",
-				Key:  "label1",
-			}, {
-				Name:  "l2",
-				Key:   "label2",
-				Regex: regexp.MustCompile(`k5=(?P<value>[^\s]+)`),
-			},
+			attributes: map[string]string{
+				"k8s.replicaset.uid": "207ea729-c779-401d-8347-008ecbc137e3",
 			},
 		},
-		attributes: map[string]string{
-			"l1": "lv1",
-			"l2": "v5",
-			"a1": "av1",
+		{
+			name: "replicasetName",
+			rules: ExtractionRules{
+				ReplicaSetName: true,
+			},
+			attributes: map[string]string{
+				"k8s.replicaset.name": "auth-service-66f5996c7c",
+			},
 		},
-	},
+		{
+			name: "daemonsetUID",
+			rules: ExtractionRules{
+				DaemonSetUID: true,
+			},
+			attributes: map[string]string{
+				"k8s.daemonset.uid": "c94d3814-2253-427a-ab13-2cf609e4dafa",
+			},
+		},
+		{
+			name: "daemonsetName",
+			rules: ExtractionRules{
+				DaemonSetName: true,
+			},
+			attributes: map[string]string{
+				"k8s.daemonset.name": "auth-daemonset",
+			},
+		},
+		{
+			name: "jobUID",
+			rules: ExtractionRules{
+				JobUID: true,
+			},
+			attributes: map[string]string{
+				"k8s.job.uid": "59f27ac1-5c71-42e5-abe9-2c499d603706",
+			},
+		},
+		{
+			name: "jobName",
+			rules: ExtractionRules{
+				JobName: true,
+			},
+			attributes: map[string]string{
+				"k8s.job.name": "auth-cronjob-27667920",
+			},
+		},
+		{
+			name: "cronJob",
+			rules: ExtractionRules{
+				CronJobName: true,
+			},
+			attributes: map[string]string{
+				"k8s.cronjob.name": "auth-cronjob",
+			},
+		},
+		{
+			name: "statefulsetUID",
+			rules: ExtractionRules{
+				StatefulSetUID: true,
+			},
+			attributes: map[string]string{
+				"k8s.statefulset.uid": "03755eb1-6175-47d5-afd5-05cfc30244d7",
+			},
+		},
+		{
+			name: "jobName",
+			rules: ExtractionRules{
+				StatefulSetName: true,
+			},
+			attributes: map[string]string{
+				"k8s.statefulset.name": "pi-statefulset",
+			},
+		},
+		{
+			name: "metadata",
+			rules: ExtractionRules{
+				DeploymentName: true,
+				DeploymentUID:  true,
+				Namespace:      true,
+				PodName:        true,
+				PodUID:         true,
+				PodHostName:    true,
+				PodIP:          true,
+				Node:           true,
+				StartTime:      true,
+			},
+			attributes: map[string]string{
+				"k8s.deployment.name": "auth-service",
+				"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
+				"k8s.namespace.name":  "ns1",
+				"k8s.node.name":       "node1",
+				"k8s.pod.name":        "auth-service-abc12-xyz3",
+				"k8s.pod.hostname":    "host1",
+				"k8s.pod.uid":         "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+				"k8s.pod.ip":          "1.1.1.1",
+				"k8s.pod.start_time": func() string {
+					b, err := pod.GetCreationTimestamp().MarshalText()
+					require.NoError(t, err)
+					return string(b)
+				}(),
+			},
+		},
+		{
+			name: "labels",
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "a1",
+						Key:  "annotation1",
+						From: MetadataFromPod,
+					},
+				},
+				Labels: []FieldExtractionRule{
+					{
+						Name: "l1",
+						Key:  "label1",
+						From: MetadataFromPod,
+					}, {
+						Name:  "l2",
+						Key:   "label2",
+						Regex: regexp.MustCompile(`k5=(?P<value>[^\s]+)`),
+						From:  MetadataFromPod,
+					},
+				},
+			},
+			attributes: map[string]string{
+				"l1": "lv1",
+				"l2": "v5",
+				"a1": "av1",
+			},
+		},
+		{
+			// By default if the From field is not set for labels and annotations we want to extract them from pod
+			name: "labels-annotations-default-pod",
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "a1",
+						Key:  "annotation1",
+					},
+				},
+				Labels: []FieldExtractionRule{
+					{
+						Name: "l1",
+						Key:  "label1",
+					}, {
+						Name:  "l2",
+						Key:   "label2",
+						Regex: regexp.MustCompile(`k5=(?P<value>[^\s]+)`),
+					},
+				},
+			},
+			attributes: map[string]string{
+				"l1": "lv1",
+				"l2": "v5",
+				"a1": "av1",
+			},
+		},
 		{
 			name: "all-labels",
 			rules: ExtractionRules{
-				Labels: []FieldExtractionRule{{
-					KeyRegex: regexp.MustCompile("^(?:la.*)$"),
-					From:     MetadataFromPod,
-				},
+				Labels: []FieldExtractionRule{
+					{
+						KeyRegex: regexp.MustCompile("^(?:la.*)$"),
+						From:     MetadataFromPod,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -899,10 +918,11 @@ func TestExtractionRules(t *testing.T) {
 		{
 			name: "all-annotations",
 			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{{
-					KeyRegex: regexp.MustCompile("^(?:an.*)$"),
-					From:     MetadataFromPod,
-				},
+				Annotations: []FieldExtractionRule{
+					{
+						KeyRegex: regexp.MustCompile("^(?:an.*)$"),
+						From:     MetadataFromPod,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -912,10 +932,11 @@ func TestExtractionRules(t *testing.T) {
 		{
 			name: "all-annotations-not-match",
 			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{{
-					KeyRegex: regexp.MustCompile("^(?:an*)$"),
-					From:     MetadataFromPod,
-				},
+				Annotations: []FieldExtractionRule{
+					{
+						KeyRegex: regexp.MustCompile("^(?:an*)$"),
+						From:     MetadataFromPod,
+					},
 				},
 			},
 			attributes: map[string]string{},
@@ -923,12 +944,13 @@ func TestExtractionRules(t *testing.T) {
 		{
 			name: "captured-groups",
 			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{{
-					Name:                 "$1",
-					KeyRegex:             regexp.MustCompile(`^(?:annotation(\d+))$`),
-					HasKeyRegexReference: true,
-					From:                 MetadataFromPod,
-				},
+				Annotations: []FieldExtractionRule{
+					{
+						Name:                 "$1",
+						KeyRegex:             regexp.MustCompile(`^(?:annotation(\d+))$`),
+						HasKeyRegexReference: true,
+						From:                 MetadataFromPod,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -938,12 +960,13 @@ func TestExtractionRules(t *testing.T) {
 		{
 			name: "captured-groups-$0",
 			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{{
-					Name:                 "prefix-$0",
-					KeyRegex:             regexp.MustCompile(`^(?:annotation(\d+))$`),
-					HasKeyRegexReference: true,
-					From:                 MetadataFromPod,
-				},
+				Annotations: []FieldExtractionRule{
+					{
+						Name:                 "prefix-$0",
+						KeyRegex:             regexp.MustCompile(`^(?:annotation(\d+))$`),
+						HasKeyRegexReference: true,
+						From:                 MetadataFromPod,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -1024,86 +1047,87 @@ func TestReplicaSetExtractionRules(t *testing.T) {
 		rules           ExtractionRules
 		ownerReferences []meta_v1.OwnerReference
 		attributes      map[string]string
-	}{{
-		name:       "no-rules",
-		rules:      ExtractionRules{},
-		attributes: nil,
-	}, {
-		name: "one_deployment_is_controller",
-		ownerReferences: []meta_v1.OwnerReference{
-			{
-				Name:       "auth-service",
-				Kind:       "Deployment",
-				UID:        "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
-				Controller: &isController,
+	}{
+		{
+			name:       "no-rules",
+			rules:      ExtractionRules{},
+			attributes: nil,
+		}, {
+			name: "one_deployment_is_controller",
+			ownerReferences: []meta_v1.OwnerReference{
+				{
+					Name:       "auth-service",
+					Kind:       "Deployment",
+					UID:        "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
+					Controller: &isController,
+				},
+			},
+			rules: ExtractionRules{
+				DeploymentName: true,
+				DeploymentUID:  true,
+				ReplicaSetID:   true,
+			},
+			attributes: map[string]string{
+				"k8s.replicaset.uid":  "207ea729-c779-401d-8347-008ecbc137e3",
+				"k8s.deployment.name": "auth-service",
+				"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
+			},
+		}, {
+			name: "one_deployment_is_controller_another_deployment_is_not_controller",
+			ownerReferences: []meta_v1.OwnerReference{
+				{
+					Name:       "auth-service",
+					Kind:       "Deployment",
+					UID:        "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
+					Controller: &isController,
+				},
+				{
+					Name:       "auth-service-not-controller",
+					Kind:       "Deployment",
+					UID:        "kkkk-gggg-hhhh-iiii-eeeeeeeeeeee",
+					Controller: &isNotController,
+				},
+			},
+			rules: ExtractionRules{
+				ReplicaSetID:   true,
+				DeploymentName: true,
+				DeploymentUID:  true,
+			},
+			attributes: map[string]string{
+				"k8s.replicaset.uid":  "207ea729-c779-401d-8347-008ecbc137e3",
+				"k8s.deployment.name": "auth-service",
+				"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
+			},
+		}, {
+			name: "one_deployment_is_not_controller",
+			ownerReferences: []meta_v1.OwnerReference{
+				{
+					Name:       "auth-service",
+					Kind:       "Deployment",
+					UID:        "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
+					Controller: &isNotController,
+				},
+			},
+			rules: ExtractionRules{
+				ReplicaSetID:   true,
+				DeploymentName: true,
+				DeploymentUID:  true,
+			},
+			attributes: map[string]string{
+				"k8s.replicaset.uid": "207ea729-c779-401d-8347-008ecbc137e3",
+			},
+		}, {
+			name:            "no_deployment",
+			ownerReferences: []meta_v1.OwnerReference{},
+			rules: ExtractionRules{
+				ReplicaSetID:   true,
+				DeploymentName: true,
+				DeploymentUID:  true,
+			},
+			attributes: map[string]string{
+				"k8s.replicaset.uid": "207ea729-c779-401d-8347-008ecbc137e3",
 			},
 		},
-		rules: ExtractionRules{
-			DeploymentName: true,
-			DeploymentUID:  true,
-			ReplicaSetID:   true,
-		},
-		attributes: map[string]string{
-			"k8s.replicaset.uid":  "207ea729-c779-401d-8347-008ecbc137e3",
-			"k8s.deployment.name": "auth-service",
-			"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
-		},
-	}, {
-		name: "one_deployment_is_controller_another_deployment_is_not_controller",
-		ownerReferences: []meta_v1.OwnerReference{
-			{
-				Name:       "auth-service",
-				Kind:       "Deployment",
-				UID:        "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
-				Controller: &isController,
-			},
-			{
-				Name:       "auth-service-not-controller",
-				Kind:       "Deployment",
-				UID:        "kkkk-gggg-hhhh-iiii-eeeeeeeeeeee",
-				Controller: &isNotController,
-			},
-		},
-		rules: ExtractionRules{
-			ReplicaSetID:   true,
-			DeploymentName: true,
-			DeploymentUID:  true,
-		},
-		attributes: map[string]string{
-			"k8s.replicaset.uid":  "207ea729-c779-401d-8347-008ecbc137e3",
-			"k8s.deployment.name": "auth-service",
-			"k8s.deployment.uid":  "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
-		},
-	}, {
-		name: "one_deployment_is_not_controller",
-		ownerReferences: []meta_v1.OwnerReference{
-			{
-				Name:       "auth-service",
-				Kind:       "Deployment",
-				UID:        "ffff-gggg-hhhh-iiii-eeeeeeeeeeee",
-				Controller: &isNotController,
-			},
-		},
-		rules: ExtractionRules{
-			ReplicaSetID:   true,
-			DeploymentName: true,
-			DeploymentUID:  true,
-		},
-		attributes: map[string]string{
-			"k8s.replicaset.uid": "207ea729-c779-401d-8347-008ecbc137e3",
-		},
-	}, {
-		name:            "no_deployment",
-		ownerReferences: []meta_v1.OwnerReference{},
-		rules: ExtractionRules{
-			ReplicaSetID:   true,
-			DeploymentName: true,
-			DeploymentUID:  true,
-		},
-		attributes: map[string]string{
-			"k8s.replicaset.uid": "207ea729-c779-401d-8347-008ecbc137e3",
-		},
-	},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1150,38 +1174,43 @@ func TestNamespaceExtractionRules(t *testing.T) {
 		name       string
 		rules      ExtractionRules
 		attributes map[string]string
-	}{{
-		name:       "no-rules",
-		rules:      ExtractionRules{},
-		attributes: nil,
-	}, {
-		name: "labels",
-		rules: ExtractionRules{
-			Annotations: []FieldExtractionRule{{
-				Name: "a1",
-				Key:  "annotation1",
-				From: MetadataFromNamespace,
+	}{
+		{
+			name:       "no-rules",
+			rules:      ExtractionRules{},
+			attributes: nil,
+		},
+		{
+			name: "labels",
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "a1",
+						Key:  "annotation1",
+						From: MetadataFromNamespace,
+					},
+				},
+				Labels: []FieldExtractionRule{
+					{
+						Name: "l1",
+						Key:  "label1",
+						From: MetadataFromNamespace,
+					},
+				},
 			},
-			},
-			Labels: []FieldExtractionRule{{
-				Name: "l1",
-				Key:  "label1",
-				From: MetadataFromNamespace,
-			},
+			attributes: map[string]string{
+				"l1": "lv1",
+				"a1": "av1",
 			},
 		},
-		attributes: map[string]string{
-			"l1": "lv1",
-			"a1": "av1",
-		},
-	},
 		{
 			name: "all-labels",
 			rules: ExtractionRules{
-				Labels: []FieldExtractionRule{{
-					KeyRegex: regexp.MustCompile("^(?:la.*)$"),
-					From:     MetadataFromNamespace,
-				},
+				Labels: []FieldExtractionRule{
+					{
+						KeyRegex: regexp.MustCompile("^(?:la.*)$"),
+						From:     MetadataFromNamespace,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -1191,10 +1220,11 @@ func TestNamespaceExtractionRules(t *testing.T) {
 		{
 			name: "all-annotations",
 			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{{
-					KeyRegex: regexp.MustCompile("^(?:an.*)$"),
-					From:     MetadataFromNamespace,
-				},
+				Annotations: []FieldExtractionRule{
+					{
+						KeyRegex: regexp.MustCompile("^(?:an.*)$"),
+						From:     MetadataFromNamespace,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -1240,38 +1270,43 @@ func TestNodeExtractionRules(t *testing.T) {
 		name       string
 		rules      ExtractionRules
 		attributes map[string]string
-	}{{
-		name:       "no-rules",
-		rules:      ExtractionRules{},
-		attributes: nil,
-	}, {
-		name: "labels",
-		rules: ExtractionRules{
-			Annotations: []FieldExtractionRule{{
-				Name: "a1",
-				Key:  "annotation1",
-				From: MetadataFromNode,
+	}{
+		{
+			name:       "no-rules",
+			rules:      ExtractionRules{},
+			attributes: nil,
+		},
+		{
+			name: "labels",
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "a1",
+						Key:  "annotation1",
+						From: MetadataFromNode,
+					},
+				},
+				Labels: []FieldExtractionRule{
+					{
+						Name: "l1",
+						Key:  "label1",
+						From: MetadataFromNode,
+					},
+				},
 			},
-			},
-			Labels: []FieldExtractionRule{{
-				Name: "l1",
-				Key:  "label1",
-				From: MetadataFromNode,
-			},
+			attributes: map[string]string{
+				"l1": "lv1",
+				"a1": "av1",
 			},
 		},
-		attributes: map[string]string{
-			"l1": "lv1",
-			"a1": "av1",
-		},
-	},
 		{
 			name: "all-labels",
 			rules: ExtractionRules{
-				Labels: []FieldExtractionRule{{
-					KeyRegex: regexp.MustCompile("^(?:la.*)$"),
-					From:     MetadataFromNode,
-				},
+				Labels: []FieldExtractionRule{
+					{
+						KeyRegex: regexp.MustCompile("^(?:la.*)$"),
+						From:     MetadataFromNode,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -1281,10 +1316,11 @@ func TestNodeExtractionRules(t *testing.T) {
 		{
 			name: "all-annotations",
 			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{{
-					KeyRegex: regexp.MustCompile("^(?:an.*)$"),
-					From:     MetadataFromNode,
-				},
+				Annotations: []FieldExtractionRule{
+					{
+						KeyRegex: regexp.MustCompile("^(?:an.*)$"),
+						From:     MetadataFromNode,
+					},
 				},
 			},
 			attributes: map[string]string{
@@ -1315,51 +1351,52 @@ func TestFilters(t *testing.T) {
 		filters Filters
 		labels  string
 		fields  string
-	}{{
-		name:    "no-filters",
-		filters: Filters{},
-	}, {
-		name: "namespace",
-		filters: Filters{
-			Namespace: "default",
-		},
-	}, {
-		name: "node",
-		filters: Filters{
-			Node: "ec2-test",
-		},
-		fields: "spec.nodeName=ec2-test",
-	}, {
-		name: "labels-and-fields",
-		filters: Filters{
-			Labels: []FieldFilter{
-				{
-					Key:   "k1",
-					Value: "v1",
-					Op:    selection.Equals,
+	}{
+		{
+			name:    "no-filters",
+			filters: Filters{},
+		}, {
+			name: "namespace",
+			filters: Filters{
+				Namespace: "default",
+			},
+		}, {
+			name: "node",
+			filters: Filters{
+				Node: "ec2-test",
+			},
+			fields: "spec.nodeName=ec2-test",
+		}, {
+			name: "labels-and-fields",
+			filters: Filters{
+				Labels: []FieldFilter{
+					{
+						Key:   "k1",
+						Value: "v1",
+						Op:    selection.Equals,
+					},
+					{
+						Key:   "k2",
+						Value: "v2",
+						Op:    selection.NotEquals,
+					},
 				},
-				{
-					Key:   "k2",
-					Value: "v2",
-					Op:    selection.NotEquals,
+				Fields: []FieldFilter{
+					{
+						Key:   "k1",
+						Value: "v1",
+						Op:    selection.Equals,
+					},
+					{
+						Key:   "k2",
+						Value: "v2",
+						Op:    selection.NotEquals,
+					},
 				},
 			},
-			Fields: []FieldFilter{
-				{
-					Key:   "k1",
-					Value: "v1",
-					Op:    selection.Equals,
-				},
-				{
-					Key:   "k2",
-					Value: "v2",
-					Op:    selection.NotEquals,
-				},
-			},
+			labels: "k1=v1,k2!=v2",
+			fields: "k1=v1,k2!=v2",
 		},
-		labels: "k1=v1,k2!=v2",
-		fields: "k1=v1,k2!=v2",
-	},
 	}
 
 	for _, tc := range testCases {
@@ -1377,81 +1414,82 @@ func TestPodIgnorePatterns(t *testing.T) {
 	testCases := []struct {
 		ignore bool
 		pod    *api_v1.Pod
-	}{{
-		ignore: false,
-		pod:    &api_v1.Pod{},
-	}, {
-		ignore: false,
-		pod: &api_v1.Pod{
-			Spec: api_v1.PodSpec{
-				HostNetwork: true,
+	}{
+		{
+			ignore: false,
+			pod:    &api_v1.Pod{},
+		}, {
+			ignore: false,
+			pod: &api_v1.Pod{
+				Spec: api_v1.PodSpec{
+					HostNetwork: true,
+				},
 			},
-		},
-	}, {
-		ignore: true,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "True ",
+		}, {
+			ignore: true,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "True ",
+					},
+				},
+			},
+		}, {
+			ignore: true,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "true",
+					},
+				},
+			},
+		}, {
+			ignore: false,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "false",
+					},
+				},
+			},
+		}, {
+			ignore: false,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Annotations: map[string]string{
+						"opentelemetry.io/k8s-processor/ignore": "",
+					},
+				},
+			},
+		}, {
+			ignore: true,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "jaeger-agent",
+				},
+			},
+		}, {
+			ignore: true,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "jaeger-collector",
+				},
+			},
+		}, {
+			ignore: true,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "jaeger-agent-b2zdv",
+				},
+			},
+		}, {
+			ignore: false,
+			pod: &api_v1.Pod{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: "test-pod-name",
 				},
 			},
 		},
-	}, {
-		ignore: true,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "true",
-				},
-			},
-		},
-	}, {
-		ignore: false,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "false",
-				},
-			},
-		},
-	}, {
-		ignore: false,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Annotations: map[string]string{
-					"opentelemetry.io/k8s-processor/ignore": "",
-				},
-			},
-		},
-	}, {
-		ignore: true,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "jaeger-agent",
-			},
-		},
-	}, {
-		ignore: true,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "jaeger-collector",
-			},
-		},
-	}, {
-		ignore: true,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "jaeger-agent-b2zdv",
-			},
-		},
-	}, {
-		ignore: false,
-		pod: &api_v1.Pod{
-			ObjectMeta: meta_v1.ObjectMeta{
-				Name: "test-pod-name",
-			},
-		},
-	},
 	}
 
 	c, _ := newTestClient(t)
@@ -1800,50 +1838,55 @@ func TestExtractNamespaceLabelsAnnotations(t *testing.T) {
 		name                   string
 		shouldExtractNamespace bool
 		rules                  ExtractionRules
-	}{{
-		name:                   "empty-rules",
-		shouldExtractNamespace: false,
-		rules:                  ExtractionRules{},
-	}, {
-		name:                   "pod-rules",
-		shouldExtractNamespace: false,
-		rules: ExtractionRules{
-			Annotations: []FieldExtractionRule{{
-				Name: "a1",
-				Key:  "annotation1",
-				From: MetadataFromPod,
+	}{
+		{
+			name:                   "empty-rules",
+			shouldExtractNamespace: false,
+			rules:                  ExtractionRules{},
+		}, {
+			name:                   "pod-rules",
+			shouldExtractNamespace: false,
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "a1",
+						Key:  "annotation1",
+						From: MetadataFromPod,
+					},
+				},
+				Labels: []FieldExtractionRule{
+					{
+						Name: "l1",
+						Key:  "label1",
+						From: MetadataFromPod,
+					},
+				},
 			},
+		}, {
+			name:                   "namespace-rules-only-annotations",
+			shouldExtractNamespace: true,
+			rules: ExtractionRules{
+				Annotations: []FieldExtractionRule{
+					{
+						Name: "a1",
+						Key:  "annotation1",
+						From: MetadataFromNamespace,
+					},
+				},
 			},
-			Labels: []FieldExtractionRule{{
-				Name: "l1",
-				Key:  "label1",
-				From: MetadataFromPod,
-			},
+		}, {
+			name:                   "namespace-rules-only-labels",
+			shouldExtractNamespace: true,
+			rules: ExtractionRules{
+				Labels: []FieldExtractionRule{
+					{
+						Name: "l1",
+						Key:  "label1",
+						From: MetadataFromNamespace,
+					},
+				},
 			},
 		},
-	}, {
-		name:                   "namespace-rules-only-annotations",
-		shouldExtractNamespace: true,
-		rules: ExtractionRules{
-			Annotations: []FieldExtractionRule{{
-				Name: "a1",
-				Key:  "annotation1",
-				From: MetadataFromNamespace,
-			},
-			},
-		},
-	}, {
-		name:                   "namespace-rules-only-labels",
-		shouldExtractNamespace: true,
-		rules: ExtractionRules{
-			Labels: []FieldExtractionRule{{
-				Name: "l1",
-				Key:  "label1",
-				From: MetadataFromNamespace,
-			},
-			},
-		},
-	},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/processor/k8sattributesprocessor/internal/kube/fake_informer.go
+++ b/processor/k8sattributesprocessor/internal/kube/fake_informer.go
@@ -163,6 +163,7 @@ func NewNoOpInformer(
 func (f *NoOpInformer) AddEventHandler(handler cache.ResourceEventHandler) (cache.ResourceEventHandlerRegistration, error) {
 	return f.AddEventHandlerWithResyncPeriod(handler, time.Second)
 }
+
 func (f *NoOpInformer) AddEventHandlerWithResyncPeriod(_ cache.ResourceEventHandler, _ time.Duration) (cache.ResourceEventHandlerRegistration, error) {
 	return nil, nil
 }
@@ -193,9 +194,11 @@ func (c *NoOpController) Run(stopCh <-chan struct{}) {
 		c.hasStopped = true
 	}()
 }
+
 func (c *NoOpController) IsStopped() bool {
 	return c.hasStopped
 }
+
 func (c *NoOpController) HasSynced() bool {
 	return true
 }

--- a/processor/logdedupprocessor/factory_test.go
+++ b/processor/logdedupprocessor/factory_test.go
@@ -23,7 +23,7 @@ func TestNewProcessorFactory(t *testing.T) {
 }
 
 func TestCreateLogs(t *testing.T) {
-	var testCases = []struct {
+	testCases := []struct {
 		name        string
 		cfg         component.Config
 		expectedErr string

--- a/processor/logstransformprocessor/factory.go
+++ b/processor/logstransformprocessor/factory.go
@@ -37,7 +37,8 @@ func createLogsProcessor(
 	_ context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Logs) (processor.Logs, error) {
+	nextConsumer consumer.Logs,
+) (processor.Logs, error) {
 	pCfg, ok := cfg.(*Config)
 	if !ok {
 		return nil, errors.New("could not initialize logs transform processor")

--- a/processor/logstransformprocessor/processor_test.go
+++ b/processor/logstransformprocessor/processor_test.go
@@ -25,30 +25,28 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/operator/parser/regex"
 )
 
-var (
-	cfg = &Config{
-		BaseConfig: adapter.BaseConfig{
-			Operators: []operator.Config{
-				{
-					Builder: func() *regex.Config {
-						cfg := regex.NewConfig()
-						cfg.Regex = "^(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$"
-						sevField := entry.NewAttributeField("sev")
-						sevCfg := helper.NewSeverityConfig()
-						sevCfg.ParseFrom = &sevField
-						cfg.SeverityConfig = &sevCfg
-						timeField := entry.NewAttributeField("time")
-						timeCfg := helper.NewTimeParser()
-						timeCfg.Layout = "%Y-%m-%d %H:%M:%S"
-						timeCfg.ParseFrom = &timeField
-						cfg.TimeParser = &timeCfg
-						return cfg
-					}(),
-				},
+var cfg = &Config{
+	BaseConfig: adapter.BaseConfig{
+		Operators: []operator.Config{
+			{
+				Builder: func() *regex.Config {
+					cfg := regex.NewConfig()
+					cfg.Regex = "^(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$"
+					sevField := entry.NewAttributeField("sev")
+					sevCfg := helper.NewSeverityConfig()
+					sevCfg.ParseFrom = &sevField
+					cfg.SeverityConfig = &sevCfg
+					timeField := entry.NewAttributeField("time")
+					timeCfg := helper.NewTimeParser()
+					timeCfg.Layout = "%Y-%m-%d %H:%M:%S"
+					timeCfg.ParseFrom = &timeField
+					cfg.TimeParser = &timeCfg
+					return cfg
+				}(),
 			},
 		},
-	}
-)
+	},
+}
 
 func parseTime(format, input string) *time.Time {
 	val, _ := time.ParseInLocation(format, input, time.Local)

--- a/processor/metricsgenerationprocessor/config.go
+++ b/processor/metricsgenerationprocessor/config.go
@@ -30,7 +30,6 @@ const (
 
 // Config defines the configuration for the processor.
 type Config struct {
-
 	// Set of rules for generating new metrics
 	Rules []Rule `mapstructure:"rules"`
 }

--- a/processor/metricsgenerationprocessor/processor_test.go
+++ b/processor/metricsgenerationprocessor/processor_test.go
@@ -40,237 +40,235 @@ type metricsGenerationTest struct {
 	outMetrics pmetric.Metrics
 }
 
-var (
-	testCases = []metricsGenerationTest{
-		{
-			name:  "metrics_generation_expect_all",
-			rules: nil,
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-		},
-		{
-			name: "metrics_generation_rule_scale",
-			rules: []Rule{
-				{
-					Name:      "metric_1_scaled",
-					Type:      "scale",
-					Metric1:   "metric_1",
-					Operation: "multiply",
-					ScaleBy:   5,
-				},
+var testCases = []metricsGenerationTest{
+	{
+		name:  "metrics_generation_expect_all",
+		rules: nil,
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_scale",
+		rules: []Rule{
+			{
+				Name:      "metric_1_scaled",
+				Type:      "scale",
+				Metric1:   "metric_1",
+				Operation: "multiply",
+				ScaleBy:   5,
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2", "metric_1_scaled"},
-				metricValues: [][]float64{{100}, {4}, {500}},
-			}),
 		},
-		{
-			name: "metrics_generation_missing_first_metric",
-			rules: []Rule{
-				{
-					Name:      "metric_1_scaled",
-					Type:      "scale",
-					Operation: "multiply",
-					ScaleBy:   5,
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2", "metric_1_scaled"},
+			metricValues: [][]float64{{100}, {4}, {500}},
+		}),
+	},
+	{
+		name: "metrics_generation_missing_first_metric",
+		rules: []Rule{
+			{
+				Name:      "metric_1_scaled",
+				Type:      "scale",
+				Operation: "multiply",
+				ScaleBy:   5,
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_divide",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_divide",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "divide",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_divide",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_divide",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "divide",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_divide"},
-				metricValues: [][]float64{{100}, {4}, {25}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_multiply",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_multiply",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "multiply",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_divide"},
+			metricValues: [][]float64{{100}, {4}, {25}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_multiply",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_multiply",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "multiply",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_multiply"},
-				metricValues: [][]float64{{100}, {4}, {400}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_add",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_add",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "add",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_multiply"},
+			metricValues: [][]float64{{100}, {4}, {400}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_add",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_add",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "add",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_add"},
-				metricValues: [][]float64{{100}, {4}, {104}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_subtract",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_subtract",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "subtract",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_add"},
+			metricValues: [][]float64{{100}, {4}, {104}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_subtract",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_subtract",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "subtract",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_subtract"},
-				metricValues: [][]float64{{100}, {4}, {96}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_percent",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_percent",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "percent",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_subtract"},
+			metricValues: [][]float64{{100}, {4}, {96}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_percent",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_percent",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "percent",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{20}, {200}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_percent"},
-				metricValues: [][]float64{{20}, {200}, {10}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_missing_2nd_metric",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_multiply",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Operation: "multiply",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{20}, {200}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2", "metric_1_calculated_percent"},
+			metricValues: [][]float64{{20}, {200}, {10}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_missing_2nd_metric",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_multiply",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Operation: "multiply",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {4}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_divide_op2_zero",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_divide",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "divide",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {4}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_divide_op2_zero",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_divide",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "divide",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {0}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {0}},
-			}),
 		},
-		{
-			name: "metrics_generation_rule_calculate_invalid_operation",
-			rules: []Rule{
-				{
-					Name:      "metric_1_calculated_invalid",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "invalid",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {0}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {0}},
+		}),
+	},
+	{
+		name: "metrics_generation_rule_calculate_invalid_operation",
+		rules: []Rule{
+			{
+				Name:      "metric_1_calculated_invalid",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "invalid",
 			},
-			inMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {0}},
-			}),
-			outMetrics: generateTestMetrics(testMetric{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]float64{{100}, {0}},
-			}),
 		},
-		{
-			name: "metrics_generation_test_int_gauge_add",
-			rules: []Rule{
-				{
-					Name:      "metric_calculated",
-					Type:      "calculate",
-					Metric1:   "metric_1",
-					Metric2:   "metric_2",
-					Operation: "add",
-				},
+		inMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {0}},
+		}),
+		outMetrics: generateTestMetrics(testMetric{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]float64{{100}, {0}},
+		}),
+	},
+	{
+		name: "metrics_generation_test_int_gauge_add",
+		rules: []Rule{
+			{
+				Name:      "metric_calculated",
+				Type:      "calculate",
+				Metric1:   "metric_1",
+				Metric2:   "metric_2",
+				Operation: "add",
 			},
-			inMetrics: generateTestMetricsWithIntDatapoint(testMetricIntGauge{
-				metricNames:  []string{"metric_1", "metric_2"},
-				metricValues: [][]int64{{100}, {5}},
-			}),
-			outMetrics: getOutputForIntGaugeTest(),
 		},
-	}
-)
+		inMetrics: generateTestMetricsWithIntDatapoint(testMetricIntGauge{
+			metricNames:  []string{"metric_1", "metric_2"},
+			metricValues: [][]int64{{100}, {5}},
+		}),
+		outMetrics: getOutputForIntGaugeTest(),
+	},
+}
 
 func TestMetricsGenerationProcessor(t *testing.T) {
 	for _, test := range testCases {

--- a/processor/metricstransformprocessor/config.go
+++ b/processor/metricstransformprocessor/config.go
@@ -42,14 +42,12 @@ const (
 
 // Config defines configuration for Resource processor.
 type Config struct {
-
 	// transform specifies a list of transforms on metrics with each transform focusing on one metric.
 	Transforms []transform `mapstructure:"transforms"`
 }
 
 // transform defines the transformation applied to the specific metric
 type transform struct {
-
 	// --- SPECIFY WHICH METRIC(S) TO MATCH ---
 
 	// MetricIncludeFilter is used to select the metric(s) to operate on.

--- a/processor/metricstransformprocessor/metrics_testcase_builder_test.go
+++ b/processor/metricstransformprocessor/metrics_testcase_builder_test.go
@@ -85,7 +85,8 @@ func (b builder) addNumberDatapoint(start, ts pcommon.Timestamp, attrValues []st
 }
 
 func (b builder) addHistogramDatapoint(start, ts pcommon.Timestamp, count uint64, sum float64, bounds []float64,
-	buckets []uint64, attrValues ...string) builder {
+	buckets []uint64, attrValues ...string,
+) builder {
 	if b.metric.Type() != pmetric.MetricTypeHistogram {
 		panic(b.metric.Type().String())
 	}
@@ -101,7 +102,8 @@ func (b builder) addHistogramDatapoint(start, ts pcommon.Timestamp, count uint64
 }
 
 func (b builder) addHistogramDatapointWithMinMaxAndExemplars(start, ts pcommon.Timestamp, count uint64, sum, min, max float64,
-	bounds []float64, buckets []uint64, exemplarValues []float64, attrValues ...string) builder {
+	bounds []float64, buckets []uint64, exemplarValues []float64, attrValues ...string,
+) builder {
 	if b.metric.Type() != pmetric.MetricTypeHistogram {
 		panic(b.metric.Type().String())
 	}

--- a/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_group_test.go
@@ -25,35 +25,33 @@ type metricsGroupingTest struct {
 	transforms []internalTransform
 }
 
-var (
-	groupingTests = []metricsGroupingTest{
-		{
-			name: "metric_group_by_strict_name",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "foo/metric"},
-					Action:              Group,
-					GroupResourceLabels: map[string]string{"resource.type": "foo"},
-				},
+var groupingTests = []metricsGroupingTest{
+	{
+		name: "metric_group_by_strict_name",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "foo/metric"},
+				Action:              Group,
+				GroupResourceLabels: map[string]string{"resource.type": "foo"},
 			},
 		},
-		{
-			name: "metric_group_regex_multiple_empty_resource",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^container.(.*)$")},
-					Action:              Group,
-					GroupResourceLabels: map[string]string{"resource.type": "container"},
-				},
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^k8s.pod.(.*)$")},
-					Action:              Group,
-					GroupResourceLabels: map[string]string{"resource.type": "k8s.pod"},
-				},
+	},
+	{
+		name: "metric_group_regex_multiple_empty_resource",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^container.(.*)$")},
+				Action:              Group,
+				GroupResourceLabels: map[string]string{"resource.type": "container"},
+			},
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^k8s.pod.(.*)$")},
+				Action:              Group,
+				GroupResourceLabels: map[string]string{"resource.type": "k8s.pod"},
 			},
 		},
-	}
-)
+	},
+}
 
 func TestMetricsGrouping(t *testing.T) {
 	for _, useOTLP := range []bool{false, true} {

--- a/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
+++ b/processor/metricstransformprocessor/metrics_transform_processor_testcases_test.go
@@ -18,2015 +18,2049 @@ type metricsTransformTest struct {
 	out        []pmetric.Metric
 }
 
-var (
-	// test cases
-	standardTests = []metricsTransformTest{
-		// UPDATE
-		{
-			name: "metric_name_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					NewName:             "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
+// test cases
+var standardTests = []metricsTransformTest{
+	// UPDATE
+	{
+		name: "metric_name_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				NewName:             "new/metric1",
 			},
 		},
-		{
-			name: "metric_name_update_chained",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					NewName:             "new/metric1",
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					NewName:             "new/metric2",
-				},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
+		},
+	},
+	{
+		name: "metric_name_update_chained",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				NewName:             "new/metric1",
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric2").build(),
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				NewName:             "new/metric2",
 			},
 		},
-		{
-			name: "metric_names_update_chained",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[12])$")},
-					Action:              Update,
-					NewName:             "new/$1/$namedsubmatch",
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "new/metric/1"},
-					Action:              Update,
-					NewName:             "new/new/metric1",
-				},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric2").build(),
+		},
+	},
+	{
+		name: "metric_names_update_chained",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[12])$")},
+				Action:              Update,
+				NewName:             "new/$1/$namedsubmatch",
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "new/new/metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric/2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").build(),
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "new/metric/1"},
+				Action:              Update,
+				NewName:             "new/new/metric1",
 			},
 		},
-		{
-			name: "metric_name_update_nonexist",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "nonexist"},
-					Action:              Update,
-					NewName:             "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "new/new/metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric/2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").build(),
+		},
+	},
+	{
+		name: "metric_name_update_nonexist",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "nonexist"},
+				Action:              Update,
+				NewName:             "new/metric1",
 			},
 		},
-		{
-			name: "metric_label_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   updateLabel,
-								Label:    "label1",
-								NewLabel: "new/label1",
-							},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+		},
+	},
+	{
+		name: "metric_label_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   updateLabel,
+							Label:    "label1",
+							NewLabel: "new/label1",
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "value1").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "new/label1").
-					addIntDatapoint(1, 2, 3, "value1").build(),
-			},
 		},
-		{
-			name: "metric_label_value_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: updateLabel,
-								Label:  "label1",
-							},
-							valueActionsMapping: map[string]string{
-								"label1-value1": "new/label1-value1",
-							},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "value1").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "new/label1").
+				addIntDatapoint(1, 2, 3, "value1").build(),
+		},
+	},
+	{
+		name: "metric_label_value_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: updateLabel,
+							Label:  "label1",
+						},
+						valueActionsMapping: map[string]string{
+							"label1-value1": "new/label1-value1",
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "label1-value1").
-					addIntDatapoint(1, 2, 3, "label1-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "new/label1-value1").
-					addIntDatapoint(1, 2, 3, "label1-value2").build(),
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "label1-value1").
+				addIntDatapoint(1, 2, 3, "label1-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "new/label1-value1").
+				addIntDatapoint(1, 2, 3, "label1-value2").build(),
+		},
+	},
+	{
+		name: "metric_label_update_label_and_label_value",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   updateLabel,
+							Label:    "label1",
+							NewLabel: "new/label1",
+						},
+						valueActionsMapping: map[string]string{"label1-value1": "new/label1-value1"},
+					},
+				},
 			},
 		},
-		{
-			name: "metric_label_update_label_and_label_value",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   updateLabel,
-								Label:    "label1",
-								NewLabel: "new/label1",
-							},
-							valueActionsMapping: map[string]string{"label1-value1": "new/label1-value1"},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "label1-value1").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "new/label1").
+				addIntDatapoint(1, 2, 3, "new/label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_update_with_regexp_filter",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^matched.*$")},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: updateLabel,
+							Label:  "label1",
+						},
+						valueActionsMapping: map[string]string{"label1-value1": "new/label1-value1"},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "matched-metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "unmatched-metric2", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "matched-metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "new/label1-value1", "label2-value1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "unmatched-metric2", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_sum_int_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").addDescription("foobar").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 4, "label1-value1").addDescription("foobar").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_mean_int_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Mean,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 2, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_max_int_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Max,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value2").
+				addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_count_int_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Count,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 4, "label1-value1", "label2-value2").
+				addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_median_int_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Median,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 4, "label1-value1", "label2-value2").
+				addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 2, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_min_int_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Min,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value2").
+				addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 1, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_sum_double_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 4, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_mean_double_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Mean,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addDoubleDatapoint(1, 2, 2, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_max_double_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Max,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addDoubleDatapoint(1, 2, 3, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_count_double_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Count,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addDoubleDatapoint(1, 2, 2, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_median_double_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Median,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addDoubleDatapoint(1, 2, 2, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_min_double_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Min,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addDoubleDatapoint(2, 2, 3, "label1-value2", "label2-value2").
+				addDoubleDatapoint(0, 2, 4, "label1-value0", "label2-value0").
+				addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value1").
+				addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addDoubleDatapoint(2, 2, 3, "label1-value2").
+				addDoubleDatapoint(0, 2, 4, "label1-value0").
+				addDoubleDatapoint(1, 2, 1, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_insert_sum_with_several_attrs_match",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric1",
+					attrMatchers: map[string]StringMatcher{"label0": strictMatcher("label0-value1")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1", "label2"},
+						},
+						labelSetMap: map[string]bool{"label1": true, "label2": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label0", "label1", "label2", "label3").
+				addDoubleDatapoint(1, 2, 3, "label0-value1", "label1-value1", "label2-value1", "label3-value1").
+				addDoubleDatapoint(1, 2, 1, "label0-value1", "label1-value1", "label2-value1", "label3-value2").
+				addDoubleDatapoint(1, 2, 1, "label0-value2", "label1-value1", "label2-value1", "label3-value1").
+				build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label0", "label1", "label2", "label3").
+				addDoubleDatapoint(1, 2, 3, "label0-value1", "label1-value1", "label2-value1", "label3-value1").
+				addDoubleDatapoint(1, 2, 1, "label0-value1", "label1-value1", "label2-value1", "label3-value2").
+				addDoubleDatapoint(1, 2, 1, "label0-value2", "label1-value1", "label2-value1", "label3-value1").
+				build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
+				addDoubleDatapoint(1, 2, 4, "label1-value1", "label2-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_values_aggregation_sum_int_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabelValues,
+							NewValue:        "new/label2-value",
+							AggregationType: aggregateutil.Sum,
+							Label:           "label2",
+						},
+						aggregatedValuesSet: map[string]bool{"label2-value1": true, "label2-value2": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(0, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(0, 2, 1, "label1-value1", "label2-value2").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value3").
+				addIntDatapoint(2, 2, 4, "label1-value1", "label2-value4").
+				build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(0, 2, 4, "label1-value1", "new/label2-value").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value3").
+				addIntDatapoint(2, 2, 4, "label1-value1", "label2-value4").
+				build(),
+		},
+	},
+	// this test case also tests the correctness of the SumOfSquaredDeviation merging
+	{
+		name: "metric_label_values_aggregation_sum_distribution_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
+				addHistogramDatapoint(0, 1, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}, "label1-value1",
+					"label2-value1"). // pointGroup1: {1, 2, 3}, SumOfSquaredDeviation = 2
+				addHistogramDatapoint(0, 1, 5, 10, []float64{1, 2, 3}, []uint64{0, 2, 1, 2}, "label1-value1",
+					"label2-value2"). // pointGroup2: {1, 2, 3, 3, 1}, SumOfSquaredDeviation = 4
+				addHistogramDatapoint(1, 1, 7, 14, []float64{1, 2, 3}, []uint64{0, 3, 1, 3}, "label1-value1",
+					"label2-value3"). // pointGroup3: {1, 1, 2, 3, 3, 1, 3}, SumOfSquaredDeviation = 6
+				build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
+				addHistogramDatapoint(0, 1, 15, 30, []float64{1, 2, 3}, []uint64{0, 6, 3, 6},
+					"label1-value1"). // pointGroupCombined: {1, 2, 3, 1, 2, 3, 3, 1, 1, 1, 2, 3, 3, 1, 3}, SumOfSquaredDeviation = 12
+				build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_empty_label_set",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{},
+						},
+						labelSetMap: map[string]bool{},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2", "label3").
+				addIntDatapoint(0, 1, 1, "a", "b", "c").
+				build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").
+				addIntDatapoint(0, 1, 1).
+				build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_ignored_for_partial_metric_match",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric1",
+					attrMatchers: map[string]StringMatcher{"label1": strictMatcher("label1-value1")},
+				},
+				Action: Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(0, 2, 1, "label1-value2", "label2-value2").
+				build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(0, 2, 1, "label1-value2", "label2-value2").
+				build(),
+		},
+	},
+	{
+		name: "metric_label_values_aggregation_not_sum_distribution_update",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Mean,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
+				addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}, "label1-value1",
+					"label2-value1").
+				build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
+				addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}, "label1-value1").
+				build(),
+		},
+	},
+	// INSERT
+	{
+		name: "metric_name_insert",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Insert,
+				NewName:             "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_multiple",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Insert,
+				NewName:             "new/metric1",
+			},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Insert,
+				NewName:             "new/metric2",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_strict",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric1",
+					attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 3, 2, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 3, 2, "value1", "value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
+				addIntDatapoint(1, 3, 2, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include:      regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile(`(.|\s)*\S(.|\s)*`)},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp_two_datapoints_positive",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include:      regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value3")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").
+				addIntDatapoint(2, 2, 3, "value3", "value4").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").
+				addIntDatapoint(2, 2, 3, "value3", "value4").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
+				addIntDatapoint(2, 2, 3, "value3", "value4").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp_two_datapoints_negative",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include:      regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value3")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").
+				addIntDatapoint(2, 2, 3, "value11", "value22").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").
+				addIntDatapoint(2, 2, 3, "value11", "value22").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp_with_full_value",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include:      regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value1")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_strict_negative",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric1",
+					attrMatchers: map[string]StringMatcher{"label1": strictMatcher("wrong_value")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp_negative",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include:      regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile(".*wrong_ending")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_strict_missing_key",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric1",
+					attrMatchers: map[string]StringMatcher{"missing_key": strictMatcher("value1")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp_missing_key",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include:      regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{"missing_key": regexp.MustCompile("value1")},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp_missing_and_present_key",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include: regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{
+						"label1":      regexp.MustCompile("value1"),
+						"missing_key": regexp.MustCompile("value2"),
+					},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_name_insert_with_match_label_regexp_missing_key_with_empty_expression",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include: regexp.MustCompile("metric1"),
+					attrMatchers: map[string]StringMatcher{
+						"label1":      regexp.MustCompile("value1"),
+						"missing_key": regexp.MustCompile("^$"),
+					},
+				},
+				Action:  Insert,
+				NewName: "new/metric1",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_label_update_with_metric_insert",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Insert,
+				NewName:             "new/metric1",
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   updateLabel,
+							Label:    "label1",
+							NewLabel: "new/label1",
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "label1-value1").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "new/label1").
-					addIntDatapoint(1, 2, 3, "new/label1-value1").build(),
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "new/label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "metric_label_value_update_with_metric_insert",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Insert,
+				NewName:             "new/metric1",
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: updateLabel,
+							Label:  "label1",
+						},
+						valueActionsMapping: map[string]string{"label1-value1": "new/label1-value1"},
+					},
+				},
 			},
 		},
-		{
-			name: "metric_label_update_with_regexp_filter",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^matched.*$")},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: updateLabel,
-								Label:  "label1",
-							},
-							valueActionsMapping: map[string]string{"label1-value1": "new/label1-value1"},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "label1-value1").
+				addIntDatapoint(1, 2, 4, "label1-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 3, "label1-value1").
+				addIntDatapoint(1, 2, 4, "label1-value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1").
+				addIntDatapoint(1, 2, 3, "new/label1-value1").
+				addIntDatapoint(1, 2, 4, "label1-value2").build(),
+		},
+	},
+	{
+		name: "metric_label_aggregation_sum_int_insert",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Insert,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
+				addIntDatapoint(1, 2, 4, "label1-value1").build(),
+		},
+	},
+	{
+		name: "metric_label_values_aggregation_sum_int_insert",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Insert,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabelValues,
+							NewValue:        "new/label2-value",
+							AggregationType: aggregateutil.Sum,
+							Label:           "label2",
+						},
+						aggregatedValuesSet: map[string]bool{"label2-value1": true, "label2-value2": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
+				addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 4, "label1-value1", "new/label2-value").build(),
+		},
+	},
+	{
+		name: "metric_labels_aggregation_sum_distribution_insert",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Insert,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"label1"},
+						},
+						labelSetMap: map[string]bool{"label1": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
+				addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2}, []uint64{0, 1, 2}, "label1-value1",
+					"label2-value1").
+				addHistogramDatapoint(1, 2, 5, 10, []float64{1, 2}, []uint64{1, 1, 3}, "label1-value1",
+					"label2-value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
+				addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2}, []uint64{0, 1, 2}, "label1-value1",
+					"label2-value1").
+				addHistogramDatapoint(1, 2, 5, 10, []float64{1, 2}, []uint64{1, 1, 3}, "label1-value1",
+					"label2-value2").build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
+				addHistogramDatapoint(1, 2, 8, 16, []float64{1, 2}, []uint64{1, 2, 5}, "label1-value1").build(),
+		},
+	},
+	// COMBINE
+	{
+		name: "combine",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^([mM]etric)(?P<namedsubmatch>[12])$")},
+				Action:              Combine,
+				NewName:             "new",
+				SubmatchCase:        "lower",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "Metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new", "$1", "namedsubmatch").
+				addIntDatapoint(1, 1, 1, "metric", "1").
+				addIntDatapoint(1, 1, 2, "metric", "2").build(),
+		},
+	},
+	{
+		name: "combine_no_matches",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^X(metric)(?P<namedsubmatch>[12])$")},
+				Action:              Combine,
+				NewName:             "new",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+	},
+	{
+		name: "combine_single_match",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^([mM]etric)(?P<namedsubmatch>[1])$")},
+				Action:              Combine,
+				NewName:             "new",
+				SubmatchCase:        "upper",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "Metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new", "$1", "namedsubmatch").addIntDatapoint(1, 1, 1, "METRIC", "1").build(),
+		},
+	},
+	{
+		name: "combine_aggregate",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+				Action:              Combine,
+				NewName:             "new",
+				AggregationType:     aggregateutil.Sum,
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new").addIntDatapoint(1, 1, 3).build(),
+		},
+	},
+	{
+		name: "combine_with_operations",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[12])$")},
+				Action:              Combine,
+				NewName:             "new",
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   addLabel,
+							NewLabel: "new_label",
+							NewValue: "new_label_value",
+						},
+					},
+					{
+						configOperation: Operation{
+							Action:          aggregateLabels,
+							AggregationType: aggregateutil.Sum,
+							LabelSet:        []string{"$1", "new_label"},
+						},
+						labelSetMap: map[string]bool{"$1": true, "new_label": true},
+					},
+				},
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "new", "$1", "new_label").
+				addIntDatapoint(1, 1, 3, "metric", "new_label_value").build(),
+		},
+	},
+	{
+		name: "combine_exponential_histogram",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{
+					include: regexp.MustCompile("^metric(?P<namedsubmatch>[12])$"),
+				},
+				Action:  Combine,
+				NewName: "new",
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric1").build(),
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "new", "namedsubmatch").build(),
+		},
+	},
+	{
+		name: "combine_error_type",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+				Action:              Combine,
+				NewName:             "new",
+				AggregationType:     aggregateutil.Sum,
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeSum, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeSum, "metric2").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+	},
+	{
+		name: "combine_error_units",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+				Action:              Combine,
+				NewName:             "new",
+				AggregationType:     aggregateutil.Sum,
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").setUnit("s").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").setUnit("ms").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").setUnit("s").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").setUnit("ms").addIntDatapoint(1, 1, 2).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+	},
+	{
+		name: "combine_error_labels1",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+				Action:              Combine,
+				NewName:             "new",
+				AggregationType:     aggregateutil.Sum,
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "b", "c").
+				addIntDatapoint(1, 1, 2, "1", "2", "3").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "b", "c").
+				addIntDatapoint(1, 1, 2, "1", "2", "3").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+	},
+	{
+		name: "combine_error_labels2",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
+				Action:              Combine,
+				NewName:             "new",
+				AggregationType:     aggregateutil.Sum,
+			},
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "c").addIntDatapoint(1, 1, 2, "1", "3").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "c").addIntDatapoint(1, 1, 2, "1", "3").build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
+		},
+	},
+	// Toggle Data Type
+	{
+		name: "metric_toggle_scalar_data_type_int64_to_double",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: toggleScalarDataType,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "matched-metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "unmatched-metric2", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "matched-metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "new/label1-value1", "label2-value1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "unmatched-metric2", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").build(),
-			},
-		},
-		{
-			name: "metric_label_aggregation_sum_int_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: toggleScalarDataType,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").addDescription("foobar").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 4, "label1-value1").addDescription("foobar").build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_mean_int_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Mean,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 1).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 1).build(),
+		},
+	},
+	{
+		name: "metric_toggle_scalar_data_type_double_to_int64",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: toggleScalarDataType,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 2, "label1-value1").build(),
-			},
-		},
-		{
-			name: "metric_label_aggregation_max_int_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Max,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: toggleScalarDataType,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value2").
-					addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "label1-value1").build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_count_int_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Count,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 1).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 1).build(),
+		},
+	},
+	{
+		name: "metric_toggle_scalar_data_type_no_effect",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: toggleScalarDataType,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 4, "label1-value1", "label2-value2").
-					addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "label1-value1").build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_median_int_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Median,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+				addHistogramDatapoint(0, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+				addHistogramDatapoint(0, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}).build(),
+		},
+	},
+	// Scale Value
+	{
+		name: "metric_experimental_scale_value_int64",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  100,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 4, "label1-value1", "label2-value2").
-					addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 2, "label1-value1").build(),
-			},
-		},
-		{
-			name: "metric_label_aggregation_min_int_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Min,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  10,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value2").
-					addIntDatapoint(1, 2, 2, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 1, "label1-value1").build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_sum_double_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 100).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 30).build(),
+		},
+	},
+	{
+		name: "metric_experimental_scale_value_double",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  100,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 4, "label1-value1").build(),
-			},
-		},
-		{
-			name: "metric_label_aggregation_mean_double_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Mean,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  .1,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addDoubleDatapoint(1, 2, 2, "label1-value1").build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_max_double_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Max,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 1).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 300).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 100).build(),
+			metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 30).build(),
+		},
+	},
+	{
+		name: "metric_experimental_scale_value_histogram",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  100,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addDoubleDatapoint(1, 2, 3, "label1-value1").build(),
-			},
-		},
-		{
-			name: "metric_label_aggregation_count_double_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Count,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  .1,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addDoubleDatapoint(1, 2, 2, "label1-value1").build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_median_double_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Median,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+				addHistogramDatapoint(1, 1, 1, 1, []float64{1}, []uint64{1, 1}).build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric2").
+				addHistogramDatapoint(1, 1, 2, 400, []float64{200}, []uint64{1, 2}).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+				addHistogramDatapoint(1, 1, 1, 100, []float64{100}, []uint64{1, 1}).build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric2").
+				addHistogramDatapoint(1, 1, 2, 40, []float64{20}, []uint64{1, 2}).build(),
+		},
+	},
+	{
+		name: "metric_experimental_scale_value_histogram_with_exemplars",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  100,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addDoubleDatapoint(1, 2, 2, "label1-value1").build(),
-			},
-		},
-		{
-			name: "metric_label_aggregation_min_double_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Min,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  .1,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addDoubleDatapoint(2, 2, 3, "label1-value2", "label2-value2").
-					addDoubleDatapoint(0, 2, 4, "label1-value0", "label2-value0").
-					addDoubleDatapoint(1, 2, 1, "label1-value1", "label2-value1").
-					addDoubleDatapoint(1, 2, 3, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addDoubleDatapoint(2, 2, 3, "label1-value2").
-					addDoubleDatapoint(0, 2, 4, "label1-value0").
-					addDoubleDatapoint(1, 2, 1, "label1-value1").build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_insert_sum_with_several_attrs_match",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						attrMatchers: map[string]StringMatcher{"label0": strictMatcher("label0-value1")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"label1", "label2"},
-							},
-							labelSetMap: map[string]bool{"label1": true, "label2": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+				addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}).build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric2").
+				addHistogramDatapointWithMinMaxAndExemplars(2, 2, 2, 400, 100, 300, []float64{200}, []uint64{1, 2}, []float64{100, 300}).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeHistogram, "metric1").
+				addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 100, 100, 100, []float64{100}, []uint64{1, 1}, []float64{100}).build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric2").
+				addHistogramDatapointWithMinMaxAndExemplars(2, 2, 2, 40, 10, 30, []float64{20}, []uint64{1, 2}, []float64{10, 30}).build(),
+		},
+	},
+	{
+		name: "metric_experimental_scale_value_exp_histogram",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  1000,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label0", "label1", "label2", "label3").
-					addDoubleDatapoint(1, 2, 3, "label0-value1", "label1-value1", "label2-value1", "label3-value1").
-					addDoubleDatapoint(1, 2, 1, "label0-value1", "label1-value1", "label2-value1", "label3-value2").
-					addDoubleDatapoint(1, 2, 1, "label0-value2", "label1-value1", "label2-value1", "label3-value1").
-					build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label0", "label1", "label2", "label3").
-					addDoubleDatapoint(1, 2, 3, "label0-value1", "label1-value1", "label2-value1", "label3-value1").
-					addDoubleDatapoint(1, 2, 1, "label0-value1", "label1-value1", "label2-value1", "label3-value2").
-					addDoubleDatapoint(1, 2, 1, "label0-value2", "label1-value1", "label2-value1", "label3-value1").
-					build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
-					addDoubleDatapoint(1, 2, 4, "label1-value1", "label2-value1").build(),
-			},
-		},
-		{
-			name: "metric_label_values_aggregation_sum_int_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabelValues,
-								NewValue:        "new/label2-value",
-								AggregationType: aggregateutil.Sum,
-								Label:           "label2",
-							},
-							aggregatedValuesSet: map[string]bool{"label2-value1": true, "label2-value2": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric2"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  .1,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(0, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(0, 2, 1, "label1-value1", "label2-value2").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value3").
-					addIntDatapoint(2, 2, 4, "label1-value1", "label2-value4").
-					build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(0, 2, 4, "label1-value1", "new/label2-value").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value3").
-					addIntDatapoint(2, 2, 4, "label1-value1", "label2-value4").
-					build(),
-			},
-		},
-		// this test case also tests the correctness of the SumOfSquaredDeviation merging
-		{
-			name: "metric_label_values_aggregation_sum_distribution_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric3"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  100000,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
-					addHistogramDatapoint(0, 1, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}, "label1-value1",
-						"label2-value1"). // pointGroup1: {1, 2, 3}, SumOfSquaredDeviation = 2
-					addHistogramDatapoint(0, 1, 5, 10, []float64{1, 2, 3}, []uint64{0, 2, 1, 2}, "label1-value1",
-						"label2-value2"). // pointGroup2: {1, 2, 3, 3, 1}, SumOfSquaredDeviation = 4
-					addHistogramDatapoint(1, 1, 7, 14, []float64{1, 2, 3}, []uint64{0, 3, 1, 3}, "label1-value1",
-						"label2-value3"). // pointGroup3: {1, 1, 2, 3, 3, 1, 3}, SumOfSquaredDeviation = 6
-					build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
-					addHistogramDatapoint(0, 1, 15, 30, []float64{1, 2, 3}, []uint64{0, 6, 3, 6},
-						"label1-value1"). // pointGroupCombined: {1, 2, 3, 1, 2, 3, 3, 1, 1, 1, 2, 3, 3, 1, 3}, SumOfSquaredDeviation = 12
-					build(),
-			},
-		},
-		{
-			name: "metric_label_aggregation_empty_label_set",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{},
-							},
-							labelSetMap: map[string]bool{},
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric4"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  42.123,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2", "label3").
-					addIntDatapoint(0, 1, 1, "a", "b", "c").
-					build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").
-					addIntDatapoint(0, 1, 1).
-					build(),
-			},
 		},
-		{
-			name: "metric_label_aggregation_ignored_for_partial_metric_match",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("label1-value1")}},
-					Action: Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric1").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          5,
+					sum:            1359,
+					scale:          4,
+					min:            10,
+					max:            500,
+					zeroThreshold:  5,
+					zeroCount:      1,
+					positiveOffset: 53,
+					positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 53: 1, 74: 1, 90: 2}), // 10, 100, 250, 499, 500
+					exemplarValues: []float64{100, 300},
+				}).build(),
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric2").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          3,
+					sum:            10100.000123,
+					scale:          2,
+					min:            0.000123,
+					max:            10000,
+					positiveOffset: -52,
+					positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 78: 1, 105: 1}), // 0.000123, 100, 10000
+					exemplarValues: []float64{100, 300},
+				}).build(),
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric3").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          3,
+					sum:            4.3678,
+					scale:          7,
+					min:            1.123,
+					max:            1.789,
+					positiveOffset: 21,
+					positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 48: 1, 86: 1}), // 1.123, 1.456, 1.789
+				}).build(),
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric4").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          3,
+					sum:            6.00003,
+					scale:          20,
+					min:            2,
+					max:            2.00002,
+					negativeOffset: 1048575,
+					negativeCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 8: 1, 16: 1}), // 2, 2.00001, 2.00002
+				}).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric1").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          5,
+					sum:            1359000,
+					scale:          4,
+					min:            10000,
+					max:            500000,
+					zeroThreshold:  5000,
+					zeroCount:      1,
+					positiveOffset: 212,
+					positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 53: 1, 74: 1, 90: 2}),
+					exemplarValues: []float64{100000, 300000},
+				}).build(),
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric2").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          3,
+					sum:            1010.0000123,
+					scale:          2,
+					min:            0.0000123,
+					max:            1000,
+					positiveOffset: -65,
+					positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 78: 1, 105: 1}),
+					exemplarValues: []float64{10, 30},
+				}).build(),
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric3").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          3,
+					sum:            436780,
+					scale:          7,
+					min:            112300,
+					max:            178900,
+					positiveOffset: 2147,
+					positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 48: 1, 86: 1}),
+				}).build(),
+			metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric4").
+				addExpHistogramDatapoint(expHistogramConfig{
+					count:          3,
+					sum:            252.73926368999997,
+					scale:          20,
+					min:            84.246,
+					max:            84.24684246,
+					negativeOffset: 6707253,
+					negativeCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 8: 1, 16: 1}),
+				}).build(),
+		},
+	},
+	{
+		name: "metric_experimental_scale_with_attr_filtering",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric1",
+					attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")},
+				},
+				Action: Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  100,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(0, 2, 1, "label1-value2", "label2-value2").
-					build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(0, 2, 1, "label1-value2", "label2-value2").
-					build(),
-			},
-		},
-		{
-			name: "metric_label_values_aggregation_not_sum_distribution_update",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Mean,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric2",
+					attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")},
+				},
+				Action: Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  10,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
-					addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}, "label1-value1",
-						"label2-value1").
-					build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
-					addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}, "label1-value1").
-					build(),
-			},
-		},
-		// INSERT
-		{
-			name: "metric_name_insert",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Insert,
-					NewName:             "new/metric1",
+			{
+				MetricIncludeFilter: internalFilterStrict{
+					include:      "metric3",
+					attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")},
 				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_multiple",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Insert,
-					NewName:             "new/metric1",
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Insert,
-					NewName:             "new/metric2",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_strict",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 3, 2, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 3, 2, "value1", "value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
-					addIntDatapoint(1, 3, 2, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile(`(.|\s)*\S(.|\s)*`)}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp_two_datapoints_positive",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").
-					addIntDatapoint(2, 2, 3, "value3", "value4").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").
-					addIntDatapoint(2, 2, 3, "value3", "value4").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
-					addIntDatapoint(2, 2, 3, "value3", "value4").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp_two_datapoints_negative",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value3")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").
-					addIntDatapoint(2, 2, 3, "value11", "value22").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").
-					addIntDatapoint(2, 2, 3, "value11", "value22").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp_with_full_value",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value1")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_strict_negative",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("wrong_value")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp_negative",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile(".*wrong_ending")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_strict_missing_key",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						attrMatchers: map[string]StringMatcher{"missing_key": strictMatcher("value1")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp_missing_key",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"missing_key": regexp.MustCompile("value1")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp_missing_and_present_key",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value1"),
-							"missing_key": regexp.MustCompile("value2")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_name_insert_with_match_label_regexp_missing_key_with_empty_expression",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("metric1"),
-						attrMatchers: map[string]StringMatcher{"label1": regexp.MustCompile("value1"),
-							"missing_key": regexp.MustCompile("^$")}},
-					Action:  Insert,
-					NewName: "new/metric1",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "metric_label_update_with_metric_insert",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Insert,
-					NewName:             "new/metric1",
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   updateLabel,
-								Label:    "label1",
-								NewLabel: "new/label1",
-							},
+				Action: Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action: scaleValue,
+							Scale:  0.1,
 						},
 					},
 				},
 			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "new/label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1", "label1").
+				addIntDatapoint(1, 1, 1, "value1").
+				addIntDatapoint(1, 1, 3, "value2").build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric2", "label1").
+				addHistogramDatapoint(1, 1, 1, 1, []float64{1}, []uint64{1, 1}, "value1").
+				addHistogramDatapoint(1, 1, 2, 4, []float64{2}, []uint64{1, 2}, "value2").build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric3", "label1").
+				addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}, "value1").
+				addHistogramDatapointWithMinMaxAndExemplars(2, 2, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}, "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeSum, "metric1", "label1").
+				addIntDatapoint(1, 1, 100, "value1").
+				addIntDatapoint(1, 1, 3, "value2").build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric2", "label1").
+				addHistogramDatapoint(1, 1, 1, 10, []float64{10}, []uint64{1, 1}, "value1").
+				addHistogramDatapoint(1, 1, 2, 4, []float64{2}, []uint64{1, 2}, "value2").build(),
+			metricBuilder(pmetric.MetricTypeHistogram, "metric3", "label1").
+				addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 0.1, 0.1, 0.1, []float64{0.1}, []uint64{1, 1}, []float64{0.1}, "value1").
+				addHistogramDatapointWithMinMaxAndExemplars(2, 2, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}, "value2").build(),
+		},
+	},
+	// Add Label to a metric
+	{
+		name: "update_existing_metric_by_adding_a_new_label_when_there_are_no_labels",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   addLabel,
+							NewLabel: "foo",
+							NewValue: "bar",
+						},
+					},
+				},
 			},
 		},
-		{
-			name: "metric_label_value_update_with_metric_insert",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Insert,
-					NewName:             "new/metric1",
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: updateLabel,
-								Label:  "label1",
-							},
-							valueActionsMapping: map[string]string{"label1-value1": "new/label1-value1"},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 2, 3).build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "foo").addIntDatapoint(1, 2, 3, "bar").build(),
+		},
+	},
+	{
+		name: "update_existing_metric_by_adding_a_new_label_when_there_are_labels",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   addLabel,
+							NewLabel: "foo",
+							NewValue: "bar",
 						},
 					},
 				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "label1-value1").
-					addIntDatapoint(1, 2, 4, "label1-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 3, "label1-value1").
-					addIntDatapoint(1, 2, 4, "label1-value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new/metric1", "label1").
-					addIntDatapoint(1, 2, 3, "new/label1-value1").
-					addIntDatapoint(1, 2, 4, "label1-value2").build(),
 			},
 		},
-		{
-			name: "metric_label_aggregation_sum_int_insert",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Insert,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2", "foo").
+				addIntDatapoint(1, 2, 3, "value1", "value2", "bar").build(),
+		},
+	},
+	{
+		name: "update_existing_metric_by_adding_a_label_that_is_duplicated_in_the_list",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric1"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   addLabel,
+							NewLabel: "label1",
+							NewValue: "value3",
 						},
 					},
 				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1").
-					addIntDatapoint(1, 2, 4, "label1-value1").build(),
 			},
 		},
-		{
-			name: "metric_label_values_aggregation_sum_int_insert",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Insert,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabelValues,
-								NewValue:        "new/label2-value",
-								AggregationType: aggregateutil.Sum,
-								Label:           "label2",
-							},
-							aggregatedValuesSet: map[string]bool{"label2-value1": true, "label2-value2": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	{
+		name: "update_does_not_happen_because_target_metric_doesn't_exist",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "mymetric"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:   addLabel,
+							NewLabel: "foo",
+							NewValue: "bar",
 						},
 					},
 				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1-value1", "label2-value1").
-					addIntDatapoint(1, 2, 1, "label1-value1", "label2-value2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 4, "label1-value1", "new/label2-value").build(),
 			},
 		},
-		{
-			name: "metric_labels_aggregation_sum_distribution_insert",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Insert,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"label1"},
-							},
-							labelSetMap: map[string]bool{"label1": true},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "value1", "value2").build(),
+		},
+	},
+	// delete label value
+	{
+		name: "delete_a_label_value",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:     deleteLabelValue,
+							Label:      "label1",
+							LabelValue: "label1value1",
 						},
 					},
 				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
-					addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2}, []uint64{0, 1, 2}, "label1-value1",
-						"label2-value1").
-					addHistogramDatapoint(1, 2, 5, 10, []float64{1, 2}, []uint64{1, 1, 3}, "label1-value1",
-						"label2-value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1", "label2").
-					addHistogramDatapoint(1, 2, 3, 6, []float64{1, 2}, []uint64{0, 1, 2}, "label1-value1",
-						"label2-value1").
-					addHistogramDatapoint(1, 2, 5, 10, []float64{1, 2}, []uint64{1, 1, 3}, "label1-value1",
-						"label2-value2").build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1", "label1").
-					addHistogramDatapoint(1, 2, 8, 16, []float64{1, 2}, []uint64{1, 2, 5}, "label1-value1").build(),
 			},
 		},
-		// COMBINE
-		{
-			name: "combine",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^([mM]etric)(?P<namedsubmatch>[12])$")},
-					Action:              Combine,
-					NewName:             "new",
-					SubmatchCase:        "lower",
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1value1", "label2value").
+				addIntDatapoint(1, 2, 4, "label1value2", "label2value").build(),
+		},
+		out: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
+				addIntDatapoint(1, 2, 4, "label1value2", "label2value").build(),
+		},
+	},
+	{
+		name: "delete_all_metric_datapoints",
+		transforms: []internalTransform{
+			{
+				MetricIncludeFilter: internalFilterStrict{include: "metric"},
+				Action:              Update,
+				Operations: []internalOperation{
+					{
+						configOperation: Operation{
+							Action:     deleteLabelValue,
+							Label:      "label1",
+							LabelValue: "label1value1",
+						},
+					},
 				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "Metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new", "$1", "namedsubmatch").
-					addIntDatapoint(1, 1, 1, "metric", "1").
-					addIntDatapoint(1, 1, 2, "metric", "2").build(),
 			},
 		},
-		{
-			name: "combine_no_matches",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^X(metric)(?P<namedsubmatch>[12])$")},
-					Action:              Combine,
-					NewName:             "new",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
+		in: []pmetric.Metric{
+			metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
+				addIntDatapoint(1, 2, 3, "label1value1", "label2value").build(),
 		},
-		{
-			name: "combine_single_match",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^([mM]etric)(?P<namedsubmatch>[1])$")},
-					Action:              Combine,
-					NewName:             "new",
-					SubmatchCase:        "upper",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "Metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new", "$1", "namedsubmatch").addIntDatapoint(1, 1, 1, "METRIC", "1").build(),
-			},
-		},
-		{
-			name: "combine_aggregate",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
-					Action:              Combine,
-					NewName:             "new",
-					AggregationType:     aggregateutil.Sum,
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new").addIntDatapoint(1, 1, 3).build(),
-			},
-		},
-		{
-			name: "combine_with_operations",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^(metric)(?P<namedsubmatch>[12])$")},
-					Action:              Combine,
-					NewName:             "new",
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   addLabel,
-								NewLabel: "new_label",
-								NewValue: "new_label_value",
-							},
-						},
-						{
-							configOperation: Operation{
-								Action:          aggregateLabels,
-								AggregationType: aggregateutil.Sum,
-								LabelSet:        []string{"$1", "new_label"},
-							},
-							labelSetMap: map[string]bool{"$1": true, "new_label": true},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "new", "$1", "new_label").
-					addIntDatapoint(1, 1, 3, "metric", "new_label_value").build(),
-			},
-		},
-		{
-			name: "combine_exponential_histogram",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{
-						include: regexp.MustCompile("^metric(?P<namedsubmatch>[12])$"),
-					},
-					Action:  Combine,
-					NewName: "new",
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric1").build(),
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "new", "namedsubmatch").build(),
-			},
-		},
-		{
-			name: "combine_error_type",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
-					Action:              Combine,
-					NewName:             "new",
-					AggregationType:     aggregateutil.Sum,
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeSum, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeSum, "metric2").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-		},
-		{
-			name: "combine_error_units",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
-					Action:              Combine,
-					NewName:             "new",
-					AggregationType:     aggregateutil.Sum,
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").setUnit("s").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").setUnit("ms").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").setUnit("s").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").setUnit("ms").addIntDatapoint(1, 1, 2).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-		},
-		{
-			name: "combine_error_labels1",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
-					Action:              Combine,
-					NewName:             "new",
-					AggregationType:     aggregateutil.Sum,
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "b", "c").
-					addIntDatapoint(1, 1, 2, "1", "2", "3").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "b", "c").
-					addIntDatapoint(1, 1, 2, "1", "2", "3").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-		},
-		{
-			name: "combine_error_labels2",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterRegexp{include: regexp.MustCompile("^metric[12]$")},
-					Action:              Combine,
-					NewName:             "new",
-					AggregationType:     aggregateutil.Sum,
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "c").addIntDatapoint(1, 1, 2, "1", "3").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "a", "b").addIntDatapoint(1, 1, 1, "1", "2").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2", "a", "c").addIntDatapoint(1, 1, 2, "1", "3").build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric3").addIntDatapoint(1, 1, 3).build(),
-			},
-		},
-		// Toggle Data Type
-		{
-			name: "metric_toggle_scalar_data_type_int64_to_double",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: toggleScalarDataType,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: toggleScalarDataType,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 1).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 1).build(),
-			},
-		},
-		{
-			name: "metric_toggle_scalar_data_type_double_to_int64",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: toggleScalarDataType,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: toggleScalarDataType,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 1).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 1).build(),
-			},
-		},
-		{
-			name: "metric_toggle_scalar_data_type_no_effect",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: toggleScalarDataType,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
-					addHistogramDatapoint(0, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
-					addHistogramDatapoint(0, 2, 3, 6, []float64{1, 2, 3}, []uint64{0, 1, 1, 1}).build(),
-			},
-		},
-		// Scale Value
-		{
-			name: "metric_experimental_scale_value_int64",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  100,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  10,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addIntDatapoint(1, 1, 100).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addIntDatapoint(1, 1, 30).build(),
-			},
-		},
-		{
-			name: "metric_experimental_scale_value_double",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  100,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  .1,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 1).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 300).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1").addDoubleDatapoint(1, 1, 100).build(),
-				metricBuilder(pmetric.MetricTypeGauge, "metric2").addDoubleDatapoint(1, 1, 30).build(),
-			},
-		},
-		{
-			name: "metric_experimental_scale_value_histogram",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  100,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  .1,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
-					addHistogramDatapoint(1, 1, 1, 1, []float64{1}, []uint64{1, 1}).build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2").
-					addHistogramDatapoint(1, 1, 2, 400, []float64{200}, []uint64{1, 2}).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
-					addHistogramDatapoint(1, 1, 1, 100, []float64{100}, []uint64{1, 1}).build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2").
-					addHistogramDatapoint(1, 1, 2, 40, []float64{20}, []uint64{1, 2}).build(),
-			},
-		},
-		{
-			name: "metric_experimental_scale_value_histogram_with_exemplars",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  100,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  .1,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
-					addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}).build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2").
-					addHistogramDatapointWithMinMaxAndExemplars(2, 2, 2, 400, 100, 300, []float64{200}, []uint64{1, 2}, []float64{100, 300}).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeHistogram, "metric1").
-					addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 100, 100, 100, []float64{100}, []uint64{1, 1}, []float64{100}).build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2").
-					addHistogramDatapointWithMinMaxAndExemplars(2, 2, 2, 40, 10, 30, []float64{20}, []uint64{1, 2}, []float64{10, 30}).build(),
-			},
-		},
-		{
-			name: "metric_experimental_scale_value_exp_histogram",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  1000,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  .1,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric3"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  100000,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric4"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  42.123,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric1").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          5,
-						sum:            1359,
-						scale:          4,
-						min:            10,
-						max:            500,
-						zeroThreshold:  5,
-						zeroCount:      1,
-						positiveOffset: 53,
-						positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 53: 1, 74: 1, 90: 2}), // 10, 100, 250, 499, 500
-						exemplarValues: []float64{100, 300},
-					}).build(),
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric2").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          3,
-						sum:            10100.000123,
-						scale:          2,
-						min:            0.000123,
-						max:            10000,
-						positiveOffset: -52,
-						positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 78: 1, 105: 1}), // 0.000123, 100, 10000
-						exemplarValues: []float64{100, 300},
-					}).build(),
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric3").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          3,
-						sum:            4.3678,
-						scale:          7,
-						min:            1.123,
-						max:            1.789,
-						positiveOffset: 21,
-						positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 48: 1, 86: 1}), // 1.123, 1.456, 1.789
-					}).build(),
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric4").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          3,
-						sum:            6.00003,
-						scale:          20,
-						min:            2,
-						max:            2.00002,
-						negativeOffset: 1048575,
-						negativeCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 8: 1, 16: 1}), // 2, 2.00001, 2.00002
-					}).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric1").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          5,
-						sum:            1359000,
-						scale:          4,
-						min:            10000,
-						max:            500000,
-						zeroThreshold:  5000,
-						zeroCount:      1,
-						positiveOffset: 212,
-						positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 53: 1, 74: 1, 90: 2}),
-						exemplarValues: []float64{100000, 300000},
-					}).build(),
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric2").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          3,
-						sum:            1010.0000123,
-						scale:          2,
-						min:            0.0000123,
-						max:            1000,
-						positiveOffset: -65,
-						positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 78: 1, 105: 1}),
-						exemplarValues: []float64{10, 30},
-					}).build(),
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric3").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          3,
-						sum:            436780,
-						scale:          7,
-						min:            112300,
-						max:            178900,
-						positiveOffset: 2147,
-						positiveCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 48: 1, 86: 1}),
-					}).build(),
-				metricBuilder(pmetric.MetricTypeExponentialHistogram, "metric4").
-					addExpHistogramDatapoint(expHistogramConfig{
-						count:          3,
-						sum:            252.73926368999997,
-						scale:          20,
-						min:            84.246,
-						max:            84.24684246,
-						negativeOffset: 6707253,
-						negativeCount:  buildExpHistogramBucket(map[int]uint64{0: 1, 8: 1, 16: 1}),
-					}).build(),
-			},
-		},
-		{
-			name: "metric_experimental_scale_with_attr_filtering",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1",
-						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")}},
-					Action: Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  100,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric2",
-						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")}},
-					Action: Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  10,
-							},
-						},
-					},
-				},
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric3",
-						attrMatchers: map[string]StringMatcher{"label1": strictMatcher("value1")}},
-					Action: Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action: scaleValue,
-								Scale:  0.1,
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1", "label1").
-					addIntDatapoint(1, 1, 1, "value1").
-					addIntDatapoint(1, 1, 3, "value2").build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2", "label1").
-					addHistogramDatapoint(1, 1, 1, 1, []float64{1}, []uint64{1, 1}, "value1").
-					addHistogramDatapoint(1, 1, 2, 4, []float64{2}, []uint64{1, 2}, "value2").build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric3", "label1").
-					addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}, "value1").
-					addHistogramDatapointWithMinMaxAndExemplars(2, 2, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}, "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeSum, "metric1", "label1").
-					addIntDatapoint(1, 1, 100, "value1").
-					addIntDatapoint(1, 1, 3, "value2").build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric2", "label1").
-					addHistogramDatapoint(1, 1, 1, 10, []float64{10}, []uint64{1, 1}, "value1").
-					addHistogramDatapoint(1, 1, 2, 4, []float64{2}, []uint64{1, 2}, "value2").build(),
-				metricBuilder(pmetric.MetricTypeHistogram, "metric3", "label1").
-					addHistogramDatapointWithMinMaxAndExemplars(1, 1, 1, 0.1, 0.1, 0.1, []float64{0.1}, []uint64{1, 1}, []float64{0.1}, "value1").
-					addHistogramDatapointWithMinMaxAndExemplars(2, 2, 1, 1, 1, 1, []float64{1}, []uint64{1, 1}, []float64{1}, "value2").build(),
-			},
-		},
-		// Add Label to a metric
-		{
-			name: "update_existing_metric_by_adding_a_new_label_when_there_are_no_labels",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   addLabel,
-								NewLabel: "foo",
-								NewValue: "bar",
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1").addIntDatapoint(1, 2, 3).build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "foo").addIntDatapoint(1, 2, 3, "bar").build(),
-			},
-		},
-		{
-			name: "update_existing_metric_by_adding_a_new_label_when_there_are_labels",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   addLabel,
-								NewLabel: "foo",
-								NewValue: "bar",
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2", "foo").
-					addIntDatapoint(1, 2, 3, "value1", "value2", "bar").build(),
-			},
-		},
-		{
-			name: "update_existing_metric_by_adding_a_label_that_is_duplicated_in_the_list",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric1"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   addLabel,
-								NewLabel: "label1",
-								NewValue: "value3",
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		{
-			name: "update_does_not_happen_because_target_metric_doesn't_exist",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "mymetric"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:   addLabel,
-								NewLabel: "foo",
-								NewValue: "bar",
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric1", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "value1", "value2").build(),
-			},
-		},
-		// delete label value
-		{
-			name: "delete_a_label_value",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:     deleteLabelValue,
-								Label:      "label1",
-								LabelValue: "label1value1",
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1value1", "label2value").
-					addIntDatapoint(1, 2, 4, "label1value2", "label2value").build(),
-			},
-			out: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
-					addIntDatapoint(1, 2, 4, "label1value2", "label2value").build(),
-			},
-		},
-		{
-			name: "delete_all_metric_datapoints",
-			transforms: []internalTransform{
-				{
-					MetricIncludeFilter: internalFilterStrict{include: "metric"},
-					Action:              Update,
-					Operations: []internalOperation{
-						{
-							configOperation: Operation{
-								Action:     deleteLabelValue,
-								Label:      "label1",
-								LabelValue: "label1value1",
-							},
-						},
-					},
-				},
-			},
-			in: []pmetric.Metric{
-				metricBuilder(pmetric.MetricTypeGauge, "metric", "label1", "label2").
-					addIntDatapoint(1, 2, 3, "label1value1", "label2value").build(),
-			},
-			out: []pmetric.Metric{},
-		},
-	}
-)
+		out: []pmetric.Metric{},
+	},
+}

--- a/processor/metricstransformprocessor/operation_scale_value.go
+++ b/processor/metricstransformprocessor/operation_scale_value.go
@@ -43,7 +43,7 @@ func scaleValueOp(metric pmetric.Metric, op internalOperation, f internalFilter)
 }
 
 func scaleHistogramOp(metric pmetric.Metric, op internalOperation, f internalFilter) {
-	var dps = metric.Histogram().DataPoints()
+	dps := metric.Histogram().DataPoints()
 
 	for i := 0; i < dps.Len(); i++ {
 		dp := dps.At(i)
@@ -70,7 +70,7 @@ func scaleHistogramOp(metric pmetric.Metric, op internalOperation, f internalFil
 }
 
 func scaleExpHistogramOp(metric pmetric.Metric, op internalOperation, f internalFilter) {
-	var dps = metric.ExponentialHistogram().DataPoints()
+	dps := metric.ExponentialHistogram().DataPoints()
 	for i := 0; i < dps.Len(); i++ {
 		dp := dps.At(i)
 		if !f.matchAttrs(dp.Attributes()) {

--- a/processor/probabilisticsamplerprocessor/config.go
+++ b/processor/probabilisticsamplerprocessor/config.go
@@ -28,7 +28,6 @@ var validAttributeSource = map[AttributeSource]bool{
 
 // Config has the configuration guiding the sampler processor.
 type Config struct {
-
 	// SamplingPercentage is the percentage rate at which traces or logs are going to be sampled. Defaults to zero, i.e.: no sample.
 	// Values greater or equal 100 are treated as "sample all traces/logs".
 	SamplingPercentage float32 `mapstructure:"sampling_percentage"`

--- a/processor/probabilisticsamplerprocessor/logsprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/logsprocessor_test.go
@@ -210,7 +210,7 @@ func TestLogsSampling(t *testing.T) {
 func TestLogsSamplingState(t *testing.T) {
 	// This hard-coded TraceID will sample at 50% and not at 49%.
 	// The equivalent randomness is 0x80000000000000.
-	var defaultTID = mustParseTID("fefefefefefefefefe80000000000000")
+	defaultTID := mustParseTID("fefefefefefefefefe80000000000000")
 
 	tests := []struct {
 		name     string

--- a/processor/probabilisticsamplerprocessor/sampler_mode.go
+++ b/processor/probabilisticsamplerprocessor/sampler_mode.go
@@ -84,10 +84,12 @@ func (rm randomnessMethod) randomness() sampling.Randomness {
 	return sampling.Randomness(rm)
 }
 
-type traceIDHashingMethod struct{ randomnessMethod }
-type traceIDW3CSpecMethod struct{ randomnessMethod }
-type samplingRandomnessMethod struct{ randomnessMethod }
-type samplingPriorityMethod struct{ randomnessMethod }
+type (
+	traceIDHashingMethod     struct{ randomnessMethod }
+	traceIDW3CSpecMethod     struct{ randomnessMethod }
+	samplingRandomnessMethod struct{ randomnessMethod }
+	samplingPriorityMethod   struct{ randomnessMethod }
+)
 
 type missingRandomnessMethod struct{}
 
@@ -124,11 +126,13 @@ func (samplingPriorityMethod) policyName() string {
 	return "sampling_priority"
 }
 
-var _ randomnessNamer = missingRandomnessMethod{}
-var _ randomnessNamer = traceIDHashingMethod{}
-var _ randomnessNamer = traceIDW3CSpecMethod{}
-var _ randomnessNamer = samplingRandomnessMethod{}
-var _ randomnessNamer = samplingPriorityMethod{}
+var (
+	_ randomnessNamer = missingRandomnessMethod{}
+	_ randomnessNamer = traceIDHashingMethod{}
+	_ randomnessNamer = traceIDW3CSpecMethod{}
+	_ randomnessNamer = samplingRandomnessMethod{}
+	_ randomnessNamer = samplingPriorityMethod{}
+)
 
 func newMissingRandomnessMethod() randomnessNamer {
 	return missingRandomnessMethod{}
@@ -243,12 +247,10 @@ func (th *hashingSampler) decide(_ samplingCarrier) sampling.Threshold {
 // consistentTracestateCommon contains the common aspects of the
 // Proportional and Equalizing sampler modes.  These samplers sample
 // using the TraceID and do not support use of logs source attribute.
-type consistentTracestateCommon struct {
-}
+type consistentTracestateCommon struct{}
 
 // neverSampler always decides false.
-type neverSampler struct {
-}
+type neverSampler struct{}
 
 func (*neverSampler) decide(_ samplingCarrier) sampling.Threshold {
 	return sampling.NeverSampleThreshold

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -501,11 +501,11 @@ func Test_parseSpanSamplingPriority(t *testing.T) {
 func Test_tracesamplerprocessor_TraceState(t *testing.T) {
 	// This hard-coded TraceID will sample at 50% and not at 49%.
 	// The equivalent randomness is 0x80000000000000.
-	var defaultTID = mustParseTID("fefefefefefefefefe80000000000000")
+	defaultTID := mustParseTID("fefefefefefefefefe80000000000000")
 
 	// improbableTraceID will sample at all supported probabilities.  In
 	// hex, the leading 18 digits do not matter, the trailing 14 are all `f`.
-	var improbableTraceID = mustParseTID("111111111111111111ffffffffffffff")
+	improbableTraceID := mustParseTID("111111111111111111ffffffffffffff")
 
 	sid := idutils.UInt64ToSpanID(0xfefefefe)
 	tests := []struct {
@@ -1249,7 +1249,7 @@ func TestHashingFunction(t *testing.T) {
 		sampled bool
 	}
 
-	var expect50PctData = []expect50PctHashed{
+	expect50PctData := []expect50PctHashed{
 		{653, "474a03c76d75951a4b4c537ced8f1122", true},
 		{563, "53a518291e91307e43cd8467bb06f986", true},
 		{142, "a56a02f843b9bc6ee0b13889249e90e6", true},

--- a/processor/redactionprocessor/config.go
+++ b/processor/redactionprocessor/config.go
@@ -4,7 +4,6 @@
 package redactionprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor"
 
 type Config struct {
-
 	// AllowAllKeys is a flag to allow all span attribute keys. Setting this
 	// to true disables the AllowedKeys list. The list of BlockedValues is
 	// applied regardless. If you just want to block values, set this to true.

--- a/processor/redactionprocessor/factory.go
+++ b/processor/redactionprocessor/factory.go
@@ -61,7 +61,8 @@ func createLogsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	next consumer.Logs) (processor.Logs, error) {
+	next consumer.Logs,
+) (processor.Logs, error) {
 	oCfg := cfg.(*Config)
 
 	red, err := newRedaction(ctx, oCfg, set.Logger)
@@ -83,7 +84,8 @@ func createMetricsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	next consumer.Metrics) (processor.Metrics, error) {
+	next consumer.Metrics,
+) (processor.Metrics, error) {
 	oCfg := cfg.(*Config)
 
 	red, err := newRedaction(ctx, oCfg, set.Logger)

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -241,7 +241,8 @@ func TestRedactSummaryInfo(t *testing.T) {
 		AllowedKeys:   []string{"id", "name", "group"},
 		BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?"},
 		IgnoredKeys:   []string{"safe_attribute"},
-		Summary:       "info"}
+		Summary:       "info",
+	}
 	allowed := map[string]pcommon.Value{
 		"id": pcommon.NewValueInt(5),
 	}
@@ -305,9 +306,11 @@ func TestRedactSummaryInfo(t *testing.T) {
 // TestRedactSummarySilent validates that the processor does not create the
 // summary attributes when set to silent
 func TestRedactSummarySilent(t *testing.T) {
-	config := &Config{AllowedKeys: []string{"id", "name", "group"},
+	config := &Config{
+		AllowedKeys:   []string{"id", "name", "group"},
 		BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?"},
-		Summary:       "silent"}
+		Summary:       "silent",
+	}
 	allowed := map[string]pcommon.Value{
 		"id": pcommon.NewValueInt(5),
 	}
@@ -403,9 +406,11 @@ func TestRedactSummaryDefault(t *testing.T) {
 // TestMultipleBlockValues validates that the processor can block multiple
 // patterns
 func TestMultipleBlockValues(t *testing.T) {
-	config := &Config{AllowedKeys: []string{"id", "name", "mystery"},
+	config := &Config{
+		AllowedKeys:   []string{"id", "name", "mystery"},
 		BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?", "(5[1-5][0-9]{3})"},
-		Summary:       "debug"}
+		Summary:       "debug",
+	}
 	allowed := map[string]pcommon.Value{
 		"id":      pcommon.NewValueInt(5),
 		"mystery": pcommon.NewValueStr("mystery 52000"),

--- a/processor/remotetapprocessor/processor.go
+++ b/processor/remotetapprocessor/processor.go
@@ -32,9 +32,11 @@ type wsprocessor struct {
 	limiter           *rate.Limiter
 }
 
-var logMarshaler = &plog.JSONMarshaler{}
-var metricMarshaler = &pmetric.JSONMarshaler{}
-var traceMarshaler = &ptrace.JSONMarshaler{}
+var (
+	logMarshaler    = &plog.JSONMarshaler{}
+	metricMarshaler = &pmetric.JSONMarshaler{}
+	traceMarshaler  = &ptrace.JSONMarshaler{}
+)
 
 func newProcessor(settings processor.Settings, config *Config) *wsprocessor {
 	return &wsprocessor{

--- a/processor/resourcedetectionprocessor/config.go
+++ b/processor/resourcedetectionprocessor/config.go
@@ -25,7 +25,6 @@ import (
 
 // Config defines configuration for Resource processor.
 type Config struct {
-
 	// Detectors is an ordered list of named detectors that should be
 	// run to attempt to detect resource information.
 	Detectors []string `mapstructure:"detectors"`

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
@@ -40,7 +40,8 @@ type ec2ClientBuilder struct{}
 func (e *ec2ClientBuilder) buildClient(region string, client *http.Client) (ec2iface.EC2API, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region:     aws.String(region),
-		HTTPClient: client},
+		HTTPClient: client,
+	},
 	)
 	if err != nil {
 		return nil, err

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2_test.go
@@ -173,7 +173,8 @@ func TestDetector_Detect(t *testing.T) {
 					InstanceType:     "c4.xlarge",
 				},
 				retHostname: "example-hostname",
-				isAvailable: true}},
+				isAvailable: true,
+			}},
 			args: args{ctx: context.Background()},
 			want: func() pcommon.Resource {
 				res := pcommon.NewResource()
@@ -188,7 +189,8 @@ func TestDetector_Detect(t *testing.T) {
 				attr.PutStr("host.type", "c4.xlarge")
 				attr.PutStr("host.name", "example-hostname")
 				return res
-			}()},
+			}(),
+		},
 		{
 			name: "success with tags",
 			fields: fields{metadataProvider: &mockMetadata{
@@ -201,7 +203,8 @@ func TestDetector_Detect(t *testing.T) {
 					InstanceType:     "c4.xlarge",
 				},
 				retHostname: "example-hostname",
-				isAvailable: true}},
+				isAvailable: true,
+			}},
 			tagKeyRegexes: []*regexp.Regexp{regexp.MustCompile("^tag1$"), regexp.MustCompile("^tag2$")},
 			args:          args{ctx: context.Background()},
 			want: func() pcommon.Resource {
@@ -234,7 +237,8 @@ func TestDetector_Detect(t *testing.T) {
 					InstanceType:     "c4.xlarge",
 				},
 				retHostname: "example-hostname",
-				isAvailable: true}},
+				isAvailable: true,
+			}},
 			args: args{ctx: context.Background()},
 			want: func() pcommon.Resource {
 				res := pcommon.NewResource()
@@ -261,7 +265,8 @@ func TestDetector_Detect(t *testing.T) {
 			}},
 			args:    args{ctx: context.Background()},
 			want:    pcommon.NewResource(),
-			wantErr: false},
+			wantErr: false,
+		},
 		{
 			name: "get fails",
 			fields: fields{metadataProvider: &mockMetadata{
@@ -271,7 +276,8 @@ func TestDetector_Detect(t *testing.T) {
 			}},
 			args:    args{ctx: context.Background()},
 			want:    pcommon.NewResource(),
-			wantErr: true},
+			wantErr: true,
+		},
 		{
 			name: "hostname fails",
 			fields: fields{metadataProvider: &mockMetadata{
@@ -282,7 +288,8 @@ func TestDetector_Detect(t *testing.T) {
 			}},
 			args:    args{ctx: context.Background()},
 			want:    pcommon.NewResource(),
-			wantErr: true},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/processor/resourcedetectionprocessor/internal/consul/config.go
+++ b/processor/resourcedetectionprocessor/internal/consul/config.go
@@ -13,7 +13,6 @@ import (
 // configuration will be provided to the API client.
 // See `consul.go#NewDetector` for more information.
 type Config struct {
-
 	// Address is the address of the Consul server
 	Address string `mapstructure:"address"`
 

--- a/processor/resourcedetectionprocessor/internal/resourcedetection.go
+++ b/processor/resourcedetectionprocessor/internal/resourcedetection.go
@@ -45,7 +45,8 @@ func (f *ResourceProviderFactory) CreateResourceProvider(
 	timeout time.Duration,
 	attributes []string,
 	detectorConfigs ResourceDetectorConfig,
-	detectorTypes ...DetectorType) (*ResourceProvider, error) {
+	detectorTypes ...DetectorType,
+) (*ResourceProvider, error) {
 	detectors, err := f.getDetectors(params, detectorConfigs, detectorTypes)
 	if err != nil {
 		return nil, err

--- a/processor/resourcedetectionprocessor/internal/system/system.go
+++ b/processor/resourcedetectionprocessor/internal/system/system.go
@@ -22,15 +22,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/system/internal/metadata"
 )
 
-var (
-	_ = featuregate.GlobalRegistry().MustRegister(
-		"processor.resourcedetection.hostCPUSteppingAsString",
-		featuregate.StageStable,
-		featuregate.WithRegisterDescription("Change type of host.cpu.stepping to string."),
-		featuregate.WithRegisterFromVersion("v0.95.0"),
-		featuregate.WithRegisterToVersion("v0.110.0"),
-		featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/semantic-conventions/issues/664"),
-	)
+var _ = featuregate.GlobalRegistry().MustRegister(
+	"processor.resourcedetection.hostCPUSteppingAsString",
+	featuregate.StageStable,
+	featuregate.WithRegisterDescription("Change type of host.cpu.stepping to string."),
+	featuregate.WithRegisterFromVersion("v0.95.0"),
+	featuregate.WithRegisterToVersion("v0.110.0"),
+	featuregate.WithRegisterReferenceURL("https://github.com/open-telemetry/semantic-conventions/issues/664"),
 )
 
 const (

--- a/processor/resourceprocessor/config.go
+++ b/processor/resourceprocessor/config.go
@@ -13,7 +13,6 @@ import (
 
 // Config defines configuration for Resource processor.
 type Config struct {
-
 	// AttributesActions specifies the list of actions to be applied on resource attributes.
 	// The set of actions are {INSERT, UPDATE, UPSERT, DELETE, HASH, EXTRACT}.
 	AttributesActions []attraction.ActionKeyValue `mapstructure:"attributes"`

--- a/processor/resourceprocessor/factory.go
+++ b/processor/resourceprocessor/factory.go
@@ -36,7 +36,8 @@ func createTracesProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Traces) (processor.Traces, error) {
+	nextConsumer consumer.Traces,
+) (processor.Traces, error) {
 	attrProc, err := attraction.NewAttrProc(&attraction.Settings{Actions: cfg.(*Config).AttributesActions})
 	if err != nil {
 		return nil, err
@@ -55,7 +56,8 @@ func createMetricsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Metrics) (processor.Metrics, error) {
+	nextConsumer consumer.Metrics,
+) (processor.Metrics, error) {
 	attrProc, err := attraction.NewAttrProc(&attraction.Settings{Actions: cfg.(*Config).AttributesActions})
 	if err != nil {
 		return nil, err
@@ -74,7 +76,8 @@ func createLogsProcessor(
 	ctx context.Context,
 	set processor.Settings,
 	cfg component.Config,
-	nextConsumer consumer.Logs) (processor.Logs, error) {
+	nextConsumer consumer.Logs,
+) (processor.Logs, error) {
 	attrProc, err := attraction.NewAttrProc(&attraction.Settings{Actions: cfg.(*Config).AttributesActions})
 	if err != nil {
 		return nil, err

--- a/processor/resourceprocessor/resource_processor_test.go
+++ b/processor/resourceprocessor/resource_processor_test.go
@@ -22,15 +22,13 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest/ptracetest"
 )
 
-var (
-	cfg = &Config{
-		AttributesActions: []attraction.ActionKeyValue{
-			{Key: "cloud.availability_zone", Value: "zone-1", Action: attraction.UPSERT},
-			{Key: "k8s.cluster.name", FromAttribute: "k8s-cluster", Action: attraction.INSERT},
-			{Key: "redundant-attribute", Action: attraction.DELETE},
-		},
-	}
-)
+var cfg = &Config{
+	AttributesActions: []attraction.ActionKeyValue{
+		{Key: "cloud.availability_zone", Value: "zone-1", Action: attraction.UPSERT},
+		{Key: "k8s.cluster.name", FromAttribute: "k8s-cluster", Action: attraction.INSERT},
+		{Key: "redundant-attribute", Action: attraction.DELETE},
+	},
+}
 
 func TestResourceProcessorAttributesUpsert(t *testing.T) {
 	tests := []struct {

--- a/processor/routingprocessor/config.go
+++ b/processor/routingprocessor/config.go
@@ -20,7 +20,6 @@ var (
 
 // Config defines configuration for the Routing processor.
 type Config struct {
-
 	// DefaultExporters contains the list of exporters to use when a more specific record can't be found in the routing table.
 	// Optional.
 	DefaultExporters []string `mapstructure:"default_exporters"`

--- a/processor/routingprocessor/router.go
+++ b/processor/routingprocessor/router.go
@@ -36,7 +36,6 @@ func newRouter[E component.Component, K any](
 	defaultExporterIDs []string,
 	settings component.TelemetrySettings,
 	parser ottl.Parser[K],
-
 ) router[E, K] {
 	return router[E, K]{
 		logger: settings.Logger,

--- a/processor/spanprocessor/span.go
+++ b/processor/spanprocessor/span.go
@@ -187,7 +187,7 @@ func (sp *spanProcessor) processToAttributes(span ptrace.Span) {
 		var sb strings.Builder
 
 		// Index in the oldName until which we traversed.
-		var oldNameIndex = 0
+		oldNameIndex := 0
 
 		attrs := span.Attributes()
 

--- a/processor/spanprocessor/span_test.go
+++ b/processor/spanprocessor/span_test.go
@@ -443,8 +443,10 @@ func TestSpanProcessor_ToAttributes(t *testing.T) {
 		},
 
 		{
-			rules: []string{`^\/api\/.*\/document\/(?P<documentId>.*)\/update\/3$`,
-				`^\/api\/(?P<version>.*)\/document\/.*\/update\/3$`},
+			rules: []string{
+				`^\/api\/.*\/document\/(?P<documentId>.*)\/update\/3$`,
+				`^\/api\/(?P<version>.*)\/document\/.*\/update\/3$`,
+			},
 			testCase: testCase{
 				inputName:  "/api/v1/document/321083210/update/3",
 				outputName: "/api/{version}/document/{documentId}/update/3",
@@ -457,8 +459,10 @@ func TestSpanProcessor_ToAttributes(t *testing.T) {
 		},
 
 		{
-			rules: []string{`^\/api\/v1\/document\/(?P<documentId>.*)\/update\/4$`,
-				`^\/api\/(?P<version>.*)\/document\/(?P<documentId>.*)\/update\/4$`},
+			rules: []string{
+				`^\/api\/v1\/document\/(?P<documentId>.*)\/update\/4$`,
+				`^\/api\/(?P<version>.*)\/document\/(?P<documentId>.*)\/update\/4$`,
+			},
 			testCase: testCase{
 				inputName:  "/api/v1/document/321083210/update/4",
 				outputName: "/api/v1/document/{documentId}/update/4",

--- a/processor/sumologicprocessor/processor_test.go
+++ b/processor/sumologicprocessor/processor_test.go
@@ -1299,9 +1299,9 @@ func TestLogFieldsConversionLogs(t *testing.T) {
 				log := logs.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty().LogRecords().AppendEmpty()
 				log.SetSeverityNumber(plog.SeverityNumberInfo)
 				log.SetSeverityText("severity")
-				var spanIDBytes = [8]byte{1, 1, 1, 1, 1, 1, 1, 1}
+				spanIDBytes := [8]byte{1, 1, 1, 1, 1, 1, 1, 1}
 				log.SetSpanID(spanIDBytes)
-				var traceIDBytes = [16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
+				traceIDBytes := [16]byte{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1}
 				log.SetTraceID(traceIDBytes)
 				return logs
 			},

--- a/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/always_sample_test.go
@@ -14,8 +14,10 @@ import (
 
 func TestEvaluate_AlwaysSample(t *testing.T) {
 	filter := NewAlwaysSample(componenttest.NewNopTelemetrySettings())
-	decision, err := filter.Evaluate(context.Background(), pcommon.TraceID([16]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-		16}), newTraceStringAttrs(nil, "example", "value"))
+	decision, err := filter.Evaluate(context.Background(), pcommon.TraceID([16]byte{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+		16,
+	}), newTraceStringAttrs(nil, "example", "value"))
 	assert.NoError(t, err)
 	assert.Equal(t, Sampled, decision)
 }

--- a/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/boolean_tag_filter_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestBooleanTagFilter(t *testing.T) {
-	var empty = map[string]any{}
+	empty := map[string]any{}
 	filter := NewBooleanAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", true, false)
 
 	resAttr := map[string]any{}
@@ -54,7 +54,7 @@ func TestBooleanTagFilter(t *testing.T) {
 }
 
 func TestBooleanTagFilterInverted(t *testing.T) {
-	var empty = map[string]any{}
+	empty := map[string]any{}
 	filter := NewBooleanAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", true, true)
 
 	resAttr := map[string]any{}

--- a/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/numeric_tag_filter_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestNumericTagFilter(t *testing.T) {
-	var empty = map[string]any{}
+	empty := map[string]any{}
 	filter := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", math.MinInt32, math.MaxInt32, false)
 
 	resAttr := map[string]any{}
@@ -85,7 +85,7 @@ func TestNumericTagFilter(t *testing.T) {
 }
 
 func TestNumericTagFilterInverted(t *testing.T) {
-	var empty = map[string]any{}
+	empty := map[string]any{}
 	filter := NewNumericAttributeFilter(componenttest.NewNopTelemetrySettings(), "example", math.MinInt32, math.MaxInt32, true)
 
 	resAttr := map[string]any{}

--- a/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/span_count_sampler_test.go
@@ -235,7 +235,7 @@ func TestEvaluate_RangeOfSpans(t *testing.T) {
 }
 
 func newTraceWithMultipleSpans(numberSpans []int32) *TraceData {
-	var totalNumberSpans = int32(0)
+	totalNumberSpans := int32(0)
 
 	// For each resource, going to create the number of spans defined in the array
 	traces := ptrace.NewTraces()

--- a/processor/tailsamplingprocessor/processor_benchmarks_test.go
+++ b/processor/tailsamplingprocessor/processor_benchmarks_test.go
@@ -37,7 +37,7 @@ func BenchmarkSampling(b *testing.B) {
 	for i := 0; i < len(batches); i++ {
 		sampleBatches = append(sampleBatches, &sampling.TraceData{
 			ArrivalTime: time.Now(),
-			//SpanCount:       spanCount,
+			// SpanCount:       spanCount,
 			ReceivedBatches: ptrace.NewTraces(),
 		})
 	}

--- a/processor/tailsamplingprocessor/processor_test.go
+++ b/processor/tailsamplingprocessor/processor_test.go
@@ -33,16 +33,18 @@ const (
 	defaultNumTraces        = 100
 )
 
-var testPolicy = []PolicyCfg{{sharedPolicyCfg: sharedPolicyCfg{Name: "test-policy", Type: AlwaysSample}}}
-var testLatencyPolicy = []PolicyCfg{
-	{
-		sharedPolicyCfg: sharedPolicyCfg{
-			Name:       "test-policy",
-			Type:       Latency,
-			LatencyCfg: LatencyCfg{ThresholdMs: 1},
+var (
+	testPolicy        = []PolicyCfg{{sharedPolicyCfg: sharedPolicyCfg{Name: "test-policy", Type: AlwaysSample}}}
+	testLatencyPolicy = []PolicyCfg{
+		{
+			sharedPolicyCfg: sharedPolicyCfg{
+				Name:       "test-policy",
+				Type:       Latency,
+				LatencyCfg: LatencyCfg{ThresholdMs: 1},
+			},
 		},
-	},
-}
+	}
+)
 
 type TestPolicyEvaluator struct {
 	Started       chan struct{}

--- a/processor/transformprocessor/internal/common/processor.go
+++ b/processor/transformprocessor/internal/common/processor.go
@@ -20,10 +20,12 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlscope"
 )
 
-var _ consumer.Traces = &resourceStatements{}
-var _ consumer.Metrics = &resourceStatements{}
-var _ consumer.Logs = &resourceStatements{}
-var _ baseContext = &resourceStatements{}
+var (
+	_ consumer.Traces  = &resourceStatements{}
+	_ consumer.Metrics = &resourceStatements{}
+	_ consumer.Logs    = &resourceStatements{}
+	_ baseContext      = &resourceStatements{}
+)
 
 type resourceStatements struct {
 	ottl.StatementSequence[ottlresource.TransformContext]
@@ -90,10 +92,12 @@ func (r resourceStatements) ConsumeLogs(ctx context.Context, ld plog.Logs) error
 	return nil
 }
 
-var _ consumer.Traces = &scopeStatements{}
-var _ consumer.Metrics = &scopeStatements{}
-var _ consumer.Logs = &scopeStatements{}
-var _ baseContext = &scopeStatements{}
+var (
+	_ consumer.Traces  = &scopeStatements{}
+	_ consumer.Metrics = &scopeStatements{}
+	_ consumer.Logs    = &scopeStatements{}
+	_ baseContext      = &scopeStatements{}
+)
 
 type scopeStatements struct {
 	ottl.StatementSequence[ottlscope.TransformContext]
@@ -215,7 +219,8 @@ func parseGlobalExpr[K any](
 	boolExprFunc func([]string, map[string]ottl.Factory[K], ottl.ErrorMode, component.TelemetrySettings) (*ottl.ConditionSequence[K], error),
 	conditions []string,
 	pc parserCollection,
-	standardFuncs map[string]ottl.Factory[K]) (expr.BoolExpr[K], error) {
+	standardFuncs map[string]ottl.Factory[K],
+) (expr.BoolExpr[K], error) {
 	if len(conditions) > 0 {
 		return boolExprFunc(conditions, standardFuncs, pc.errorMode, pc.settings)
 	}

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist.go
@@ -160,7 +160,8 @@ func calculateBucketCounts(dp pmetric.ExponentialHistogramDataPoint, boundaries 
 //     upper = math.Exp((index+1) * factor)
 var upperAlgorithm distAlgorithm = func(count uint64,
 	upper, _ float64, boundaries []float64,
-	bucketCountsDst *[]uint64) {
+	bucketCountsDst *[]uint64,
+) {
 	// count := bucketCountsSrc.At(index)
 
 	// At this point we know that the upper bound represents the highest value that can be in this bucket, so we take the
@@ -181,7 +182,8 @@ var upperAlgorithm distAlgorithm = func(count uint64,
 // The midpoint is calculated as (upper + lower) / 2.
 var midpointAlgorithm distAlgorithm = func(count uint64,
 	upper, lower float64, boundaries []float64,
-	bucketCountsDst *[]uint64) {
+	bucketCountsDst *[]uint64,
+) {
 	midpoint := (upper + lower) / 2
 
 	for j, boundary := range boundaries {
@@ -200,8 +202,8 @@ var midpointAlgorithm distAlgorithm = func(count uint64,
 // uniformAlgorithm distributes counts from a given set of bucket sounrces into a set of linear boundaries using uniform distribution
 var uniformAlgorithm distAlgorithm = func(count uint64,
 	upper, lower float64, boundaries []float64,
-	bucketCountsDst *[]uint64) {
-
+	bucketCountsDst *[]uint64,
+) {
 	// Find the boundaries that intersect with the bucket range
 	var start, end int
 	for start = 0; start < len(boundaries); start++ {
@@ -242,7 +244,8 @@ var uniformAlgorithm distAlgorithm = func(count uint64,
 // randomAlgorithm distributes counts from a given set of bucket sources into a set of linear boundaries using random distribution
 var randomAlgorithm distAlgorithm = func(count uint64,
 	upper, lower float64, boundaries []float64,
-	bucketCountsDst *[]uint64) {
+	bucketCountsDst *[]uint64,
+) {
 	// Find the boundaries that intersect with the bucket range
 	start := 0
 	for start < len(boundaries) && boundaries[start] < lower {

--- a/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_exponential_hist_to_explicit_hist_test.go
@@ -138,7 +138,6 @@ func TestUpper_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			},
 		},
 		{
-
 			name:         "convert exponential histogram to explicit history",
 			input:        defaultTestMetric,
 			arg:          []float64{160.0, 170.0, 180.0, 190.0, 200.0},
@@ -350,7 +349,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			},
 		},
 		{
-
 			name:         "convert exponential histogram to explicit hist",
 			input:        defaultTestMetric,
 			arg:          []float64{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0},
@@ -376,7 +374,6 @@ func TestMidpoint_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			},
 		},
 		{
-
 			name: "convert exponential histogram to explicit hist with zero count",
 			input: func() pmetric.Metric {
 				m := defaultTestMetric()
@@ -534,7 +531,6 @@ func TestUniforn_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			},
 		},
 		{
-
 			name:         "convert exponential histogram to explicit hist",
 			input:        defaultTestMetric,
 			arg:          []float64{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0},
@@ -664,7 +660,6 @@ func TestRandom_convert_exponential_hist_to_explicit_hist(t *testing.T) {
 			},
 		},
 		{
-
 			name:         "convert exponential histogram to explicit hist",
 			input:        defaultTestMetric,
 			arg:          []float64{10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0},


### PR DESCRIPTION
#### Description

[gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) enforces a stricter format than gofmt

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36363