### PR TITLE
[chore]: enable whitespace linter globally

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -166,6 +166,7 @@ linters:
     - unused
     - usestdlibvars
     - wastedassign
+    - whitespace
 
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source

--- a/cmd/checkapi/main.go
+++ b/cmd/checkapi/main.go
@@ -99,7 +99,6 @@ func handleFile(f *ast.File, result *api) {
 						result.Structs = append(result.Structs, t.Name.String())
 					}
 				}
-
 			}
 		}
 		if fn, isFn := d.(*ast.FuncDecl); isFn {
@@ -112,7 +111,6 @@ func handleFile(f *ast.File, result *api) {
 				exported = true
 			}
 			if fn.Recv.NumFields() > 0 {
-
 				for _, t := range fn.Recv.List {
 					for _, n := range t.Names {
 						exported = exported || n.IsExported()

--- a/cmd/githubgen/issuetemplates.go
+++ b/cmd/githubgen/issuetemplates.go
@@ -64,7 +64,6 @@ func (itg issueTemplatesGenerator) generate(data *githubData) error {
 				return err
 			}
 		}
-
 	}
 	return nil
 }

--- a/cmd/githubgen/main.go
+++ b/cmd/githubgen/main.go
@@ -112,7 +112,6 @@ func loadMetadata(filePath string) (metadata, error) {
 }
 
 func run(folder string, allowlistFilePath string, generators []generator) error {
-
 	components := map[string]metadata{}
 	var foldersList []string
 	maxLength := 0

--- a/cmd/opampsupervisor/main_windows.go
+++ b/cmd/opampsupervisor/main_windows.go
@@ -31,7 +31,6 @@ func run() error {
 			// ignore this error and only return other errors
 			return fmt.Errorf("alloc console: %w", err)
 		}
-
 	}
 	defer func() {
 		_ = freeConsole()

--- a/cmd/opampsupervisor/supervisor/persistence_test.go
+++ b/cmd/opampsupervisor/supervisor/persistence_test.go
@@ -36,7 +36,6 @@ func TestCreateOrLoadPersistentState(t *testing.T) {
 		require.Equal(t, uuid.MustParse("018feed6-905b-7aa6-ba37-b0eec565de03"), state.InstanceID)
 		require.FileExists(t, f)
 	})
-
 }
 
 func TestPersistentState_SetInstanceID(t *testing.T) {

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -878,7 +878,6 @@ func (s *Supervisor) setupOwnMetrics(_ context.Context, settings *protobufs.Tele
 			s.logger.Error("Could not setup own metrics", zap.Error(err))
 			return
 		}
-
 	}
 	s.agentConfigOwnMetricsSection.Store(cfg.String())
 
@@ -1274,7 +1273,6 @@ func (s *Supervisor) onMessage(ctx context.Context, msg *types.MessageData) {
 
 	// Update the agent config if any messages have touched the config
 	if configChanged {
-
 		err := s.opampClient.UpdateEffectiveConfig(ctx)
 		if err != nil {
 			s.logger.Error("The OpAMP client failed to update the effective config", zap.Error(err))

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -369,7 +369,6 @@ func Test_onMessage(t *testing.T) {
 		require.Contains(t, mergedCfg, "runtime.type: test")
 	})
 	t.Run("RemoteConfig - Remote Config message is processed and merged into local config", func(t *testing.T) {
-
 		const testConfigMessage = `receivers:
   debug:`
 
@@ -468,7 +467,6 @@ service:
 		assert.True(t, remoteConfigStatusUpdated)
 	})
 	t.Run("RemoteConfig - Remote Config message is processed but OpAmp Client fails", func(t *testing.T) {
-
 		const testConfigMessage = `receivers:
   debug:`
 
@@ -567,7 +565,6 @@ service:
 		assert.True(t, remoteConfigStatusUpdated)
 	})
 	t.Run("RemoteConfig - Invalid Remote Config message is detected and status is set appropriately", func(t *testing.T) {
-
 		const testConfigMessage = `invalid`
 
 		remoteConfig := &protobufs.AgentRemoteConfig{
@@ -635,7 +632,6 @@ service:
 		assert.Nil(t, s.cfgState.Load())
 		assert.True(t, remoteConfigStatusUpdated)
 	})
-
 }
 
 func Test_handleAgentOpAMPMessage(t *testing.T) {
@@ -1165,7 +1161,6 @@ service:
 }
 
 func TestSupervisor_createEffectiveConfigMsg(t *testing.T) {
-
 	t.Run("empty config", func(t *testing.T) {
 		s := Supervisor{
 			effectiveConfig: &atomic.Value{},
@@ -1200,13 +1195,10 @@ func TestSupervisor_createEffectiveConfigMsg(t *testing.T) {
 
 		assert.Equal(t, []byte("merged"), got.ConfigMap.ConfigMap[""].Body)
 	})
-
 }
 
 func TestSupervisor_loadAndWriteInitialMergedConfig(t *testing.T) {
-
 	t.Run("load initial config", func(t *testing.T) {
-
 		configDir := t.TempDir()
 
 		const testLastReceivedRemoteConfig = `receiver:
@@ -1328,11 +1320,9 @@ service:
 		replacedMergedConfig := portRegex.ReplaceAll([]byte(gotMergedConfig), []byte(":55555"))
 		assert.Equal(t, expectedMergedConfig, string(replacedMergedConfig))
 	})
-
 }
 
 func TestSupervisor_composeNoopConfig(t *testing.T) {
-
 	const expectedConfig = `exporters:
     nop: null
 extensions:

--- a/cmd/telemetrygen/config.go
+++ b/cmd/telemetrygen/config.go
@@ -76,7 +76,6 @@ func init() {
 	// Disabling completion command for end user
 	// https://github.com/spf13/cobra/blob/master/shell_completions.md
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
-
 }
 
 // Execute tries to run the input command

--- a/cmd/telemetrygen/internal/logs/worker.go
+++ b/cmd/telemetrygen/internal/logs/worker.go
@@ -53,7 +53,6 @@ func (w worker) simulateLogs(res *resource.Resource, exporterFunc func() (sdklog
 	}()
 
 	for w.running.Load() {
-
 		var tid trace.TraceID
 		var sid trace.SpanID
 

--- a/cmd/telemetrygen/internal/metrics/config.go
+++ b/cmd/telemetrygen/internal/metrics/config.go
@@ -36,7 +36,6 @@ func (c *Config) Flags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&c.TraceID, "trace-id", "", "TraceID to use as exemplar")
 	fs.StringVar(&c.SpanID, "span-id", "", "SpanID to use as exemplar")
-
 }
 
 // Validate validates the test scenario parameters.

--- a/cmd/telemetrygen/internal/traces/worker_test.go
+++ b/cmd/telemetrygen/internal/traces/worker_test.go
@@ -391,5 +391,4 @@ func configWithMultipleAttributes(qty int, statusCode string) *Config {
 		NumTraces:  qty,
 		StatusCode: statusCode,
 	}
-
 }

--- a/confmap/provider/aesprovider/provider.go
+++ b/confmap/provider/aesprovider/provider.go
@@ -46,7 +46,6 @@ func (*provider) Shutdown(context.Context) error {
 }
 
 func (p *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc) (*confmap.Retrieved, error) {
-
 	if !strings.HasPrefix(uri, schemaName+":") {
 		return nil, fmt.Errorf("%q uri is not supported by %q provider", uri, schemaName)
 	}
@@ -76,7 +75,6 @@ func (p *provider) Retrieve(_ context.Context, uri string, _ confmap.WatcherFunc
 }
 
 func (p *provider) decrypt(cipherText string) (string, error) {
-
 	cipherBytes, err := base64.StdEncoding.DecodeString(cipherText)
 	if err != nil {
 		return "", err

--- a/confmap/provider/aesprovider/provider_test.go
+++ b/confmap/provider/aesprovider/provider_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAESCredentialProvider(t *testing.T) {
-
 	tests := []struct {
 		name          string
 		configValue   string

--- a/confmap/provider/s3provider/provider_test.go
+++ b/confmap/provider/s3provider/provider_test.go
@@ -61,7 +61,6 @@ func TestFunctionalityS3URISplit(t *testing.T) {
 }
 
 func TestURIs(t *testing.T) {
-
 	tests := []struct {
 		name   string
 		uri    string

--- a/examples/demo/client/main.go
+++ b/examples/demo/client/main.go
@@ -174,7 +174,6 @@ func main() {
 }
 
 func makeRequest(ctx context.Context) {
-
 	demoServerAddr, ok := os.LookupEnv("DEMO_SERVER_ENDPOINT")
 	if !ok {
 		demoServerAddr = "http://0.0.0.0:7080/hello"

--- a/examples/demo/server/main.go
+++ b/examples/demo/server/main.go
@@ -152,7 +152,6 @@ func main() {
 			http.Error(w, "write operation failed.", http.StatusInternalServerError)
 			return
 		}
-
 	})
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
#### Description

[whitespace](https://golangci-lint.run/usage/linters/#whitespace) is a linter that checks for unnecessary newlines at the start and end of functions.
