### PR TITLE
[receiver/receiver_creator] Add support for enabling logs' collection from K8s hints

### DIFF
--- a/.chloggen/f_hints_logs.yaml
+++ b/.chloggen/f_hints_logs.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receivercreator
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for starting logs' collection based on provided k8s annotations' hints
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34427]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -458,7 +458,8 @@ receiver_creator/metrics:
      # ignore_receivers: []
 ```
 
-Find bellow the supported annotations that user can define to automatically enable receivers to start collecting metrics signals from the target Pods/containers.
+Find bellow the supported annotations that user can define to automatically enable receivers to start
+collecting metrics signals from the target Pods/containers.
 
 ### Supported metrics annotations
 
@@ -511,11 +512,82 @@ The current implementation relies on the implementation of `k8sobserver` extensi
 the [pod_endpoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.111.0/extension/observer/k8sobserver/pod_endpoint.go).
 The hints are evaluated per container by extracting the annotations from each [`Port` endpoint](#Port) that is emitted. 
 
+### Supported logs annotations
+
+This feature enables `filelog` receiver along with the `container` parser in order to collect logs from the discovered
+Pods.
+
+#### Enable/disable discovery
+
+`io.opentelemetry.discovery.logs/enabled` (Required. Example: `"true"`)
+
+By default `"false"`.
+
+The following configuration can be used:
+
+```yaml
+receiver_creator/logs:
+  watch_observers: [ k8s_observer ]
+  discovery:
+    enabled: true
+```
+#### Define configuration
+The default configuration for the `filelog` receiver is the following:
+
+```yaml
+include:
+  - /var/log/pods/`pod.namespace`_`pod.name`_`pod.uid`/`container_name`/*.log
+include_file_name: false
+include_file_path: true
+operators:
+  - id: container-parser
+    type: container
+```
+This default can be extended using the respective annotation:
+`io.opentelemetry.discovery.logs/config`
+
+**Example:**
+
+```yaml
+io.opentelemetry.discovery.logs/config: |
+  include_file_name: true
+  max_log_size: "2MiB"
+  operators:
+    - type: regex_parser
+      regex: "^(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$"
+```
+
+Note that individual settings are overridden by the configuration provided by the hints while the operators list
+is extended keeping first the `container` parser.
+
+
+#### Support multiple target containers
+
+Users can target the annotation to a specific container by suffixing it with the name of that container:
+`io.opentelemetry.discovery.logs.<container_name>/endpoint`.
+For example:
+```yaml
+io.opentelemetry.discovery.logs.busybox/config: |
+  max_log_size: "3MiB"
+  operators:
+    - id: some
+      type: add
+      field: attributes.tag
+      value: hints
+```
+where `busybox` is the name of the target container.
+
+If a Pod is annotated with both container level hints and pod level hints the container level hints have priority and
+the Pod level hints are used as a fallback (see detailed example bellow).
+
+The current implementation relies on the implementation of `k8sobserver` extension and specifically
+the [pod_endpoint](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.111.0/extension/observer/k8sobserver/pod_endpoint.go).
+The hints are evaluated per container by extracting the annotations from each [`Pod Container` endpoint](#Pod Container) that is emitted.
 
 
 ### Examples
 
-#### Metrics example
+#### Metrics and Logs example
 
 Collector's configuration:
 ```yaml
@@ -525,12 +597,22 @@ receivers:
     discovery:
       enabled: true
     receivers:
+  
+  receiver_creator/logs:
+    watch_observers: [ k8s_observer ]
+    discovery:
+      enabled: true
+    receivers:
 
 service:
   extensions: [ k8s_observer]
   pipelines:
     metrics:
-      receivers: [ receiver_creator ]
+      receivers: [ receiver_creator/metrics ]
+      processors: []
+      exporters: [ debug ]
+    logs:
+      receivers: [ receiver_creator/logs ]
       processors: []
       exporters: [ debug ]
 ```
@@ -600,6 +682,21 @@ spec:
           endpoint: "http://`endpoint`/nginx_status"
           collection_interval: "30s"
           timeout: "20s"
+
+        # redis pod container logs hints
+        io.opentelemetry.discovery.logs.redis/enabled: "true"
+        io.opentelemetry.discovery.logs.redis/config: |
+          max_log_size: "4MiB"
+          operators:
+            - id: some
+              type: add
+              field: attributes.tag
+              value: logs_hints
+
+        # nginx pod container logs hints
+        io.opentelemetry.discovery.logs.webserver/enabled: "true"
+        io.opentelemetry.discovery.logs.webserver/config: |
+          max_log_size: "3MiB"
     spec:
       volumes:
         - name: nginx-conf

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -514,8 +514,7 @@ The hints are evaluated per container by extracting the annotations from each [`
 
 ### Supported logs annotations
 
-This feature enables `filelog` receiver along with the `container` parser in order to collect logs from the discovered
-Pods.
+This feature enables `filelog` receiver in order to collect logs from the discovered Pods.
 
 #### Enable/disable discovery
 
@@ -523,15 +522,8 @@ Pods.
 
 By default `"false"`.
 
-The following configuration can be used:
-
-```yaml
-receiver_creator/logs:
-  watch_observers: [ k8s_observer ]
-  discovery:
-    enabled: true
-```
 #### Define configuration
+
 The default configuration for the `filelog` receiver is the following:
 
 ```yaml

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -543,7 +543,7 @@ operators:
   - id: container-parser
     type: container
 ```
-This default can be extended using the respective annotation:
+This default can be extended or overridden using the respective annotation:
 `io.opentelemetry.discovery.logs/config`
 
 **Example:**
@@ -553,16 +553,13 @@ io.opentelemetry.discovery.logs/config: |
   include_file_name: true
   max_log_size: "2MiB"
   operators:
+    - type: container
+      id: container-parser
     - type: regex_parser
       regex: "^(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$"
 ```
 
-Note that individual settings are overridden by the configuration provided by the hints while the operators list
-is extended keeping first the `container` parser. If `container` parser is explicitly set by the user the default
-will be overridden.
-
 `include` cannot be overridden and is fixed to discovered container's log file path.
-
 
 #### Support multiple target containers
 
@@ -573,6 +570,8 @@ For example:
 io.opentelemetry.discovery.logs.busybox/config: |
   max_log_size: "3MiB"
   operators:
+    - type: container
+      id: container-parser
     - id: some
       type: add
       field: attributes.tag
@@ -691,6 +690,8 @@ spec:
         io.opentelemetry.discovery.logs.redis/config: |
           max_log_size: "4MiB"
           operators:
+            - type: container
+              id: container-parser
             - id: some
               type: add
               field: attributes.tag

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -459,7 +459,7 @@ receiver_creator/metrics:
 ```
 
 Find bellow the supported annotations that user can define to automatically enable receivers to start
-collecting metrics signals from the target Pods/containers.
+collecting metrics and logs signals from the target Pods/containers.
 
 ### Supported metrics annotations
 

--- a/receiver/receivercreator/README.md
+++ b/receiver/receivercreator/README.md
@@ -558,7 +558,10 @@ io.opentelemetry.discovery.logs/config: |
 ```
 
 Note that individual settings are overridden by the configuration provided by the hints while the operators list
-is extended keeping first the `container` parser.
+is extended keeping first the `container` parser. If `container` parser is explicitly set by the user the default
+will be overridden.
+
+`include` cannot be overridden and is fixed to discovered container's log file path.
 
 
 #### Support multiple target containers

--- a/receiver/receivercreator/config_test.go
+++ b/receiver/receivercreator/config_test.go
@@ -299,3 +299,40 @@ func (*nopWithoutEndpointFactory) CreateTraces(
 		cfg:      cfg,
 	}, nil
 }
+
+type nopWithFilelogConfig struct {
+	Include         []string `mapstructure:"include"`
+	IncludeFileName bool     `mapstructure:"include_file_name"`
+	IncludeFilePath bool     `mapstructure:"include_file_path"`
+	Operators       []any    `mapstructure:"operators"`
+}
+
+type nopWithFilelogFactory struct {
+	rcvr.Factory
+}
+
+type nopWithFilelogReceiver struct {
+	mockComponent
+	consumer.Logs
+	consumer.Metrics
+	consumer.Traces
+	rcvr.Settings
+	cfg component.Config
+}
+
+func (*nopWithFilelogFactory) CreateDefaultConfig() component.Config {
+	return &nopWithFilelogConfig{}
+}
+
+func (*nopWithFilelogFactory) CreateLogs(
+	_ context.Context,
+	rcs rcvr.Settings,
+	cfg component.Config,
+	nextConsumer consumer.Logs,
+) (rcvr.Logs, error) {
+	return &nopWithEndpointReceiver{
+		Logs:     nextConsumer,
+		Settings: rcs,
+		cfg:      cfg,
+	}, nil
+}

--- a/receiver/receivercreator/discovery.go
+++ b/receiver/receivercreator/discovery.go
@@ -166,7 +166,7 @@ func (builder *k8sHintsBuilder) createLogsReceiver(
 		builder.logger)
 
 	recTemplate, err := newReceiverTemplate(fmt.Sprintf("%v/%v_%v", subreceiverKey, pod.UID, containerName), userConfMap)
-	recTemplate.signals = receiverSignals{false, true, false}
+	recTemplate.signals = receiverSignals{metrics: false, logs: true, traces: false}
 
 	return &recTemplate, err
 }
@@ -230,10 +230,10 @@ func createLogsConfig(
 	for k, v := range userConf {
 		if k == "include" {
 			// path cannot be other than the one of the target container
+			logger.Warn("include setting cannot be set through annotation's hints")
 			continue
-		} else {
-			defaultConfMap[k] = v
 		}
+		defaultConfMap[k] = v
 	}
 
 	return defaultConfMap

--- a/receiver/receivercreator/discovery_test.go
+++ b/receiver/receivercreator/discovery_test.go
@@ -230,12 +230,16 @@ func TestK8sHintsBuilderLogs(t *testing.T) {
 include_file_name: true
 max_log_size: "2MiB"
 operators:
+- type: container
+  id: container-parser
 - type: regex_parser
   regex: "^(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$"`
 	configNginx := `
 include_file_name: true
 max_log_size: "4MiB"
 operators:
+- type: container
+  id: container-parser
 - type: add
   field: attributes.tag
   value: beta`
@@ -614,6 +618,8 @@ func TestCreateLogsConfig(t *testing.T) {
 include_file_name: true
 max_log_size: "2MiB"
 operators:
+- type: container
+  id: container-parser
 - type: regex_parser
   regex: "^(?P<time>\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}) (?P<sev>[A-Z]*) (?P<msg>.*)$"`
 	tests := map[string]struct {

--- a/receiver/receivercreator/fixtures_test.go
+++ b/receiver/receivercreator/fixtures_test.go
@@ -78,6 +78,22 @@ var portEndpointWithHints = observer.Endpoint{
 	},
 }
 
+var podContainerEndpointWithHints = observer.Endpoint{
+	ID:     "namespace/pod-2-UID/redis(6379)",
+	Target: "1.2.3.4:6379",
+	Details: &observer.PodContainer{
+		Name: "redis", Pod: observer.Pod{
+			Name:      "pod-2",
+			Namespace: "default",
+			UID:       "pod-2-UID",
+			Labels:    map[string]string{"env": "prod"},
+			Annotations: map[string]string{
+				otelLogsHints + "/enabled": "true",
+			},
+		},
+	},
+}
+
 var hostportEndpoint = observer.Endpoint{
 	ID:     "port-1",
 	Target: "localhost:1234",

--- a/receiver/receivercreator/observerhandler_test.go
+++ b/receiver/receivercreator/observerhandler_test.go
@@ -285,6 +285,75 @@ func TestOnAddForLogs(t *testing.T) {
 	}
 }
 
+func TestOnAddForLogsWithHints(t *testing.T) {
+	for _, test := range []struct {
+		name                   string
+		expectedReceiverType   component.Component
+		expectedReceiverConfig component.Config
+		target                 observer.Endpoint
+		hintsConfig            DiscoveryConfig
+		expectedError          string
+	}{
+		{
+			name:                 "dynamically generated standard filelog receiver with explicit enablement",
+			target:               podContainerEndpointWithHints,
+			hintsConfig:          DiscoveryConfig{Enabled: true},
+			expectedReceiverType: &nopWithFilelogReceiver{},
+			expectedReceiverConfig: &nopWithFilelogConfig{
+				Include:         []string{"/var/log/pods/default_pod-2_pod-2-UID/redis/*.log"},
+				IncludeFileName: false,
+				IncludeFilePath: true,
+				Operators:       []any{map[string]any{"id": "container-parser", "type": "container"}},
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := createDefaultConfig().(*Config)
+			cfg.Discovery = test.hintsConfig
+
+			handler, mr := newObserverHandler(t, cfg, consumertest.NewNop(), nil, nil)
+			handler.OnAdd([]observer.Endpoint{
+				test.target,
+				unsupportedEndpoint,
+			})
+
+			if test.expectedError != "" {
+				assert.Equal(t, 0, handler.receiversByEndpointID.Size())
+				require.Error(t, mr.lastError)
+				require.ErrorContains(t, mr.lastError, test.expectedError)
+				require.Nil(t, mr.startedComponent)
+				return
+			}
+
+			assert.Equal(t, 1, handler.receiversByEndpointID.Size())
+			require.NoError(t, mr.lastError)
+			require.NotNil(t, mr.startedComponent)
+
+			wr, ok := mr.startedComponent.(*wrappedReceiver)
+			require.True(t, ok)
+
+			require.Nil(t, wr.metrics)
+			require.Nil(t, wr.traces)
+
+			var actualConfig component.Config
+			switch v := wr.logs.(type) {
+			case *nopWithEndpointReceiver:
+				require.NotNil(t, v)
+				actualConfig = v.cfg
+			case *nopWithoutEndpointReceiver:
+				require.NotNil(t, v)
+				actualConfig = v.cfg
+			case *nopWithFilelogReceiver:
+				require.NotNil(t, v)
+				actualConfig = v.cfg
+			default:
+				t.Fatalf("unexpected startedComponent: %T", v)
+			}
+			require.Equal(t, test.expectedReceiverConfig, actualConfig)
+		})
+	}
+}
+
 func TestOnAddForTraces(t *testing.T) {
 	for _, test := range []struct {
 		name                   string
@@ -516,6 +585,7 @@ func newMockHost(t *testing.T, host component.Host) *mockHost {
 	factories, err := otelcoltest.NopFactories()
 	require.NoError(t, err)
 	factories.Receivers[component.MustNewType("with_endpoint")] = &nopWithEndpointFactory{Factory: receivertest.NewNopFactory()}
+	factories.Receivers[component.MustNewType("filelog")] = &nopWithFilelogFactory{Factory: receivertest.NewNopFactory()}
 	factories.Receivers[component.MustNewType("without_endpoint")] = &nopWithoutEndpointFactory{Factory: receivertest.NewNopFactory()}
 	return &mockHost{t: t, factories: factories, Host: host}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds the logs part for https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34427 based on the design decided at https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34427#issuecomment-2436140051.

See the README docs for the description of this feature: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35617/files#diff-4127365c4062a7510fb7fede0fa239e9232549732898303d94c12fef0433d39d

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34427

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added unit-tests

<!--Describe the documentation added.-->
#### Documentation
Added README section

<!--Please delete paragraphs that you did not use before submitting.-->

#### How to test this manually

1. Deploy the Collector helm chart:
```yaml
mode: daemonset

image:
  repository: otelcontribcol-dev
  tag: "latest"
  pullPolicy: IfNotPresent

command:
  name: otelcontribcol

clusterRole:
  create: true
  rules:
   - apiGroups:
     - ''
     resources:
     - 'pods'
     - 'nodes'
     verbs:
     - 'get'
     - 'list'
     - 'watch'
   - apiGroups: [ "" ]
     resources: [ "nodes/proxy"]
     verbs: [ "get" ]
   - apiGroups:
       - ""
     resources:
       - nodes/stats
     verbs:
       - get
   - nonResourceURLs:
       - "/metrics"
     verbs:
       - get

extraVolumeMounts:
 - name: varlogpods
   mountPath: /var/log/pods
   readOnly: true

extraVolumes:
  - name: varlogpods
    hostPath:
      path: /var/log/pods

config:
  extensions:
    k8s_observer:
      auth_type: serviceAccount
      node: ${env:K8S_NODE_NAME}
      observe_nodes: true
  exporters:
    debug:
      verbosity: detailed

  receivers:
    receiver_creator/metrics:
      watch_observers: [ k8s_observer ]
      discovery:
        enabled: true
        ignore_receivers:
          - nginx2
      receivers:

    receiver_creator/logs:
      watch_observers: [ k8s_observer ]
      discovery:
        enabled: true
        default_logs_discovery: false
      receivers:


  service:
    extensions: [health_check, k8s_observer]
    telemetry:
      logs:
        level: INFO
    pipelines:
      metrics:
        receivers: [ receiver_creator/metrics ]
        processors: [ batch ]
        exporters: [ debug ]
      logs/discovery:
        receivers: [ receiver_creator/logs ]
        #processors: [ batch ]
        exporters: [ debug ]
```
2. Then deploy a target Pod with 2 containers:
```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis-deployment
  labels:
    app: redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
      annotations:
        io.opentelemetry.discovery.metrics.6379/enabled: "true"
        io.opentelemetry.discovery.metrics.6379/scraper: redis
        io.opentelemetry.discovery.metrics.6379/signals: metrics
        io.opentelemetry.discovery.metrics.6379/config: |
          collection_interval: "20s"
          timeout: "10s"

        io.opentelemetry.discovery.logs.busybox/enabled: "true"
        io.opentelemetry.discovery.logs.busybox/config: |
          operators:
            - id: some
              type: add
              field: attributes.tag
              value: hints
    spec:
      containers:
        - image: redis
          imagePullPolicy: IfNotPresent
          name: redis
          ports:
            - name: redis
              containerPort: 6379
              protocol: TCP
        - name: busybox
          image: busybox
          args:
            - /bin/sh
            - -c
            - while true; do echo "otel logs at $(date +%H:%M:%S)" && sleep 15s; done
```
3. Esnure that logs are collected from both containers and that Redis metrics are collected from the Redis container:
```console
2024-11-28T11:04:14.921Z	info	receivercreator@v0.114.0/observerhandler.go:201	starting receiver	{"kind": "receiver", "name": "receiver_creator/metrics", "data_type": "metrics", "name": "redis/91ec7d5c-c6fb-4977-9dbb-c24a85101326_6379", "endpoint": "10.244.0.6:6379", "endpoint_id": "k8s_observer/91ec7d5c-c6fb-4977-9dbb-c24a85101326/redis(6379)", "config": {"collection_interval":"20s","endpoint":"10.244.0.6:6379","timeout":"10s"}}
2024-11-28T11:04:14.921Z	info	receivercreator@v0.114.0/observerhandler.go:201	starting receiver	{"kind": "receiver", "name": "receiver_creator/logs", "data_type": "logs", "name": "filelog/91ec7d5c-c6fb-4977-9dbb-c24a85101326_busybox", "endpoint": "10.244.0.6", "endpoint_id": "k8s_observer/91ec7d5c-c6fb-4977-9dbb-c24a85101326/busybox", "config": {"include":["/var/log/pods/default_redis-deployment-7777bf7db4-5rm6d_91ec7d5c-c6fb-4977-9dbb-c24a85101326/busybox/*.log"],"include_file_name":false,"include_file_path":true,"operators":[{"id":"container-parser","type":"container"},{"field":"attributes.tag","id":"some","type":"add","value":"hints"}]}}
2024-11-28T11:04:14.922Z	info	adapter/receiver.go:41	Starting stanza receiver	{"kind": "receiver", "name": "receiver_creator/logs", "data_type": "logs", "name": "filelog/91ec7d5c-c6fb-4977-9dbb-c24a85101326_busybox/receiver_creator/logs{endpoint=\"10.244.0.6\"}/k8s_observer/91ec7d5c-c6fb-4977-9dbb-c24a85101326/busybox"}
2024-11-28T11:04:15.122Z	info	fileconsumer/file.go:265	Started watching file	{"kind": "receiver", "name": "receiver_creator/logs", "data_type": "logs", "name": "filelog/91ec7d5c-c6fb-4977-9dbb-c24a85101326_busybox/receiver_creator/logs{endpoint=\"10.244.0.6\"}/k8s_observer/91ec7d5c-c6fb-4977-9dbb-c24a85101326/busybox", "component": "fileconsumer", "path": "/var/log/pods/default_redis-deployment-7777bf7db4-5rm6d_91ec7d5c-c6fb-4977-9dbb-c24a85101326/busybox/0.log"}
2024-11-28T11:04:15.979Z	info	Metrics	{"kind": "exporter", "data_type": "metrics", "name": "debug/2", "resource metrics": 1, "metrics": 26, "data points": 31}
```

### Follow-ups

1. File an issue for enhancing default behaviors: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36581#discussion_r1864013358