### PR TITLE
[chore] `make generate` uses `.tools/mdatagen`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ docker-telemetrygen:
 
 .PHONY: generate
 generate: install-tools
-	PATH="$$PWD/.tools:$$PATH" $(MAKE) $(FOR_GROUP_TARGET) TARGET="modgenerate"
+	PATH="$$PWD/.tools:$$PATH" $(MAKE) for-all CMD="$(GOCMD) generate ./..."
 	$(MAKE) gofmt
 
 .PHONY: githubgen-install

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ PKG_MODS := $(shell find ./pkg/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 CMD_MODS_0 := $(shell find ./cmd/[a-m]* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 CMD_MODS_1 := $(shell find ./cmd/[n-z]* $(FIND_MOD_ARGS) -not -path "./cmd/otel*col/*" -exec $(TO_MOD_DIR) )
 CMD_MODS := $(CMD_MODS_0) $(CMD_MODS_1)
-OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) .
+OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver 
 

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ PKG_MODS := $(shell find ./pkg/* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 CMD_MODS_0 := $(shell find ./cmd/[a-m]* $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) )
 CMD_MODS_1 := $(shell find ./cmd/[n-z]* $(FIND_MOD_ARGS) -not -path "./cmd/otel*col/*" -exec $(TO_MOD_DIR) )
 CMD_MODS := $(CMD_MODS_0) $(CMD_MODS_1)
-OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) $(PWD)
+OTHER_MODS := $(shell find . $(EX_COMPONENTS) $(EX_INTERNAL) $(EX_PKG) $(EX_CMD) $(FIND_MOD_ARGS) -exec $(TO_MOD_DIR) ) .
 ALL_MODS := $(RECEIVER_MODS) $(PROCESSOR_MODS) $(EXPORTER_MODS) $(EXTENSION_MODS) $(CONNECTOR_MODS) $(INTERNAL_MODS) $(PKG_MODS) $(CMD_MODS) $(OTHER_MODS)
 CGO_MODS := ./receiver/hostmetricsreceiver 
 
@@ -307,8 +307,7 @@ docker-telemetrygen:
 
 .PHONY: generate
 generate: install-tools
-	cd ./internal/tools && go install go.opentelemetry.io/collector/cmd/mdatagen
-	$(MAKE) for-all CMD="$(GOCMD) generate ./..."
+	PATH="$$PWD/.tools:$$PATH" $(MAKE) $(FOR_GROUP_TARGET) TARGET="modgenerate"
 	$(MAKE) gofmt
 
 .PHONY: githubgen-install

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -83,29 +83,29 @@ TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subte
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 
-ALL_PKG_DIRS = $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | $(NORMALIZE_DIRS))
+ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | $(NORMALIZE_DIRS))
 
-ALL_SRC = $(shell find $(ALL_PKG_DIRS) -name '*.go' \
+ALL_SRC := $(shell find $(ALL_PKG_DIRS) -name '*.go' \
                                 -not -path '*/third_party/*' \
                                 -not -path '*/local/*' \
                                 -type f | sort)
 
-ALL_SRC_AND_SHELL = find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort
+ALL_SRC_AND_SHELL := find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort
 
 # All source code and documents. Used in spell check.
-ALL_SRC_AND_DOC_CMD = find $(ALL_PKG_DIRS) -name "*.md" -o -name "*.go" -o -name "*.yaml" -not -path '*/third_party/*' -type f | sort
+ALL_SRC_AND_DOC_CMD := find $(ALL_PKG_DIRS) -name "*.md" -o -name "*.go" -o -name "*.yaml" -not -path '*/third_party/*' -type f | sort
 ifeq ($(UNIX_SHELL_ON_WINDOWS),true)
 	# Windows has a low limit, 8192 chars, to create a process. Workaround it by breaking it in smaller commands.
-	MISSPELL_CMD = $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL)
-	MISSPELL_CORRECTION_CMD = $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL_CORRECTION)
+	MISSPELL_CMD := $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL)
+	MISSPELL_CORRECTION_CMD := $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL_CORRECTION)
 else
-	ALL_SRC_AND_DOC = $(shell $(ALL_SRC_AND_DOC_CMD))
-	MISSPELL_CMD = $(MISSPELL) $(ALL_SRC_AND_DOC)
-	MISSPELL_CORRECTION_CMD = $(MISSPELL_CORRECTION) $(ALL_SRC_AND_DOC)
+	ALL_SRC_AND_DOC := $(shell $(ALL_SRC_AND_DOC_CMD))
+	MISSPELL_CMD := $(MISSPELL) $(ALL_SRC_AND_DOC)
+	MISSPELL_CORRECTION_CMD := $(MISSPELL_CORRECTION) $(ALL_SRC_AND_DOC)
 endif
 
 # ALL_PKGS is used with 'go cover'
-ALL_PKGS = $(shell $(GOCMD) list $(sort $(dir $(ALL_SRC))))
+ALL_PKGS := $(shell $(GOCMD) list $(sort $(dir $(ALL_SRC))))
 
 ADDLICENSE_CMD := $(ADDLICENSE) -s=only -y "" -c "The OpenTelemetry Authors"
 

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -83,29 +83,29 @@ TESTIFYLINT_OPT?= --enable-all --disable=float-compare,require-error,suite-subte
 # BUILD_TYPE should be one of (dev, release).
 BUILD_TYPE?=release
 
-ALL_PKG_DIRS := $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | $(NORMALIZE_DIRS))
+ALL_PKG_DIRS = $(shell $(GOCMD) list -f '{{ .Dir }}' ./... | $(NORMALIZE_DIRS))
 
-ALL_SRC := $(shell find $(ALL_PKG_DIRS) -name '*.go' \
+ALL_SRC = $(shell find $(ALL_PKG_DIRS) -name '*.go' \
                                 -not -path '*/third_party/*' \
                                 -not -path '*/local/*' \
                                 -type f | sort)
 
-ALL_SRC_AND_SHELL := find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort
+ALL_SRC_AND_SHELL = find . -type f \( -iname '*.go' -o -iname "*.sh" \) ! -path '**/third_party/*' | sort
 
 # All source code and documents. Used in spell check.
-ALL_SRC_AND_DOC_CMD := find $(ALL_PKG_DIRS) -name "*.md" -o -name "*.go" -o -name "*.yaml" -not -path '*/third_party/*' -type f | sort
+ALL_SRC_AND_DOC_CMD = find $(ALL_PKG_DIRS) -name "*.md" -o -name "*.go" -o -name "*.yaml" -not -path '*/third_party/*' -type f | sort
 ifeq ($(UNIX_SHELL_ON_WINDOWS),true)
 	# Windows has a low limit, 8192 chars, to create a process. Workaround it by breaking it in smaller commands.
-	MISSPELL_CMD := $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL)
-	MISSPELL_CORRECTION_CMD := $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL_CORRECTION)
+	MISSPELL_CMD = $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL)
+	MISSPELL_CORRECTION_CMD = $(ALL_SRC_AND_DOC_CMD) | xargs -n 20 $(MISSPELL_CORRECTION)
 else
-	ALL_SRC_AND_DOC := $(shell $(ALL_SRC_AND_DOC_CMD))
-	MISSPELL_CMD := $(MISSPELL) $(ALL_SRC_AND_DOC)
-	MISSPELL_CORRECTION_CMD := $(MISSPELL_CORRECTION) $(ALL_SRC_AND_DOC)
+	ALL_SRC_AND_DOC = $(shell $(ALL_SRC_AND_DOC_CMD))
+	MISSPELL_CMD = $(MISSPELL) $(ALL_SRC_AND_DOC)
+	MISSPELL_CORRECTION_CMD = $(MISSPELL_CORRECTION) $(ALL_SRC_AND_DOC)
 endif
 
 # ALL_PKGS is used with 'go cover'
-ALL_PKGS := $(shell $(GOCMD) list $(sort $(dir $(ALL_SRC))))
+ALL_PKGS = $(shell $(GOCMD) list $(sort $(dir $(ALL_SRC))))
 
 ADDLICENSE_CMD := $(ADDLICENSE) -s=only -y "" -c "The OpenTelemetry Authors"
 
@@ -254,3 +254,7 @@ testifylint-fix:
 gci: $(TOOLS_BIN_DIR)/gci
 	@echo "running $(GCI)"
 	@$(GCI) write -s standard -s default -s "prefix(github.com/open-telemetry/opentelemetry-collector-contrib)" $(ALL_SRC_AND_DOC)
+
+.PHONY: modgenerate
+modgenerate:
+	$(GOCMD) generate ./...

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -254,7 +254,3 @@ testifylint-fix:
 gci: $(TOOLS_BIN_DIR)/gci
 	@echo "running $(GCI)"
 	@$(GCI) write -s standard -s default -s "prefix(github.com/open-telemetry/opentelemetry-collector-contrib)" $(ALL_SRC_AND_DOC)
-
-.PHONY: modgenerate
-modgenerate:
-	$(GOCMD) generate ./...


### PR DESCRIPTION
#### Description

This PR is in the context of [this PR on the core Collector modifying `make check-contrib` to use the latest version of `mdatagen`](https://github.com/open-telemetry/opentelemetry-collector/pull/11670).

The `make generate` commands currently starts by compiling build tools in the `.tools` folder, then it `go install`s mdatagen globally for use in `go:generate`. Unfortunately, `go install` does not take into account the version of `mdatagen` referenced in `internal/tools/go.mod`. This means it isn't possible to generate using the local version of `mdatagen` for testing, even with `replace` statements.

This PR fixes this by prepending `.tools` to the `$PATH` before running the generate command, which makes `go:generate` use the version of `mdatagen` in that folder instead of a global one.

(Originally, this PR also added a new `modgenerate` target in `Makefile.Common`, to allow running generate commands on a specific group of modules instead of all of them for efficiency reasons. After discussing it with @mx-psi, we decided to hold off on that change for a later PR, as it warrants further discussion.)