### PR TITLE
[chore] ignore datadog-api-client-go in renovate bot

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -109,7 +109,7 @@
     ],
     "ignoreDeps": [
       "github.com/DataDog/datadog-agent/pkg/trace/exportable",
-      "github.com/datadog/datadog-api-client-go/v2"
+      "github.com/DataDog/datadog-api-client-go"
     ],
     "prConcurrentLimit": 200,
     "suppressNotifications": ["prEditedNotification"]


### PR DESCRIPTION
#### Description

2nd attempt of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36339, the previous PR does not seem working properly.
