### PR TITLE
[chore]: enable gofumpt linter for extension

### DIFF
--- a/extension/awsproxy/config.go
+++ b/extension/awsproxy/config.go
@@ -9,7 +9,6 @@ import (
 
 // Config defines the configuration for an AWS X-Ray proxy.
 type Config struct {
-
 	// ProxyServer defines configurations related to the local TCP proxy server.
 	ProxyConfig proxy.Config `mapstructure:",squash"`
 }

--- a/extension/awsproxy/extension.go
+++ b/extension/awsproxy/extension.go
@@ -27,7 +27,6 @@ var _ extension.Extension = (*xrayProxy)(nil)
 
 func (x *xrayProxy) Start(_ context.Context, host component.Host) error {
 	srv, err := proxy.NewServer(&x.config.ProxyConfig, x.settings.Logger)
-
 	if err != nil {
 		return err
 	}

--- a/extension/basicauthextension/config.go
+++ b/extension/basicauthextension/config.go
@@ -28,7 +28,6 @@ type ClientAuthSettings struct {
 	Password configopaque.String `mapstructure:"password"`
 }
 type Config struct {
-
 	// Htpasswd settings.
 	Htpasswd *HtpasswdSettings `mapstructure:"htpasswd,omitempty"`
 

--- a/extension/basicauthextension/extension_test.go
+++ b/extension/basicauthextension/extension_test.go
@@ -17,33 +17,31 @@ import (
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 
-var (
-	credentials = [][]string{
-		{"htpasswd-md5", "$apr1$FVVioVP7$ZdIWPG1p4E/ErujO7kA2n0"},
-		{"openssl-apr1", "$apr1$peiE49Vv$lo.z77Z.6.a.Lm7GMjzQh0"},
-		{"openssl-md5", "$1$mvmz31IB$U9KpHBLegga2doA0e3s3N0"},
-		{"htpasswd-sha", "{SHA}vFznddje0Ht4+pmO0FaxwrUKN/M="},
-		{"htpasswd-bcrypt", "$2y$10$Q6GeMFPd0dAxhQULPDdAn.DFy6NDmLaU0A7e2XoJz7PFYAEADFKbC"},
-		{"", "$2a$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s."},
-		{"", "$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye"},
-		{"", "$2a$10$k1wbIrmNyFAPwPVPSVa/zecw2BCEnBwVS2GbrmgzxFUOqW9dk4TCW"},
-		{"", "$2a$12$k42ZFHFWqBp3vWli.nIn8uYyIkbvYRvodzbfbK18SSsY.CsIQPlxO"},
-		{"a", "$2a$06$m0CrhHm10qJ3lXRY.5zDGO3rS2KdeeWLuGmsfGlMfOxih58VYVfxe"},
-		{"a", "$2a$08$cfcvVd2aQ8CMvoMpP2EBfeodLEkkFJ9umNEfPD18.hUF62qqlC/V."},
-		{"a", "$2a$10$k87L/MF28Q673VKh8/cPi.SUl7MU/rWuSiIDDFayrKk/1tBsSQu4u"},
-		{"a", "$2a$12$8NJH3LsPrANStV6XtBakCez0cKHXVxmvxIlcz785vxAIZrihHZpeS"},
-		{"abc", "$2a$06$If6bvum7DFjUnE9p2uDeDu0YHzrHM6tf.iqN8.yx.jNN1ILEf7h0i"},
-		{"abcdefghijklmnopqrstuvwxyz", "$2a$06$.rCVZVOThsIa97pEDOxvGuRRgzG64bvtJ0938xuqzv18d3ZpQhstC"},
-		{"abcdefghijklmnopqrstuvwxyz", "$2a$08$aTsUwsyowQuzRrDqFflhgekJ8d9/7Z3GV3UcgvzQW3J5zMyrTvlz."},
-		{"abcdefghijklmnopqrstuvwxyz", "$2a$10$fVH8e28OQRj9tqiDXs1e1uxpsjN0c7II7YPKXua2NAKYvM6iQk7dq"},
-		{"abcdefghijklmnopqrstuvwxyz", "$2a$12$D4G5f18o7aMMfwasBL7GpuQWuP3pkrZrOAnqP.bmezbMng.QwJ/pG"},
-		{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$06$fPIsBO8qRqkjj273rfaOI.HtSV9jLDpTbZn782DC6/t7qT67P6FfO"},
-		{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$08$Eq2r4G/76Wv39MzSX262huzPz612MZiYHVUJe/OcOql2jo4.9UxTW"},
-		{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$10$LgfYWkbzEvQ4JakH7rOvHe0y8pHKF9OaFgwUZ2q7W2FFZmZzJYlfS"},
-		{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$12$WApznUOJfkEGSmYRfnkrPOr466oFDCaj4b6HY3EXGvfxm43seyhgC"},
-		{"ππππππππ", "$2a$10$.TtQJ4Jr6isd4Hp.mVfZeuh6Gws4rOQ/vdBczhDx.19NFK0Y84Dle"},
-	}
-)
+var credentials = [][]string{
+	{"htpasswd-md5", "$apr1$FVVioVP7$ZdIWPG1p4E/ErujO7kA2n0"},
+	{"openssl-apr1", "$apr1$peiE49Vv$lo.z77Z.6.a.Lm7GMjzQh0"},
+	{"openssl-md5", "$1$mvmz31IB$U9KpHBLegga2doA0e3s3N0"},
+	{"htpasswd-sha", "{SHA}vFznddje0Ht4+pmO0FaxwrUKN/M="},
+	{"htpasswd-bcrypt", "$2y$10$Q6GeMFPd0dAxhQULPDdAn.DFy6NDmLaU0A7e2XoJz7PFYAEADFKbC"},
+	{"", "$2a$06$DCq7YPn5Rq63x1Lad4cll.TV4S6ytwfsfvkgY8jIucDrjc8deX1s."},
+	{"", "$2a$08$HqWuK6/Ng6sg9gQzbLrgb.Tl.ZHfXLhvt/SgVyWhQqgqcZ7ZuUtye"},
+	{"", "$2a$10$k1wbIrmNyFAPwPVPSVa/zecw2BCEnBwVS2GbrmgzxFUOqW9dk4TCW"},
+	{"", "$2a$12$k42ZFHFWqBp3vWli.nIn8uYyIkbvYRvodzbfbK18SSsY.CsIQPlxO"},
+	{"a", "$2a$06$m0CrhHm10qJ3lXRY.5zDGO3rS2KdeeWLuGmsfGlMfOxih58VYVfxe"},
+	{"a", "$2a$08$cfcvVd2aQ8CMvoMpP2EBfeodLEkkFJ9umNEfPD18.hUF62qqlC/V."},
+	{"a", "$2a$10$k87L/MF28Q673VKh8/cPi.SUl7MU/rWuSiIDDFayrKk/1tBsSQu4u"},
+	{"a", "$2a$12$8NJH3LsPrANStV6XtBakCez0cKHXVxmvxIlcz785vxAIZrihHZpeS"},
+	{"abc", "$2a$06$If6bvum7DFjUnE9p2uDeDu0YHzrHM6tf.iqN8.yx.jNN1ILEf7h0i"},
+	{"abcdefghijklmnopqrstuvwxyz", "$2a$06$.rCVZVOThsIa97pEDOxvGuRRgzG64bvtJ0938xuqzv18d3ZpQhstC"},
+	{"abcdefghijklmnopqrstuvwxyz", "$2a$08$aTsUwsyowQuzRrDqFflhgekJ8d9/7Z3GV3UcgvzQW3J5zMyrTvlz."},
+	{"abcdefghijklmnopqrstuvwxyz", "$2a$10$fVH8e28OQRj9tqiDXs1e1uxpsjN0c7II7YPKXua2NAKYvM6iQk7dq"},
+	{"abcdefghijklmnopqrstuvwxyz", "$2a$12$D4G5f18o7aMMfwasBL7GpuQWuP3pkrZrOAnqP.bmezbMng.QwJ/pG"},
+	{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$06$fPIsBO8qRqkjj273rfaOI.HtSV9jLDpTbZn782DC6/t7qT67P6FfO"},
+	{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$08$Eq2r4G/76Wv39MzSX262huzPz612MZiYHVUJe/OcOql2jo4.9UxTW"},
+	{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$10$LgfYWkbzEvQ4JakH7rOvHe0y8pHKF9OaFgwUZ2q7W2FFZmZzJYlfS"},
+	{"~!@#$%^&*()      ~!@#$%^&*()PNBFRD", "$2a$12$WApznUOJfkEGSmYRfnkrPOr466oFDCaj4b6HY3EXGvfxm43seyhgC"},
+	{"ππππππππ", "$2a$10$.TtQJ4Jr6isd4Hp.mVfZeuh6Gws4rOQ/vdBczhDx.19NFK0Y84Dle"},
+}
 
 func TestBasicAuth_Valid(t *testing.T) {
 	t.Parallel()

--- a/extension/bearertokenauthextension/bearertokenauth_test.go
+++ b/extension/bearertokenauthextension/bearertokenauth_test.go
@@ -127,7 +127,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.True(t, credential.RequireTransportSecurity())
 
 	// change file content once
-	assert.NoError(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0o600))
 	time.Sleep(5 * time.Second)
 	credential, _ = bauth.PerRPCCredentials()
 	md, err = credential.GetRequestMetadata(context.Background())
@@ -136,7 +136,7 @@ func TestBearerStartWatchStop(t *testing.T) {
 	assert.NoError(t, err)
 
 	// change file content back
-	assert.NoError(t, os.WriteFile(bauth.filename, token, 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, token, 0o600))
 	time.Sleep(5 * time.Second)
 	credential, _ = bauth.PerRPCCredentials()
 	md, err = credential.GetRequestMetadata(context.Background())
@@ -177,7 +177,7 @@ func TestBearerTokenFileContentUpdate(t *testing.T) {
 	assert.Equal(t, authHeaderValue, fmt.Sprintf("%s %s", scheme, string(token)))
 
 	// change file content once
-	assert.NoError(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, []byte(fmt.Sprintf("%stest", token)), 0o600))
 	time.Sleep(5 * time.Second)
 
 	tokenNew, err := os.ReadFile(bauth.filename)
@@ -191,7 +191,7 @@ func TestBearerTokenFileContentUpdate(t *testing.T) {
 	assert.Equal(t, authHeaderValue, fmt.Sprintf("%s %s", scheme, string(tokenNew)))
 
 	// change file content back
-	assert.NoError(t, os.WriteFile(bauth.filename, token, 0600))
+	assert.NoError(t, os.WriteFile(bauth.filename, token, 0o600))
 	time.Sleep(5 * time.Second)
 
 	// check if request is updated with the old token

--- a/extension/bearertokenauthextension/config.go
+++ b/extension/bearertokenauthextension/config.go
@@ -12,7 +12,6 @@ import (
 
 // Config specifies how the Per-RPC bearer token based authentication data should be obtained.
 type Config struct {
-
 	// Scheme specifies the auth-scheme for the token. Defaults to "Bearer"
 	Scheme string `mapstructure:"scheme,omitempty"`
 
@@ -23,8 +22,10 @@ type Config struct {
 	Filename string `mapstructure:"filename,omitempty"`
 }
 
-var _ component.Config = (*Config)(nil)
-var errNoTokenProvided = errors.New("no bearer token provided")
+var (
+	_                  component.Config = (*Config)(nil)
+	errNoTokenProvided                  = errors.New("no bearer token provided")
+)
 
 // Validate checks if the extension configuration is valid
 func (cfg *Config) Validate() error {

--- a/extension/encoding/avrologencodingextension/extension.go
+++ b/extension/encoding/avrologencodingextension/extension.go
@@ -15,9 +15,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 )
 
-var (
-	_ encoding.LogsUnmarshalerExtension = (*avroLogExtension)(nil)
-)
+var _ encoding.LogsUnmarshalerExtension = (*avroLogExtension)(nil)
 
 type avroLogExtension struct {
 	deserializer avroDeserializer

--- a/extension/encoding/jaegerencodingextension/extension.go
+++ b/extension/encoding/jaegerencodingextension/extension.go
@@ -13,8 +13,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/encoding"
 )
 
-var _ encoding.TracesUnmarshalerExtension = &jaegerExtension{}
-var _ ptrace.Unmarshaler = &jaegerExtension{}
+var (
+	_ encoding.TracesUnmarshalerExtension = &jaegerExtension{}
+	_ ptrace.Unmarshaler                  = &jaegerExtension{}
+)
 
 type jaegerExtension struct {
 	config      *Config

--- a/extension/encoding/jaegerencodingextension/jaeger.go
+++ b/extension/encoding/jaegerencodingextension/jaeger.go
@@ -13,8 +13,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger"
 )
 
-type jaegerProtobufTrace struct {
-}
+type jaegerProtobufTrace struct{}
 
 func (j jaegerProtobufTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}
@@ -25,8 +24,7 @@ func (j jaegerProtobufTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) 
 	return jaegerSpanToTraces(span)
 }
 
-type jaegerJSONTrace struct {
-}
+type jaegerJSONTrace struct{}
 
 func (j jaegerJSONTrace) UnmarshalTraces(buf []byte) (ptrace.Traces, error) {
 	span := &jaegerproto.Span{}

--- a/extension/encoding/otlpencodingextension/extension_test.go
+++ b/extension/encoding/otlpencodingextension/extension_test.go
@@ -147,7 +147,7 @@ func createAndExtension0(c *Config, t *testing.T) *otlpExtension {
 }
 
 func generateTraces() ptrace.Traces {
-	var num = 10
+	num := 10
 	now := time.Now()
 	md := ptrace.NewTraces()
 	ilm := md.ResourceSpans().AppendEmpty().ScopeSpans().AppendEmpty()
@@ -162,7 +162,7 @@ func generateTraces() ptrace.Traces {
 }
 
 func generateLogs() plog.Logs {
-	var num = 10
+	num := 10
 	md := plog.NewLogs()
 	ilm := md.ResourceLogs().AppendEmpty().ScopeLogs().AppendEmpty()
 	ilm.LogRecords().EnsureCapacity(num)
@@ -174,7 +174,7 @@ func generateLogs() plog.Logs {
 }
 
 func generateMetrics() pmetric.Metrics {
-	var num = 10
+	num := 10
 	now := time.Now()
 	startTime := pcommon.NewTimestampFromTime(now.Add(-10 * time.Second))
 	endTime := pcommon.NewTimestampFromTime(now)
@@ -194,7 +194,7 @@ func generateMetrics() pmetric.Metrics {
 }
 
 func generateProfiles() pprofile.Profiles {
-	var num = 10
+	num := 10
 	now := time.Now()
 	pd := pprofile.NewProfiles()
 	ilm := pd.ResourceProfiles().AppendEmpty().ScopeProfiles().AppendEmpty()

--- a/extension/headerssetterextension/config_test.go
+++ b/extension/headerssetterextension/config_test.go
@@ -36,7 +36,8 @@ func TestLoadConfig(t *testing.T) {
 						Action:      INSERT,
 						FromContext: stringp("tenant_id"),
 						Value:       nil,
-					}, {
+					},
+					{
 						Key:          stringp("X-Scope-OrgID"),
 						Action:       INSERT,
 						FromContext:  stringp("tenant_id"),

--- a/extension/headerssetterextension/extension.go
+++ b/extension/headerssetterextension/extension.go
@@ -35,7 +35,7 @@ func newHeadersSetterExtension(cfg *Config, logger *zap.Logger) (auth.Client, er
 				Value: *header.Value,
 			}
 		} else if header.FromContext != nil {
-			var defaultValue = ""
+			defaultValue := ""
 			if header.DefaultValue != nil {
 				defaultValue = *header.DefaultValue
 			}

--- a/extension/healthcheckv2extension/extension.go
+++ b/extension/healthcheckv2extension/extension.go
@@ -34,9 +34,11 @@ type healthCheckExtension struct {
 	host          component.Host
 }
 
-var _ component.Component = (*healthCheckExtension)(nil)
-var _ extensioncapabilities.ConfigWatcher = (*healthCheckExtension)(nil)
-var _ extensioncapabilities.PipelineWatcher = (*healthCheckExtension)(nil)
+var (
+	_ component.Component                   = (*healthCheckExtension)(nil)
+	_ extensioncapabilities.ConfigWatcher   = (*healthCheckExtension)(nil)
+	_ extensioncapabilities.PipelineWatcher = (*healthCheckExtension)(nil)
+)
 
 func newExtension(
 	ctx context.Context,

--- a/extension/healthcheckv2extension/internal/http/server.go
+++ b/extension/healthcheckv2extension/internal/http/server.go
@@ -35,8 +35,10 @@ type Server struct {
 	doneCh         chan struct{}
 }
 
-var _ component.Component = (*Server)(nil)
-var _ extensioncapabilities.ConfigWatcher = (*Server)(nil)
+var (
+	_ component.Component                 = (*Server)(nil)
+	_ extensioncapabilities.ConfigWatcher = (*Server)(nil)
+)
 
 func NewServer(
 	config *Config,

--- a/extension/httpforwarderextension/config.go
+++ b/extension/httpforwarderextension/config.go
@@ -9,7 +9,6 @@ import (
 
 // Config defines configuration for http forwarder extension.
 type Config struct {
-
 	// Ingress holds config settings for HTTP server listening for requests.
 	Ingress confighttp.ServerConfig `mapstructure:"ingress"`
 

--- a/extension/httpforwarderextension/extension.go
+++ b/extension/httpforwarderextension/extension.go
@@ -116,7 +116,7 @@ func newHTTPForwarder(config *Config, settings component.TelemetrySettings) (ext
 		return nil, errors.New("'egress.endpoint' config option cannot be empty")
 	}
 
-	var url, err = url.Parse(config.Egress.Endpoint)
+	url, err := url.Parse(config.Egress.Endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("enter a valid URL for 'egress.endpoint': %w", err)
 	}

--- a/extension/httpforwarderextension/extension_test.go
+++ b/extension/httpforwarderextension/extension_test.go
@@ -266,7 +266,7 @@ func readBody(body io.ReadCloser) []byte {
 }
 
 func getParsedURL(t *testing.T, rawURL string) *url.URL {
-	var url, err = url.Parse(rawURL)
+	url, err := url.Parse(rawURL)
 	require.NoError(t, err)
 	return url
 }

--- a/extension/jaegerremotesampling/internal/grpc_test.go
+++ b/extension/jaegerremotesampling/internal/grpc_test.go
@@ -94,9 +94,11 @@ func (g *grpcServerMock) Serve(_ net.Listener) error {
 	g.quit = make(chan bool)
 	return nil
 }
+
 func (g *grpcServerMock) Stop() {
 	g.quit <- true
 }
+
 func (g *grpcServerMock) GracefulStop() {
 	select {
 	case <-g.quit:

--- a/extension/jaegerremotesampling/internal/http.go
+++ b/extension/jaegerremotesampling/internal/http.go
@@ -18,9 +18,7 @@ import (
 	"go.opentelemetry.io/collector/config/confighttp"
 )
 
-var (
-	errMissingStrategyStore = errors.New("the strategy store has not been provided")
-)
+var errMissingStrategyStore = errors.New("the strategy store has not been provided")
 
 var _ component.Component = (*SamplingHTTPServer)(nil)
 

--- a/extension/oauth2clientauthextension/config.go
+++ b/extension/oauth2clientauthextension/config.go
@@ -21,7 +21,6 @@ var (
 
 // Config stores the configuration for OAuth2 Client Credentials (2-legged OAuth2 flow) setup.
 type Config struct {
-
 	// ClientID is the application's ID.
 	// See https://datatracker.ietf.org/doc/html/rfc6749#section-2.2
 	ClientID string `mapstructure:"client_id"`

--- a/extension/observer/ecsobserver/config.go
+++ b/extension/observer/ecsobserver/config.go
@@ -17,7 +17,6 @@ const (
 )
 
 type Config struct {
-
 	// ClusterName is the target ECS cluster name for service discovery.
 	ClusterName string `mapstructure:"cluster_name" yaml:"cluster_name"`
 	// ClusterRegion is the target ECS cluster's AWS region.

--- a/extension/observer/ecsobserver/fetcher.go
+++ b/extension/observer/ecsobserver/fetcher.go
@@ -289,7 +289,8 @@ func (f *taskFetcher) attachContainerInstance(ctx context.Context, tasks []*task
 
 // Run ecs.DescribeContainerInstances and ec2.DescribeInstances for a batch (less than 100 container instances).
 func (f *taskFetcher) describeContainerInstances(ctx context.Context, instanceList []*string,
-	ci2EC2 map[string]*ec2.Instance) error {
+	ci2EC2 map[string]*ec2.Instance,
+) error {
 	// Get container instances
 	res, err := f.ecs.DescribeContainerInstancesWithContext(ctx, &ecs.DescribeContainerInstancesInput{
 		Cluster:            aws.String(f.cluster),

--- a/extension/observer/ecsobserver/internal/ecsmock/service.go
+++ b/extension/observer/ecsobserver/internal/ecsmock/service.go
@@ -26,7 +26,6 @@ type PageLimit struct {
 	DescribeServiceInput           int // max 10
 	DescribeContainerInstanceInput int // max 100
 	DescribeInstanceOutput         int // max 1000
-
 }
 
 func DefaultPageLimit() PageLimit {

--- a/extension/observer/ecsobserver/sd.go
+++ b/extension/observer/ecsobserver/sd.go
@@ -83,7 +83,7 @@ func (s *serviceDiscovery) runAndWriteFile(ctx context.Context) error {
 				return err
 			}
 			// NOTE: We assume the folder already exists and does NOT try to create one.
-			if err := os.WriteFile(s.cfg.ResultFile, b, 0600); err != nil {
+			if err := os.WriteFile(s.cfg.ResultFile, b, 0o600); err != nil {
 				return err
 			}
 		}

--- a/extension/observer/ecsobserver/target.go
+++ b/extension/observer/ecsobserver/target.go
@@ -121,9 +121,7 @@ func trimEmptyValueByKeyPrefix(m map[string]string, prefix string) {
 	}
 }
 
-var (
-	invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
-)
+var invalidLabelCharRE = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 
 // Copied from https://github.com/prometheus/prometheus/blob/8d2a8f493905e46fe6181e8c1b79ccdfcbdb57fc/util/strutil/strconv.go#L40-L44
 func sanitizeLabelName(s string) string {

--- a/extension/observer/ecstaskobserver/extension.go
+++ b/extension/observer/ecstaskobserver/extension.go
@@ -19,9 +19,11 @@ import (
 
 const runningStatus = "RUNNING"
 
-var _ extension.Extension = (*ecsTaskObserver)(nil)
-var _ observer.EndpointsLister = (*ecsTaskObserver)(nil)
-var _ observer.Observable = (*ecsTaskObserver)(nil)
+var (
+	_ extension.Extension      = (*ecsTaskObserver)(nil)
+	_ observer.EndpointsLister = (*ecsTaskObserver)(nil)
+	_ observer.Observable      = (*ecsTaskObserver)(nil)
+)
 
 type ecsTaskObserver struct {
 	extension.Extension
@@ -97,7 +99,6 @@ func (e *ecsTaskObserver) portFromLabels(labels map[string]string) uint16 {
 	for _, portLabel := range e.config.PortLabels {
 		if p, ok := labels[portLabel]; ok {
 			port, err := strconv.ParseUint(p, 10, 16)
-
 			if err != nil {
 				e.telemetry.Logger.Warn("failed parsing port label", zap.String("label", portLabel), zap.Error(err))
 				continue

--- a/extension/observer/hostobserver/extension_test.go
+++ b/extension/observer/hostobserver/extension_test.go
@@ -155,7 +155,8 @@ func getExpectedHost(host string, isIPv6 bool) string {
 
 func startAndStopObserver(
 	t *testing.T,
-	getConnectionsOverride func() (conns []psnet.ConnectionStat, err error)) mockNotifier {
+	getConnectionsOverride func() (conns []psnet.ConnectionStat, err error),
+) mockNotifier {
 	ml := endpointsLister{
 		logger:                zap.NewNop(),
 		observerName:          "host_observer/1",

--- a/extension/observer/k8sobserver/extension.go
+++ b/extension/observer/k8sobserver/extension.go
@@ -21,8 +21,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 )
 
-var _ extension.Extension = (*k8sObserver)(nil)
-var _ observer.Observable = (*k8sObserver)(nil)
+var (
+	_ extension.Extension = (*k8sObserver)(nil)
+	_ observer.Observable = (*k8sObserver)(nil)
+)
 
 type k8sObserver struct {
 	*observer.EndpointsWatcher
@@ -111,7 +113,7 @@ func newObserver(config *Config, set extension.Settings) (extension.Extension, e
 
 	var serviceListerWatcher cache.ListerWatcher
 	if config.ObserveServices {
-		var serviceSelector = fields.Everything()
+		serviceSelector := fields.Everything()
 		set.Logger.Debug("observing services")
 		serviceListerWatcher = cache.NewListWatchFromClient(restClient, "services", v1.NamespaceAll, serviceSelector)
 	}
@@ -130,7 +132,7 @@ func newObserver(config *Config, set extension.Settings) (extension.Extension, e
 
 	var ingressListerWatcher cache.ListerWatcher
 	if config.ObserveIngresses {
-		var ingressSelector = fields.Everything()
+		ingressSelector := fields.Everything()
 		set.Logger.Debug("observing ingresses")
 		ingressListerWatcher = cache.NewListWatchFromClient(client.NetworkingV1().RESTClient(), "ingresses", v1.NamespaceAll, ingressSelector)
 	}

--- a/extension/observer/k8sobserver/handler.go
+++ b/extension/observer/k8sobserver/handler.go
@@ -15,8 +15,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/observer"
 )
 
-var _ cache.ResourceEventHandler = (*handler)(nil)
-var _ observer.EndpointsLister = (*handler)(nil)
+var (
+	_ cache.ResourceEventHandler = (*handler)(nil)
+	_ observer.EndpointsLister   = (*handler)(nil)
+)
 
 // handler handles k8s cache informer callbacks.
 type handler struct {

--- a/extension/observer/k8sobserver/handler_test.go
+++ b/extension/observer/k8sobserver/handler_test.go
@@ -48,7 +48,10 @@ func TestPodEndpointsAdded(t *testing.T) {
 					Name:      "pod-2",
 					Namespace: "default",
 					UID:       "pod-2-UID",
-					Labels:    map[string]string{"env": "prod"}}}},
+					Labels:    map[string]string{"env": "prod"},
+				},
+			},
+		},
 		{
 			ID:     "test-1/pod-2-UID/https(443)",
 			Target: "1.2.3.4:443",
@@ -63,7 +66,8 @@ func TestPodEndpointsAdded(t *testing.T) {
 				Port:      443,
 				Transport: observer.ProtocolTCP,
 			},
-		}}, th.ListEndpoints())
+		},
+	}, th.ListEndpoints())
 }
 
 func TestPodEndpointsRemoved(t *testing.T) {
@@ -102,7 +106,9 @@ func TestPodEndpointsChanged(t *testing.T) {
 				Name:      "pod-2",
 				Namespace: "default",
 				UID:       "pod-2-UID",
-				Labels:    map[string]string{"env": "prod", "updated-label": "true"}}},
+				Labels:    map[string]string{"env": "prod", "updated-label": "true"},
+			},
+		},
 		{
 			ID:     "test-1/pod-2-UID/container-2",
 			Target: "1.2.3.4",
@@ -114,7 +120,10 @@ func TestPodEndpointsChanged(t *testing.T) {
 					Name:      "pod-2",
 					Namespace: "default",
 					UID:       "pod-2-UID",
-					Labels:    map[string]string{"env": "prod", "updated-label": "true"}}}},
+					Labels:    map[string]string{"env": "prod", "updated-label": "true"},
+				},
+			},
+		},
 		{
 			ID:     "test-1/pod-2-UID/https(443)",
 			Target: "1.2.3.4:443",
@@ -123,9 +132,12 @@ func TestPodEndpointsChanged(t *testing.T) {
 					Name:      "pod-2",
 					Namespace: "default",
 					UID:       "pod-2-UID",
-					Labels:    map[string]string{"env": "prod", "updated-label": "true"}},
+					Labels:    map[string]string{"env": "prod", "updated-label": "true"},
+				},
 				Port:      443,
-				Transport: observer.ProtocolTCP}},
+				Transport: observer.ProtocolTCP,
+			},
+		},
 	}, th.ListEndpoints())
 }
 
@@ -144,7 +156,8 @@ func TestServiceEndpointsAdded(t *testing.T) {
 				ServiceType: "ClusterIP",
 				ClusterIP:   "1.2.3.4",
 			},
-		}}, th.ListEndpoints())
+		},
+	}, th.ListEndpoints())
 }
 
 func TestServiceEndpointsRemoved(t *testing.T) {
@@ -186,7 +199,8 @@ func TestServiceEndpointsChanged(t *testing.T) {
 				Labels:      map[string]string{"env": "prod", "updated-label": "true"},
 				ServiceType: "ClusterIP",
 				ClusterIP:   "1.2.3.4",
-			}},
+			},
+		},
 	}, th.ListEndpoints())
 }
 
@@ -206,7 +220,8 @@ func TestIngressEndpointsAdded(t *testing.T) {
 				Host:      "host-1",
 				Path:      "/",
 			},
-		}}, th.ListEndpoints())
+		},
+	}, th.ListEndpoints())
 }
 
 func TestIngressEndpointsRemoved(t *testing.T) {

--- a/extension/observer/k8sobserver/k8s_fixtures_test.go
+++ b/extension/observer/k8sobserver/k8s_fixtures_test.go
@@ -39,12 +39,14 @@ func newPod(name, host string) *v1.Pod {
 	return pod
 }
 
-var pod1V1 = newPod("pod1", "localhost")
-var pod1V2 = func() *v1.Pod {
-	pod := pod1V1.DeepCopy()
-	pod.Labels["pod-version"] = "2"
-	return pod
-}()
+var (
+	pod1V1 = newPod("pod1", "localhost")
+	pod1V2 = func() *v1.Pod {
+		pod := pod1V1.DeepCopy()
+		pod.Labels["pod-version"] = "2"
+		return pod
+	}()
+)
 
 var container1 = v1.Container{
 	Name:  "container-1",
@@ -276,9 +278,11 @@ func newNode(name, hostname string) *v1.Node {
 	}
 }
 
-var node1V1 = newNode("node1", "localhost")
-var node1V2 = func() *v1.Node {
-	node := node1V1.DeepCopy()
-	node.Labels["node-version"] = "2"
-	return node
-}()
+var (
+	node1V1 = newNode("node1", "localhost")
+	node1V2 = func() *v1.Node {
+		node := node1V1.DeepCopy()
+		node.Labels["node-version"] = "2"
+		return node
+	}()
+)

--- a/extension/observer/k8sobserver/pod_endpoint_test.go
+++ b/extension/observer/k8sobserver/pod_endpoint_test.go
@@ -20,7 +20,9 @@ func TestPodObjectToPortEndpoint(t *testing.T) {
 				Name:      "pod-2",
 				Namespace: "default",
 				UID:       "pod-2-UID",
-				Labels:    map[string]string{"env": "prod"}}},
+				Labels:    map[string]string{"env": "prod"},
+			},
+		},
 		{
 			ID:     "namespace/pod-2-UID/container-2",
 			Target: "1.2.3.4",
@@ -32,7 +34,10 @@ func TestPodObjectToPortEndpoint(t *testing.T) {
 					Name:      "pod-2",
 					Namespace: "default",
 					UID:       "pod-2-UID",
-					Labels:    map[string]string{"env": "prod"}}}},
+					Labels:    map[string]string{"env": "prod"},
+				},
+			},
+		},
 		{
 			ID:     "namespace/pod-2-UID/https(443)",
 			Target: "1.2.3.4:443",
@@ -41,9 +46,12 @@ func TestPodObjectToPortEndpoint(t *testing.T) {
 					Name:      "pod-2",
 					Namespace: "default",
 					UID:       "pod-2-UID",
-					Labels:    map[string]string{"env": "prod"}},
+					Labels:    map[string]string{"env": "prod"},
+				},
 				Port:      443,
-				Transport: observer.ProtocolTCP}},
+				Transport: observer.ProtocolTCP,
+			},
+		},
 	}
 
 	endpoints := convertPodToEndpoints("namespace", podWithNamedPorts)

--- a/extension/observer/k8sobserver/service_endpoint_test.go
+++ b/extension/observer/k8sobserver/service_endpoint_test.go
@@ -23,7 +23,8 @@ func TestServiceObjectToEndpoint(t *testing.T) {
 				Labels:      map[string]string{"env": "prod"},
 				ServiceType: "ClusterIP",
 				ClusterIP:   "1.2.3.4",
-			}},
+			},
+		},
 	}
 
 	endpoints := convertServiceToEndpoints("namespace", serviceWithClusterIP)

--- a/extension/oidcauthextension/config.go
+++ b/extension/oidcauthextension/config.go
@@ -5,7 +5,6 @@ package oidcauthextension // import "github.com/open-telemetry/opentelemetry-col
 
 // Config has the configuration for the OIDC Authenticator extension.
 type Config struct {
-
 	// The attribute (header name) to look for auth data. Optional, default value: "authorization".
 	Attribute string `mapstructure:"attribute"`
 

--- a/extension/opampextension/auth_test.go
+++ b/extension/opampextension/auth_test.go
@@ -113,6 +113,7 @@ func (m mockAuthClient) RoundTripper(base http.RoundTripper) (http.RoundTripper,
 		base:   base,
 	}, nil
 }
+
 func (mockAuthClient) PerRPCCredentials() (credentials.PerRPCCredentials, error) {
 	return nil, nil
 }

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -64,9 +64,11 @@ type opampAgent struct {
 	customCapabilityRegistry *customCapabilityRegistry
 }
 
-var _ opampcustommessages.CustomCapabilityRegistry = (*opampAgent)(nil)
-var _ extensioncapabilities.Dependent = (*opampAgent)(nil)
-var _ extensioncapabilities.ConfigWatcher = (*opampAgent)(nil)
+var (
+	_ opampcustommessages.CustomCapabilityRegistry = (*opampAgent)(nil)
+	_ extensioncapabilities.Dependent              = (*opampAgent)(nil)
+	_ extensioncapabilities.ConfigWatcher          = (*opampAgent)(nil)
+)
 
 func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
 	o.reportFunc = func(event *componentstatus.Event) {

--- a/extension/pprofextension/config.go
+++ b/extension/pprofextension/config.go
@@ -11,7 +11,6 @@ import (
 // Config has the configuration for the extension enabling the golang
 // net/http/pprof (Performance Profiler) extension.
 type Config struct {
-
 	// TCPAddr is the address and port in which the pprof will be listening to.
 	// Use localhost:<port> to make it available only locally, or ":<port>" to
 	// make it available on all network interfaces.

--- a/extension/solarwindsapmsettingsextension/extension.go
+++ b/extension/solarwindsapmsettingsextension/extension.go
@@ -165,7 +165,7 @@ func refresh(extension *solarwindsapmSettingsExtension, filename string) {
 		if content, err := json.Marshal(settings); err != nil {
 			extension.telemetrySettings.Logger.Error("unable to marshal setting JSON[] byte from settings", zap.Error(err))
 		} else {
-			if err := os.WriteFile(filename, content, 0600); err != nil {
+			if err := os.WriteFile(filename, content, 0o600); err != nil {
 				extension.telemetrySettings.Logger.Error("unable to write "+filename, zap.Error(err))
 			} else {
 				if len(response.GetWarning()) > 0 {

--- a/extension/storage/filestorage/client.go
+++ b/extension/storage/filestorage/client.go
@@ -50,7 +50,7 @@ func bboltOptions(timeout time.Duration, noSync bool) *bbolt.Options {
 
 func newClient(logger *zap.Logger, filePath string, timeout time.Duration, compactionCfg *CompactionConfig, noSync bool) (*fileStorageClient, error) {
 	options := bboltOptions(timeout, noSync)
-	db, err := bbolt.Open(filePath, 0600, options)
+	db, err := bbolt.Open(filePath, 0o600, options)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +188,7 @@ func (c *fileStorageClient) Compact(compactionDirectory string, timeout time.Dur
 		zap.String(tempDirectoryKey, file.Name()))
 
 	// cannot reuse newClient as db shouldn't contain any bucket
-	compactedDb, err = bbolt.Open(file.Name(), 0600, options)
+	compactedDb, err = bbolt.Open(file.Name(), 0o600, options)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func (c *fileStorageClient) Compact(compactionDirectory string, timeout time.Dur
 	// replace current db file with compacted db file
 	// we reopen the DB file irrespective of the success of the replace, as we can't leave it closed
 	moveErr := moveFileWithFallback(compactedDbPath, dbPath)
-	c.db, openErr = bbolt.Open(dbPath, 0600, options)
+	c.db, openErr = bbolt.Open(dbPath, 0o600, options)
 
 	// if we got errors for both rename and open, we'd rather return the open one
 	// this should not happen in any kind of normal circumstance - maybe we should panic instead?
@@ -337,7 +337,7 @@ func moveFileWithFallback(src string, dest string) error {
 		return err
 	}
 
-	if err = os.WriteFile(dest, data, 0600); err != nil {
+	if err = os.WriteFile(dest, data, 0o600); err != nil {
 		return err
 	}
 

--- a/extension/storage/filestorage/config.go
+++ b/extension/storage/filestorage/config.go
@@ -12,8 +12,10 @@ import (
 	"time"
 )
 
-var errInvalidOctal = errors.New("directory_permissions value must be a valid octal representation")
-var errInvalidPermissionBits = errors.New("directory_permissions contain invalid bits for file access")
+var (
+	errInvalidOctal          = errors.New("directory_permissions value must be a valid octal representation")
+	errInvalidPermissionBits = errors.New("directory_permissions contain invalid bits for file access")
+)
 
 // Config defines configuration for file storage extension.
 type Config struct {

--- a/extension/storage/filestorage/config_test.go
+++ b/extension/storage/filestorage/config_test.go
@@ -99,6 +99,7 @@ func TestHandleProvidingFilePathAsDirWithAnError(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, file.Name()+" is not a directory")
 }
+
 func TestDirectoryCreateConfig(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/extension/storage/filestorage/extension.go
+++ b/extension/storage/filestorage/extension.go
@@ -72,7 +72,6 @@ func (lfs *localFileStorage) GetClient(_ context.Context, kind component.Kind, e
 	rawName = sanitize(rawName)
 	absoluteName := filepath.Join(lfs.cfg.Directory, rawName)
 	client, err := newClient(lfs.logger, absoluteName, lfs.cfg.Timeout, lfs.cfg.Compaction, !lfs.cfg.FSync)
-
 	if err != nil {
 		return nil, err
 	}

--- a/extension/storage/filestorage/extension_test.go
+++ b/extension/storage/filestorage/extension_test.go
@@ -551,9 +551,9 @@ func TestDirectoryCreation(t *testing.T) {
 				require.NoError(t, err)
 				var expectedFileMode os.FileMode
 				if runtime.GOOS == "windows" { // on Windows, we get 0777 for writable directories
-					expectedFileMode = os.FileMode(0777)
+					expectedFileMode = os.FileMode(0o777)
 				} else {
-					expectedFileMode = os.FileMode(0750)
+					expectedFileMode = os.FileMode(0o750)
 				}
 				require.Equal(t, expectedFileMode, s.Mode()&os.ModePerm)
 			},
@@ -576,9 +576,9 @@ func TestDirectoryCreation(t *testing.T) {
 				require.NoError(t, err)
 				var expectedFileMode os.FileMode
 				if runtime.GOOS == "windows" { // on Windows, we get 0777 for writable directories
-					expectedFileMode = os.FileMode(0777)
+					expectedFileMode = os.FileMode(0o777)
 				} else {
-					expectedFileMode = os.FileMode(0700)
+					expectedFileMode = os.FileMode(0o700)
 				}
 				require.Equal(t, expectedFileMode, s.Mode()&os.ModePerm)
 			},

--- a/extension/storage/storagetest/client.go
+++ b/extension/storage/storagetest/client.go
@@ -16,9 +16,7 @@ import (
 	"go.opentelemetry.io/collector/extension/experimental/storage"
 )
 
-var (
-	errClientClosed = errors.New("client closed")
-)
+var errClientClosed = errors.New("client closed")
 
 type TestClient struct {
 	cache    map[string][]byte
@@ -139,7 +137,7 @@ func (p *TestClient) Close(_ context.Context) error {
 		return err
 	}
 
-	return os.WriteFile(p.storageFile, contents, os.FileMode(0600))
+	return os.WriteFile(p.storageFile, contents, os.FileMode(0o600))
 }
 
 const clientCreatorID = "client_creator_id"

--- a/extension/sumologicextension/credentials/credentialsstore_localfs.go
+++ b/extension/sumologicextension/credentials/credentialsstore_localfs.go
@@ -133,7 +133,6 @@ func (cr LocalFsStore) Get(key string) (CollectorCredentials, error) {
 	}
 
 	creds, err := f(_getHasher(), key)
-
 	if err != nil {
 		return CollectorCredentials{}, err
 	}
@@ -170,7 +169,7 @@ func (cr LocalFsStore) Store(key string, creds CollectorCredentials) error {
 			return err
 		}
 
-		if err = os.WriteFile(path, encryptedCreds, 0600); err != nil {
+		if err = os.WriteFile(path, encryptedCreds, 0o600); err != nil {
 			return fmt.Errorf("failed to save credentials file '%s': %w",
 				path, err,
 			)
@@ -239,7 +238,7 @@ func (cr LocalFsStore) Validate() error {
 func ensureDir(path string) error {
 	fi, err := os.Stat(path)
 	if err != nil {
-		if err := os.Mkdir(path, 0700); err != nil {
+		if err := os.Mkdir(path, 0o700); err != nil {
 			return err
 		}
 		return nil
@@ -247,8 +246,8 @@ func ensureDir(path string) error {
 
 	// If the directory doesn't have the execution bit then
 	// set it so that we can 'exec' into it.
-	if fi.Mode().Perm() != 0700 {
-		if err := os.Chmod(path, 0700); err != nil {
+	if fi.Mode().Perm() != 0o700 {
+		if err := os.Chmod(path, 0o700); err != nil {
 			return err
 		}
 	}

--- a/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
+++ b/extension/sumologicextension/credentials/credentialsstore_localfs_test.go
@@ -69,11 +69,11 @@ func TestCredentialsStoreValidate(t *testing.T) {
 	var expectedFileMode fs.FileMode
 	dir := filepath.Join(t.TempDir(), "store")
 	if runtime.GOOS == "windows" { // on Windows, we get 0777 for writable directories
-		expectedFileMode = fs.FileMode(0777)
+		expectedFileMode = fs.FileMode(0o777)
 	} else {
-		expectedFileMode = fs.FileMode(0700)
+		expectedFileMode = fs.FileMode(0o700)
 	}
-	err := os.Mkdir(dir, 0400)
+	err := os.Mkdir(dir, 0o400)
 	require.NoError(t, err)
 
 	store, err := NewLocalFsStore(WithCredentialsDirectory(dir), WithLogger(zap.NewNop()))

--- a/extension/sumologicextension/credentials/encrypt.go
+++ b/extension/sumologicextension/credentials/encrypt.go
@@ -83,7 +83,6 @@ func encrypt(data []byte, encryptionKey []byte) ([]byte, error) {
 	}
 
 	ret, err := f(_getHasher(), data, encryptionKey)
-
 	if err != nil {
 		return ret, err
 	}
@@ -115,7 +114,6 @@ func decrypt(data []byte, encryptionKey []byte) ([]byte, error) {
 	}
 
 	ret, err := f(_getHasher(), data, encryptionKey)
-
 	if err != nil {
 		return ret, err
 	}

--- a/extension/sumologicextension/extension.go
+++ b/extension/sumologicextension/extension.go
@@ -621,8 +621,10 @@ func (se *SumologicExtension) heartbeatLoop() {
 	}
 }
 
-var errUnauthorizedHeartbeat = errors.New("heartbeat unauthorized")
-var errUnauthorizedMetadata = errors.New("metadata update unauthorized")
+var (
+	errUnauthorizedHeartbeat = errors.New("heartbeat unauthorized")
+	errUnauthorizedMetadata  = errors.New("metadata update unauthorized")
+)
 
 type ErrorAPI struct {
 	status int

--- a/extension/sumologicextension/extension_test.go
+++ b/extension/sumologicextension/extension_test.go
@@ -31,7 +31,6 @@ import (
 func setupTestMain(m *testing.M) {
 	// Enable the feature gates before all tests to avoid flaky tests.
 	err := featuregate.GlobalRegistry().Set(updateCollectorMetadataID, true)
-
 	if err != nil {
 		panic("unable to set feature gates")
 	}
@@ -236,7 +235,7 @@ func TestStoreCredentials(t *testing.T) {
 		cfg.CollectorCredentialsDirectory = dir
 
 		// Ensure the directory has 600 permissions
-		require.NoError(t, os.Chmod(dir, 0600))
+		require.NoError(t, os.Chmod(dir, 0o600))
 
 		se, err := newSumologicExtension(cfg, zap.NewNop(), component.NewID(metadata.Type), "1.0.0")
 		require.NoError(t, err)
@@ -261,7 +260,7 @@ func TestStoreCredentials(t *testing.T) {
 		cfg.CollectorCredentialsDirectory = dir
 
 		// Ensure the directory has 700 permissions
-		require.NoError(t, os.Chmod(dir, 0700))
+		require.NoError(t, os.Chmod(dir, 0o700))
 
 		se, err := newSumologicExtension(cfg, zap.NewNop(), component.NewID(metadata.Type), "1.0.0")
 		require.NoError(t, err)


### PR DESCRIPTION
#### Description

[gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) enforces a stricter format than gofmt

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36363