### PR TITLE
[chore][pkg/stanza] - Fix Flaky test TestMatcher

### DIFF
--- a/pkg/stanza/fileconsumer/matcher/matcher_test.go
+++ b/pkg/stanza/fileconsumer/matcher/matcher_test.go
@@ -853,7 +853,7 @@ func TestMatcher(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-			assert.Equal(t, tc.expected, files)
+			assert.ElementsMatch(t, tc.expected, files)
 		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36623

We're using a map to store groups and we then do a `for .. range` over keys.
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/6119d51a5a85565c409bb225027d6d1ab353aecc/pkg/stanza/fileconsumer/matcher/matcher.go#L200-L206

For maps, the ordering of keys is not guaranteed. Hence, the check fails.
We should instead check with `assert.ElementsMatch` (which was previously the case, but https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36518 changed it to `assert.Equal`)