### PR TITLE
[chore][exporter/loadbalancing] Add debug statements after failed export operation

### DIFF
--- a/exporter/loadbalancingexporter/factory.go
+++ b/exporter/loadbalancingexporter/factory.go
@@ -83,22 +83,22 @@ func buildExporterResilienceOptions(options []exporterhelper.Option, cfg *Config
 
 func createTracesExporter(ctx context.Context, params exporter.Settings, cfg component.Config) (exporter.Traces, error) {
 	c := cfg.(*Config)
-	exporter, err := newTracesExporter(params, cfg)
+	exp, err := newTracesExporter(params, cfg)
 	if err != nil {
 		return nil, fmt.Errorf("cannot configure loadbalancing traces exporter: %w", err)
 	}
 
 	options := []exporterhelper.Option{
-		exporterhelper.WithStart(exporter.Start),
-		exporterhelper.WithShutdown(exporter.Shutdown),
-		exporterhelper.WithCapabilities(exporter.Capabilities()),
+		exporterhelper.WithStart(exp.Start),
+		exporterhelper.WithShutdown(exp.Shutdown),
+		exporterhelper.WithCapabilities(exp.Capabilities()),
 	}
 
 	return exporterhelper.NewTraces(
 		ctx,
 		params,
 		cfg,
-		exporter.ConsumeTraces,
+		exp.ConsumeTraces,
 		buildExporterResilienceOptions(options, c)...,
 	)
 }

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal"
@@ -27,6 +28,7 @@ var _ exporter.Logs = (*logExporterImp)(nil)
 type logExporterImp struct {
 	loadBalancer *loadBalancer
 
+	logger     *zap.Logger
 	started    bool
 	shutdownWg sync.WaitGroup
 	telemetry  *metadata.TelemetryBuilder
@@ -54,6 +56,7 @@ func newLogsExporter(params exporter.Settings, cfg component.Config) (*logExport
 	return &logExporterImp{
 		loadBalancer: lb,
 		telemetry:    telemetry,
+		logger:       params.Logger,
 	}, nil
 }
 
@@ -112,6 +115,7 @@ func (e *logExporterImp) consumeLog(ctx context.Context, ld plog.Logs) error {
 		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(le.successAttr))
 	} else {
 		e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(le.failureAttr))
+		e.logger.Debug("failed to export log", zap.Error(err))
 	}
 
 	return err

--- a/exporter/loadbalancingexporter/metrics_exporter.go
+++ b/exporter/loadbalancingexporter/metrics_exporter.go
@@ -18,6 +18,7 @@ import (
 	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.opentelemetry.io/otel/metric"
 	"go.uber.org/multierr"
+	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/loadbalancingexporter/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/exp/metrics"
@@ -30,6 +31,7 @@ type metricExporterImp struct {
 	loadBalancer *loadBalancer
 	routingKey   routingKey
 
+	logger     *zap.Logger
 	stopped    bool
 	shutdownWg sync.WaitGroup
 	telemetry  *metadata.TelemetryBuilder
@@ -57,6 +59,7 @@ func newMetricsExporter(params exporter.Settings, cfg component.Config) (*metric
 		loadBalancer: lb,
 		routingKey:   svcRouting,
 		telemetry:    telemetry,
+		logger:       params.Logger,
 	}
 
 	switch cfg.(*Config).RoutingKey {
@@ -142,6 +145,7 @@ func (e *metricExporterImp) ConsumeMetrics(ctx context.Context, md pmetric.Metri
 			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.successAttr))
 		} else {
 			e.telemetry.LoadbalancerBackendOutcome.Add(ctx, 1, metric.WithAttributeSet(exp.failureAttr))
+			e.logger.Debug("failed to export metrics", zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
This adds some debug logging to the load balancing exporter, to help identify causes of 503, reported as part of issues like #35512. The statements should only be logged when the logging mode is set to debug, meaning that there should not be a difference to the current behavior of production setups.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>
