### PR TITLE
[chore][allowlist] remove `emreyalvac` as he's already a member

### DIFF
--- a/cmd/githubgen/allowlist.txt
+++ b/cmd/githubgen/allowlist.txt
@@ -1,5 +1,4 @@
 Caleb-Hurshman
-emreyalvac
 cheempz
 jerrytfleung
 driverpt


### PR DESCRIPTION
This PR fixes the `make check` failure on `main`. [CI Link](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/11830611046/job/32964502752)

cc: @emreyalvac

