### PR TITLE
[chore][exporter/azuremonitor] Force the telemetry to be sent to azuremonitor

### DIFF
--- a/.chloggen/azuremonitor-bug-fix.yaml
+++ b/.chloggen/azuremonitor-bug-fix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fixes an issue where the Azure Monitor exporter was not sending data to App Insights due to the Telemetry Channel not being flushed."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35037]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/azuremonitor-bug-fix.yaml
+++ b/.chloggen/azuremonitor-bug-fix.yaml
@@ -4,7 +4,7 @@
 change_type: 'bug_fix'
 
 # The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
-component: azuremonitor
+component: azuremonitorexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: "Fixes an issue where the Azure Monitor exporter was not sending data to App Insights due to the Telemetry Channel not being flushed."

--- a/exporter/azuremonitorexporter/channels.go
+++ b/exporter/azuremonitorexporter/channels.go
@@ -7,4 +7,5 @@ import "github.com/microsoft/ApplicationInsights-Go/appinsights/contracts"
 
 type transportChannel interface {
 	Send(*contracts.Envelope)
+	Flush()
 }

--- a/exporter/azuremonitorexporter/logexporter.go
+++ b/exporter/azuremonitorexporter/logexporter.go
@@ -35,7 +35,8 @@ func (exporter *logExporter) onLogData(_ context.Context, logData plog.Logs) err
 			}
 		}
 	}
-
+	// Flush the transport channel to force the telemetry to be sent
+	exporter.transportChannel.Flush()
 	return nil
 }
 

--- a/exporter/azuremonitorexporter/metricexporter.go
+++ b/exporter/azuremonitorexporter/metricexporter.go
@@ -37,6 +37,8 @@ func (exporter *metricExporter) onMetricData(_ context.Context, metricData pmetr
 		}
 	}
 
+	// Flush the transport channel to force the telemetry to be sent
+	exporter.transportChannel.Flush()
 	return nil
 }
 

--- a/exporter/azuremonitorexporter/mock_transportChannel.go
+++ b/exporter/azuremonitorexporter/mock_transportChannel.go
@@ -19,3 +19,7 @@ type mockTransportChannel struct {
 func (_m *mockTransportChannel) Send(_a0 *contracts.Envelope) {
 	_m.Called(_a0)
 }
+
+func (_m *mockTransportChannel) Flush() {
+	_m.Called()
+}

--- a/exporter/azuremonitorexporter/traceexporter.go
+++ b/exporter/azuremonitorexporter/traceexporter.go
@@ -46,6 +46,8 @@ func (v *traceVisitor) visit(
 		v.exporter.transportChannel.Send(envelope)
 	}
 
+	// Flush the transport channel to force the telemetry to be sent
+	v.exporter.transportChannel.Flush()
 	v.processed++
 
 	return true

--- a/exporter/azuremonitorexporter/traceexporter_test.go
+++ b/exporter/azuremonitorexporter/traceexporter_test.go
@@ -118,6 +118,7 @@ func TestExporterTraceDataCallbackSingleSpanNoEnvelope(t *testing.T) {
 func getMockTransportChannel() *mockTransportChannel {
 	transportChannelMock := mockTransportChannel{}
 	transportChannelMock.On("Send", mock.Anything)
+	transportChannelMock.On("Flush", mock.Anything)
 	return &transportChannelMock
 }
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

1. Resolved an issue where traces weren't being sent to App Insights due to not flushing the Telemetry Channel. Added the necessary flush operation to ensure all traces, metrics and logs are properly sent to the queue, leveraging App Insights' batch handling for more efficient processing.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Resolves #35037 