### PR TITLE
[chore] Fix markdown linter by lowercasing #uuid anchor

### DIFF
--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -472,7 +472,7 @@ Available Converters:
 - [UnixNano](#unixnano)
 - [UnixSeconds](#unixseconds)
 - [UserAgent](#useragent)
-- [UUID](#UUID)
+- [UUID](#uuid)
 - [Year](#year)
 
 ### Base64Decode (Deprecated)


### PR DESCRIPTION
No related issue just trying to fix markdown failures e.g: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/12068945579/job/33655141758?pr=36582