### PR TITLE
[chore] track markdown-link-check with renovate

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ env:
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MD_LINK_CHECK_VERSION: "3.13.6"
+  MD_LINK_CHECK_VERSION: "3.12.2"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ env:
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MD_LINK_CHECK_VERSION: 3.13.6
+  MD_LINK_CHECK_VERSION: "3.13.6"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -15,6 +15,8 @@ env:
   # Make sure to exit early if cache segment download times out after 2 minutes.
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
+  # renovate: datasource=github-releases depName=tcort/markdown-link-check
+  MD_LINK_CHECK_VERSION: 3.13.6
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -84,7 +86,7 @@ jobs:
         run: make chlog-preview > changelog_preview.md
       - name: Install markdown-link-check
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
-        run: npm install -g markdown-link-check@3.12.2
+        run: npm install -g markdown-link-check@${{ env.MD_LINK_CHECK_VERSION }}
       - name: Run markdown-link-check
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependencies') && !contains(github.event.pull_request.labels.*.name, 'Skip Changelog') && !contains(github.event.pull_request.title, '[chore]')}}
         run: |

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MD_LINK_CHECK_VERSION: "3.13.6"
+  MD_LINK_CHECK_VERSION: "3.12.2"
 
 jobs:
   changedfiles:

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MD_LINK_CHECK_VERSION: 3.13.6
+  MD_LINK_CHECK_VERSION: "3.13.6"
 
 jobs:
   changedfiles:

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -9,6 +9,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  # renovate: datasource=github-releases depName=tcort/markdown-link-check
+  MD_LINK_CHECK_VERSION: 3.13.6
+
 jobs:
   changedfiles:
     name: changed files
@@ -36,7 +40,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install markdown-link-check
-        run: npm install -g markdown-link-check@3.12.2
+        run: npm install -g markdown-link-check@${{ env.MD_LINK_CHECK_VERSION }}
 
       - name: Run markdown-link-check
         run: |

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ The official distributions, core and contrib, are available as part of the [open
 
 Each component has its own support levels, as defined in the following sections. For each signal that a component supports, there's a stability level, setting the right expectations. It is possible then that a component will be **Stable** for traces but **Alpha** for metrics and **Development** for logs.
 
+some random markdown change
+
 ## Stability levels
 
 Stability level for components in this repository follow the [definitions](https://github.com/open-telemetry/opentelemetry-collector#stability-levels) from the OpenTelemetry Collector repository.

--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ The official distributions, core and contrib, are available as part of the [open
 
 Each component has its own support levels, as defined in the following sections. For each signal that a component supports, there's a stability level, setting the right expectations. It is possible then that a component will be **Stable** for traces but **Alpha** for metrics and **Development** for logs.
 
-some random markdown change
-
 ## Stability levels
 
 Stability level for components in this repository follow the [definitions](https://github.com/open-telemetry/opentelemetry-collector#stability-levels) from the OpenTelemetry Collector repository.

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,10 @@
       "go": "1.22.0"
     },
     "schedule": ["every tuesday"],
-    "extends": ["config:recommended"],
+    "extends": [
+      "config:recommended",
+      "customManagers:githubActionsVersions"
+    ],
     "ignorePaths": [
       "**/receiver/apachesparkreceiver/testdata/integration/Dockerfile.apache-spark",
       "**/receiver/elasticsearchreceiver/testdata/integration/Dockerfile.elasticsearch.7_16_3",


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds markdown-link-check to the tracked dependencies of renovate. It achieves that by using the [`customManagers:githubActionsVersions`](https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions) renovate preset that enables user to update arbitrary versions in github actions files without having to maintain their own regex for them.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36259

<!--Describe what testing was performed and which tests were added.-->
#### Testing
This setup is already in use in the dynatrace collector distro and works great: [latest update PR](https://github.com/Dynatrace/dynatrace-otel-collector/pull/382), [renovate config](https://github.com/Dynatrace/dynatrace-otel-collector/blob/07e4662f92b0cadfb311eca74c9269c1c1598634/renovate.json#L6)
