### PR TITLE
Add ArthurSens as a codeowner for prometheus exporters

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,8 +71,8 @@ exporter/lokiexporter/                            @open-telemetry/collector-cont
 exporter/mezmoexporter/                           @open-telemetry/collector-contrib-approvers @dashpole @billmeyer @gjanco
 exporter/opencensusexporter/                      @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
 exporter/otelarrowexporter/                       @open-telemetry/collector-contrib-approvers @jmacd @moh-osman3 @lquerel
-exporter/prometheusexporter/                      @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole
-exporter/prometheusremotewriteexporter/           @open-telemetry/collector-contrib-approvers @Aneurysm9 @rapphil @dashpole
+exporter/prometheusexporter/                      @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole @ArthurSens
+exporter/prometheusremotewriteexporter/           @open-telemetry/collector-contrib-approvers @Aneurysm9 @rapphil @dashpole @ArthurSens
 exporter/pulsarexporter/                          @open-telemetry/collector-contrib-approvers @dmitryax @dao-jun
 exporter/rabbitmqexporter/                        @open-telemetry/collector-contrib-approvers @swar8080 @atoulme
 exporter/sapmexporter/                            @open-telemetry/collector-contrib-approvers @dmitryax @atoulme
@@ -161,7 +161,7 @@ pkg/translator/azurelogs/                         @open-telemetry/collector-cont
 pkg/translator/jaeger/                            @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers @frzifus
 pkg/translator/loki/                              @open-telemetry/collector-contrib-approvers @gouthamve @jpkrohling @mar4uk
 pkg/translator/opencensus/                        @open-telemetry/collector-contrib-approvers @open-telemetry/collector-approvers
-pkg/translator/prometheus/                        @open-telemetry/collector-contrib-approvers @dashpole @bertysentry
+pkg/translator/prometheus/                        @open-telemetry/collector-contrib-approvers @dashpole @bertysentry @ArthurSens
 pkg/translator/prometheusremotewrite/             @open-telemetry/collector-contrib-approvers @Aneurysm9 @dashpole
 pkg/translator/signalfx/                          @open-telemetry/collector-contrib-approvers @dmitryax
 pkg/translator/skywalking/                        @open-telemetry/collector-contrib-approvers @JaredTan95

--- a/exporter/prometheusexporter/README.md
+++ b/exporter/prometheusexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [core], [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Fprometheus%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Fprometheus) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Fprometheus%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Fprometheus) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@dashpole](https://www.github.com/dashpole) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@dashpole](https://www.github.com/dashpole), [@ArthurSens](https://www.github.com/ArthurSens) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/exporter/prometheusexporter/metadata.yaml
+++ b/exporter/prometheusexporter/metadata.yaml
@@ -8,7 +8,7 @@ status:
   - core
   - contrib
   codeowners:
-    active: [Aneurysm9, dashpole]
+    active: [Aneurysm9, dashpole, ArthurSens]
 
 tests:
   config:

--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [core], [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Fprometheusremotewrite%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Fprometheusremotewrite) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Fprometheusremotewrite%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Fprometheusremotewrite) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@rapphil](https://www.github.com/rapphil), [@dashpole](https://www.github.com/dashpole) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@Aneurysm9](https://www.github.com/Aneurysm9), [@rapphil](https://www.github.com/rapphil), [@dashpole](https://www.github.com/dashpole), [@ArthurSens](https://www.github.com/ArthurSens) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta
 [core]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol

--- a/exporter/prometheusremotewriteexporter/metadata.yaml
+++ b/exporter/prometheusremotewriteexporter/metadata.yaml
@@ -6,7 +6,7 @@ status:
     beta: [metrics]
   distributions: [core, contrib]
   codeowners:
-    active: [Aneurysm9, rapphil, dashpole]
+    active: [Aneurysm9, rapphil, dashpole, ArthurSens]
 
 tests:
   expect_consumer_error: true

--- a/pkg/translator/prometheus/metadata.yaml
+++ b/pkg/translator/prometheus/metadata.yaml
@@ -1,3 +1,3 @@
 status:
   codeowners:
-    active: [dashpole, bertysentry]
+    active: [dashpole, bertysentry, ArthurSens]


### PR DESCRIPTION
#### Description

Add @ArthurSens as a codeowner for the prometheus exporters and prometheus translator.  He has been an active contributor and reviewer of changes to these components, and has shown good judgement in that regard. He is also active in related efforts (OTLP support, PRW 2.0 support) in the prometheus server.

Thanks for the contributions @ArthurSens!

cc @Aneurysm9 @rapphil @bertysentry 
As existing codeowners.