### PR TITLE
[chore] Add CI check to enforce merge freezes

### DIFF
--- a/.github/workflows/check-merge-freeze.yml
+++ b/.github/workflows/check-merge-freeze.yml
@@ -1,0 +1,23 @@
+name: Merge freeze
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check-merge-freeze:
+    name: Check
+    # This condition is to avoid blocking the PR causing the freeze in the first place.
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'release:merge-freeze') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: .github/workflows/scripts
+      - run: ./.github/workflows/scripts/check-merge-freeze.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: open-telemetry/opentelemetry-collector-contrib

--- a/.github/workflows/scripts/check-merge-freeze.sh
+++ b/.github/workflows/scripts/check-merge-freeze.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -e
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+BLOCKERS=$( gh pr list --search "label:release:merge-freeze" --json url --jq '.[].url' --repo "${REPO}" )
+if [ "${BLOCKERS}" != "" ]; then
+    echo "Merging in main is frozen, as there are open PRs labeled 'release:merge-freeze': ${BLOCKERS}"
+    echo "If you believe this is no longer true, re-run this job to unblock your PR."
+    exit 1
+fi

--- a/.github/workflows/scripts/release-prepare-release.sh
+++ b/.github/workflows/scripts/release-prepare-release.sh
@@ -64,7 +64,8 @@ make otelcontribcol
 
 git push origin "${BRANCH}"
 
-gh pr create --title "[chore] Prepare release ${CANDIDATE_BETA}" --body "
+# The `release:merge-freeze` label will cause the `check-merge-freeze` workflow to fail, enforcing the freeze.
+gh pr create --title "[chore] Prepare release ${CANDIDATE_BETA}" --label release:merge-freeze --body "
 The following commands were run to prepare this release:
 - make chlog-update VERSION=v${CANDIDATE_BETA}
 - sed -i.bak s/${CURRENT_BETA_ESCAPED}/${CANDIDATE_BETA}/g versions.yaml


### PR DESCRIPTION
#### Description

Adds a CI check to block merging in main if a "Prepare release" PR is open. See [the equivalent PR in the core repo](https://github.com/open-telemetry/opentelemetry-collector/pull/11744) for details.
