### PR TITLE
Revert "Update dependency tcort/markdown-link-check to v3.13.6"

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ env:
   # We limit cache download as a whole to 5 minutes.
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MD_LINK_CHECK_VERSION: "3.13.6"
+  MD_LINK_CHECK_VERSION: "3.12.2"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -11,7 +11,7 @@ concurrency:
 
 env:
   # renovate: datasource=github-releases depName=tcort/markdown-link-check
-  MD_LINK_CHECK_VERSION: "3.13.6"
+  MD_LINK_CHECK_VERSION: "3.12.2"
 
 jobs:
   changedfiles:


### PR DESCRIPTION
Reverts open-telemetry/opentelemetry-collector-contrib#36555.

After the update of the version the check is failing: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/12068945579/job/33655141758#step:10:16

The PR introduced the dependency had the version pinned: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36552