### PR TITLE
[fix][googlecloudmonitoringreceiver]: remove creds check

### DIFF
--- a/.chloggen/googlecloud-monitoring-receiver.yaml
+++ b/.chloggen/googlecloud-monitoring-receiver.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudmonitoringreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix "no validation found" error if workload is running on Google Cloud Platform
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36607]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/googlecloudmonitoringreceiver/receiver.go
+++ b/receiver/googlecloudmonitoringreceiver/receiver.go
@@ -159,9 +159,6 @@ func (mr *monitoringReceiver) initializeClient(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to find default credentials: %w", err)
 	}
-	if creds == nil || creds.JSON == nil {
-		return errors.New("no valid credentials found")
-	}
 
 	// Attempt to create the monitoring client
 	client, err := monitoring.NewMetricClient(ctx, option.WithCredentials(creds))


### PR DESCRIPTION
#### Description
Fix "no validation found" error if workload is running on Google Cloud Platform. 
There's no need to check for `creds` or `creds.JSON` explicitly. If any errors are encountered, it will be thrown by `FindDefaultCredentials`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36607
