### PR TITLE
[chore] [deltatocumulative]: linear histograms

### DIFF
--- a/processor/deltatocumulativeprocessor/benchmark_test.go
+++ b/processor/deltatocumulativeprocessor/benchmark_test.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -19,7 +18,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/expo"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/expo/expotest"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/histo"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testing/sdktest"
 )
 
 var out *consumertest.MetricsSink
@@ -30,44 +28,15 @@ func BenchmarkProcessor(gb *testing.B) {
 		streams = 10
 	)
 
+	now := time.Now()
+	start := pcommon.NewTimestampFromTime(now)
+	ts := pcommon.NewTimestampFromTime(now.Add(time.Minute))
+
 	type Case struct {
 		name string
 		fill func(m pmetric.Metric)
 		next func(m pmetric.Metric)
 	}
-
-	run := func(b *testing.B, proc consumer.Metrics, cs Case) {
-		md := pmetric.NewMetrics()
-		ms := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
-		for i := range metrics {
-			m := ms.AppendEmpty()
-			m.SetName(strconv.Itoa(i))
-			cs.fill(m)
-		}
-
-		b.ReportAllocs()
-		b.ResetTimer()
-		b.StopTimer()
-
-		ctx := context.Background()
-		for range b.N {
-			for i := range ms.Len() {
-				cs.next(ms.At(i))
-			}
-			req := pmetric.NewMetrics()
-			md.CopyTo(req)
-
-			b.StartTimer()
-			err := proc.ConsumeMetrics(ctx, req)
-			b.StopTimer()
-			require.NoError(b, err)
-		}
-	}
-
-	now := time.Now()
-	start := pcommon.NewTimestampFromTime(now)
-	ts := pcommon.NewTimestampFromTime(now.Add(time.Minute))
-
 	cases := []Case{{
 		name: "sums",
 		fill: func(m pmetric.Metric) {
@@ -81,7 +50,16 @@ func BenchmarkProcessor(gb *testing.B) {
 				dp.SetTimestamp(ts)
 			}
 		},
-		next: next(pmetric.Metric.Sum),
+		next: func(m pmetric.Metric) {
+			dps := m.Sum().DataPoints()
+			for i := range dps.Len() {
+				dp := dps.At(i)
+				dp.SetStartTimestamp(dp.Timestamp())
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(
+					dp.Timestamp().AsTime().Add(time.Minute),
+				))
+			}
+		},
 	}, {
 		name: "histogram",
 		fill: func(m pmetric.Metric) {
@@ -101,7 +79,16 @@ func BenchmarkProcessor(gb *testing.B) {
 				dp.Attributes().PutStr("idx", strconv.Itoa(i))
 			}
 		},
-		next: next(pmetric.Metric.Histogram),
+		next: func(m pmetric.Metric) {
+			dps := m.Histogram().DataPoints()
+			for i := range dps.Len() {
+				dp := dps.At(i)
+				dp.SetStartTimestamp(dp.Timestamp())
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(
+					dp.Timestamp().AsTime().Add(time.Minute),
+				))
+			}
+		},
 	}, {
 		name: "exponential",
 		fill: func(m pmetric.Metric) {
@@ -123,60 +110,52 @@ func BenchmarkProcessor(gb *testing.B) {
 				dp.Attributes().PutStr("idx", strconv.Itoa(i))
 			}
 		},
-		next: next(pmetric.Metric.ExponentialHistogram),
+		next: func(m pmetric.Metric) {
+			dps := m.ExponentialHistogram().DataPoints()
+			for i := range dps.Len() {
+				dp := dps.At(i)
+				dp.SetStartTimestamp(dp.Timestamp())
+				dp.SetTimestamp(pcommon.NewTimestampFromTime(
+					dp.Timestamp().AsTime().Add(time.Minute),
+				))
+			}
+		},
 	}}
-
-	tel := func(n int) sdktest.Spec {
-		total := int64(n * metrics * streams)
-		tracked := int64(metrics * streams)
-		return sdktest.Expect(map[string]sdktest.Metric{
-			"otelcol_deltatocumulative.datapoints.linear": {
-				Type:      sdktest.TypeSum,
-				Numbers:   []sdktest.Number{{Int: &total}},
-				Monotonic: true,
-			},
-			"otelcol_deltatocumulative.streams.tracked.linear": {
-				Type:    sdktest.TypeSum,
-				Numbers: []sdktest.Number{{Int: &tracked}},
-			},
-		})
-	}
 
 	for _, cs := range cases {
 		gb.Run(cs.name, func(b *testing.B) {
 			st := setup(b, nil)
 			out = st.sink
-			run(b, st.proc, cs)
+
+			md := pmetric.NewMetrics()
+			ms := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
+			for i := range metrics {
+				m := ms.AppendEmpty()
+				m.SetName(strconv.Itoa(i))
+				cs.fill(m)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.StopTimer()
+
+			ctx := context.Background()
+			for range b.N {
+				for i := range ms.Len() {
+					cs.next(ms.At(i))
+				}
+				req := pmetric.NewMetrics()
+				md.CopyTo(req)
+
+				b.StartTimer()
+				err := st.proc.ConsumeMetrics(ctx, req)
+				b.StopTimer()
+				require.NoError(b, err)
+			}
 
 			// verify all dps are processed without error
 			b.StopTimer()
-			if err := sdktest.Test(tel(b.N), st.tel.reader); err != nil {
-				b.Fatal(err)
-			}
+			require.Equal(b, b.N*metrics*streams, st.sink.DataPointCount())
 		})
-	}
-}
-
-func next[
-	T interface{ DataPoints() Ps },
-	Ps interface {
-		At(int) P
-		Len() int
-	},
-	P interface {
-		Timestamp() pcommon.Timestamp
-		SetStartTimestamp(pcommon.Timestamp)
-		SetTimestamp(pcommon.Timestamp)
-	},
-](sel func(pmetric.Metric) T) func(m pmetric.Metric) {
-	return func(m pmetric.Metric) {
-		dps := sel(m).DataPoints()
-		for i := range dps.Len() {
-			dp := dps.At(i)
-			dp.SetStartTimestamp(dp.Timestamp())
-			dp.SetTimestamp(pcommon.NewTimestampFromTime(
-				dp.Timestamp().AsTime().Add(time.Minute),
-			))
-		}
 	}
 }

--- a/processor/deltatocumulativeprocessor/benchmark_test.go
+++ b/processor/deltatocumulativeprocessor/benchmark_test.go
@@ -1,0 +1,181 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package deltatocumulativeprocessor
+
+import (
+	"context"
+	"math/rand/v2"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/expo"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/expo/expotest"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/data/histo"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testing/sdktest"
+)
+
+var out consumertest.MetricsSink
+
+func BenchmarkProcessor(gb *testing.B) {
+	const (
+		metrics = 5
+		streams = 10
+	)
+
+	type Case struct {
+		name string
+		fill func(m pmetric.Metric)
+		next func(m pmetric.Metric)
+	}
+
+	run := func(b *testing.B, proc consumer.Metrics, cs Case) {
+		md := pmetric.NewMetrics()
+		ms := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics()
+		for i := range metrics {
+			m := ms.AppendEmpty()
+			m.SetName(strconv.Itoa(i))
+			cs.fill(m)
+		}
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		b.StopTimer()
+
+		ctx := context.Background()
+		for range b.N {
+			for i := range ms.Len() {
+				cs.next(ms.At(i))
+			}
+			req := pmetric.NewMetrics()
+			md.CopyTo(req)
+
+			b.StartTimer()
+			err := proc.ConsumeMetrics(ctx, req)
+			b.StopTimer()
+			require.NoError(b, err)
+		}
+	}
+
+	now := time.Now()
+	start := pcommon.NewTimestampFromTime(now)
+	ts := pcommon.NewTimestampFromTime(now.Add(time.Minute))
+
+	cases := []Case{{
+		name: "sums",
+		fill: func(m pmetric.Metric) {
+			sum := m.SetEmptySum()
+			sum.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+			for i := range streams {
+				dp := sum.DataPoints().AppendEmpty()
+				dp.SetIntValue(int64(rand.IntN(10)))
+				dp.Attributes().PutStr("idx", strconv.Itoa(i))
+				dp.SetStartTimestamp(start)
+				dp.SetTimestamp(ts)
+			}
+		},
+		next: next(pmetric.Metric.Sum),
+	}, {
+		name: "histogram",
+		fill: func(m pmetric.Metric) {
+			hist := m.SetEmptyHistogram()
+			hist.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+			for i := range streams {
+				dp := hist.DataPoints().AppendEmpty()
+				histo.DefaultBounds.Observe(
+					float64(rand.IntN(1000)),
+					float64(rand.IntN(1000)),
+					float64(rand.IntN(1000)),
+					float64(rand.IntN(1000)),
+				).CopyTo(dp)
+
+				dp.SetStartTimestamp(start)
+				dp.SetTimestamp(ts)
+				dp.Attributes().PutStr("idx", strconv.Itoa(i))
+			}
+		},
+		next: next(pmetric.Metric.Histogram),
+	}, {
+		name: "exponential",
+		fill: func(m pmetric.Metric) {
+			ex := m.SetEmptyExponentialHistogram()
+			ex.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+			for i := range streams {
+				dp := ex.DataPoints().AppendEmpty()
+				o := expotest.Observe(expo.Scale(2),
+					float64(rand.IntN(31)+1),
+					float64(rand.IntN(31)+1),
+					float64(rand.IntN(31)+1),
+					float64(rand.IntN(31)+1),
+				)
+				o.CopyTo(dp.Positive())
+				o.CopyTo(dp.Negative())
+
+				dp.SetStartTimestamp(start)
+				dp.SetTimestamp(ts)
+				dp.Attributes().PutStr("idx", strconv.Itoa(i))
+			}
+		},
+		next: next(pmetric.Metric.ExponentialHistogram),
+	}}
+
+	tel := func(n int) sdktest.Spec {
+		total := int64(n * metrics * streams)
+		tracked := int64(metrics * streams)
+		return sdktest.Expect(map[string]sdktest.Metric{
+			"otelcol_deltatocumulative.datapoints.linear": {
+				Type:      sdktest.TypeSum,
+				Numbers:   []sdktest.Number{{Int: &total}},
+				Monotonic: true,
+			},
+			"otelcol_deltatocumulative.streams.tracked.linear": {
+				Type:    sdktest.TypeSum,
+				Numbers: []sdktest.Number{{Int: &tracked}},
+			},
+		})
+	}
+
+	for _, cs := range cases {
+		gb.Run(cs.name, func(b *testing.B) {
+			st := setup(b, nil)
+			run(b, st.proc, cs)
+
+			// verify all dps are processed without error
+			b.StopTimer()
+			if err := sdktest.Test(tel(b.N), st.tel.reader); err != nil {
+				b.Fatal(err)
+			}
+		})
+	}
+}
+
+func next[
+	T interface{ DataPoints() Ps },
+	Ps interface {
+		At(int) P
+		Len() int
+	},
+	P interface {
+		Timestamp() pcommon.Timestamp
+		SetStartTimestamp(pcommon.Timestamp)
+		SetTimestamp(pcommon.Timestamp)
+	},
+](sel func(pmetric.Metric) T) func(m pmetric.Metric) {
+	return func(m pmetric.Metric) {
+		dps := sel(m).DataPoints()
+		for i := range dps.Len() {
+			dp := dps.At(i)
+			dp.SetStartTimestamp(dp.Timestamp())
+			dp.SetTimestamp(pcommon.NewTimestampFromTime(
+				dp.Timestamp().AsTime().Add(time.Minute),
+			))
+		}
+	}
+}

--- a/processor/deltatocumulativeprocessor/benchmark_test.go
+++ b/processor/deltatocumulativeprocessor/benchmark_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/testing/sdktest"
 )
 
-var out consumertest.MetricsSink
+var out *consumertest.MetricsSink
 
 func BenchmarkProcessor(gb *testing.B) {
 	const (
@@ -145,6 +145,7 @@ func BenchmarkProcessor(gb *testing.B) {
 	for _, cs := range cases {
 		gb.Run(cs.name, func(b *testing.B) {
 			st := setup(b, nil)
+			out = st.sink
 			run(b, st.proc, cs)
 
 			// verify all dps are processed without error

--- a/processor/deltatocumulativeprocessor/internal/lineartelemetry/attr.go
+++ b/processor/deltatocumulativeprocessor/internal/lineartelemetry/attr.go
@@ -1,0 +1,9 @@
+package telemetry
+
+import "go.opentelemetry.io/otel/attribute"
+
+type Attributes []attribute.KeyValue
+
+func (a *Attributes) Set(attr attribute.KeyValue) {
+	*a = append(*a, attr)
+}

--- a/processor/deltatocumulativeprocessor/internal/lineartelemetry/attr.go
+++ b/processor/deltatocumulativeprocessor/internal/lineartelemetry/attr.go
@@ -1,4 +1,7 @@
-package telemetry
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package telemetry // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor/internal/lineartelemetry"
 
 import "go.opentelemetry.io/otel/attribute"
 

--- a/processor/deltatocumulativeprocessor/internal/metrics/data.go
+++ b/processor/deltatocumulativeprocessor/internal/metrics/data.go
@@ -115,6 +115,7 @@ func (s Gauge) Filter(expr func(data.Number) bool) {
 		return !expr(data.Number{NumberDataPoint: dp})
 	})
 }
+func (s Gauge) SetAggregationTemporality(pmetric.AggregationTemporality) {}
 
 type Summary Metric
 
@@ -136,3 +137,4 @@ func (s Summary) Filter(expr func(data.Summary) bool) {
 		return !expr(data.Summary{SummaryDataPoint: dp})
 	})
 }
+func (s Summary) SetAggregationTemporality(pmetric.AggregationTemporality) {}

--- a/processor/deltatocumulativeprocessor/internal/metrics/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/metrics/metrics.go
@@ -47,7 +47,7 @@ func (m Metric) AggregationTemporality() pmetric.AggregationTemporality {
 	return pmetric.AggregationTemporalityUnspecified
 }
 
-func (m Metric) Typed() any {
+func (m Metric) Typed() Any {
 	//exhaustive:enforce
 	switch m.Type() {
 	case pmetric.MetricTypeSum:
@@ -62,4 +62,50 @@ func (m Metric) Typed() any {
 		return Summary(m)
 	}
 	panic("unreachable")
+}
+
+var (
+	_ Any = Sum{}
+	_ Any = Gauge{}
+	_ Any = ExpHistogram{}
+	_ Any = Histogram{}
+	_ Any = Summary{}
+)
+
+type Any interface {
+	Len() int
+	Ident() identity.Metric
+
+	SetAggregationTemporality(pmetric.AggregationTemporality)
+}
+
+func (m Metric) Filter(ok func(id identity.Stream, dp any) bool) {
+	mid := m.Ident()
+	switch m.Type() {
+	case pmetric.MetricTypeSum:
+		m.Sum().DataPoints().RemoveIf(func(dp pmetric.NumberDataPoint) bool {
+			id := identity.OfStream(mid, dp)
+			return !ok(id, dp)
+		})
+	case pmetric.MetricTypeGauge:
+		m.Gauge().DataPoints().RemoveIf(func(dp pmetric.NumberDataPoint) bool {
+			id := identity.OfStream(mid, dp)
+			return !ok(id, dp)
+		})
+	case pmetric.MetricTypeHistogram:
+		m.Histogram().DataPoints().RemoveIf(func(dp pmetric.HistogramDataPoint) bool {
+			id := identity.OfStream(mid, dp)
+			return !ok(id, dp)
+		})
+	case pmetric.MetricTypeExponentialHistogram:
+		m.ExponentialHistogram().DataPoints().RemoveIf(func(dp pmetric.ExponentialHistogramDataPoint) bool {
+			id := identity.OfStream(mid, dp)
+			return !ok(id, dp)
+		})
+	case pmetric.MetricTypeSummary:
+		m.Summary().DataPoints().RemoveIf(func(dp pmetric.SummaryDataPoint) bool {
+			id := identity.OfStream(mid, dp)
+			return !ok(id, dp)
+		})
+	}
 }

--- a/processor/deltatocumulativeprocessor/internal/testing/sdktest/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/testing/sdktest/metrics.go
@@ -123,14 +123,3 @@ func (attr attributes) Into() attribute.Set {
 //
 // Temporality is optional and defaults to [sdk.CumulativeTemporality]
 type Format = []byte
-
-func Expect(metrics map[string]Metric) Spec {
-	for name, m := range metrics {
-		m.Name = name
-		if m.Temporality == 0 {
-			m.Temporality = sdk.CumulativeTemporality
-		}
-		metrics[name] = m
-	}
-	return metrics
-}

--- a/processor/deltatocumulativeprocessor/internal/testing/sdktest/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/testing/sdktest/metrics.go
@@ -123,3 +123,14 @@ func (attr attributes) Into() attribute.Set {
 //
 // Temporality is optional and defaults to [sdk.CumulativeTemporality]
 type Format = []byte
+
+func Expect(metrics map[string]Metric) Spec {
+	for name, m := range metrics {
+		m.Name = name
+		if m.Temporality == 0 {
+			m.Temporality = sdk.CumulativeTemporality
+		}
+		metrics[name] = m
+	}
+	return Spec(metrics)
+}

--- a/processor/deltatocumulativeprocessor/internal/testing/sdktest/metrics.go
+++ b/processor/deltatocumulativeprocessor/internal/testing/sdktest/metrics.go
@@ -132,5 +132,5 @@ func Expect(metrics map[string]Metric) Spec {
 		}
 		metrics[name] = m
 	}
-	return Spec(metrics)
+	return metrics
 }

--- a/processor/deltatocumulativeprocessor/processor_test.go
+++ b/processor/deltatocumulativeprocessor/processor_test.go
@@ -97,7 +97,7 @@ func config(t *testing.T, file string) *Config {
 	return cfg
 }
 
-func setup(t *testing.T, cfg *Config) State {
+func setup(t testing.TB, cfg *Config) State {
 	t.Helper()
 
 	next := &consumertest.MetricsSink{}

--- a/processor/deltatocumulativeprocessor/testdata/exponential/1.test
+++ b/processor/deltatocumulativeprocessor/testdata/exponential/1.test
@@ -92,5 +92,5 @@ resourceMetrics:
                     bucketCounts: [3,7,5,0,0]
 
 -- telemetry --
-updown otelcol_deltatocumulative.streams.tracked:
+updown otelcol_deltatocumulative.streams.tracked.linear:
 - int: 2

--- a/processor/deltatocumulativeprocessor/testdata/histograms/1.test
+++ b/processor/deltatocumulativeprocessor/testdata/histograms/1.test
@@ -49,5 +49,5 @@ resourceMetrics:
                   bucketCounts: [   1, 2, 3, 4]
 
 -- telemetry --
-updown otelcol_deltatocumulative.streams.tracked:
+updown otelcol_deltatocumulative.streams.tracked.linear:
 - int: 1


### PR DESCRIPTION

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Finishes work started in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35048

That PR only partially introduced a less complex processor architecture by only using it for Sums.
Back then I was not sure of the best way to do it for multiple datatypes, as generics seemed to introduce a lot of complexity regardless of usage. 

I since then did of a lot of perf analysis and due to the way Go works (see gcshapes), we do not really gain anything at runtime from using generics, given method calls are still dynamic.

This implementation uses regular Go interfaces and a good old type switch in the hot path (ConsumeMetrics), which lowers mental complexity quite a lot imo. 

The value of the new architecture is backed up by the following benchmark:

```
goos: linux
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/processor/deltatocumulativeprocessor
                 │ sums.nested │             sums.linear             │
                 │   sec/op    │   sec/op     vs base                │
Processor/sums-8   56.35µ ± 1%   39.99µ ± 1%  -29.04% (p=0.000 n=10)

                 │  sums.nested  │             sums.linear              │
                 │     B/op      │     B/op      vs base                │
Processor/sums-8   11.520Ki ± 0%   3.683Ki ± 0%  -68.03% (p=0.000 n=10)

                 │ sums.nested │            sums.linear             │
                 │  allocs/op  │ allocs/op   vs base                │
Processor/sums-8    365.0 ± 0%   260.0 ± 0%  -28.77% (p=0.000 n=10)

```

<!--Describe what testing was performed and which tests were added.-->
#### Testing

This is a refactor, existing tests pass unaltered.

<!--Describe the documentation added.-->
#### Documentation

not needed

<!--Please delete paragraphs that you did not use before submitting.-->
