### PR TITLE
[OTTL] Fix empty string matching for replace_all_patterns

### DIFF
--- a/pkg/ottl/ottlfuncs/func_replace_all_matches.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches.go
@@ -75,6 +75,9 @@ func replaceAllMatches[K any](target ottl.PMapGetter[K], pattern string, replace
 			}
 		}
 		val.Range(func(_ string, value pcommon.Value) bool {
+			if value.Type() != pcommon.ValueTypeStr {
+				return true
+			}
 			if glob.Match(value.Str()) {
 				value.SetStr(replacementVal)
 			}

--- a/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_matches_test.go
@@ -20,6 +20,8 @@ func Test_replaceAllMatches(t *testing.T) {
 	input.PutStr("test", "hello world")
 	input.PutStr("test2", "hello")
 	input.PutStr("test3", "goodbye")
+	input.PutStr("test4", "")
+	input.PutInt("test5", 123)
 
 	ottlValue := ottl.StandardFunctionGetter[pcommon.Map]{
 		FCtx: ottl.FunctionContext{
@@ -64,6 +66,8 @@ func Test_replaceAllMatches(t *testing.T) {
 				expectedMap.PutStr("test", "prefix=hash(hello {universe})")
 				expectedMap.PutStr("test2", "prefix=hash(hello {universe})")
 				expectedMap.PutStr("test3", "goodbye")
+				expectedMap.PutStr("test4", "")
+				expectedMap.PutInt("test5", 123)
 			},
 		},
 		{
@@ -81,6 +85,8 @@ func Test_replaceAllMatches(t *testing.T) {
 				expectedMap.PutStr("test", "hello {universe}")
 				expectedMap.PutStr("test2", "hello {universe}")
 				expectedMap.PutStr("test3", "goodbye")
+				expectedMap.PutStr("test4", "")
+				expectedMap.PutInt("test5", 123)
 			},
 		},
 		{
@@ -98,6 +104,27 @@ func Test_replaceAllMatches(t *testing.T) {
 				expectedMap.PutStr("test", "hello world")
 				expectedMap.PutStr("test2", "hello")
 				expectedMap.PutStr("test3", "goodbye")
+				expectedMap.PutStr("test4", "")
+				expectedMap.PutInt("test5", 123)
+			},
+		},
+		{
+			name:    "replace empty string",
+			target:  target,
+			pattern: "",
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (any, error) {
+					return "empty_string_replacement", nil
+				},
+			},
+			function:          ottl.Optional[ottl.FunctionGetter[pcommon.Map]]{},
+			replacementFormat: ottl.Optional[ottl.StringGetter[pcommon.Map]]{},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutStr("test2", "hello")
+				expectedMap.PutStr("test3", "goodbye")
+				expectedMap.PutStr("test4", "empty_string_replacement")
+				expectedMap.PutInt("test5", 123)
 			},
 		},
 	}

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns.go
@@ -65,7 +65,7 @@ func replaceAllPatterns[K any](target ottl.PMapGetter[K], mode string, regexPatt
 		val.Range(func(key string, originalValue pcommon.Value) bool {
 			switch mode {
 			case modeValue:
-				if compiledPattern.MatchString(originalValue.Str()) {
+				if originalValue.Type() == pcommon.ValueTypeStr && compiledPattern.MatchString(originalValue.Str()) {
 					if !fn.IsEmpty() {
 						updatedString, err := applyOptReplaceFunction(ctx, tCtx, compiledPattern, fn, originalValue.Str(), replacementVal, replacementFormat)
 						if err != nil {

--- a/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
+++ b/pkg/ottl/ottlfuncs/func_replace_all_patterns_test.go
@@ -23,6 +23,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 	input.PutInt("test4", 1234)
 	input.PutDouble("test5", 1234)
 	input.PutBool("test6", true)
+	input.PutStr("test7", "")
 
 	ottlValue := ottl.StandardFunctionGetter[pcommon.Map]{
 		FCtx: ottl.FunctionContext{
@@ -77,6 +78,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -97,6 +99,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -117,6 +120,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -137,6 +141,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -158,6 +163,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -196,6 +202,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -217,6 +224,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -238,6 +246,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -258,6 +267,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -278,6 +288,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -298,6 +309,8 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -318,6 +331,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -338,6 +352,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -360,6 +375,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -382,6 +398,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -404,6 +421,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test.4", 1234)
 				expectedMap.PutDouble("test.5", 1234)
 				expectedMap.PutBool("test.6", true)
+				expectedMap.PutStr("test.7", "")
 			},
 		},
 		{
@@ -426,6 +444,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
 			},
 		},
 		{
@@ -447,6 +466,7 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test-4", 1234)
 				expectedMap.PutDouble("test-5", 1234)
 				expectedMap.PutBool("test-6", true)
+				expectedMap.PutStr("test-7", "")
 			},
 		},
 		{
@@ -469,6 +489,30 @@ func Test_replaceAllPatterns(t *testing.T) {
 				expectedMap.PutInt("test4", 1234)
 				expectedMap.PutDouble("test5", 1234)
 				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "")
+			},
+		},
+		{
+			name:    "replacement for empty string",
+			target:  target,
+			mode:    modeValue,
+			pattern: `^$`,
+			replacement: ottl.StandardStringGetter[pcommon.Map]{
+				Getter: func(context.Context, pcommon.Map) (any, error) {
+					return "empty_string_replacement", nil
+				},
+			},
+			replacementFormat: ottl.Optional[ottl.StringGetter[pcommon.Map]]{},
+			function:          ottl.Optional[ottl.FunctionGetter[pcommon.Map]]{},
+			want: func(expectedMap pcommon.Map) {
+				expectedMap.Clear()
+				expectedMap.PutStr("test", "hello world")
+				expectedMap.PutStr("test2", "hello")
+				expectedMap.PutStr("test3", "goodbye world1 and world2")
+				expectedMap.PutInt("test4", 1234)
+				expectedMap.PutDouble("test5", 1234)
+				expectedMap.PutBool("test6", true)
+				expectedMap.PutStr("test7", "empty_string_replacement")
 			},
 		},
 	}


### PR DESCRIPTION
Fix empty string matching for *replace_all_patterns*, *replace_all_matches* OTTL functions

#### Description

OTTL functions *replace_all_patterns*, *replace_all_matches* apply pattern matching on all attribute values including non string types by casting value to string using `value.Str()` method (see [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/main...pkcll:opentelemetry-collector-contrib:fix-ottl-replace-all-patterns-empty-string?expand=1#diff-e32bc80bd4c118a00799c436d182176663ce5d64ae3d7c7775fd7371d0f6899eL68), [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/main...pkcll:opentelemetry-collector-contrib:fix-ottl-replace-all-patterns-empty-string?expand=1#diff-9c0c4968ea50f0f84810af37cd6c103a50dfd6d5f459fd773d35167310ba0c7aL78)) . For non string types `Str()` returns empty string.
In case when empty string patterns is used that creates unintended side effect when pattern matching is applied for non string types.

Example: 
- replace_all_patterns(attributes, "value", "^$", "EMPTY_STRING_REPLACEMENT")
- replace_all_matches(attributes, "value", "", "EMPTY_STRING_REPLACEMENT")

**Current behavior**:
- Replaces all empty string attribute values with "EMPTY_STRING_REPLACEMENT" value. 
- Replaces all non string attribute values with "EMPTY_STRING_REPLACEMENT" and converts the type of attributes to string type.

**Expected behavior**:
- Replaces empty string values in attributes of string type. Skips non string attribute values for matching. 


<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added new test case [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/main...pkcll:opentelemetry-collector-contrib:fix-ottl-replace-all-patterns-empty-string?expand=1#diff-de79bd63c84fd31d4258872723373b8ea42749c19828cfcb895b71cad6abc766R112) and [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/compare/main...pkcll:opentelemetry-collector-contrib:fix-ottl-replace-all-patterns-empty-string?expand=1#diff-85314ad468f897a2f8f57fa831804e3087a58da91faf284477a0d058865ea0bfR496)

