### PR TITLE
[chore] skip v1.68.0 of grpc dep

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -108,6 +108,10 @@
           "https://github.com/open-telemetry/opentelemetry-go-contrib"
         ],
         "groupName": "All opentelemetry-go-contrib packages"
+      },
+      {
+        "matchPackageNames": ["google.golang.org/grpc"],
+        "allowedVersions": "!/v1.68.0$/"
       }
     ],
     "ignoreDeps": [


### PR DESCRIPTION
Trying to add this to avoid getting notified until the next release is available.

Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36548