### PR TITLE
fix: support indexing more types

### DIFF
--- a/.chloggen/index_more_types.yaml
+++ b/.chloggen/index_more_types.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow indexing {int64, float64, bool, []byte} slice types
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29441]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/index_more_types.yaml
+++ b/.chloggen/index_more_types.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Allow indexing []int64, []float64, []bool, []byte slices
+note: Allow indexing []int64, []float64, []bool, and []byte slices
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [29441]
@@ -15,7 +15,7 @@ issues: [29441]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext:
+subtext: It should now be possible to index all slice types
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/index_more_types.yaml
+++ b/.chloggen/index_more_types.yaml
@@ -7,7 +7,7 @@ change_type: bug_fix
 component: pkg/ottl
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Allow indexing {int64, float64, bool, []byte} slice types
+note: Allow indexing []int64, []float64, []bool, []byte slices
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [29441]

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -135,7 +135,7 @@ func (g exprGetter[K]) Get(ctx context.Context, tCtx K) (any, error) {
 				if err != nil {
 					return nil, err
 				}
-			case [][]byte:
+			case []byte:
 				result, err = getElementByIndex(r, k.Int)
 				if err != nil {
 					return nil, err

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -120,6 +120,26 @@ func (g exprGetter[K]) Get(ctx context.Context, tCtx K) (any, error) {
 				if err != nil {
 					return nil, err
 				}
+			case []bool:
+				result, err = getElementByIndex(r, k.Int)
+				if err != nil {
+					return nil, err
+				}
+			case []float64:
+				result, err = getElementByIndex(r, k.Int)
+				if err != nil {
+					return nil, err
+				}
+			case []int64:
+				result, err = getElementByIndex(r, k.Int)
+				if err != nil {
+					return nil, err
+				}
+			case [][]byte:
+				result, err = getElementByIndex(r, k.Int)
+				if err != nil {
+					return nil, err
+				}
 			default:
 				return nil, fmt.Errorf("type, %T, does not support int indexing", result)
 			}

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -102,7 +102,9 @@ func basicSliceFloat() (ExprFunc[any], error) {
 func basicSliceBytes() (ExprFunc[any], error) {
 	return func(_ context.Context, _ any) (any, error) {
 		return []any{
-			[]byte("pass"),
+			[][]byte{
+				[]byte("pass"),
+			},
 		}, nil
 	}, nil
 }

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -99,11 +99,11 @@ func basicSliceFloat() (ExprFunc[any], error) {
 	}, nil
 }
 
-func basicSliceBytes() (ExprFunc[any], error) {
+func basicSliceByte() (ExprFunc[any], error) {
 	return func(_ context.Context, _ any) (any, error) {
 		return []any{
-			[][]byte{
-				[]byte("pass"),
+			[]byte{
+				byte('p'),
 			},
 		}, nil
 	}, nil
@@ -314,7 +314,6 @@ func Test_newGetter(t *testing.T) {
 						Function: "SliceBool",
 						Keys: []key{
 							{
-								// note for review: not sure if this is correct
 								Int: ottltest.Intp(0),
 							},
 							{
@@ -334,7 +333,6 @@ func Test_newGetter(t *testing.T) {
 						Function: "SliceInteger",
 						Keys: []key{
 							{
-								// note for review: not sure if this is correct
 								Int: ottltest.Intp(0),
 							},
 							{
@@ -354,7 +352,6 @@ func Test_newGetter(t *testing.T) {
 						Function: "SliceFloat",
 						Keys: []key{
 							{
-								// note for review: not sure if this is correct
 								Int: ottltest.Intp(0),
 							},
 							{
@@ -367,14 +364,13 @@ func Test_newGetter(t *testing.T) {
 			want: 1.0,
 		},
 		{
-			name: "function call nested SliceBytes",
+			name: "function call nested SliceByte",
 			val: value{
 				Literal: &mathExprLiteral{
 					Converter: &converter{
-						Function: "SliceBytes",
+						Function: "SliceByte",
 						Keys: []key{
 							{
-								// note for review: not sure if this is correct
 								Int: ottltest.Intp(0),
 							},
 							{
@@ -384,7 +380,7 @@ func Test_newGetter(t *testing.T) {
 					},
 				},
 			},
-			want: []byte("pass"),
+			want: byte('p'),
 		},
 		{
 			name: "enum",
@@ -685,7 +681,7 @@ func Test_newGetter(t *testing.T) {
 		createFactory("SliceBool", &struct{}{}, basicSliceBool),
 		createFactory("SliceInteger", &struct{}{}, basicSliceInteger),
 		createFactory("SliceFloat", &struct{}{}, basicSliceFloat),
-		createFactory("SliceBytes", &struct{}{}, basicSliceBytes),
+		createFactory("SliceByte", &struct{}{}, basicSliceByte),
 	)
 
 	p, _ := NewParser[any](

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -69,6 +69,44 @@ func basicSliceString() (ExprFunc[any], error) {
 	}, nil
 }
 
+func basicSliceBool() (ExprFunc[any], error) {
+	return func(_ context.Context, _ any) (any, error) {
+		return []any{
+			[]bool{
+				true,
+			},
+		}, nil
+	}, nil
+}
+
+func basicSliceInteger() (ExprFunc[any], error) {
+	return func(_ context.Context, _ any) (any, error) {
+		return []any{
+			[]int64{
+				1,
+			},
+		}, nil
+	}, nil
+}
+
+func basicSliceFloat() (ExprFunc[any], error) {
+	return func(_ context.Context, _ any) (any, error) {
+		return []any{
+			[]float64{
+				1,
+			},
+		}, nil
+	}, nil
+}
+
+func basicSliceBytes() (ExprFunc[any], error) {
+	return func(_ context.Context, _ any) (any, error) {
+		return []any{
+			[]byte("pass"),
+		}, nil
+	}, nil
+}
+
 func Test_newGetter(t *testing.T) {
 	tests := []struct {
 		name string
@@ -265,6 +303,86 @@ func Test_newGetter(t *testing.T) {
 				},
 			},
 			want: "pass",
+		},
+		{
+			name: "function call nested SliceBool",
+			val: value{
+				Literal: &mathExprLiteral{
+					Converter: &converter{
+						Function: "SliceBool",
+						Keys: []key{
+							{
+								// note for review: not sure if this is correct
+								Int: ottltest.Intp(0),
+							},
+							{
+								Int: ottltest.Intp(0),
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "function call nested SliceInteger",
+			val: value{
+				Literal: &mathExprLiteral{
+					Converter: &converter{
+						Function: "SliceInteger",
+						Keys: []key{
+							{
+								// note for review: not sure if this is correct
+								Int: ottltest.Intp(0),
+							},
+							{
+								Int: ottltest.Intp(0),
+							},
+						},
+					},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "function call nested SliceFloat",
+			val: value{
+				Literal: &mathExprLiteral{
+					Converter: &converter{
+						Function: "SliceFloat",
+						Keys: []key{
+							{
+								// note for review: not sure if this is correct
+								Int: ottltest.Intp(0),
+							},
+							{
+								Int: ottltest.Intp(0),
+							},
+						},
+					},
+				},
+			},
+			want: 1.0,
+		},
+		{
+			name: "function call nested SliceBytes",
+			val: value{
+				Literal: &mathExprLiteral{
+					Converter: &converter{
+						Function: "SliceBytes",
+						Keys: []key{
+							{
+								// note for review: not sure if this is correct
+								Int: ottltest.Intp(0),
+							},
+							{
+								Int: ottltest.Intp(0),
+							},
+						},
+					},
+				},
+			},
+			want: []byte("pass"),
 		},
 		{
 			name: "enum",
@@ -562,6 +680,10 @@ func Test_newGetter(t *testing.T) {
 		createFactory("PSlice", &struct{}{}, pslice),
 		createFactory("Slice", &struct{}{}, basicSlice),
 		createFactory("SliceString", &struct{}{}, basicSliceString),
+		createFactory("SliceBool", &struct{}{}, basicSliceBool),
+		createFactory("SliceInteger", &struct{}{}, basicSliceInteger),
+		createFactory("SliceFloat", &struct{}{}, basicSliceFloat),
+		createFactory("SliceBytes", &struct{}{}, basicSliceBytes),
 	)
 
 	p, _ := NewParser[any](


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Bugfix: support indexing more types

> [!IMPORTANT]  
> I'm not sure if this should support indexing into slices of `byte` or `[]byte` (I've gone with `[]byte` for now


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #29441

<!--Describe what testing was performed and which tests were added.-->
#### Testing

currently running `make gotest` (it's taking longer than I expected). I noticed that https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35581 added to `e2e_test.go`. I can add a test case there, but it'll take me a bit longer to grok how those are working 

Update: I'm currently getting `make gotest` failures on `main` from `internal/scraper/processscraper`

<!--Describe the documentation added.-->
#### Documentation

changelog

<!--Please delete paragraphs that you did not use before submitting.-->
