### PR TITLE
[cmd/githubgen] Add a flag to skip GitHub organization membership checks

### DIFF
--- a/.chloggen/feat_githubgen_skipmembercheck.yaml
+++ b/.chloggen/feat_githubgen_skipmembercheck.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: cmd/githubgen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds a flag to skip checking GitHub organization membership for CODEOWNERS
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36263]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/cmd/githubgen/README.md
+++ b/cmd/githubgen/README.md
@@ -19,7 +19,7 @@ $> GITHUB_TOKEN=<mypattoken> githubgen --folder . [--allowlist cmd/githubgen/all
 
 ## Checking codeowners against OpenTelemetry membership via Github API
 
-To authenticate, set the environment variable `GITHUB_TOKEN` to a PAT token.
+To authenticate, set the environment variable `GITHUB_TOKEN` to a PAT token.  If a PAT is not available you can use the `--skipgithub` flag to avoid checking for membership in the GitHub organization.
 
 For each codeowner, the script will check if the user is registered as a member of the OpenTelemetry organization.
 

--- a/cmd/githubgen/codeowners.go
+++ b/cmd/githubgen/codeowners.go
@@ -71,6 +71,7 @@ const distributionCodeownersHeader = `
 `
 
 type codeownersGenerator struct {
+	skipGithub bool
 }
 
 func (cg codeownersGenerator) generate(data *githubData) error {
@@ -91,7 +92,7 @@ func (cg codeownersGenerator) generate(data *githubData) error {
 	}
 	var missingCodeowners []string
 	var duplicateCodeowners []string
-	members, err := getGithubMembers()
+	members, err := cg.getGithubMembers()
 	if err != nil {
 		return err
 	}
@@ -109,7 +110,7 @@ func (cg codeownersGenerator) generate(data *githubData) error {
 			duplicateCodeowners = append(duplicateCodeowners, codeowner)
 		}
 	}
-	if len(missingCodeowners) > 0 {
+	if len(missingCodeowners) > 0 && !cg.skipGithub {
 		sort.Strings(missingCodeowners)
 		return fmt.Errorf("codeowners are not members: %s", strings.Join(missingCodeowners, ", "))
 	}
@@ -189,7 +190,11 @@ LOOP:
 	return nil
 }
 
-func getGithubMembers() (map[string]struct{}, error) {
+func (cg codeownersGenerator) getGithubMembers() (map[string]struct{}, error) {
+	if cg.skipGithub {
+		// don't try to get organization members if no token is expected
+		return map[string]struct{}{}, nil
+	}
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken == "" {
 		return nil, fmt.Errorf("Set the environment variable `GITHUB_TOKEN` to a PAT token to authenticate")

--- a/cmd/githubgen/main.go
+++ b/cmd/githubgen/main.go
@@ -32,6 +32,7 @@ type generator interface {
 func main() {
 	folder := flag.String("folder", ".", "folder investigated for codeowners")
 	allowlistFilePath := flag.String("allowlist", "cmd/githubgen/allowlist.txt", "path to a file containing an allowlist of members outside the OpenTelemetry organization")
+	skipGithubCheck := flag.Bool("skipgithub", false, "skip checking GitHub membership check for CODEOWNERS generator")
 	flag.Parse()
 	var generators []generator
 	for _, arg := range flag.Args() {
@@ -39,7 +40,7 @@ func main() {
 		case "issue-templates":
 			generators = append(generators, issueTemplatesGenerator{})
 		case "codeowners":
-			generators = append(generators, codeownersGenerator{})
+			generators = append(generators, codeownersGenerator{skipGithub: *skipGithubCheck})
 		case "distributions":
 			generators = append(generators, distributionsGenerator{})
 		default:
@@ -47,7 +48,7 @@ func main() {
 		}
 	}
 	if len(generators) == 0 {
-		generators = []generator{issueTemplatesGenerator{}, codeownersGenerator{}}
+		generators = []generator{issueTemplatesGenerator{}, codeownersGenerator{skipGithub: *skipGithubCheck}}
 	}
 	if err := run(*folder, *allowlistFilePath, generators); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds a `--skipgithub` flag to allow generating the `CODEOWNERS` file without requiring a PAT to verify membership in the OpenTelemetry GitHub organization.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36263

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Executed command without providing a PAT and confirmed it did not produce errors or unexpected changes to the `CODEOWNERS` file.

<!--Describe the documentation added.-->
#### Documentation

Updated `README`

<!--Please delete paragraphs that you did not use before submitting.-->
