### PR TITLE
[chore]: enable gofumpt linter for connector

### DIFF
--- a/connector/countconnector/config_test.go
+++ b/connector/countconnector/config_test.go
@@ -279,7 +279,8 @@ func TestLoadConfig(t *testing.T) {
 				},
 				Metrics: map[string]MetricInfo{
 					"my.metric.count": {
-						Description: "My metric count."},
+						Description: "My metric count.",
+					},
 					"limited.metric.count": {
 						Description: "Limited metric count.",
 						Conditions:  []string{`IsMatch(resource.attributes["host.name"], "pod-m")`},

--- a/connector/otlpjsonconnector/factory.go
+++ b/connector/otlpjsonconnector/factory.go
@@ -14,9 +14,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/otlpjsonconnector/internal/metadata"
 )
 
-var logRegex = regexp.MustCompile(`^\{\s*"resourceLogs"\s*:\s*\[`)
-var metricRegex = regexp.MustCompile(`^\{\s*"resourceMetrics"\s*:\s*\[`)
-var traceRegex = regexp.MustCompile(`^\{\s*"resourceSpans"\s*:\s*\[`)
+var (
+	logRegex    = regexp.MustCompile(`^\{\s*"resourceLogs"\s*:\s*\[`)
+	metricRegex = regexp.MustCompile(`^\{\s*"resourceMetrics"\s*:\s*\[`)
+	traceRegex  = regexp.MustCompile(`^\{\s*"resourceSpans"\s*:\s*\[`)
+)
 
 // NewFactory returns a ConnectorFactory.
 func NewFactory() connector.Factory {

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -45,7 +45,6 @@ func newLogsConnector(
 		cfg.DefaultPipelines,
 		lr.Consumer,
 		set.TelemetrySettings)
-
 	if err != nil {
 		return nil, err
 	}

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -45,7 +45,6 @@ func newMetricsConnector(
 		cfg.DefaultPipelines,
 		mr.Consumer,
 		set.TelemetrySettings)
-
 	if err != nil {
 		return nil, err
 	}

--- a/connector/routingconnector/request.go
+++ b/connector/routingconnector/request.go
@@ -18,9 +18,11 @@ import (
 // future if needed. For now, it expects the condition to be in exactly the format:
 // 'request["<name>"] <comparator> <value>' where <comparator> is either '==' or '!='.
 
-var requestFieldRegex = regexp.MustCompile(`request\[".*"\]`)
-var valueFieldRegex = regexp.MustCompile(`".*"`)
-var comparatorRegex = regexp.MustCompile(`==|!=`)
+var (
+	requestFieldRegex = regexp.MustCompile(`request\[".*"\]`)
+	valueFieldRegex   = regexp.MustCompile(`".*"`)
+	comparatorRegex   = regexp.MustCompile(`==|!=`)
+)
 
 type requestCondition struct {
 	attributeName string

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -45,7 +45,6 @@ func newTracesConnector(
 		cfg.DefaultPipelines,
 		tr.Consumer,
 		set.TelemetrySettings)
-
 	if err != nil {
 		return nil, err
 	}

--- a/connector/servicegraphconnector/config.go
+++ b/connector/servicegraphconnector/config.go
@@ -9,7 +9,6 @@ import (
 
 // Config defines the configuration options for servicegraphprocessor.
 type Config struct {
-
 	// MetricsExporter is the name of the metrics exporter to use to ship metrics.
 	//
 	// Deprecated: The exporter is defined as part of the pipeline and this option is currently noop.

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -441,7 +441,6 @@ func TestUpdateDurationMetrics(t *testing.T) {
 		caseStr  string
 		duration float64
 	}{
-
 		{
 			caseStr:  "index 0 latency",
 			duration: 0,

--- a/connector/servicegraphconnector/internal/store/store.go
+++ b/connector/servicegraphconnector/internal/store/store.go
@@ -12,9 +12,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
-var (
-	ErrTooManyItems = errors.New("too many items")
-)
+var ErrTooManyItems = errors.New("too many items")
 
 type Callback func(e *Edge)
 

--- a/connector/spanmetricsconnector/config_test.go
+++ b/connector/spanmetricsconnector/config_test.go
@@ -67,7 +67,8 @@ func TestLoadConfig(t *testing.T) {
 						},
 					},
 				},
-			}},
+			},
+		},
 		{
 			id: component.NewIDWithName(metadata.Type, "exponential_histogram"),
 			expected: &Config{

--- a/connector/spanmetricsconnector/connector_test.go
+++ b/connector/spanmetricsconnector/connector_test.go
@@ -1544,6 +1544,7 @@ func TestSpanMetrics_Events(t *testing.T) {
 		})
 	}
 }
+
 func TestExemplarsAreDiscardedAfterFlushing(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/connector/spanmetricsconnector/internal/metrics/unit.go
+++ b/connector/spanmetricsconnector/internal/metrics/unit.go
@@ -20,8 +20,10 @@ const (
 
 type Unit int8
 
-var _ encoding.TextMarshaler = (*Unit)(nil)
-var _ encoding.TextUnmarshaler = (*Unit)(nil)
+var (
+	_ encoding.TextMarshaler   = (*Unit)(nil)
+	_ encoding.TextUnmarshaler = (*Unit)(nil)
+)
 
 func (u Unit) String() string {
 	switch u {


### PR DESCRIPTION
#### Description

[gofumpt](https://golangci-lint.run/usage/linters/#gofumpt) enforces a stricter format than gofmt

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36363