### PR TITLE
[receiver/azuremonitorreceiver] feat: multi subscriptions support and automatic discovery

### DIFF
--- a/.chloggen/feat_discovery.yaml
+++ b/.chloggen/feat_discovery.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/azuremonitorreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "multi subscriptions support and automatic discovery"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36612]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azuremonitorreceiver/README.md
+++ b/receiver/azuremonitorreceiver/README.md
@@ -18,7 +18,9 @@ This receiver scrapes Azure Monitor API for resources metrics.
 
 The following settings are required:
 
-- `subscription_id`
+- `subscription_ids`: list of subscriptions on which the resource's metrics are collected
+- or `subscriptions_id`: same as `subscription_ids` but not a list
+- or `discover_subscriptions`: (default = `false`) If set to true, will collect metrics from all subscriptions in the tenant.
 
 The following settings are optional:
 

--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -21,12 +21,12 @@ const (
 
 var (
 	// Predefined error responses for configuration validation failures
-	errMissingTenantID       = errors.New(`TenantID" is not specified in config`)
-	errMissingSubscriptionID = errors.New(`SubscriptionID" is not specified in config`)
-	errMissingClientID       = errors.New(`ClientID" is not specified in config`)
-	errMissingClientSecret   = errors.New(`ClientSecret" is not specified in config`)
-	errMissingFedTokenFile   = errors.New(`FederatedTokenFile is not specified in config`)
-	errInvalidCloud          = errors.New(`Cloud" is invalid`)
+	errMissingTenantID        = errors.New(`"TenantID" is not specified in config`)
+	errMissingSubscriptionIDs = errors.New(`neither "SubscriptionID" nor "SubscriptionIDs" nor "DiscoverSubscription" is specified in the config`)
+	errMissingClientID        = errors.New(`"ClientID" is not specified in config`)
+	errMissingClientSecret    = errors.New(`"ClientSecret" is not specified in config`)
+	errMissingFedTokenFile    = errors.New(`"FederatedTokenFile"" is not specified in config`)
+	errInvalidCloud           = errors.New(`"Cloud" is invalid`)
 
 	monitorServices = []string{
 		"Microsoft.EventGrid/eventSubscriptions",
@@ -234,6 +234,8 @@ type Config struct {
 	MetricsBuilderConfig              metadata.MetricsBuilderConfig `mapstructure:",squash"`
 	Cloud                             string                        `mapstructure:"cloud"`
 	SubscriptionID                    string                        `mapstructure:"subscription_id"`
+	SubscriptionIDs                   []string                      `mapstructure:"subscription_ids"`
+	DiscoverSubscriptions             bool                          `mapstructure:"discover_subscriptions"`
 	Authentication                    string                        `mapstructure:"auth"`
 	TenantID                          string                        `mapstructure:"tenant_id"`
 	ClientID                          string                        `mapstructure:"client_id"`
@@ -257,8 +259,8 @@ const (
 
 // Validate validates the configuration by checking for missing or invalid fields
 func (c Config) Validate() (err error) {
-	if c.SubscriptionID == "" {
-		err = multierr.Append(err, errMissingSubscriptionID)
+	if c.SubscriptionID == "" && len(c.SubscriptionIDs) == 0 && !c.DiscoverSubscriptions {
+		err = multierr.Append(err, errMissingSubscriptionIDs)
 	}
 
 	switch c.Authentication {

--- a/receiver/azuremonitorreceiver/go.mod
+++ b/receiver/azuremonitorreceiver/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0
 	github.com/google/go-cmp v0.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/golden v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatatest v0.117.0

--- a/receiver/azuremonitorreceiver/go.sum
+++ b/receiver/azuremonitorreceiver/go.sum
@@ -14,6 +14,8 @@ github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/monitor/armmonitor v0.11.0/go.mod h1:jj6P8ybImR+5topJ+eH6fgcemSFBmU6/6bFF8KkwuDI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0 h1:wxQx2Bt4xzPIKvW59WQf1tJNx/ZZKPfN+EhPX3Z6CYY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armsubscriptions v1.3.0/go.mod h1:TpiwjwnW/khS0LKs4vW5UmmT9OWcxaveS8U7+tlknzo=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1/go.mod h1:tCcJZ0uHAmvjsVYzEFivsRTN00oz5BEsRgQHu5JZ9WE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 h1:XHOnouVk1mxXfQidrMEnLlPk9UMeRtyBTnEFtxkV0kU=

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_golden.yaml
@@ -1,9 +1,6 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: azuremonitor.subscription_id
-          value:
-            stringValue: ""
         - key: azuremonitor.tenant_id
           value:
             stringValue: ""
@@ -15,7 +12,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -38,7 +38,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -61,7 +64,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -84,7 +90,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -107,7 +116,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -136,7 +148,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -165,7 +180,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -194,7 +212,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -217,7 +238,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -240,7 +264,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -266,7 +293,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -289,7 +319,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -312,7 +345,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -335,7 +371,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -358,7 +397,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId3
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId3
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -384,7 +426,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -413,7 +458,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -439,7 +487,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -462,7 +513,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -485,7 +539,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -508,7 +565,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -531,7 +591,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -554,7 +617,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -577,7 +643,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -606,7 +675,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -629,7 +701,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -652,7 +727,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -675,7 +753,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -701,7 +782,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -727,7 +811,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -750,7 +837,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_tags_golden.yaml
@@ -1,9 +1,6 @@
 resourceMetrics:
   - resource:
       attributes:
-        - key: azuremonitor.subscription_id
-          value:
-            stringValue: ""
         - key: azuremonitor.tenant_id
           value:
             stringValue: ""
@@ -15,7 +12,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -44,7 +44,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -70,7 +73,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -96,7 +102,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -122,7 +131,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -148,7 +160,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -174,7 +189,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -200,7 +218,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -223,7 +244,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId3
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId3
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -249,7 +273,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -275,7 +302,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -301,7 +331,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -327,7 +360,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -356,7 +392,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -382,7 +421,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -408,7 +450,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -437,7 +482,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -463,7 +511,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -489,7 +540,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -515,7 +569,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -544,7 +601,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -570,7 +630,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -596,7 +659,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -619,7 +685,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -648,7 +717,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -671,7 +743,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -697,7 +772,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -723,7 +801,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId1
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -749,7 +830,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -772,7 +856,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1
@@ -798,7 +885,10 @@ resourceMetrics:
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscriptions/subscriptionId1/resourceGroups/group1/resourceId2
+                    - key: azuremonitor.subscription_id
+                      value:
+                        stringValue: subscriptionId1
                     - key: location
                       value:
                         stringValue: location1


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR allows to discover and scrape all the subscriptions located in the tenant. 
I'm adding also at the same time the ability to give multiple subscriptions as it's free and can also be desired.

This is a part of this PR:  https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/29593 that has been split for readability.
Indeed in a next PR, I'll propose the usage of the getBatch of metrics Azure API.  Because if your tenant contains a lot of subscription, you can face rate limitations.


It contains also a little refactor of the tests and the "backdoor" used to mock the API. Now the tests are using the way provided by Azure: the fake API. https://github.com/Azure/azure-sdk-for-go/tree/main/sdk/samples/fakes
The "backdoor" is now only the client options. So no weird interfaces nor weird constructor for the Azure clients inside the ``scraper.go`` file. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36612

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
