### PR TITLE
googlemanagedprometheusexporter: add config option for cumulative normalization

### DIFF
--- a/.chloggen/configure-cumulative-normalization.yaml
+++ b/.chloggen/configure-cumulative-normalization.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlemanagedprometheus
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `CumulativeNormalization` config option to allow users to configure to specify whether to report normalized or un-normalized points. Defaults to normalized.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36357]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/googlemanagedprometheusexporter/config.go
+++ b/exporter/googlemanagedprometheusexporter/config.go
@@ -37,12 +37,18 @@ type MetricConfig struct {
 	ClientConfig    collector.ClientConfig         `mapstructure:",squash"`
 	Config          googlemanagedprometheus.Config `mapstructure:",squash"`
 	ResourceFilters []collector.ResourceFilter     `mapstructure:"resource_filters"`
+	// CumulativeNormalization normalizes cumulative metrics without start times or with
+	// explicit reset points by subtracting subsequent points from the initial point.
+	// It is enabled by default. Since it caches starting points, it may result in
+	// increased memory usage.
+	CumulativeNormalization bool `mapstructure:"cumulative_normalization"`
 }
 
 func (c *GMPConfig) toCollectorConfig() collector.Config {
 	// start with whatever the default collector config is.
 	cfg := collector.DefaultConfig()
 	cfg.MetricConfig.Prefix = c.MetricConfig.Prefix
+	cfg.MetricConfig.CumulativeNormalization = c.MetricConfig.CumulativeNormalization
 	if c.MetricConfig.Prefix == "" {
 		cfg.MetricConfig.Prefix = "prometheus.googleapis.com"
 	}

--- a/exporter/googlemanagedprometheusexporter/config_test.go
+++ b/exporter/googlemanagedprometheusexporter/config_test.go
@@ -77,6 +77,7 @@ func TestLoadConfig(t *testing.T) {
 						Regex: "host.id",
 					},
 				},
+				CumulativeNormalization: false,
 			},
 		},
 		QueueSettings: exporterhelper.QueueConfig{

--- a/exporter/googlemanagedprometheusexporter/factory.go
+++ b/exporter/googlemanagedprometheusexporter/factory.go
@@ -39,7 +39,8 @@ func createDefaultConfig() component.Config {
 		QueueSettings:   exporterhelper.NewDefaultQueueConfig(),
 		GMPConfig: GMPConfig{
 			MetricConfig: MetricConfig{
-				Config: googlemanagedprometheus.DefaultConfig(),
+				Config:                  googlemanagedprometheus.DefaultConfig(),
+				CumulativeNormalization: true,
 			},
 		},
 	}

--- a/exporter/googlemanagedprometheusexporter/testdata/config.yaml
+++ b/exporter/googlemanagedprometheusexporter/testdata/config.yaml
@@ -17,23 +17,22 @@ exporters:
     metric:
       prefix: my-metric-domain.com
       add_metric_suffixes: false
+      cumulative_normalization: false
       extra_metrics_config:
         enable_target_info: false
         enable_scope_info: false
       resource_filters:
-      - prefix: "cloud"
-      - prefix: "k8s"
-      - prefix: "faas"
-      - regex: "container.id"
-      - regex: "process.pid"
-      - regex: "host.name"
-      - regex: "host.id"
-
+        - prefix: "cloud"
+        - prefix: "k8s"
+        - prefix: "faas"
+        - regex: "container.id"
+        - regex: "process.pid"
+        - regex: "host.name"
+        - regex: "host.id"
 
 service:
   pipelines:
     traces:
-        receivers: [nop]
-        processors: [nop]
-        exporters: [googlemanagedprometheus]
-
+      receivers: [nop]
+      processors: [nop]
+      exporters: [googlemanagedprometheus]


### PR DESCRIPTION
This change will allow the configurer to set whether cumulative normalization should be set. The main benefit from this is so we can send the first point immediately as we see them.  This will allow our serverless offering to unfork the exporter:
https://github.com/GoogleCloudPlatform/run-gmp-sidecar/tree/main/collector/exporter/googlemanagedprometheusexporter