### PR TITLE
[chore] use skipgithub to test the file is generated first

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -230,10 +230,14 @@ jobs:
           make gendistributions
           git diff -s --exit-code || (echo 'Generated code is out of date, please run "make gendistributions" and commit the changes in this PR.' && exit 1)
       - name: Gen CODEOWNERS
+        run: |
+          make githubgen-install
+          githubgen --skipgithub
+          git diff -s --exit-code || (echo 'Generated code is out of date, please apply this diff and commit the changes in this PR.' && git diff && exit 1)
+      - name: Check codeowners membership
         if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
         run: |
-          GITHUB_TOKEN=${{ secrets.READ_ORG_AND_USER_TOKEN }} make gengithub
-          git diff -s --exit-code || (echo 'Generated code is out of date, please apply this diff and commit the changes in this PR.' && git diff && exit 1)
+          GITHUB_TOKEN=${{ secrets.READ_ORG_AND_USER_TOKEN }} githubgen
       - name: CodeGen
         run: |
           make -j2 generate


### PR DESCRIPTION
#### Description
use skipgithub to test the file is generated first, and then check that codeowners are set

