### PR TITLE
[processor/tailsampling] Allow invert matches in composite policy to continue processing

### DIFF
--- a/.chloggen/tailsampling-composite-inverted-not-sample.yaml
+++ b/.chloggen/tailsampling-composite-inverted-not-sample.yaml
@@ -5,7 +5,7 @@ change_type: breaking
 component: processor/tailsampling
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Reverts #34085, allowing for composite policies to specify inverted clauses in conjunction with other policies. This is a change bringing the previous state into place, breaking users who rely on what was introduced as part of #34085."
+note: "Reverts #33671, allowing for composite policies to specify inverted clauses in conjunction with other policies. This is a change bringing the previous state into place, breaking users who rely on what was introduced as part of #33671."
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [34085]

--- a/.chloggen/tailsampling-composite-inverted-not-sample.yaml
+++ b/.chloggen/tailsampling-composite-inverted-not-sample.yaml
@@ -1,0 +1,12 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/tailsampling
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Reverts #34085, allowing for composite policies to specify inverted clauses in conjunction with other policies. This is a change bringing the previous state into place, breaking users who rely on what was introduced as part of #34085."
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34085]
+

--- a/processor/tailsamplingprocessor/internal/sampling/and.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and.go
@@ -29,14 +29,14 @@ func NewAnd(
 // Evaluate looks at the trace data and returns a corresponding SamplingDecision.
 func (c *And) Evaluate(ctx context.Context, traceID pcommon.TraceID, trace *TraceData) (Decision, error) {
 	// The policy iterates over all sub-policies and returns Sampled if all sub-policies returned a Sampled Decision.
-	// If any subpolicy returns NotSampled or InvertNotSampled it returns that
+	// If any subpolicy returns NotSampled or InvertNotSampled, it returns NotSampled Decision.
 	for _, sub := range c.subpolicies {
 		decision, err := sub.Evaluate(ctx, traceID, trace)
 		if err != nil {
 			return Unspecified, err
 		}
 		if decision == NotSampled || decision == InvertNotSampled {
-			return decision, nil
+			return NotSampled, nil
 		}
 	}
 	return Sampled, nil

--- a/processor/tailsamplingprocessor/internal/sampling/and_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/and_test.go
@@ -110,5 +110,5 @@ func TestAndEvaluatorStringInvertNotSampled(t *testing.T) {
 	}
 	decision, err := and.Evaluate(context.Background(), traceID, trace)
 	require.NoError(t, err, "Failed to evaluate and policy: %v", err)
-	assert.Equal(t, InvertNotSampled, decision)
+	assert.Equal(t, NotSampled, decision)
 }


### PR DESCRIPTION
Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>

#### Description
The PR #33671 aligned the behavior of the composite policy with the behavior of the processor as a whole, but in the process, caused a breaking change to users relying on exception lists, like one of the examples from the readme. Given that this is affecting a good number of users, we are reverting that behavior, so that we can have more discussions and a better solution.

#### Link to tracking issue
Fixes #34085

