### PR TITLE
[chore]: enable gofumpt linter for internal

### DIFF
--- a/internal/aws/awsutil/conn.go
+++ b/internal/aws/awsutil/conn.go
@@ -45,7 +45,8 @@ const (
 
 // newHTTPClient returns new HTTP client instance with provided configuration.
 func newHTTPClient(logger *zap.Logger, maxIdle int, requestTimeout int, noVerify bool,
-	proxyAddress string) (*http.Client, error) {
+	proxyAddress string,
+) (*http.Client, error) {
 	logger.Debug("Using proxy address: ",
 		zap.String("proxyAddr", proxyAddress),
 	)
@@ -206,7 +207,6 @@ func (c *Conn) newAWSSession(logger *zap.Logger, roleArn string, region string) 
 		s, err = session.NewSession(&aws.Config{
 			Credentials: stsCreds,
 		})
-
 		if err != nil {
 			logger.Error("Error in creating session object : ", zap.Error(err))
 			return s, err
@@ -245,7 +245,8 @@ func getSTSCreds(logger *zap.Logger, region string, roleArn string) (*credential
 // AWS STS recommends that you provide both the Region and endpoint when you make calls to a Regional endpoint.
 // Reference: https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html#id_credentials_temp_enable-regions_writing_code
 func getSTSCredsFromRegionEndpoint(logger *zap.Logger, sess *session.Session, region string,
-	roleArn string) *credentials.Credentials {
+	roleArn string,
+) *credentials.Credentials {
 	regionalEndpoint := getSTSRegionalEndpoint(region)
 	// if regionalEndpoint is "", the STS endpoint is Global endpoint for classic regions except ap-east-1 - (HKG)
 	// for other opt-in regions, region value will create STS regional endpoint.
@@ -259,7 +260,8 @@ func getSTSCredsFromRegionEndpoint(logger *zap.Logger, sess *session.Session, re
 // getSTSCredsFromPrimaryRegionEndpoint fetches STS credentials for provided roleARN from primary region endpoint in
 // the respective partition.
 func getSTSCredsFromPrimaryRegionEndpoint(logger *zap.Logger, t *session.Session, roleArn string,
-	region string) *credentials.Credentials {
+	region string,
+) *credentials.Credentials {
 	logger.Info("Credentials for provided RoleARN being fetched from STS primary region endpoint.")
 	partitionID := getPartition(region)
 	switch partitionID {

--- a/internal/aws/awsutil/conn_test.go
+++ b/internal/aws/awsutil/conn_test.go
@@ -58,7 +58,7 @@ func TestRegionEnv(t *testing.T) {
 	region := "us-east-1"
 	t.Setenv("AWS_REGION", region)
 
-	var m = &mockConn{}
+	m := &mockConn{}
 	var expectedSession *session.Session
 	expectedSession, _ = session.NewSession()
 	m.sn = expectedSession

--- a/internal/aws/containerinsight/utils_test.go
+++ b/internal/aws/containerinsight/utils_test.go
@@ -132,7 +132,8 @@ func convertToFloat64(value any) float64 {
 }
 
 func checkMetricsAreExpected(t *testing.T, md pmetric.Metrics, fields map[string]any, tags map[string]string,
-	expectedUnits map[string]string) {
+	expectedUnits map[string]string,
+) {
 	rms := md.ResourceMetrics()
 	assert.Equal(t, 1, rms.Len())
 

--- a/internal/aws/cwlogs/cwlog_client.go
+++ b/internal/aws/cwlogs/cwlog_client.go
@@ -26,9 +26,7 @@ const (
 	errCodeThrottlingException = "ThrottlingException"
 )
 
-var (
-	containerInsightsRegexPattern = regexp.MustCompile(`^/aws/.*containerinsights/.*/(performance|prometheus)$`)
-)
+var containerInsightsRegexPattern = regexp.MustCompile(`^/aws/.*containerinsights/.*/(performance|prometheus)$`)
 
 // Possible exceptions are combination of common errors (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/CommonErrors.html)
 // and API specific erros (e.g. https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html#API_PutLogEvents_Errors)
@@ -53,10 +51,12 @@ func WithUserAgentExtras(userAgentExtras ...string) ClientOption {
 
 // Create a log client based on the actual cloudwatch logs client.
 func newCloudWatchLogClient(svc cloudwatchlogsiface.CloudWatchLogsAPI, logRetention int64, tags map[string]*string, logger *zap.Logger) *Client {
-	logClient := &Client{svc: svc,
+	logClient := &Client{
+		svc:          svc,
 		logRetention: logRetention,
 		tags:         tags,
-		logger:       logger}
+		logger:       logger,
+	}
 	return logClient
 }
 
@@ -124,7 +124,7 @@ func (client *Client) PutLogEvents(input *cloudwatchlogs.PutLogEventsInput, retr
 			}
 		}
 
-		//TODO: Should have metrics to provide visibility of these failures
+		// TODO: Should have metrics to provide visibility of these failures
 		if response != nil {
 			if response.RejectedLogEventsInfo != nil {
 				rejectedLogEventsInfo := response.RejectedLogEventsInfo

--- a/internal/aws/cwlogs/cwlog_client_test.go
+++ b/internal/aws/cwlogs/cwlog_client_test.go
@@ -27,7 +27,8 @@ func newAlwaysPassMockLogClient(putLogEventsFunc func(args mock.Arguments)) *Cli
 
 	svc.On("PutLogEvents", mock.Anything).Return(
 		&cloudwatchlogs.PutLogEventsOutput{
-			NextSequenceToken: &expectedNextSequenceToken},
+			NextSequenceToken: &expectedNextSequenceToken,
+		},
 		nil).Run(putLogEventsFunc)
 
 	svc.On("CreateLogGroup", mock.Anything).Return(new(cloudwatchlogs.CreateLogGroupOutput), nil)
@@ -36,7 +37,8 @@ func newAlwaysPassMockLogClient(putLogEventsFunc func(args mock.Arguments)) *Cli
 
 	svc.On("DescribeLogStreams", mock.Anything).Return(
 		&cloudwatchlogs.DescribeLogStreamsOutput{
-			LogStreams: []*cloudwatchlogs.LogStream{{UploadSequenceToken: &expectedNextSequenceToken}}},
+			LogStreams: []*cloudwatchlogs.LogStream{{UploadSequenceToken: &expectedNextSequenceToken}},
+		},
 		nil)
 	return newCloudWatchLogClient(svc, 0, nil, logger)
 }
@@ -77,11 +79,13 @@ func (svc *mockCloudWatchLogsClient) TagResource(input *cloudwatchlogs.TagResour
 }
 
 // Tests
-var previousSequenceToken = "0000"
-var expectedNextSequenceToken = "1111"
-var logGroup = "logGroup"
-var logStreamName = "logStream"
-var emptySequenceToken = ""
+var (
+	previousSequenceToken     = "0000"
+	expectedNextSequenceToken = "1111"
+	logGroup                  = "logGroup"
+	logStreamName             = "logStream"
+	emptySequenceToken        = ""
+)
 
 func TestPutLogEvents_HappyCase(t *testing.T) {
 	logger := zap.NewNop()
@@ -92,7 +96,8 @@ func TestPutLogEvents_HappyCase(t *testing.T) {
 		SequenceToken: &previousSequenceToken,
 	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, nil)
 
@@ -114,7 +119,8 @@ func TestPutLogEvents_HappyCase_SomeRejectedInfo(t *testing.T) {
 	rejectedLogEventsInfo := &cloudwatchlogs.RejectedLogEventsInfo{
 		ExpiredLogEventEndIndex:  aws.Int64(1),
 		TooNewLogEventStartIndex: aws.Int64(2),
-		TooOldLogEventEndIndex:   aws.Int64(3)}
+		TooOldLogEventEndIndex:   aws.Int64(3),
+	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
 		NextSequenceToken:     &expectedNextSequenceToken,
 		RejectedLogEventsInfo: rejectedLogEventsInfo,
@@ -138,7 +144,8 @@ func TestPutLogEvents_NonAWSError(t *testing.T) {
 		SequenceToken: &previousSequenceToken,
 	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, errors.New("some random error")).Once()
 
@@ -158,7 +165,8 @@ func TestPutLogEvents_InvalidParameterException(t *testing.T) {
 		SequenceToken: &previousSequenceToken,
 	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 
 	invalidParameterException := &cloudwatchlogs.InvalidParameterException{}
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, invalidParameterException).Once()
@@ -179,7 +187,8 @@ func TestPutLogEvents_OperationAbortedException(t *testing.T) {
 		SequenceToken: &previousSequenceToken,
 	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 
 	operationAbortedException := &cloudwatchlogs.OperationAbortedException{}
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, operationAbortedException).Once()
@@ -200,7 +209,8 @@ func TestPutLogEvents_ServiceUnavailableException(t *testing.T) {
 		SequenceToken: &previousSequenceToken,
 	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 
 	serviceUnavailableException := &cloudwatchlogs.ServiceUnavailableException{}
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, serviceUnavailableException).Once()
@@ -221,7 +231,8 @@ func TestPutLogEvents_UnknownException(t *testing.T) {
 		SequenceToken: &previousSequenceToken,
 	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 
 	unknownException := awserr.New("unknownException", "", nil)
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, unknownException).Once()
@@ -242,7 +253,8 @@ func TestPutLogEvents_ThrottlingException(t *testing.T) {
 		SequenceToken: &previousSequenceToken,
 	}
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 
 	throttlingException := awserr.New(errCodeThrottlingException, "", nil)
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, throttlingException).Once()
@@ -264,7 +276,8 @@ func TestPutLogEvents_ResourceNotFoundException(t *testing.T) {
 	}
 
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 	awsErr := &cloudwatchlogs.ResourceNotFoundException{}
 
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, awsErr).Once()
@@ -291,7 +304,8 @@ func TestLogRetention_NeverExpire(t *testing.T) {
 	}
 
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 	awsErr := &cloudwatchlogs.ResourceNotFoundException{}
 
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, awsErr).Once()
@@ -326,7 +340,8 @@ func TestLogRetention_RetentionDaysInputted(t *testing.T) {
 	}
 
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 	awsErr := &cloudwatchlogs.ResourceNotFoundException{}
 
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, awsErr).Once()
@@ -362,7 +377,8 @@ func TestSetTags_NotCalled(t *testing.T) {
 	}
 
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 	awsErr := &cloudwatchlogs.ResourceNotFoundException{}
 
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, awsErr).Once()
@@ -397,7 +413,8 @@ func TestSetTags_Called(t *testing.T) {
 	}
 
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: &expectedNextSequenceToken}
+		NextSequenceToken: &expectedNextSequenceToken,
+	}
 	awsErr := &cloudwatchlogs.ResourceNotFoundException{}
 
 	avalue := "avalue"
@@ -433,7 +450,8 @@ func TestPutLogEvents_AllRetriesFail(t *testing.T) {
 	}
 
 	putLogEventsOutput := &cloudwatchlogs.PutLogEventsOutput{
-		NextSequenceToken: nil}
+		NextSequenceToken: nil,
+	}
 	awsErr := &cloudwatchlogs.ResourceNotFoundException{}
 
 	svc.On("PutLogEvents", putLogEventsInput).Return(putLogEventsOutput, awsErr).Twice()

--- a/internal/aws/cwlogs/pusher.go
+++ b/internal/aws/cwlogs/pusher.go
@@ -29,9 +29,7 @@ const (
 	evenTimestampLimitInFuture = -2 * time.Hour      // None of the log events in the batch can be more than 2 hours in the future.
 )
 
-var (
-	maxEventPayloadBytes = defaultMaxEventPayloadBytes
-)
+var maxEventPayloadBytes = defaultMaxEventPayloadBytes
 
 // Event struct to present a log event.
 type Event struct {
@@ -48,7 +46,8 @@ func NewEvent(timestampMs int64, message string) *Event {
 	event := &Event{
 		InputLogEvent: &cloudwatchlogs.InputLogEvent{
 			Timestamp: aws.Int64(timestampMs),
-			Message:   aws.String(message)},
+			Message:   aws.String(message),
+		},
 	}
 	return event
 }
@@ -115,7 +114,8 @@ func newEventBatch(key StreamKey) *eventBatch {
 		putLogEventsInput: &cloudwatchlogs.PutLogEventsInput{
 			LogGroupName:  aws.String(key.LogGroupName),
 			LogStreamName: aws.String(key.LogStreamName),
-			LogEvents:     make([]*cloudwatchlogs.InputLogEvent, 0, maxRequestEventCount)},
+			LogEvents:     make([]*cloudwatchlogs.InputLogEvent, 0, maxRequestEventCount),
+		},
 	}
 }
 
@@ -194,7 +194,8 @@ type logPusher struct {
 
 // NewPusher creates a logPusher instance
 func NewPusher(streamKey StreamKey, retryCnt int,
-	svcStructuredLog Client, logger *zap.Logger) Pusher {
+	svcStructuredLog Client, logger *zap.Logger,
+) Pusher {
 	pusher := newLogPusher(streamKey, svcStructuredLog, logger)
 
 	pusher.retryCnt = defaultRetryCount
@@ -207,7 +208,8 @@ func NewPusher(streamKey StreamKey, retryCnt int,
 
 // Only create a logPusher, but not start the instance.
 func newLogPusher(streamKey StreamKey,
-	svcStructuredLog Client, logger *zap.Logger) *logPusher {
+	svcStructuredLog Client, logger *zap.Logger,
+) *logPusher {
 	pusher := &logPusher{
 		logGroupName:     aws.String(streamKey.LogGroupName),
 		logStreamName:    aws.String(streamKey.LogStreamName),
@@ -260,7 +262,6 @@ func (p *logPusher) pushEventBatch(req any) error {
 	startTime := time.Now()
 
 	err := p.svcStructuredLog.PutLogEvents(putLogEventsInput, p.retryCnt)
-
 	if err != nil {
 		return err
 	}

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -83,7 +83,9 @@ func TestLogEventBatch_sortLogEvents(t *testing.T) {
 	totalEvents := 10
 	logEventBatch := &eventBatch{
 		putLogEventsInput: &cloudwatchlogs.PutLogEventsInput{
-			LogEvents: make([]*cloudwatchlogs.InputLogEvent, 0, totalEvents)}}
+			LogEvents: make([]*cloudwatchlogs.InputLogEvent, 0, totalEvents),
+		},
+	}
 
 	for i := 0; i < totalEvents; i++ {
 		timestamp := rand.Int()
@@ -120,8 +122,10 @@ func newMockPusher() *logPusher {
 // pusher Tests
 //
 
-var timestampMs = time.Now().UnixNano() / 1e6
-var msg = "test log message"
+var (
+	timestampMs = time.Now().UnixNano() / 1e6
+	msg         = "test log message"
+)
 
 func TestPusher_newLogEventBatch(t *testing.T) {
 	p := newMockPusher()

--- a/internal/aws/ecsutil/metadata_provider.go
+++ b/internal/aws/ecsutil/metadata_provider.go
@@ -64,7 +64,6 @@ func (md *ecsMetadataProviderImpl) FetchTaskMetadata() (*TaskMetadata, error) {
 	taskMetadata := &TaskMetadata{}
 
 	err = json.NewDecoder(bytes.NewReader(resp)).Decode(taskMetadata)
-
 	if err != nil {
 		return nil, fmt.Errorf("encountered unexpected error reading response from ECS Task Metadata Endpoint: %w", err)
 	}
@@ -82,7 +81,6 @@ func (md *ecsMetadataProviderImpl) FetchContainerMetadata() (*ContainerMetadata,
 	containerMetadata := &ContainerMetadata{}
 
 	err = json.NewDecoder(bytes.NewReader(resp)).Decode(containerMetadata)
-
 	if err != nil {
 		return nil, fmt.Errorf("encountered unexpected error reading response from ECS Container Metadata Endpoint: %w", err)
 	}

--- a/internal/aws/k8s/k8sclient/helpers_test.go
+++ b/internal/aws/k8s/k8sclient/helpers_test.go
@@ -10,11 +10,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-type mockReflectorSyncChecker struct {
-}
+type mockReflectorSyncChecker struct{}
 
 func (m *mockReflectorSyncChecker) Check(_ cacheReflector, _ string) {
-
 }
 
 var kubeConfigPath string
@@ -54,7 +52,7 @@ users:
 	if err != nil {
 		t.Error(err)
 	}
-	if err := os.WriteFile(tmpfile.Name(), []byte(content), 0600); err != nil {
+	if err := os.WriteFile(tmpfile.Name(), []byte(content), 0o600); err != nil {
 		t.Error(err)
 	}
 	// overwrite the default kube config path

--- a/internal/aws/k8s/k8sclient/job.go
+++ b/internal/aws/k8s/k8sclient/job.go
@@ -27,8 +27,7 @@ type JobClient interface {
 	JobToCronJob() map[string]string
 }
 
-type noOpJobClient struct {
-}
+type noOpJobClient struct{}
 
 func (nc *noOpJobClient) JobToCronJob() map[string]string {
 	return map[string]string{}

--- a/internal/aws/k8s/k8sclient/replicaset.go
+++ b/internal/aws/k8s/k8sclient/replicaset.go
@@ -27,8 +27,7 @@ type ReplicaSetClient interface {
 	ReplicaSetToDeployment() map[string]string
 }
 
-type noOpReplicaSetClient struct {
-}
+type noOpReplicaSetClient struct{}
 
 func (nc *noOpReplicaSetClient) ReplicaSetToDeployment() map[string]string {
 	return map[string]string{}

--- a/internal/aws/proxy/conn.go
+++ b/internal/aws/proxy/conn.go
@@ -60,7 +60,6 @@ var newAWSSession = func(roleArn string, region string, log *zap.Logger) (*sessi
 	sess, err := session.NewSession(&aws.Config{
 		Credentials: stsCreds,
 	})
-
 	if err != nil {
 		return nil, err
 	}

--- a/internal/aws/proxy/conn_test.go
+++ b/internal/aws/proxy/conn_test.go
@@ -43,7 +43,8 @@ func logSetup() (*zap.Logger, *observer.ObservedLogs) {
 }
 
 func setupMock(sess *session.Session) (f1 func(s *session.Session) (string, error),
-	f2 func(roleArn string, region string, logger *zap.Logger) (*session.Session, error)) {
+	f2 func(roleArn string, region string, logger *zap.Logger) (*session.Session, error),
+) {
 	f1 = getEC2Region
 	f2 = newAWSSession
 	m := mock{sn: sess}
@@ -399,8 +400,7 @@ func TestGetSTSCredsFromPrimaryRegionEndpoint(t *testing.T) {
 		"expected error message")
 }
 
-type mockAWSErr struct {
-}
+type mockAWSErr struct{}
 
 func (m *mockAWSErr) Error() string {
 	return "mockAWSErr"
@@ -433,6 +433,7 @@ func (m *mockProvider) Retrieve() (credentials.Value, error) {
 func (m *mockProvider) IsExpired() bool {
 	return true
 }
+
 func TestSTSRegionalEndpointDisabled(t *testing.T) {
 	logger, recordedLogs := logSetup()
 

--- a/internal/aws/xray/telemetry/nop_sender.go
+++ b/internal/aws/xray/telemetry/nop_sender.go
@@ -12,8 +12,7 @@ func NewNopSender() Sender {
 
 var nopSenderInstance Sender = &nopSender{}
 
-type nopSender struct {
-}
+type nopSender struct{}
 
 func (n nopSender) Rotate() *xray.TelemetryRecord {
 	return nil

--- a/internal/aws/xray/testdata/sampleapp/sample.go
+++ b/internal/aws/xray/testdata/sampleapp/sample.go
@@ -28,7 +28,8 @@ type Record struct {
 func main() {
 	dynamo = dynamodb.New(session.Must(session.NewSession(
 		&aws.Config{
-			Region: aws.String("us-west-2")},
+			Region: aws.String("us-west-2"),
+		},
 	)))
 	xray.AWS(dynamo.Client)
 

--- a/internal/aws/xray/xray_client.go
+++ b/internal/aws/xray/xray_client.go
@@ -20,9 +20,11 @@ import (
 )
 
 // Constant prefixes used to identify information in user-agent
-const agentPrefix = "xray-otel-exporter/"
-const execEnvPrefix = " exec-env/"
-const osPrefix = " OS/"
+const (
+	agentPrefix   = "xray-otel-exporter/"
+	execEnvPrefix = " exec-env/"
+	osPrefix      = " OS/"
+)
 
 // XRayClient represents X-Ray client.
 type XRayClient interface {

--- a/internal/common/docker/images.go
+++ b/internal/common/docker/images.go
@@ -10,9 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	extractImageRegexp = regexp.MustCompile(`^(?P<repository>([^/\s]+/)?([^:\s]+))(:(?P<tag>[^@\s]+))?(@sha256:(?P<sha256>\d+))?$`)
-)
+var extractImageRegexp = regexp.MustCompile(`^(?P<repository>([^/\s]+/)?([^:\s]+))(:(?P<tag>[^@\s]+))?(@sha256:(?P<sha256>\d+))?$`)
 
 type ImageRef struct {
 	Repository string

--- a/internal/common/testutil/testutil_test.go
+++ b/internal/common/testutil/testutil_test.go
@@ -26,6 +26,7 @@ func TestGetAvailableLocalAddress(t *testing.T) {
 	require.Error(t, err)
 	require.Nil(t, ln1)
 }
+
 func TestGetAvailableLocalUDPAddress(t *testing.T) {
 	addr := GetAvailableLocalNetworkAddress(t, "udp")
 	// Endpoint should be free.

--- a/internal/coreinternal/aggregateutil/aggregate.go
+++ b/internal/coreinternal/aggregateutil/aggregate.go
@@ -283,7 +283,8 @@ func mergeHistogramDataPoints(dpsMap map[string]pmetric.HistogramDataPointSlice,
 }
 
 func mergeExponentialHistogramDataPoints(dpsMap map[string]pmetric.ExponentialHistogramDataPointSlice,
-	to pmetric.ExponentialHistogramDataPointSlice) {
+	to pmetric.ExponentialHistogramDataPointSlice,
+) {
 	for _, dps := range dpsMap {
 		dp := to.AppendEmpty()
 		dps.At(0).MoveTo(dp)
@@ -316,7 +317,8 @@ func mergeExponentialHistogramDataPoints(dpsMap map[string]pmetric.ExponentialHi
 }
 
 func groupNumberDataPoints(dps pmetric.NumberDataPointSlice, useStartTime bool,
-	dpsByAttrsAndTs map[string]pmetric.NumberDataPointSlice) {
+	dpsByAttrsAndTs map[string]pmetric.NumberDataPointSlice,
+) {
 	var keyHashParts []any
 	for i := 0; i < dps.Len(); i++ {
 		if useStartTime {
@@ -331,7 +333,8 @@ func groupNumberDataPoints(dps pmetric.NumberDataPointSlice, useStartTime bool,
 }
 
 func groupHistogramDataPoints(dps pmetric.HistogramDataPointSlice, useStartTime bool,
-	dpsByAttrsAndTs map[string]pmetric.HistogramDataPointSlice) {
+	dpsByAttrsAndTs map[string]pmetric.HistogramDataPointSlice,
+) {
 	for i := 0; i < dps.Len(); i++ {
 		dp := dps.At(i)
 		keyHashParts := make([]any, 0, dp.ExplicitBounds().Len()+4)
@@ -352,7 +355,8 @@ func groupHistogramDataPoints(dps pmetric.HistogramDataPointSlice, useStartTime 
 }
 
 func groupExponentialHistogramDataPoints(dps pmetric.ExponentialHistogramDataPointSlice, useStartTime bool,
-	dpsByAttrsAndTs map[string]pmetric.ExponentialHistogramDataPointSlice) {
+	dpsByAttrsAndTs map[string]pmetric.ExponentialHistogramDataPointSlice,
+) {
 	for i := 0; i < dps.Len(); i++ {
 		dp := dps.At(i)
 		keyHashParts := make([]any, 0, 5)

--- a/internal/coreinternal/attraction/attraction_test.go
+++ b/internal/coreinternal/attraction/attraction_test.go
@@ -400,7 +400,6 @@ func TestAttributes_Extract(t *testing.T) {
 
 	cfg := &Settings{
 		Actions: []ActionKeyValue{
-
 			{Key: "user_key", RegexPattern: "^\\/api\\/v1\\/document\\/(?P<new_user_key>.*)\\/update\\/(?P<version>.*)$", Action: EXTRACT},
 		},
 	}
@@ -853,7 +852,8 @@ func TestInvalidConfig(t *testing.T) {
 			},
 			errorString: "error creating AttrProc due to missing required field \"pattern\" for action \"extract\" at the 0-th action",
 		},
-		{name: "set value for extract",
+		{
+			name: "set value for extract",
 			actionLists: []ActionKeyValue{
 				{Key: "Key", RegexPattern: "(?P<operation_website>.*?)$", Value: "value", Action: EXTRACT},
 			},
@@ -915,7 +915,8 @@ func TestValidConfiguration(t *testing.T) {
 	compiledRegex := regexp.MustCompile(`^\/api\/v1\/document\/(?P<documentId>.*)\/update$`)
 	assert.Equal(t, []attributeAction{
 		{Key: "one", Action: DELETE},
-		{Key: "two", Action: INSERT,
+		{
+			Key: "two", Action: INSERT,
 			AttributeValue: &av,
 		},
 		{Key: "three", FromAttribute: "two", Action: UPDATE},

--- a/internal/coreinternal/goldendataset/traces_generator.go
+++ b/internal/coreinternal/goldendataset/traces_generator.go
@@ -50,7 +50,8 @@ func GenerateTraces(tracePairsFile string, spanPairsFile string) ([]ptrace.Trace
 //
 // The generated resource spans. If err is not nil, some or all of the resource spans fields will be nil.
 func appendResourceSpan(tracingInputs *PICTTracingInputs, spanPairsFile string,
-	random io.Reader, resourceSpansSlice ptrace.ResourceSpansSlice) error {
+	random io.Reader, resourceSpansSlice ptrace.ResourceSpansSlice,
+) error {
 	resourceSpan := resourceSpansSlice.AppendEmpty()
 	err := appendScopeSpans(tracingInputs, spanPairsFile, random, resourceSpan.ScopeSpans())
 	if err != nil {
@@ -61,7 +62,8 @@ func appendResourceSpan(tracingInputs *PICTTracingInputs, spanPairsFile string,
 }
 
 func appendScopeSpans(tracingInputs *PICTTracingInputs, spanPairsFile string,
-	random io.Reader, scopeSpansSlice ptrace.ScopeSpansSlice) error {
+	random io.Reader, scopeSpansSlice ptrace.ScopeSpansSlice,
+) error {
 	var count int
 	switch tracingInputs.InstrumentationLibrary {
 	case LibraryNone:

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt.go
@@ -16,9 +16,11 @@ import (
 	"time"
 )
 
-var ctimeRegexp = regexp.MustCompile(`%.`)
-var invalidFractionalSecondsStrptime = regexp.MustCompile(`[^.,]%[Lfs]`)
-var decimalsRegexp = regexp.MustCompile(`\d`)
+var (
+	ctimeRegexp                      = regexp.MustCompile(`%.`)
+	invalidFractionalSecondsStrptime = regexp.MustCompile(`[^.,]%[Lfs]`)
+	decimalsRegexp                   = regexp.MustCompile(`\d`)
+)
 
 var ctimeSubstitutes = map[string]string{
 	"%Y": "2006",

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
@@ -16,12 +16,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var format1 = "%Y-%m-%d %H:%M:%S.%f"
-var format2 = "%Y-%m-%d %l:%M:%S.%L %P, %a"
-var value1 = "2019-01-02 15:04:05.666666"
-var value2 = "2019-01-02 3:04:05.666 pm, Wed"
-var dt1 = time.Date(2019, 1, 2, 15, 4, 5, 666666000, time.UTC)
-var dt2 = time.Date(2019, 1, 2, 15, 4, 5, 666000000, time.UTC)
+var (
+	format1 = "%Y-%m-%d %H:%M:%S.%f"
+	format2 = "%Y-%m-%d %l:%M:%S.%L %P, %a"
+	value1  = "2019-01-02 15:04:05.666666"
+	value2  = "2019-01-02 3:04:05.666 pm, Wed"
+	dt1     = time.Date(2019, 1, 2, 15, 4, 5, 666666000, time.UTC)
+	dt2     = time.Date(2019, 1, 2, 15, 4, 5, 666000000, time.UTC)
+)
 
 func TestFormat(t *testing.T) {
 	s, err := Format(format1, dt1)

--- a/internal/coreinternal/timeutils/parser_test.go
+++ b/internal/coreinternal/timeutils/parser_test.go
@@ -19,40 +19,40 @@ func TestParseGoTimeBadLocation(t *testing.T) {
 func Test_setTimestampYear(t *testing.T) {
 	t.Run("Normal", func(t *testing.T) {
 		Now = func() time.Time {
-			return time.Date(2020, 06, 16, 3, 31, 34, 525, time.UTC)
+			return time.Date(2020, 0o6, 16, 3, 31, 34, 525, time.UTC)
 		}
 
-		noYear := time.Date(0, 06, 16, 3, 31, 34, 525, time.UTC)
+		noYear := time.Date(0, 0o6, 16, 3, 31, 34, 525, time.UTC)
 		yearAdded := SetTimestampYear(noYear)
-		expected := time.Date(2020, 06, 16, 3, 31, 34, 525, time.UTC)
+		expected := time.Date(2020, 0o6, 16, 3, 31, 34, 525, time.UTC)
 		require.Equal(t, expected, yearAdded)
 	})
 
 	t.Run("FutureOneDay", func(t *testing.T) {
 		Now = func() time.Time {
-			return time.Date(2020, 01, 16, 3, 31, 34, 525, time.UTC)
+			return time.Date(2020, 0o1, 16, 3, 31, 34, 525, time.UTC)
 		}
 
-		noYear := time.Date(0, 01, 17, 3, 31, 34, 525, time.UTC)
+		noYear := time.Date(0, 0o1, 17, 3, 31, 34, 525, time.UTC)
 		yearAdded := SetTimestampYear(noYear)
-		expected := time.Date(2020, 01, 17, 3, 31, 34, 525, time.UTC)
+		expected := time.Date(2020, 0o1, 17, 3, 31, 34, 525, time.UTC)
 		require.Equal(t, expected, yearAdded)
 	})
 
 	t.Run("FutureEightDays", func(t *testing.T) {
 		Now = func() time.Time {
-			return time.Date(2020, 01, 16, 3, 31, 34, 525, time.UTC)
+			return time.Date(2020, 0o1, 16, 3, 31, 34, 525, time.UTC)
 		}
 
-		noYear := time.Date(0, 01, 24, 3, 31, 34, 525, time.UTC)
+		noYear := time.Date(0, 0o1, 24, 3, 31, 34, 525, time.UTC)
 		yearAdded := SetTimestampYear(noYear)
-		expected := time.Date(2019, 01, 24, 3, 31, 34, 525, time.UTC)
+		expected := time.Date(2019, 0o1, 24, 3, 31, 34, 525, time.UTC)
 		require.Equal(t, expected, yearAdded)
 	})
 
 	t.Run("RolloverYear", func(t *testing.T) {
 		Now = func() time.Time {
-			return time.Date(2020, 01, 01, 3, 31, 34, 525, time.UTC)
+			return time.Date(2020, 0o1, 0o1, 3, 31, 34, 525, time.UTC)
 		}
 
 		noYear := time.Date(0, 12, 31, 3, 31, 34, 525, time.UTC)

--- a/internal/docker/matcher.go
+++ b/internal/docker/matcher.go
@@ -56,7 +56,6 @@ func newStringMatcher(items []string) (*stringMatcher, error) {
 			// by definition this must lead and end with '/' chars
 			reText := item[1 : len(item)-1]
 			re, err = regexp.Compile(reText)
-
 			if err != nil {
 				return nil, fmt.Errorf("invalid regex item: %w", err)
 			}

--- a/internal/filter/filterset/config.go
+++ b/internal/filter/filterset/config.go
@@ -22,9 +22,7 @@ const (
 	MatchTypeFieldName = "match_type"
 )
 
-var (
-	validMatchTypes = []MatchType{Regexp, Strict}
-)
+var validMatchTypes = []MatchType{Regexp, Strict}
 
 // Config configures the matching behavior of a FilterSet.
 type Config struct {

--- a/internal/filter/filterset/regexp/regexpfilterset_test.go
+++ b/internal/filter/filterset/regexp/regexpfilterset_test.go
@@ -10,18 +10,16 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var (
-	validRegexpFilters = []string{
-		"prefix/.*",
-		"prefix_.*",
-		".*/suffix",
-		".*_suffix",
-		".*/contains/.*",
-		".*_contains_.*",
-		"full/name/match",
-		"full_name_match",
-	}
-)
+var validRegexpFilters = []string{
+	"prefix/.*",
+	"prefix_.*",
+	".*/suffix",
+	".*_suffix",
+	".*/contains/.*",
+	".*_contains_.*",
+	"full/name/match",
+	"full_name_match",
+}
 
 func TestNewRegexpFilterSet(t *testing.T) {
 	tests := []struct {

--- a/internal/filter/filterset/strict/strictfilterset_test.go
+++ b/internal/filter/filterset/strict/strictfilterset_test.go
@@ -9,13 +9,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	validStrictFilters = []string{
-		"exact_string_match",
-		".*/suffix",
-		"(a|b)",
-	}
-)
+var validStrictFilters = []string{
+	"exact_string_match",
+	".*/suffix",
+	"(a|b)",
+}
 
 func TestNewStrictFilterSet(t *testing.T) {
 	tests := []struct {

--- a/internal/k8sconfig/config.go
+++ b/internal/k8sconfig/config.go
@@ -101,7 +101,6 @@ func CreateRestConfig(apiConf APIConfig) (*rest.Config, error) {
 		}
 		authConf, err = clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
 			loadingRules, configOverrides).ClientConfig()
-
 		if err != nil {
 			return nil, fmt.Errorf("error connecting to k8s with auth_type=%s: %w", AuthTypeKubeConfig, err)
 		}

--- a/internal/k8stest/client.go
+++ b/internal/k8stest/client.go
@@ -41,5 +41,6 @@ func NewK8sClient(kubeconfigPath string) (*K8sClient, error) {
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
 	return &K8sClient{
-		DynamicClient: dynamicClient, DiscoveryClient: discoveryClient, Mapper: mapper}, nil
+		DynamicClient: dynamicClient, DiscoveryClient: discoveryClient, Mapper: mapper,
+	}, nil
 }

--- a/internal/kubelet/client_test.go
+++ b/internal/kubelet/client_test.go
@@ -28,9 +28,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
 
-const certPath = "./testdata/testcert.crt"
-const keyFile = "./testdata/testkey.key"
-const errSignedByUnknownCA = "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+const (
+	certPath             = "./testdata/testcert.crt"
+	keyFile              = "./testdata/testkey.key"
+	errSignedByUnknownCA = "tls: failed to verify certificate: x509: certificate signed by unknown authority"
+)
 
 func TestClient(t *testing.T) {
 	tr := &fakeRoundTripper{}

--- a/internal/metadataproviders/aws/ec2/metadata_test.go
+++ b/internal/metadataproviders/aws/ec2/metadata_test.go
@@ -39,8 +39,7 @@ func TestMetadataProviderGetError(t *testing.T) {
 }
 
 func TestMetadataProvider_available(t *testing.T) {
-	type fields struct {
-	}
+	type fields struct{}
 	type args struct {
 		ctx  context.Context
 		sess *session.Session

--- a/internal/otelarrow/admission2/boundedqueue.go
+++ b/internal/otelarrow/admission2/boundedqueue.go
@@ -15,8 +15,10 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-var ErrTooMuchWaiting = status.Error(grpccodes.ResourceExhausted, "rejecting request, too much pending data")
-var ErrRequestTooLarge = status.Errorf(grpccodes.InvalidArgument, "rejecting request, request is too large")
+var (
+	ErrTooMuchWaiting  = status.Error(grpccodes.ResourceExhausted, "rejecting request, too much pending data")
+	ErrRequestTooLarge = status.Errorf(grpccodes.InvalidArgument, "rejecting request, request is too large")
+)
 
 // BoundedQueue is a LIFO-oriented admission-controlled Queue.
 type BoundedQueue struct {

--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -78,13 +78,15 @@ type testConsumer struct {
 
 var _ consumer.Traces = &testConsumer{}
 
-type ExpConfig = otelarrowexporter.Config
-type RecvConfig = otelarrowreceiver.Config
-type CfgFunc func(*ExpConfig, *RecvConfig)
-type GenFunc func(int) ptrace.Traces
-type MkGen func() GenFunc
-type EndFunc func(t *testing.T, tp testParams, testCon *testConsumer, expect [][]ptrace.Traces) (rops, eops map[string]int)
-type ConsumerErrFunc func(t *testing.T, err error)
+type (
+	ExpConfig       = otelarrowexporter.Config
+	RecvConfig      = otelarrowreceiver.Config
+	CfgFunc         func(*ExpConfig, *RecvConfig)
+	GenFunc         func(int) ptrace.Traces
+	MkGen           func() GenFunc
+	EndFunc         func(t *testing.T, tp testParams, testCon *testConsumer, expect [][]ptrace.Traces) (rops, eops map[string]int)
+	ConsumerErrFunc func(t *testing.T, err error)
+)
 
 func (*testConsumer) Capabilities() consumer.Capabilities {
 	return consumer.Capabilities{}
@@ -462,7 +464,7 @@ func TestIntegrationTracesSimple(t *testing.T) {
 			defer cancel()
 
 			// until 10 threads can write 1000 spans
-			var params = testParams{
+			params := testParams{
 				threadCount: 10,
 				requestWhileTrue: func(test *testConsumer) bool {
 					return test.sink.SpanCount() < 1000
@@ -483,7 +485,7 @@ func TestIntegrationDeadlinePropagation(t *testing.T) {
 			defer cancel()
 
 			// Until at least one span is written.
-			var params = testParams{
+			params := testParams{
 				threadCount: 1,
 				requestWhileTrue: func(test *testConsumer) bool {
 					return test.sink.SpanCount() < 1
@@ -596,7 +598,7 @@ func TestIntegrationSelfTracing(t *testing.T) {
 	defer cancel()
 
 	// until 2 Arrow stream spans are received from self instrumentation
-	var params = testParams{
+	params := testParams{
 		threadCount: 10,
 		requestWhileTrue: func(test *testConsumer) bool {
 			cnt := 0

--- a/internal/pdatautil/logs_test.go
+++ b/internal/pdatautil/logs_test.go
@@ -142,13 +142,15 @@ func TestGroupByResourceLogs(t *testing.T) {
 		},
 		{
 			name: "single",
-			input: []resourceLogs{newResourceLogs(1,
-				newScopeLogs(11, 101, 102, 103),
-			),
+			input: []resourceLogs{
+				newResourceLogs(1,
+					newScopeLogs(11, 101, 102, 103),
+				),
 			},
-			expected: []resourceLogs{newResourceLogs(1,
-				newScopeLogs(11, 101, 102, 103),
-			),
+			expected: []resourceLogs{
+				newResourceLogs(1,
+					newScopeLogs(11, 101, 102, 103),
+				),
 			},
 		},
 		{

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -38,9 +38,7 @@ const (
 	metricNamePattern = "^metric_name:([A-Za-z\\.:][A-Za-z0-9_\\.:]*)$"
 )
 
-var (
-	metricNameRegexp = regexp.MustCompile(metricNamePattern)
-)
+var metricNameRegexp = regexp.MustCompile(metricNamePattern)
 
 // AccessTokenPassthroughConfig configures passing through access tokens.
 type AccessTokenPassthroughConfig struct {

--- a/internal/sqlquery/scraper_test.go
+++ b/internal/sqlquery/scraper_test.go
@@ -378,17 +378,18 @@ func TestScraper_FakeDB_MultiRows_Error(t *testing.T) {
 		Client: NewDbClient(db, "", logger, TelemetryConfig{}),
 		Logger: logger,
 		Query: Query{
-			Metrics: []MetricCfg{{
-				MetricName:  "my.col.0",
-				ValueColumn: "col_0",
-				Description: "my description 0",
-				Unit:        "my-unit-0",
-			}, {
-				MetricName:  "my.col.1",
-				ValueColumn: "col_1",
-				Description: "my description 1",
-				Unit:        "my-unit-1",
-			},
+			Metrics: []MetricCfg{
+				{
+					MetricName:  "my.col.0",
+					ValueColumn: "col_0",
+					Description: "my description 0",
+					Unit:        "my-unit-0",
+				}, {
+					MetricName:  "my.col.1",
+					ValueColumn: "col_1",
+					Description: "my description 1",
+					Unit:        "my-unit-1",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
#### Description

[gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) enforces a stricter format than gofmt

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36363