### PR TITLE
[chore] update calls to underlying library

### DIFF
--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -636,11 +636,11 @@ func (s *Supervisor) onOpampConnectionSettings(_ context.Context, settings *prot
 		newServerConfig.Headers = s.getHeadersFromSettings(settings.Headers)
 	}
 	if settings.Certificate != nil {
-		if len(settings.Certificate.CaPublicKey) != 0 {
-			newServerConfig.TLSSetting.CAPem = configopaque.String(settings.Certificate.CaPublicKey)
+		if len(settings.Certificate.CaCert) != 0 {
+			newServerConfig.TLSSetting.CAPem = configopaque.String(settings.Certificate.CaCert)
 		}
-		if len(settings.Certificate.PublicKey) != 0 {
-			newServerConfig.TLSSetting.CertPem = configopaque.String(settings.Certificate.PublicKey)
+		if len(settings.Certificate.Cert) != 0 {
+			newServerConfig.TLSSetting.CertPem = configopaque.String(settings.Certificate.Cert)
 		}
 		if len(settings.Certificate.PrivateKey) != 0 {
 			newServerConfig.TLSSetting.KeyPem = configopaque.String(settings.Certificate.PrivateKey)

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -1037,6 +1037,8 @@ func (m mockOpAMPClient) SendCustomMessage(message *protobufs.CustomMessage) (me
 	return msgChan, nil
 }
 
+func (m mockOpAMPClient) SetFlags(_ protobufs.AgentToServerFlags) {}
+
 type mockConn struct {
 	sendFunc func(ctx context.Context, message *protobufs.ServerToAgent) error
 }


### PR DESCRIPTION
Fixes calls to renamed struct members in opamp-go
