### PR TITLE
[chore] Add a default printf logger for debugging integration tests

### DIFF
--- a/internal/coreinternal/scraperinttest/README.md
+++ b/internal/coreinternal/scraperinttest/README.md
@@ -3,3 +3,22 @@
 This package is intended to be a temporary workspace for extracting common functionality
 from scraper integration tests. Once stabilized, this code can likely move to `pdatatest`
 or its sub-packages `pmetrictest`, etc.
+
+If you're having issue with your `testcontainers.ContainerRequest` starting up, you can use the provided `PrintfLogConsumer` in a [`LogConsumerCfg`](https://pkg.go.dev/github.com/testcontainers/testcontainers-go#LogConsumerConfig) to display the startup logs
+
+```golang
+    scraperinttest.NewIntegrationTest(
+            // ...
+            scraperinttest.WithContainerRequest(
+            testcontainers.ContainerRequest{
+            // ...
+                LogConsumerCfg: &testcontainers.LogConsumerConfig{
+                    Consumers: []testcontainers.LogConsumer{
+                        &scraperinttest.PrintfLogConsumer{},
+                    },
+                },
+            // ...
+            }
+        )
+    )
+```

--- a/internal/coreinternal/scraperinttest/scraperint.go
+++ b/internal/coreinternal/scraperinttest/scraperint.go
@@ -314,3 +314,9 @@ func RunScript(script []string) testcontainers.ContainerHook {
 		return errors.New(strings.TrimSpace(errStr))
 	}
 }
+
+type PrintfLogConsumer struct{}
+
+func (g *PrintfLogConsumer) Accept(l testcontainers.Log) {
+	fmt.Printf("[Container] %s", string(l.Content))
+}


### PR DESCRIPTION
This aims to help in authoring/debugging integration tests without having to copy paste some tribal knowledge.