### PR TITLE
[exporter/elasticsearch] Merge *.geo.location.{lat,lon} to *.geo.location in OTel mode

### DIFF
--- a/.chloggen/elasticsearchexporter_merge-geo-location.yaml
+++ b/.chloggen/elasticsearchexporter_merge-geo-location.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: elasticsearchexporter
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Merge *.geo.location.{lat,lon} to *.geo.location in OTel mode
+note: Map *.geo.location.{lat,lon} as geo_point field in OTel mode
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [36565]

--- a/.chloggen/elasticsearchexporter_merge-geo-location.yaml
+++ b/.chloggen/elasticsearchexporter_merge-geo-location.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Merge *.geo.location.{lat,lon} to *.geo.location in OTel mode
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36565]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: In OTel mapping mode, merge *.geo.location.{lat,lon} to *.geo.location such that they are stored as geo_point in Elasticsearch.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -600,7 +600,7 @@ func (m *encodeModel) encodeResourceOTelMode(document *objmodel.Document, resour
 		}
 		return false
 	})
-
+	mergeGeolocation(resourceAttrMap)
 	document.Add("resource", objmodel.ValueFromAttribute(resourceMapVal))
 }
 
@@ -626,6 +626,7 @@ func (m *encodeModel) encodeScopeOTelMode(document *objmodel.Document, scope pco
 		}
 		return false
 	})
+	mergeGeolocation(scopeAttrMap)
 	document.Add("scope", objmodel.ValueFromAttribute(scopeMapVal))
 }
 
@@ -645,6 +646,7 @@ func (m *encodeModel) encodeAttributesOTelMode(document *objmodel.Document, attr
 		}
 		return false
 	})
+	mergeGeolocation(attrsCopy)
 	document.AddAttributes("attributes", attrsCopy)
 }
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -1033,24 +1033,22 @@ func mergeGeolocation(attributes pcommon.Map) {
 		if val.Type() != pcommon.ValueTypeDouble {
 			return false
 		}
-		v := val.Double()
 
 		if key == lonKey {
-			setLon("", v)
+			setLon("", val.Double())
 			return true
 		} else if key == latKey {
-			setLat("", v)
+			setLat("", val.Double())
 			return true
 		} else if namespace, found := strings.CutSuffix(key, "."+lonKey); found {
 			prefix := namespace + "."
-			setLon(prefix, v)
+			setLon(prefix, val.Double())
 			return true
 		} else if namespace, found := strings.CutSuffix(key, "."+latKey); found {
 			prefix := namespace + "."
-			setLat(prefix, v)
+			setLat(prefix, val.Double())
 			return true
 		}
-
 		return false
 	})
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1278,3 +1278,36 @@ func TestEncodeLogBodyMapMode(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrInvalidTypeForBodyMapMode)
 }
+
+func TestMergeGeolocation(t *testing.T) {
+	attributes := map[string]any{
+		"geo.location.lon":          1.1,
+		"geo.location.lat":          2.2,
+		"foo.bar.geo.location.lon":  3.3,
+		"foo.bar.geo.location.lat":  4.4,
+		"a.geo.location.lon":        5.5,
+		"b.geo.location.lat":        6.6,
+		"unrelatedgeo.location.lon": 7.7,
+		"unrelatedgeo.location.lat": 8.8,
+		"d":                         9.9,
+		"e.geo.location.lon":        "foo",
+		"e.geo.location.lat":        "bar",
+	}
+	wantAttributes := map[string]any{
+		"geo.location":              []any{1.1, 2.2},
+		"foo.bar.geo.location":      []any{3.3, 4.4},
+		"a.geo.location.lon":        5.5,
+		"b.geo.location.lat":        6.6,
+		"unrelatedgeo.location.lon": 7.7,
+		"unrelatedgeo.location.lat": 8.8,
+		"d":                         9.9,
+		"e.geo.location.lon":        "foo",
+		"e.geo.location.lat":        "bar",
+	}
+	input := pcommon.NewMap()
+	err := input.FromRaw(attributes)
+	require.NoError(t, err)
+	mergeGeolocation(input)
+	after := input.AsRaw()
+	assert.Equal(t, wantAttributes, after)
+}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In OTel mapping mode, merge *.geo.location.{lat,lon} to *.geo.location such that they are stored as [geo_point](https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-point.html) in Elasticsearch.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36565

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
