### PR TITLE
[awsfirehosereceiver] Add auto type

### DIFF
--- a/.chloggen/auto-record-type.yaml
+++ b/.chloggen/auto-record-type.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsfirehosereceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add auto record type.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36708]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Add the auto record type, capable of distinguishing between all current possible record types.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/awsfirehosereceiver/factory.go
+++ b/receiver/awsfirehosereceiver/factory.go
@@ -61,17 +61,21 @@ func validateRecordType(recordType string) error {
 func defaultMetricsUnmarshalers(logger *zap.Logger) map[string]unmarshaler.MetricsUnmarshaler {
 	cwmsu := cwmetricstream.NewUnmarshaler(logger)
 	otlpv1msu := otlpmetricstream.NewUnmarshaler(logger)
+	autoUnmarshaler := auto.NewUnmarshaler(logger)
 	return map[string]unmarshaler.MetricsUnmarshaler{
 		cwmsu.Type():     cwmsu,
 		otlpv1msu.Type(): otlpv1msu,
+		auto.TypeStr:     autoUnmarshaler,
 	}
 }
 
 // defaultLogsUnmarshalers creates a map of the available logs unmarshalers.
 func defaultLogsUnmarshalers(logger *zap.Logger) map[string]unmarshaler.LogsUnmarshaler {
 	u := cwlog.NewUnmarshaler(logger)
+	autoUnmarshaler := auto.NewUnmarshaler(logger)
 	return map[string]unmarshaler.LogsUnmarshaler{
-		u.Type(): u,
+		u.Type():     u,
+		auto.TypeStr: autoUnmarshaler,
 	}
 }
 

--- a/receiver/awsfirehosereceiver/factory.go
+++ b/receiver/awsfirehosereceiver/factory.go
@@ -16,6 +16,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/auto"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream"
@@ -32,6 +33,7 @@ var (
 		cwmetricstream.TypeStr:   true,
 		cwlog.TypeStr:            true,
 		otlpmetricstream.TypeStr: true,
+		auto.TypeStr:             true,
 	}
 )
 

--- a/receiver/awsfirehosereceiver/factory_test.go
+++ b/receiver/awsfirehosereceiver/factory_test.go
@@ -12,6 +12,7 @@ import (
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/auto"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream"
 )
 
@@ -46,5 +47,6 @@ func TestValidateRecordType(t *testing.T) {
 	require.NoError(t, validateRecordType(defaultMetricsRecordType))
 	require.NoError(t, validateRecordType(defaultLogsRecordType))
 	require.NoError(t, validateRecordType(otlpmetricstream.TypeStr))
+	require.NoError(t, validateRecordType(auto.TypeStr))
 	require.Error(t, validateRecordType("nop"))
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller.go
@@ -71,6 +71,8 @@ func isCloudwatchMetrics(data []byte) bool {
 	return true
 }
 
+// addCloudwatchLog unmarshalls the record to a cwlog.CWLog and adds
+// it to the logs
 func (u *Unmarshaler) addCloudwatchLog(
 	record []byte,
 	resourceLogs map[cwlog.ResourceAttributes]*cwlog.ResourceLogsBuilder,
@@ -94,6 +96,8 @@ func (u *Unmarshaler) addCloudwatchLog(
 	return nil
 }
 
+// addCloudwatchMetric unmarshalls the record to a cwmetric.CWMetric and adds
+// it to the metrics
 func (u *Unmarshaler) addCloudwatchMetric(
 	record []byte,
 	resourceMetrics map[cwmetricstream.ResourceAttributes]*cwmetricstream.ResourceMetricsBuilder,
@@ -118,6 +122,8 @@ func (u *Unmarshaler) addCloudwatchMetric(
 	return nil
 }
 
+// unmarshalJSONMetrics tries to unmarshal each JSON record as a metric
+// and returns all valid metrics
 func (u *Unmarshaler) unmarshalJSONMetrics(records [][]byte) (pmetric.Metrics, error) {
 	md := pmetric.NewMetrics()
 	resourceMetrics := make(map[cwmetricstream.ResourceAttributes]*cwmetricstream.ResourceMetricsBuilder)
@@ -162,6 +168,8 @@ func (u *Unmarshaler) unmarshalJSONMetrics(records [][]byte) (pmetric.Metrics, e
 	return md, nil
 }
 
+// unmarshalJSONLogs tries to unmarshal each JSON record as a log
+// and returns all valid logs
 func (u *Unmarshaler) unmarshalJSONLogs(records [][]byte) (plog.Logs, error) {
 	ld := plog.NewLogs()
 	resourceLogs := make(map[cwlog.ResourceAttributes]*cwlog.ResourceLogsBuilder)
@@ -207,6 +215,8 @@ func (u *Unmarshaler) unmarshalJSONLogs(records [][]byte) (plog.Logs, error) {
 	return ld, nil
 }
 
+// unmarshallProtobufMetrics tries to unmarshal every record and
+// returns all valid metrics from these records
 func (u *Unmarshaler) unmarshallProtobufMetrics(records [][]byte) (pmetric.Metrics, error) {
 	md := pmetric.NewMetrics()
 	for recordIndex, record := range records {

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller.go
@@ -51,7 +51,8 @@ func isJSON(record []byte) bool {
 	return lastIndex > 0 && record[0] == '{' && record[lastIndex] == '}'
 }
 
-// isCloudWatchLog checks if the data has the entries needed to be considered a cloudwatch log
+// isCloudWatchLog checks if the data has the entries needed to be considered a cloudwatch
+// log (struct cwlog.CWLog)
 func isCloudWatchLog(data []byte) bool {
 	if !bytes.Contains(data, []byte(`"owner":`)) {
 		return false
@@ -65,7 +66,8 @@ func isCloudWatchLog(data []byte) bool {
 	return true
 }
 
-// isCloudwatchMetrics checks if the data has the entries needed to be considered a cloudwatch metric
+// isCloudwatchMetrics checks if the data has the entries needed to be considered a cloudwatch
+// metric (struct cwmetricstream.CWMetric)
 func isCloudwatchMetrics(data []byte) bool {
 	if !bytes.Contains(data, []byte(`"metric_name":`)) {
 		return false

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller.go
@@ -1,0 +1,150 @@
+package auto
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+
+	"go.opentelemetry.io/collector/pdata/plog"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/compression"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream"
+)
+
+const (
+	TypeStr         = "auto"
+	recordDelimiter = "\n"
+)
+
+var errInvalidRecords = errors.New("record format invalid")
+
+// Unmarshaler for the CloudWatch Log JSON record format.
+type Unmarshaler struct {
+	logger *zap.Logger
+}
+
+var _ unmarshaler.Unmarshaler = (*Unmarshaler)(nil)
+
+// NewUnmarshaler creates a new instance of the Unmarshaler.
+func NewUnmarshaler(logger *zap.Logger) *Unmarshaler {
+	return &Unmarshaler{logger}
+}
+
+// isCloudWatchLog checks if the data has the entries needed to be considered a cloudwatch log
+func isCloudWatchLog(data []byte) bool {
+	if !bytes.Contains(data, []byte(`"owner":`)) {
+		return false
+	}
+	if !bytes.Contains(data, []byte(`"logGroup":`)) {
+		return false
+	}
+	if !bytes.Contains(data, []byte(`"logStream":`)) {
+		return false
+	}
+	return true
+}
+
+// isCloudwatchMetrics checks if the data has the entries needed to be considered a cloudwatch metric
+func isCloudwatchMetrics(data []byte) bool {
+	if !bytes.Contains(data, []byte(`"metric_name":`)) {
+		return false
+	}
+	if !bytes.Contains(data, []byte(`"namespace":`)) {
+		return false
+	}
+	if !bytes.Contains(data, []byte(`"unit":`)) {
+		return false
+	}
+	if !bytes.Contains(data, []byte(`"value":`)) {
+		return false
+	}
+	return true
+}
+
+func (u Unmarshaler) Unmarshal(records [][]byte) (pmetric.Metrics, plog.Logs, error) {
+	ld := plog.NewLogs()
+	resourceLogs := make(map[cwlog.ResourceAttributes]*cwlog.ResourceLogsBuilder)
+
+	md := pmetric.NewMetrics()
+	resourceMetrics := make(map[cwmetricstream.ResourceAttributes]*cwmetricstream.ResourceMetricsBuilder)
+
+	for i, compressed := range records {
+		record, err := compression.Unzip(compressed)
+		if err != nil {
+			u.logger.Error("Failed to unzip record",
+				zap.Error(err),
+				zap.Int("record_index", i),
+			)
+			continue
+		}
+		// Multiple metrics/logs in each record separated by newline character
+		for j, single := range bytes.Split(record, []byte(recordDelimiter)) {
+			if len(single) == 0 {
+				continue
+			}
+
+			if isCloudWatchLog(single) {
+				var log cwlog.CWLog
+				if err = json.Unmarshal(single, &log); err != nil {
+					u.logger.Error(
+						"Unable to unmarshal record to cloudwatch log",
+						zap.Error(err),
+						zap.Int("record_index", i),
+						zap.Int("single_index", j),
+					)
+					continue
+				}
+				attrs := cwlog.ResourceAttributes{
+					Owner:     log.Owner,
+					LogGroup:  log.LogGroup,
+					LogStream: log.LogStream,
+				}
+				lb, exists := resourceLogs[attrs]
+				if !exists {
+					lb = cwlog.NewResourceLogsBuilder(ld, attrs)
+					resourceLogs[attrs] = lb
+				}
+				lb.AddLog(log)
+			}
+
+			if isCloudwatchMetrics(single) {
+				var metric cwmetricstream.CWMetric
+				if err = json.Unmarshal(single, &metric); err != nil {
+					u.logger.Error(
+						"Unable to unmarshal input",
+						zap.Error(err),
+						zap.Int("single_index", j),
+						zap.Int("record_index", i),
+					)
+					continue
+				}
+				attrs := cwmetricstream.ResourceAttributes{
+					MetricStreamName: metric.MetricStreamName,
+					Namespace:        metric.Namespace,
+					AccountID:        metric.AccountID,
+					Region:           metric.Region,
+				}
+				mb, exists := resourceMetrics[attrs]
+				if !exists {
+					mb = cwmetricstream.NewResourceMetricsBuilder(md, attrs)
+					resourceMetrics[attrs] = mb
+				}
+				mb.AddMetric(metric)
+			}
+		}
+	}
+
+	if len(resourceLogs) == 0 && len(resourceMetrics) == 0 {
+		return md, ld, errInvalidRecords
+	}
+
+	return md, ld, nil
+}
+
+func (u Unmarshaler) Type() string {
+	return TypeStr
+}

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
@@ -1,0 +1,138 @@
+package auto
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
+	"go.uber.org/zap"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/compression"
+)
+
+func TestType(t *testing.T) {
+	unmarshaler := NewUnmarshaler(zap.NewExample())
+	require.Equal(t, TypeStr, unmarshaler.Type())
+}
+
+// Unmarshall cloudwatch metrics and logs
+func TestUnmarshal_CW(t *testing.T) {
+	unmarshaler := NewUnmarshaler(zap.NewNop())
+
+	testCases := map[string]struct {
+		dir                  string
+		filename             string
+		logResourceCount     int
+		logRecordCount       int
+		metricResourceCount  int
+		metricCount          int
+		metricDataPointCount int
+		err                  error
+	}{
+		"cwlog:WithMultipleRecords": {
+			dir:              "cwlog",
+			filename:         "multiple_records",
+			logResourceCount: 1,
+			logRecordCount:   2,
+		},
+		"cwlog:WithSingleRecord": {
+			dir:              "cwlog",
+			filename:         "single_record",
+			logResourceCount: 1,
+			logRecordCount:   1,
+		},
+		"cwlog:WithInvalidRecords": {
+			dir:      "cwlog",
+			filename: "invalid_records",
+			err:      errInvalidRecords,
+		},
+		"cwlog:WithSomeInvalidRecords": {
+			dir:              "cwlog",
+			filename:         "some_invalid_records",
+			logResourceCount: 1,
+			logRecordCount:   2,
+		},
+		"cwlog:WithMultipleResources": {
+			dir:              "cwlog",
+			filename:         "multiple_resources",
+			logResourceCount: 3,
+			logRecordCount:   6,
+		},
+		"cwmetric:WithMultipleRecords": {
+			dir:                  "cwmetricstream",
+			filename:             "multiple_records",
+			metricResourceCount:  6,
+			metricCount:          33,
+			metricDataPointCount: 127,
+		},
+		"cwmetric:WithSingleRecord": {
+			dir:                  "cwmetricstream",
+			filename:             "single_record",
+			metricResourceCount:  1,
+			metricCount:          1,
+			metricDataPointCount: 1,
+		},
+		"cwmetric:WithInvalidRecords": {
+			dir:      "cwmetricstream",
+			filename: "invalid_records",
+			err:      errInvalidRecords,
+		},
+		"cwmetric:WithSomeInvalidRecords": {
+			dir:                  "cwmetricstream",
+			filename:             "some_invalid_records",
+			metricResourceCount:  5,
+			metricCount:          35,
+			metricDataPointCount: 88,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			record, err := os.ReadFile(filepath.Join("..", testCase.dir, "testdata", testCase.filename))
+			require.NoError(t, err)
+
+			compressedRecord, err := compression.Zip(record)
+			require.NoError(t, err)
+			records := [][]byte{compressedRecord}
+
+			metrics, logs, err := unmarshaler.Unmarshal(records)
+			require.Equal(t, testCase.err, err)
+
+			require.Equal(t, testCase.logResourceCount, logs.ResourceLogs().Len())
+			require.Equal(t, testCase.logRecordCount, logs.LogRecordCount())
+
+			require.Equal(t, testCase.metricResourceCount, metrics.ResourceMetrics().Len())
+			require.Equal(t, testCase.metricDataPointCount, metrics.DataPointCount())
+			require.Equal(t, testCase.metricCount, metrics.MetricCount())
+		})
+	}
+
+}
+
+func createMetricRecord() []byte {
+	er := pmetricotlp.NewExportRequest()
+	rsm := er.Metrics().ResourceMetrics().AppendEmpty()
+	sm := rsm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	sm.SetName("TestMetric")
+	dp := sm.SetEmptySummary().DataPoints().AppendEmpty()
+	dp.SetCount(1)
+	dp.SetSum(1)
+	qv := dp.QuantileValues()
+	min := qv.AppendEmpty()
+	min.SetQuantile(0)
+	min.SetValue(0)
+	max := qv.AppendEmpty()
+	max.SetQuantile(1)
+	max.SetValue(1)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	temp, _ := er.MarshalProto()
+	record := proto.EncodeVarint(uint64(len(temp)))
+	record = append(record, temp...)
+	return record
+}

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
@@ -17,9 +17,10 @@ func TestType(t *testing.T) {
 }
 
 // Unmarshall cloudwatch metrics and logs
-func TestUnmarshal_CW(t *testing.T) {
-	unmarshaler := NewUnmarshaler(zap.NewNop())
+func TestUnmarshal_JSON(t *testing.T) {
+	t.Parallel()
 
+	unmarshaler := NewUnmarshaler(zap.NewNop())
 	testCases := map[string]struct {
 		dir                  string
 		filename             string
@@ -96,7 +97,7 @@ func TestUnmarshal_CW(t *testing.T) {
 			require.NoError(t, err)
 			records := [][]byte{compressedRecord}
 
-			metrics, logs, err := unmarshaler.Unmarshal(records)
+			metrics, logs, err := unmarshaler.Unmarshal("application/json", records)
 			require.Equal(t, testCase.err, err)
 
 			require.Equal(t, testCase.logResourceCount, logs.ResourceLogs().Len())

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
@@ -164,6 +164,8 @@ func createMetricRecord() []byte {
 }
 
 func TestUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	unmarshaler := NewUnmarshaler(zap.NewNop())
 	testCases := map[string]struct {
 		records            [][]byte

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
@@ -4,12 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/collector/pdata/pcommon"
-	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/compression"
@@ -112,27 +108,4 @@ func TestUnmarshal_CW(t *testing.T) {
 		})
 	}
 
-}
-
-func createMetricRecord() []byte {
-	er := pmetricotlp.NewExportRequest()
-	rsm := er.Metrics().ResourceMetrics().AppendEmpty()
-	sm := rsm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	sm.SetName("TestMetric")
-	dp := sm.SetEmptySummary().DataPoints().AppendEmpty()
-	dp.SetCount(1)
-	dp.SetSum(1)
-	qv := dp.QuantileValues()
-	min := qv.AppendEmpty()
-	min.SetQuantile(0)
-	min.SetValue(0)
-	max := qv.AppendEmpty()
-	max.SetQuantile(1)
-	max.SetValue(1)
-	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
-
-	temp, _ := er.MarshalProto()
-	record := proto.EncodeVarint(uint64(len(temp)))
-	record = append(record, temp...)
-	return record
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
@@ -4,8 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric/pmetricotlp"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/compression"
@@ -132,6 +136,93 @@ func TestUnmarshalLogs_JSON(t *testing.T) {
 
 			require.Equal(t, testCase.logResourceCount, logs.ResourceLogs().Len())
 			require.Equal(t, testCase.logRecordCount, logs.LogRecordCount())
+		})
+	}
+}
+
+func createMetricRecord() []byte {
+	er := pmetricotlp.NewExportRequest()
+	rsm := er.Metrics().ResourceMetrics().AppendEmpty()
+	sm := rsm.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	sm.SetName("TestMetric")
+	dp := sm.SetEmptySummary().DataPoints().AppendEmpty()
+	dp.SetCount(1)
+	dp.SetSum(1)
+	qv := dp.QuantileValues()
+	min := qv.AppendEmpty()
+	min.SetQuantile(0)
+	min.SetValue(0)
+	max := qv.AppendEmpty()
+	max.SetQuantile(1)
+	max.SetValue(1)
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
+
+	temp, _ := er.MarshalProto()
+	record := proto.EncodeVarint(uint64(len(temp)))
+	record = append(record, temp...)
+	return record
+}
+
+func TestUnmarshal(t *testing.T) {
+	unmarshaler := NewUnmarshaler(zap.NewNop())
+	testCases := map[string]struct {
+		records            [][]byte
+		wantResourceCount  int
+		wantMetricCount    int
+		wantDatapointCount int
+		wantErr            error
+	}{
+		"WithSingleRecord": {
+			records: [][]byte{
+				createMetricRecord(),
+			},
+			wantResourceCount:  1,
+			wantMetricCount:    1,
+			wantDatapointCount: 1,
+		},
+		"WithMultipleRecords": {
+			records: [][]byte{
+				createMetricRecord(),
+				createMetricRecord(),
+				createMetricRecord(),
+				createMetricRecord(),
+				createMetricRecord(),
+				createMetricRecord(),
+			},
+			wantResourceCount:  6,
+			wantMetricCount:    6,
+			wantDatapointCount: 6,
+		},
+		"WithEmptyRecord": {
+			records:            make([][]byte, 0),
+			wantResourceCount:  0,
+			wantMetricCount:    0,
+			wantDatapointCount: 0,
+		},
+		"WithInvalidRecords": {
+			records:            [][]byte{{1, 2}},
+			wantResourceCount:  0,
+			wantMetricCount:    0,
+			wantDatapointCount: 0,
+		},
+		"WithSomeInvalidRecords": {
+			records: [][]byte{
+				createMetricRecord(),
+				{1, 2},
+				createMetricRecord(),
+			},
+			wantResourceCount:  2,
+			wantMetricCount:    2,
+			wantDatapointCount: 2,
+		},
+	}
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			got, err := unmarshaler.UnmarshalMetrics("application/x-protobuf", testCase.records)
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())
+			require.Equal(t, testCase.wantMetricCount, got.MetricCount())
+			require.Equal(t, testCase.wantDatapointCount, got.DataPointCount())
 		})
 	}
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
@@ -16,50 +16,18 @@ func TestType(t *testing.T) {
 	require.Equal(t, TypeStr, unmarshaler.Type())
 }
 
-// Unmarshall cloudwatch metrics and logs
-func TestUnmarshal_JSON(t *testing.T) {
+func TestUnmarshalMetrics_JSON(t *testing.T) {
 	t.Parallel()
 
 	unmarshaler := NewUnmarshaler(zap.NewNop())
 	testCases := map[string]struct {
 		dir                  string
 		filename             string
-		logResourceCount     int
-		logRecordCount       int
 		metricResourceCount  int
 		metricCount          int
 		metricDataPointCount int
 		err                  error
 	}{
-		"cwlog:WithMultipleRecords": {
-			dir:              "cwlog",
-			filename:         "multiple_records",
-			logResourceCount: 1,
-			logRecordCount:   2,
-		},
-		"cwlog:WithSingleRecord": {
-			dir:              "cwlog",
-			filename:         "single_record",
-			logResourceCount: 1,
-			logRecordCount:   1,
-		},
-		"cwlog:WithInvalidRecords": {
-			dir:      "cwlog",
-			filename: "invalid_records",
-			err:      errInvalidRecords,
-		},
-		"cwlog:WithSomeInvalidRecords": {
-			dir:              "cwlog",
-			filename:         "some_invalid_records",
-			logResourceCount: 1,
-			logRecordCount:   2,
-		},
-		"cwlog:WithMultipleResources": {
-			dir:              "cwlog",
-			filename:         "multiple_resources",
-			logResourceCount: 3,
-			logRecordCount:   6,
-		},
 		"cwmetric:WithMultipleRecords": {
 			dir:                  "cwmetricstream",
 			filename:             "multiple_records",
@@ -97,16 +65,73 @@ func TestUnmarshal_JSON(t *testing.T) {
 			require.NoError(t, err)
 			records := [][]byte{compressedRecord}
 
-			metrics, logs, err := unmarshaler.Unmarshal("application/json", records)
+			metrics, err := unmarshaler.UnmarshalMetrics("application/json", records)
 			require.Equal(t, testCase.err, err)
-
-			require.Equal(t, testCase.logResourceCount, logs.ResourceLogs().Len())
-			require.Equal(t, testCase.logRecordCount, logs.LogRecordCount())
 
 			require.Equal(t, testCase.metricResourceCount, metrics.ResourceMetrics().Len())
 			require.Equal(t, testCase.metricDataPointCount, metrics.DataPointCount())
 			require.Equal(t, testCase.metricCount, metrics.MetricCount())
 		})
 	}
+}
 
+// Unmarshall cloudwatch metrics and logs
+func TestUnmarshalLogs_JSON(t *testing.T) {
+	t.Parallel()
+
+	unmarshaler := NewUnmarshaler(zap.NewNop())
+	testCases := map[string]struct {
+		dir              string
+		filename         string
+		logResourceCount int
+		logRecordCount   int
+		err              error
+	}{
+		"cwlog:WithMultipleRecords": {
+			dir:              "cwlog",
+			filename:         "multiple_records",
+			logResourceCount: 1,
+			logRecordCount:   2,
+		},
+		"cwlog:WithSingleRecord": {
+			dir:              "cwlog",
+			filename:         "single_record",
+			logResourceCount: 1,
+			logRecordCount:   1,
+		},
+		"cwlog:WithInvalidRecords": {
+			dir:      "cwlog",
+			filename: "invalid_records",
+			err:      errInvalidRecords,
+		},
+		"cwlog:WithSomeInvalidRecords": {
+			dir:              "cwlog",
+			filename:         "some_invalid_records",
+			logResourceCount: 1,
+			logRecordCount:   2,
+		},
+		"cwlog:WithMultipleResources": {
+			dir:              "cwlog",
+			filename:         "multiple_resources",
+			logResourceCount: 3,
+			logRecordCount:   6,
+		},
+	}
+
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			record, err := os.ReadFile(filepath.Join("..", testCase.dir, "testdata", testCase.filename))
+			require.NoError(t, err)
+
+			compressedRecord, err := compression.Zip(record)
+			require.NoError(t, err)
+			records := [][]byte{compressedRecord}
+
+			logs, err := unmarshaler.UnmarshalLogs("application/json", records)
+			require.Equal(t, testCase.err, err)
+
+			require.Equal(t, testCase.logResourceCount, logs.ResourceLogs().Len())
+			require.Equal(t, testCase.logRecordCount, logs.LogRecordCount())
+		})
+	}
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/auto/unmarshaller_test.go
@@ -1,7 +1,6 @@
 package auto
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -61,13 +60,10 @@ func TestUnmarshalMetrics_JSON(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			data, err := os.ReadFile(filepath.Join("..", testCase.dir, "testdata", testCase.filename))
+			record, err := os.ReadFile(filepath.Join("..", testCase.dir, "testdata", testCase.filename))
 			require.NoError(t, err)
 
-			var records [][]byte
-			for _, record := range bytes.Split(data, []byte("\n")) {
-				records = append(records, record)
-			}
+			records := [][]byte{record}
 
 			metrics, err := unmarshaler.UnmarshalMetrics(records)
 			require.Equal(t, testCase.err, err)
@@ -83,7 +79,7 @@ func TestUnmarshalMetrics_JSON(t *testing.T) {
 func TestUnmarshalLogs_JSON(t *testing.T) {
 	t.Parallel()
 
-	unmarshaler := NewUnmarshaler(zap.NewNop())
+	unmarshaler := NewUnmarshaler(zap.NewExample())
 	testCases := map[string]struct {
 		dir              string
 		filename         string
@@ -124,13 +120,10 @@ func TestUnmarshalLogs_JSON(t *testing.T) {
 
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			data, err := os.ReadFile(filepath.Join("..", testCase.dir, "testdata", testCase.filename))
+			record, err := os.ReadFile(filepath.Join("..", testCase.dir, "testdata", testCase.filename))
 			require.NoError(t, err)
 
-			var records [][]byte
-			for _, record := range bytes.Split(data, []byte("\n")) {
-				records = append(records, record)
-			}
+			records := [][]byte{record}
 
 			logs, err := unmarshaler.UnmarshalLogs(records)
 			require.Equal(t, testCase.err, err)

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/compression/compression.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/compression/compression.go
@@ -18,10 +18,7 @@ func Zip(data []byte) ([]byte, error) {
 		return nil, err
 	}
 
-	if err = w.Flush(); err != nil {
-		return nil, err
-	}
-
+	//Close handles flushing.
 	if err = w.Close(); err != nil {
 		return nil, err
 	}
@@ -37,6 +34,7 @@ func Unzip(data []byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer r.Close()
 
 	var rv bytes.Buffer
 	_, err = rv.ReadFrom(r)

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/cwlog.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/cwlog.go
@@ -3,7 +3,7 @@
 
 package cwlog // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog"
 
-type cWLog struct {
+type CWLog struct {
 	MessageType         string   `json:"messageType"`
 	Owner               string   `json:"owner"`
 	LogGroup            string   `json:"logGroup"`

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/logsbuilder.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/logsbuilder.go
@@ -16,34 +16,36 @@ const (
 	attributeAWSCloudWatchLogStreamName = "aws.cloudwatch.log_stream_name"
 )
 
-// resourceAttributes are the CloudWatch log attributes that define a unique resource.
-type resourceAttributes struct {
-	owner, logGroup, logStream string
+// ResourceAttributes are the CloudWatch log attributes that define a unique resource.
+type ResourceAttributes struct {
+	Owner     string
+	LogGroup  string
+	LogStream string
 }
 
-// resourceLogsBuilder provides convenient access to the a Resource's LogRecordSlice.
-type resourceLogsBuilder struct {
+// ResourceLogsBuilder provides convenient access to a Resource's LogRecordSlice.
+type ResourceLogsBuilder struct {
 	rls plog.LogRecordSlice
 }
 
-// setAttributes applies the resourceAttributes to the provided Resource.
-func (ra *resourceAttributes) setAttributes(resource pcommon.Resource) {
+// setAttributes applies the ResourceAttributes to the provided Resource.
+func (ra *ResourceAttributes) setAttributes(resource pcommon.Resource) {
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudAccountID, ra.owner)
-	attrs.PutStr(attributeAWSCloudWatchLogGroupName, ra.logGroup)
-	attrs.PutStr(attributeAWSCloudWatchLogStreamName, ra.logStream)
+	attrs.PutStr(conventions.AttributeCloudAccountID, ra.Owner)
+	attrs.PutStr(attributeAWSCloudWatchLogGroupName, ra.LogGroup)
+	attrs.PutStr(attributeAWSCloudWatchLogStreamName, ra.LogStream)
 }
 
-// newResourceLogsBuilder to capture logs for the Resource defined by the provided attributes.
-func newResourceLogsBuilder(logs plog.Logs, attrs resourceAttributes) *resourceLogsBuilder {
+// NewResourceLogsBuilder to capture logs for the Resource defined by the provided attributes.
+func NewResourceLogsBuilder(logs plog.Logs, attrs ResourceAttributes) *ResourceLogsBuilder {
 	rls := logs.ResourceLogs().AppendEmpty()
 	attrs.setAttributes(rls.Resource())
-	return &resourceLogsBuilder{rls.ScopeLogs().AppendEmpty().LogRecords()}
+	return &ResourceLogsBuilder{rls.ScopeLogs().AppendEmpty().LogRecords()}
 }
 
 // AddLog events to the LogRecordSlice. Resource attributes are captured when creating
-// the resourceLogsBuilder, so we only need to consider the LogEvents themselves.
-func (rlb *resourceLogsBuilder) AddLog(log cWLog) {
+// the ResourceLogsBuilder, so we only need to consider the LogEvents themselves.
+func (rlb *ResourceLogsBuilder) AddLog(log CWLog) {
 	for _, event := range log.LogEvents {
 		logLine := rlb.rls.AppendEmpty()
 		// pcommon.Timestamp is a time specified as UNIX Epoch time in nanoseconds

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler.go
@@ -34,10 +34,10 @@ func NewUnmarshaler(logger *zap.Logger) *Unmarshaler {
 	return &Unmarshaler{logger}
 }
 
-// Unmarshal deserializes the records into cWLogs and uses the
+// UnmarshalLogs deserializes the records into CWLog and uses the
 // ResourceLogsBuilder to group them into a single plog.Logs.
-// Skips invalid cWLogs received in the record.
-func (u Unmarshaler) Unmarshal(records [][]byte) (plog.Logs, error) {
+// Skips invalid CWLog received in the record.
+func (u Unmarshaler) UnmarshalLogs(_ string, records [][]byte) (plog.Logs, error) {
 	md := plog.NewLogs()
 	builders := make(map[ResourceAttributes]*ResourceLogsBuilder)
 	for recordIndex, compressedRecord := range records {

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
@@ -61,7 +61,7 @@ func TestUnmarshal(t *testing.T) {
 			require.NoError(t, err)
 			records := [][]byte{compressedRecord}
 
-			got, err := unmarshaler.Unmarshal(records)
+			got, err := unmarshaler.UnmarshalLogs("", records)
 			require.Equal(t, testCase.wantErr, err)
 			require.NotNil(t, got)
 			require.Equal(t, testCase.wantResourceCount, got.ResourceLogs().Len())
@@ -79,7 +79,7 @@ func TestLogTimestamp(t *testing.T) {
 	require.NoError(t, err)
 	records := [][]byte{compressedRecord}
 
-	got, err := unmarshaler.Unmarshal(records)
+	got, err := unmarshaler.UnmarshalLogs("", records)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, 1, got.ResourceLogs().Len())

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
@@ -4,7 +4,6 @@
 package cwlog
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,13 +52,10 @@ func TestUnmarshal(t *testing.T) {
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			data, err := os.ReadFile(filepath.Join(".", "testdata", testCase.filename))
+			record, err := os.ReadFile(filepath.Join(".", "testdata", testCase.filename))
 			require.NoError(t, err)
 
-			var records [][]byte
-			for _, record := range bytes.Split(data, []byte("\n")) {
-				records = append(records, record)
-			}
+			records := [][]byte{record}
 
 			got, err := unmarshaler.UnmarshalLogs(records)
 			require.Equal(t, testCase.wantErr, err)

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/unmarshaler_test.go
@@ -62,22 +62,10 @@ func TestUnmarshal(t *testing.T) {
 			records := [][]byte{compressedRecord}
 
 			got, err := unmarshaler.Unmarshal(records)
-			if testCase.wantErr != nil {
-				require.Error(t, err)
-				require.Equal(t, testCase.wantErr, err)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, got)
-				require.Equal(t, testCase.wantResourceCount, got.ResourceLogs().Len())
-				gotLogCount := 0
-				for i := 0; i < got.ResourceLogs().Len(); i++ {
-					rm := got.ResourceLogs().At(i)
-					require.Equal(t, 1, rm.ScopeLogs().Len())
-					ilm := rm.ScopeLogs().At(0)
-					gotLogCount += ilm.LogRecords().Len()
-				}
-				require.Equal(t, testCase.wantLogCount, gotLogCount)
-			}
+			require.Equal(t, testCase.wantErr, err)
+			require.NotNil(t, got)
+			require.Equal(t, testCase.wantResourceCount, got.ResourceLogs().Len())
+			require.Equal(t, testCase.wantLogCount, got.LogRecordCount())
 		})
 	}
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/cwmetric.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/cwmetric.go
@@ -24,9 +24,9 @@ type CWMetric struct {
 	// Timestamp is the milliseconds since epoch for
 	// the metric.
 	Timestamp int64 `json:"timestamp"`
-	// Value is the cWMetricValue, which has the min, max,
+	// Value is the CWMetricValue, which has the min, max,
 	// sum, and count.
-	Value *cWMetricValue `json:"value"`
+	Value *CWMetricValue `json:"value"`
 	// Unit is the unit for the metric.
 	//
 	// More details can be found at:
@@ -34,8 +34,8 @@ type CWMetric struct {
 	Unit string `json:"unit"`
 }
 
-// The cWMetricValue is the actual values of the CloudWatch metric.
-type cWMetricValue struct {
+// The CWMetricValue is the actual values of the CloudWatch metric.
+type CWMetricValue struct {
 	// Max is the highest value observed.
 	Max float64 `json:"max"`
 	// Min is the lowest value observed.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/cwmetric.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/cwmetric.go
@@ -3,11 +3,11 @@
 
 package cwmetricstream // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream"
 
-// The cWMetric is the format for the CloudWatch metric stream records.
+// The CWMetric is the format for the CloudWatch metric stream records.
 //
 // More details can be found at:
 // https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-metric-streams-formats-json.html
-type cWMetric struct {
+type CWMetric struct {
 	// MetricStreamName is the name of the CloudWatch metric stream.
 	MetricStreamName string `json:"metric_stream_name"`
 	// AccountID is the AWS account ID associated with the metric.

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
@@ -45,7 +45,7 @@ func TestToSemConvAttributeKey(t *testing.T) {
 
 func TestMetricBuilder(t *testing.T) {
 	t.Run("WithSingleMetric", func(t *testing.T) {
-		metric := cWMetric{
+		metric := CWMetric{
 			MetricName: "name",
 			Unit:       "unit",
 			Timestamp:  time.Now().UnixMilli(),
@@ -72,7 +72,7 @@ func TestMetricBuilder(t *testing.T) {
 	})
 	t.Run("WithTimestampCollision", func(t *testing.T) {
 		timestamp := time.Now().UnixMilli()
-		metrics := []cWMetric{
+		metrics := []CWMetric{
 			{
 				Timestamp: timestamp,
 				Value:     testCWMetricValue(),
@@ -136,21 +136,21 @@ func TestResourceMetricsBuilder(t *testing.T) {
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			metric := cWMetric{
+			metric := CWMetric{
 				MetricName: "name",
 				Unit:       "unit",
 				Timestamp:  time.Now().UnixMilli(),
 				Value:      testCWMetricValue(),
 				Dimensions: map[string]string{},
 			}
-			attrs := resourceAttributes{
-				metricStreamName: testStreamName,
-				accountID:        testAccountID,
-				region:           testRegion,
-				namespace:        testCase.namespace,
+			attrs := ResourceAttributes{
+				MetricStreamName: testStreamName,
+				AccountID:        testAccountID,
+				Region:           testRegion,
+				Namespace:        testCase.namespace,
 			}
 			gots := pmetric.NewMetrics()
-			rmb := newResourceMetricsBuilder(gots, attrs)
+			rmb := NewResourceMetricsBuilder(gots, attrs)
 			rmb.AddMetric(metric)
 			require.Equal(t, 1, gots.ResourceMetrics().Len())
 			got := gots.ResourceMetrics().At(0)
@@ -167,7 +167,7 @@ func TestResourceMetricsBuilder(t *testing.T) {
 		})
 	}
 	t.Run("WithSameMetricDifferentDimensions", func(t *testing.T) {
-		metrics := []cWMetric{
+		metrics := []CWMetric{
 			{
 				MetricName: "name",
 				Unit:       "unit",
@@ -185,14 +185,14 @@ func TestResourceMetricsBuilder(t *testing.T) {
 				},
 			},
 		}
-		attrs := resourceAttributes{
-			metricStreamName: testStreamName,
-			accountID:        testAccountID,
-			region:           testRegion,
-			namespace:        "AWS/EC2",
+		attrs := ResourceAttributes{
+			MetricStreamName: testStreamName,
+			AccountID:        testAccountID,
+			Region:           testRegion,
+			Namespace:        "AWS/EC2",
 		}
 		gots := pmetric.NewMetrics()
-		rmb := newResourceMetricsBuilder(gots, attrs)
+		rmb := NewResourceMetricsBuilder(gots, attrs)
 		for _, metric := range metrics {
 			rmb.AddMetric(metric)
 		}

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/metricsbuilder_test.go
@@ -206,7 +206,7 @@ func TestResourceMetricsBuilder(t *testing.T) {
 	})
 }
 
-// testCWMetricValue is a convenience function for creating a test cWMetricValue
-func testCWMetricValue() *cWMetricValue {
-	return &cWMetricValue{100, 0, float64(rand.Int63n(100)), float64(rand.Int63n(4))}
+// testCWMetricValue is a convenience function for creating a test CWMetricValue
+func testCWMetricValue() *CWMetricValue {
+	return &CWMetricValue{100, 0, float64(rand.Int63n(100)), float64(rand.Int63n(4))}
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
@@ -36,10 +36,10 @@ func NewUnmarshaler(logger *zap.Logger) *Unmarshaler {
 	return &Unmarshaler{logger}
 }
 
-// Unmarshal deserializes the records into cWMetrics and uses the
+// UnmarshalMetrics deserializes the records into CWMetric and uses the
 // ResourceMetricsBuilder to group them into a single pmetric.Metrics.
-// Skips invalid cWMetrics received in the record and
-func (u Unmarshaler) Unmarshal(records [][]byte) (pmetric.Metrics, error) {
+// Skips invalid CWMetric received in the record.
+func (u Unmarshaler) UnmarshalMetrics(_ string, records [][]byte) (pmetric.Metrics, error) {
 	md := pmetric.NewMetrics()
 	builders := make(map[ResourceAttributes]*ResourceMetricsBuilder)
 	for recordIndex, record := range records {

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler.go
@@ -37,16 +37,16 @@ func NewUnmarshaler(logger *zap.Logger) *Unmarshaler {
 }
 
 // Unmarshal deserializes the records into cWMetrics and uses the
-// resourceMetricsBuilder to group them into a single pmetric.Metrics.
+// ResourceMetricsBuilder to group them into a single pmetric.Metrics.
 // Skips invalid cWMetrics received in the record and
 func (u Unmarshaler) Unmarshal(records [][]byte) (pmetric.Metrics, error) {
 	md := pmetric.NewMetrics()
-	builders := make(map[resourceAttributes]*resourceMetricsBuilder)
+	builders := make(map[ResourceAttributes]*ResourceMetricsBuilder)
 	for recordIndex, record := range records {
 		// Multiple metrics in each record separated by newline character
 		for datumIndex, datum := range bytes.Split(record, []byte(recordDelimiter)) {
 			if len(datum) > 0 {
-				var metric cWMetric
+				var metric CWMetric
 				err := json.Unmarshal(datum, &metric)
 				if err != nil {
 					u.logger.Error(
@@ -65,15 +65,15 @@ func (u Unmarshaler) Unmarshal(records [][]byte) (pmetric.Metrics, error) {
 					)
 					continue
 				}
-				attrs := resourceAttributes{
-					metricStreamName: metric.MetricStreamName,
-					namespace:        metric.Namespace,
-					accountID:        metric.AccountID,
-					region:           metric.Region,
+				attrs := ResourceAttributes{
+					MetricStreamName: metric.MetricStreamName,
+					Namespace:        metric.Namespace,
+					AccountID:        metric.AccountID,
+					Region:           metric.Region,
 				}
 				mb, ok := builders[attrs]
 				if !ok {
-					mb = newResourceMetricsBuilder(md, attrs)
+					mb = NewResourceMetricsBuilder(md, attrs)
 					builders[attrs] = mb
 				}
 				mb.AddMetric(metric)
@@ -88,8 +88,8 @@ func (u Unmarshaler) Unmarshal(records [][]byte) (pmetric.Metrics, error) {
 	return md, nil
 }
 
-// isValid validates that the cWMetric has been unmarshalled correctly.
-func (u Unmarshaler) isValid(metric cWMetric) bool {
+// isValid validates that the CWMetric has been unmarshalled correctly.
+func (u Unmarshaler) isValid(metric CWMetric) bool {
 	return metric.MetricName != "" && metric.Namespace != "" && metric.Unit != "" && metric.Value != nil
 }
 

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
@@ -57,28 +57,11 @@ func TestUnmarshal(t *testing.T) {
 			records := [][]byte{record}
 
 			got, err := unmarshaler.Unmarshal(records)
-			if testCase.wantErr != nil {
-				require.Error(t, err)
-				require.Equal(t, testCase.wantErr, err)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, got)
-				require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())
-				gotMetricCount := 0
-				gotDatapointCount := 0
-				for i := 0; i < got.ResourceMetrics().Len(); i++ {
-					rm := got.ResourceMetrics().At(i)
-					require.Equal(t, 1, rm.ScopeMetrics().Len())
-					ilm := rm.ScopeMetrics().At(0)
-					gotMetricCount += ilm.Metrics().Len()
-					for j := 0; j < ilm.Metrics().Len(); j++ {
-						metric := ilm.Metrics().At(j)
-						gotDatapointCount += metric.Summary().DataPoints().Len()
-					}
-				}
-				require.Equal(t, testCase.wantMetricCount, gotMetricCount)
-				require.Equal(t, testCase.wantDatapointCount, gotDatapointCount)
-			}
+			require.Equal(t, testCase.wantErr, err)
+			require.NotNil(t, got)
+			require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())
+			require.Equal(t, testCase.wantMetricCount, got.MetricCount())
+			require.Equal(t, testCase.wantDatapointCount, got.DataPointCount())
 		})
 	}
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
@@ -56,7 +56,7 @@ func TestUnmarshal(t *testing.T) {
 
 			records := [][]byte{record}
 
-			got, err := unmarshaler.Unmarshal(records)
+			got, err := unmarshaler.UnmarshalMetrics("", records)
 			require.Equal(t, testCase.wantErr, err)
 			require.NotNil(t, got)
 			require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
@@ -4,7 +4,6 @@
 package cwmetricstream
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -52,13 +51,10 @@ func TestUnmarshal(t *testing.T) {
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			data, err := os.ReadFile(filepath.Join(".", "testdata", testCase.filename))
+			record, err := os.ReadFile(filepath.Join(".", "testdata", testCase.filename))
 			require.NoError(t, err)
 
-			var records [][]byte
-			for _, record := range bytes.Split(data, []byte("\n")) {
-				records = append(records, record)
-			}
+			records := [][]byte{record}
 
 			got, err := unmarshaler.UnmarshalMetrics(records)
 			require.Equal(t, testCase.wantErr, err)

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/cwmetricstream/unmarshaler_test.go
@@ -4,6 +4,7 @@
 package cwmetricstream
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -51,12 +52,15 @@ func TestUnmarshal(t *testing.T) {
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			record, err := os.ReadFile(filepath.Join(".", "testdata", testCase.filename))
+			data, err := os.ReadFile(filepath.Join(".", "testdata", testCase.filename))
 			require.NoError(t, err)
 
-			records := [][]byte{record}
+			var records [][]byte
+			for _, record := range bytes.Split(data, []byte("\n")) {
+				records = append(records, record)
+			}
 
-			got, err := unmarshaler.UnmarshalMetrics("", records)
+			got, err := unmarshaler.UnmarshalMetrics(records)
 			require.Equal(t, testCase.wantErr, err)
 			require.NotNil(t, got)
 			require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler.go
@@ -36,8 +36,8 @@ func NewUnmarshaler(logger *zap.Logger) *Unmarshaler {
 	return &Unmarshaler{logger}
 }
 
-// Unmarshal deserializes the records into pmetric.Metrics
-func (u Unmarshaler) Unmarshal(records [][]byte) (pmetric.Metrics, error) {
+// UnmarshalMetrics deserializes the records into pmetric.Metrics
+func (u Unmarshaler) UnmarshalMetrics(_ string, records [][]byte) (pmetric.Metrics, error) {
 	md := pmetric.NewMetrics()
 	for recordIndex, record := range records {
 		dataLen, pos := len(record), 0

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler.go
@@ -37,7 +37,7 @@ func NewUnmarshaler(logger *zap.Logger) *Unmarshaler {
 }
 
 // UnmarshalMetrics deserializes the records into pmetric.Metrics
-func (u Unmarshaler) UnmarshalMetrics(_ string, records [][]byte) (pmetric.Metrics, error) {
+func (u Unmarshaler) UnmarshalMetrics(records [][]byte) (pmetric.Metrics, error) {
 	md := pmetric.NewMetrics()
 	for recordIndex, record := range records {
 		dataLen, pos := len(record), 0

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler_test.go
@@ -98,28 +98,10 @@ func TestUnmarshal(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			got, err := unmarshaler.Unmarshal(testCase.records)
-			if testCase.wantErr != nil {
-				require.Error(t, err)
-				require.Equal(t, testCase.wantErr, err)
-			} else {
-				require.NoError(t, err)
-				require.NotNil(t, got)
-				require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())
-				gotMetricCount := 0
-				gotDatapointCount := 0
-				for i := 0; i < got.ResourceMetrics().Len(); i++ {
-					rm := got.ResourceMetrics().At(i)
-					require.Equal(t, 1, rm.ScopeMetrics().Len())
-					ilm := rm.ScopeMetrics().At(0)
-					gotMetricCount += ilm.Metrics().Len()
-					for j := 0; j < ilm.Metrics().Len(); j++ {
-						metric := ilm.Metrics().At(j)
-						gotDatapointCount += metric.Summary().DataPoints().Len()
-					}
-				}
-				require.Equal(t, testCase.wantMetricCount, gotMetricCount)
-				require.Equal(t, testCase.wantDatapointCount, gotDatapointCount)
-			}
+			require.NoError(t, err)
+			require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())
+			require.Equal(t, testCase.wantMetricCount, got.MetricCount())
+			require.Equal(t, testCase.wantDatapointCount, got.DataPointCount())
 		})
 	}
 }

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler_test.go
@@ -97,7 +97,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, err := unmarshaler.UnmarshalMetrics("", testCase.records)
+			got, err := unmarshaler.UnmarshalMetrics(testCase.records)
 			require.NoError(t, err)
 			require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())
 			require.Equal(t, testCase.wantMetricCount, got.MetricCount())

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/otlpmetricstream/unmarshaler_test.go
@@ -97,7 +97,7 @@ func TestUnmarshal(t *testing.T) {
 	}
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
-			got, err := unmarshaler.Unmarshal(testCase.records)
+			got, err := unmarshaler.UnmarshalMetrics("", testCase.records)
 			require.NoError(t, err)
 			require.Equal(t, testCase.wantResourceCount, got.ResourceMetrics().Len())
 			require.Equal(t, testCase.wantMetricCount, got.MetricCount())

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
@@ -10,8 +10,8 @@ import (
 
 // MetricsUnmarshaler deserializes the message body
 type MetricsUnmarshaler interface {
-	// Unmarshal deserializes the records into metrics.
-	Unmarshal(records [][]byte) (pmetric.Metrics, error)
+	// UnmarshalMetrics deserializes the records into metrics.
+	UnmarshalMetrics(contentType string, records [][]byte) (pmetric.Metrics, error)
 
 	// Type of the serialized messages.
 	Type() string
@@ -19,8 +19,8 @@ type MetricsUnmarshaler interface {
 
 // LogsUnmarshaler deserializes the message body
 type LogsUnmarshaler interface {
-	// Unmarshal deserializes the records into logs.
-	Unmarshal(records [][]byte) (plog.Logs, error)
+	// UnmarshalLogs deserializes the records into logs.
+	UnmarshalLogs(contentType string, records [][]byte) (plog.Logs, error)
 
 	// Type of the serialized messages.
 	Type() string
@@ -28,8 +28,11 @@ type LogsUnmarshaler interface {
 
 // Unmarshaler deserializes the message body
 type Unmarshaler interface {
-	// Unmarshal deserializes the records into metrics or logs.
-	Unmarshal(contentType string, records [][]byte) (pmetric.Metrics, plog.Logs, error)
+	// UnmarshalMetrics deserializes the records into metrics.
+	UnmarshalMetrics(contentType string, records [][]byte) (pmetric.Metrics, error)
+
+	// UnmarshalLogs deserializes the records into logs.
+	UnmarshalLogs(contentType string, records [][]byte) (plog.Logs, error)
 
 	// Type of the serialized messages.
 	Type() string

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
@@ -11,7 +11,7 @@ import (
 // MetricsUnmarshaler deserializes the message body
 type MetricsUnmarshaler interface {
 	// UnmarshalMetrics deserializes the records into metrics.
-	UnmarshalMetrics(contentType string, records [][]byte) (pmetric.Metrics, error)
+	UnmarshalMetrics(records [][]byte) (pmetric.Metrics, error)
 
 	// Type of the serialized messages.
 	Type() string
@@ -20,7 +20,7 @@ type MetricsUnmarshaler interface {
 // LogsUnmarshaler deserializes the message body
 type LogsUnmarshaler interface {
 	// UnmarshalLogs deserializes the records into logs.
-	UnmarshalLogs(contentType string, records [][]byte) (plog.Logs, error)
+	UnmarshalLogs(records [][]byte) (plog.Logs, error)
 
 	// Type of the serialized messages.
 	Type() string
@@ -29,10 +29,10 @@ type LogsUnmarshaler interface {
 // Unmarshaler deserializes the message body
 type Unmarshaler interface {
 	// UnmarshalMetrics deserializes the records into metrics.
-	UnmarshalMetrics(contentType string, records [][]byte) (pmetric.Metrics, error)
+	UnmarshalMetrics(records [][]byte) (pmetric.Metrics, error)
 
 	// UnmarshalLogs deserializes the records into logs.
-	UnmarshalLogs(contentType string, records [][]byte) (plog.Logs, error)
+	UnmarshalLogs(records [][]byte) (plog.Logs, error)
 
 	// Type of the serialized messages.
 	Type() string

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
@@ -29,7 +29,7 @@ type LogsUnmarshaler interface {
 // Unmarshaler deserializes the message body
 type Unmarshaler interface {
 	// Unmarshal deserializes the records into metrics or logs.
-	Unmarshal(records [][]byte) (pmetric.Metrics, plog.Logs, error)
+	Unmarshal(contentType string, records [][]byte) (pmetric.Metrics, plog.Logs, error)
 
 	// Type of the serialized messages.
 	Type() string

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshaler.go
@@ -25,3 +25,12 @@ type LogsUnmarshaler interface {
 	// Type of the serialized messages.
 	Type() string
 }
+
+// Unmarshaler deserializes the message body
+type Unmarshaler interface {
+	// Unmarshal deserializes the records into metrics or logs.
+	Unmarshal(records [][]byte) (pmetric.Metrics, plog.Logs, error)
+
+	// Type of the serialized messages.
+	Type() string
+}

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler.go
@@ -18,26 +18,14 @@ type NopLogsUnmarshaler struct {
 
 var _ unmarshaler.LogsUnmarshaler = (*NopLogsUnmarshaler)(nil)
 
-// NewNopLogs provides a nop logs unmarshaler with the default
-// plog.Logs and no error.
-func NewNopLogs() *NopLogsUnmarshaler {
-	return &NopLogsUnmarshaler{}
-}
-
-// NewWithLogs provides a nop logs unmarshaler with the passed
-// in logs as the result of the UnmarshalLogs and no error.
-func NewWithLogs(logs plog.Logs) *NopLogsUnmarshaler {
-	return &NopLogsUnmarshaler{logs: logs}
-}
-
-// NewErrLogs provides a nop logs unmarshaler with the passed
-// in error as the UnmarshalLogs error.
-func NewErrLogs(err error) *NopLogsUnmarshaler {
-	return &NopLogsUnmarshaler{err: err}
+// NewNopLogs provides a nop logs unmarshaler with the passed
+// error and logs as the result of the unmarshal.
+func NewNopLogs(logs plog.Logs, err error) *NopLogsUnmarshaler {
+	return &NopLogsUnmarshaler{logs: logs, err: err}
 }
 
 // UnmarshalLogs deserializes the records into logs.
-func (u *NopLogsUnmarshaler) UnmarshalLogs(string, [][]byte) (plog.Logs, error) {
+func (u *NopLogsUnmarshaler) UnmarshalLogs([][]byte) (plog.Logs, error) {
 	return u.logs, u.err
 }
 

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler.go
@@ -25,19 +25,19 @@ func NewNopLogs() *NopLogsUnmarshaler {
 }
 
 // NewWithLogs provides a nop logs unmarshaler with the passed
-// in logs as the result of the Unmarshal and no error.
+// in logs as the result of the UnmarshalLogs and no error.
 func NewWithLogs(logs plog.Logs) *NopLogsUnmarshaler {
 	return &NopLogsUnmarshaler{logs: logs}
 }
 
 // NewErrLogs provides a nop logs unmarshaler with the passed
-// in error as the Unmarshal error.
+// in error as the UnmarshalLogs error.
 func NewErrLogs(err error) *NopLogsUnmarshaler {
 	return &NopLogsUnmarshaler{err: err}
 }
 
-// Unmarshal deserializes the records into logs.
-func (u *NopLogsUnmarshaler) Unmarshal([][]byte) (plog.Logs, error) {
+// UnmarshalLogs deserializes the records into logs.
+func (u *NopLogsUnmarshaler) UnmarshalLogs(string, [][]byte) (plog.Logs, error) {
 	return u.logs, u.err
 }
 

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_logs_unmarshaler_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewNopLogs(t *testing.T) {
 	unmarshaler := NewNopLogs()
-	got, err := unmarshaler.Unmarshal(nil)
+	got, err := unmarshaler.UnmarshalLogs("", nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, typeStr, unmarshaler.Type())
@@ -23,7 +23,7 @@ func TestNewWithLogs(t *testing.T) {
 	logs := plog.NewLogs()
 	logs.ResourceLogs().AppendEmpty()
 	unmarshaler := NewWithLogs(logs)
-	got, err := unmarshaler.Unmarshal(nil)
+	got, err := unmarshaler.UnmarshalLogs("", nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, logs, got)
@@ -33,7 +33,7 @@ func TestNewWithLogs(t *testing.T) {
 func TestNewErrLogs(t *testing.T) {
 	wantErr := errors.New("test error")
 	unmarshaler := NewErrLogs(wantErr)
-	got, err := unmarshaler.Unmarshal(nil)
+	got, err := unmarshaler.UnmarshalLogs("", nil)
 	require.Error(t, err)
 	require.Equal(t, wantErr, err)
 	require.NotNil(t, got)

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler.go
@@ -27,19 +27,19 @@ func NewNopMetrics() *NopMetricsUnmarshaler {
 }
 
 // NewWithMetrics provides a nop metrics unmarshaler with the passed
-// in metrics as the result of the Unmarshal and no error.
+// in metrics as the result of the UnmarshalMetrics and no error.
 func NewWithMetrics(metrics pmetric.Metrics) *NopMetricsUnmarshaler {
 	return &NopMetricsUnmarshaler{metrics: metrics}
 }
 
 // NewErrMetrics provides a nop metrics unmarshaler with the passed
-// in error as the Unmarshal error.
+// in error as the UnmarshalMetrics error.
 func NewErrMetrics(err error) *NopMetricsUnmarshaler {
 	return &NopMetricsUnmarshaler{err: err}
 }
 
-// Unmarshal deserializes the records into metrics.
-func (u *NopMetricsUnmarshaler) Unmarshal([][]byte) (pmetric.Metrics, error) {
+// UnmarshalMetrics deserializes the records into metrics.
+func (u *NopMetricsUnmarshaler) UnmarshalMetrics(string, [][]byte) (pmetric.Metrics, error) {
 	return u.metrics, u.err
 }
 

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler.go
@@ -20,26 +20,14 @@ type NopMetricsUnmarshaler struct {
 
 var _ unmarshaler.MetricsUnmarshaler = (*NopMetricsUnmarshaler)(nil)
 
-// NewNopMetrics provides a nop metrics unmarshaler with the default
-// pmetric.Metrics and no error.
-func NewNopMetrics() *NopMetricsUnmarshaler {
-	return &NopMetricsUnmarshaler{}
-}
-
-// NewWithMetrics provides a nop metrics unmarshaler with the passed
-// in metrics as the result of the UnmarshalMetrics and no error.
-func NewWithMetrics(metrics pmetric.Metrics) *NopMetricsUnmarshaler {
-	return &NopMetricsUnmarshaler{metrics: metrics}
-}
-
-// NewErrMetrics provides a nop metrics unmarshaler with the passed
-// in error as the UnmarshalMetrics error.
-func NewErrMetrics(err error) *NopMetricsUnmarshaler {
-	return &NopMetricsUnmarshaler{err: err}
+// NewNopMetrics provides a nop metrics unmarshaler with the passed
+// error and metrics as the result of the unmarshal.
+func NewNopMetrics(metrics pmetric.Metrics, err error) *NopMetricsUnmarshaler {
+	return &NopMetricsUnmarshaler{metrics: metrics, err: err}
 }
 
 // UnmarshalMetrics deserializes the records into metrics.
-func (u *NopMetricsUnmarshaler) UnmarshalMetrics(string, [][]byte) (pmetric.Metrics, error) {
+func (u *NopMetricsUnmarshaler) UnmarshalMetrics([][]byte) (pmetric.Metrics, error) {
 	return u.metrics, u.err
 }
 

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestNewNopMetrics(t *testing.T) {
 	unmarshaler := NewNopMetrics()
-	got, err := unmarshaler.Unmarshal(nil)
+	got, err := unmarshaler.UnmarshalMetrics("", nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, typeStr, unmarshaler.Type())
@@ -23,7 +23,7 @@ func TestNewWithMetrics(t *testing.T) {
 	metrics := pmetric.NewMetrics()
 	metrics.ResourceMetrics().AppendEmpty()
 	unmarshaler := NewWithMetrics(metrics)
-	got, err := unmarshaler.Unmarshal(nil)
+	got, err := unmarshaler.UnmarshalMetrics("", nil)
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	require.Equal(t, metrics, got)
@@ -33,7 +33,7 @@ func TestNewWithMetrics(t *testing.T) {
 func TestNewErrMetrics(t *testing.T) {
 	wantErr := errors.New("test error")
 	unmarshaler := NewErrMetrics(wantErr)
-	got, err := unmarshaler.Unmarshal(nil)
+	got, err := unmarshaler.UnmarshalMetrics("", nil)
 	require.Error(t, err)
 	require.Equal(t, wantErr, err)
 	require.NotNil(t, got)

--- a/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler_test.go
+++ b/receiver/awsfirehosereceiver/internal/unmarshaler/unmarshalertest/nop_metrics_unmarshaler_test.go
@@ -12,30 +12,31 @@ import (
 )
 
 func TestNewNopMetrics(t *testing.T) {
-	unmarshaler := NewNopMetrics()
-	got, err := unmarshaler.UnmarshalMetrics("", nil)
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	require.Equal(t, typeStr, unmarshaler.Type())
-}
+	t.Parallel()
+	tests := []struct {
+		name    string
+		metrics pmetric.Metrics
+		err     error
+	}{
+		{
+			name:    "no error",
+			metrics: pmetric.NewMetrics(),
+			err:     nil,
+		},
+		{
+			name:    "with error",
+			metrics: pmetric.NewMetrics(),
+			err:     errors.New("test error"),
+		},
+	}
 
-func TestNewWithMetrics(t *testing.T) {
-	metrics := pmetric.NewMetrics()
-	metrics.ResourceMetrics().AppendEmpty()
-	unmarshaler := NewWithMetrics(metrics)
-	got, err := unmarshaler.UnmarshalMetrics("", nil)
-	require.NoError(t, err)
-	require.NotNil(t, got)
-	require.Equal(t, metrics, got)
-	require.Equal(t, typeStr, unmarshaler.Type())
-}
-
-func TestNewErrMetrics(t *testing.T) {
-	wantErr := errors.New("test error")
-	unmarshaler := NewErrMetrics(wantErr)
-	got, err := unmarshaler.UnmarshalMetrics("", nil)
-	require.Error(t, err)
-	require.Equal(t, wantErr, err)
-	require.NotNil(t, got)
-	require.Equal(t, typeStr, unmarshaler.Type())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			unmarshaler := NewNopMetrics(test.metrics, test.err)
+			got, err := unmarshaler.UnmarshalMetrics(nil)
+			require.Equal(t, test.err, err)
+			require.Equal(t, test.metrics, got)
+			require.Equal(t, typeStr, unmarshaler.Type())
+		})
+	}
 }

--- a/receiver/awsfirehosereceiver/logs_receiver.go
+++ b/receiver/awsfirehosereceiver/logs_receiver.go
@@ -68,7 +68,7 @@ func (mc *logsConsumer) Consume(
 	records [][]byte,
 	commonAttributes map[string]string,
 ) (int, error) {
-	md, err := mc.unmarshaler.Unmarshal(records)
+	md, err := mc.unmarshaler.UnmarshalLogs(contentType, records)
 
 	if err != nil {
 		return http.StatusBadRequest, err

--- a/receiver/awsfirehosereceiver/logs_receiver.go
+++ b/receiver/awsfirehosereceiver/logs_receiver.go
@@ -62,8 +62,14 @@ func newLogsReceiver(
 // Consume uses the configured unmarshaler to deserialize the records into a
 // single plog.Logs. It will send the final result
 // to the next consumer.
-func (mc *logsConsumer) Consume(ctx context.Context, records [][]byte, commonAttributes map[string]string) (int, error) {
+func (mc *logsConsumer) Consume(
+	ctx context.Context,
+	contentType string,
+	records [][]byte,
+	commonAttributes map[string]string,
+) (int, error) {
 	md, err := mc.unmarshaler.Unmarshal(records)
+
 	if err != nil {
 		return http.StatusBadRequest, err
 	}

--- a/receiver/awsfirehosereceiver/logs_receiver.go
+++ b/receiver/awsfirehosereceiver/logs_receiver.go
@@ -64,11 +64,10 @@ func newLogsReceiver(
 // to the next consumer.
 func (mc *logsConsumer) Consume(
 	ctx context.Context,
-	contentType string,
 	records [][]byte,
 	commonAttributes map[string]string,
 ) (int, error) {
-	md, err := mc.unmarshaler.UnmarshalLogs(contentType, records)
+	md, err := mc.unmarshaler.UnmarshalLogs(records)
 
 	if err != nil {
 		return http.StatusBadRequest, err

--- a/receiver/awsfirehosereceiver/logs_receiver_test.go
+++ b/receiver/awsfirehosereceiver/logs_receiver_test.go
@@ -97,10 +97,10 @@ func TestLogsConsumer(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			mc := &logsConsumer{
-				unmarshaler: unmarshalertest.NewErrLogs(testCase.unmarshalerErr),
+				unmarshaler: unmarshalertest.NewNopLogs(plog.NewLogs(), testCase.unmarshalerErr),
 				consumer:    consumertest.NewErr(testCase.consumerErr),
 			}
-			gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, nil)
+			gotStatus, gotErr := mc.Consume(context.TODO(), nil, nil)
 			require.Equal(t, testCase.wantStatus, gotStatus)
 			require.Equal(t, testCase.wantErr, gotErr)
 		})
@@ -111,10 +111,10 @@ func TestLogsConsumer(t *testing.T) {
 		base.ResourceLogs().AppendEmpty()
 		rc := logsRecordConsumer{}
 		mc := &logsConsumer{
-			unmarshaler: unmarshalertest.NewWithLogs(base),
+			unmarshaler: unmarshalertest.NewNopLogs(base, nil),
 			consumer:    &rc,
 		}
-		gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, map[string]string{
+		gotStatus, gotErr := mc.Consume(context.TODO(), nil, map[string]string{
 			"CommonAttributes": "Test",
 		})
 		require.Equal(t, http.StatusOK, gotStatus)

--- a/receiver/awsfirehosereceiver/logs_receiver_test.go
+++ b/receiver/awsfirehosereceiver/logs_receiver_test.go
@@ -100,7 +100,7 @@ func TestLogsConsumer(t *testing.T) {
 				unmarshaler: unmarshalertest.NewErrLogs(testCase.unmarshalerErr),
 				consumer:    consumertest.NewErr(testCase.consumerErr),
 			}
-			gotStatus, gotErr := mc.Consume(context.TODO(), nil, nil)
+			gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, nil)
 			require.Equal(t, testCase.wantStatus, gotStatus)
 			require.Equal(t, testCase.wantErr, gotErr)
 		})
@@ -114,7 +114,7 @@ func TestLogsConsumer(t *testing.T) {
 			unmarshaler: unmarshalertest.NewWithLogs(base),
 			consumer:    &rc,
 		}
-		gotStatus, gotErr := mc.Consume(context.TODO(), nil, map[string]string{
+		gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, map[string]string{
 			"CommonAttributes": "Test",
 		})
 		require.Equal(t, http.StatusOK, gotStatus)

--- a/receiver/awsfirehosereceiver/metrics_receiver.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver.go
@@ -70,7 +70,7 @@ func (mc *metricsConsumer) Consume(
 	records [][]byte,
 	commonAttributes map[string]string,
 ) (int, error) {
-	md, err := mc.unmarshaler.Unmarshal(records)
+	md, err := mc.unmarshaler.UnmarshalMetrics(contentType, records)
 	if err != nil {
 		return http.StatusBadRequest, err
 	}

--- a/receiver/awsfirehosereceiver/metrics_receiver.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver.go
@@ -64,7 +64,12 @@ func newMetricsReceiver(
 // single pmetric.Metrics. If there are common attributes available, then it will
 // attach those to each of the pcommon.Resources. It will send the final result
 // to the next consumer.
-func (mc *metricsConsumer) Consume(ctx context.Context, records [][]byte, commonAttributes map[string]string) (int, error) {
+func (mc *metricsConsumer) Consume(
+	ctx context.Context,
+	contentType string,
+	records [][]byte,
+	commonAttributes map[string]string,
+) (int, error) {
 	md, err := mc.unmarshaler.Unmarshal(records)
 	if err != nil {
 		return http.StatusBadRequest, err

--- a/receiver/awsfirehosereceiver/metrics_receiver.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver.go
@@ -66,11 +66,10 @@ func newMetricsReceiver(
 // to the next consumer.
 func (mc *metricsConsumer) Consume(
 	ctx context.Context,
-	contentType string,
 	records [][]byte,
 	commonAttributes map[string]string,
 ) (int, error) {
-	md, err := mc.unmarshaler.UnmarshalMetrics(contentType, records)
+	md, err := mc.unmarshaler.UnmarshalMetrics(records)
 	if err != nil {
 		return http.StatusBadRequest, err
 	}

--- a/receiver/awsfirehosereceiver/metrics_receiver_test.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver_test.go
@@ -101,7 +101,7 @@ func TestMetricsConsumer(t *testing.T) {
 				unmarshaler: unmarshalertest.NewErrMetrics(testCase.unmarshalerErr),
 				consumer:    consumertest.NewErr(testCase.consumerErr),
 			}
-			gotStatus, gotErr := mc.Consume(context.TODO(), nil, nil)
+			gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, nil)
 			require.Equal(t, testCase.wantStatus, gotStatus)
 			require.Equal(t, testCase.wantErr, gotErr)
 		})
@@ -115,7 +115,7 @@ func TestMetricsConsumer(t *testing.T) {
 			unmarshaler: unmarshalertest.NewWithMetrics(base),
 			consumer:    &rc,
 		}
-		gotStatus, gotErr := mc.Consume(context.TODO(), nil, map[string]string{
+		gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, map[string]string{
 			"CommonAttributes": "Test",
 		})
 		require.Equal(t, http.StatusOK, gotStatus)

--- a/receiver/awsfirehosereceiver/metrics_receiver_test.go
+++ b/receiver/awsfirehosereceiver/metrics_receiver_test.go
@@ -98,10 +98,10 @@ func TestMetricsConsumer(t *testing.T) {
 	for name, testCase := range testCases {
 		t.Run(name, func(t *testing.T) {
 			mc := &metricsConsumer{
-				unmarshaler: unmarshalertest.NewErrMetrics(testCase.unmarshalerErr),
+				unmarshaler: unmarshalertest.NewNopMetrics(pmetric.NewMetrics(), testCase.unmarshalerErr),
 				consumer:    consumertest.NewErr(testCase.consumerErr),
 			}
-			gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, nil)
+			gotStatus, gotErr := mc.Consume(context.TODO(), nil, nil)
 			require.Equal(t, testCase.wantStatus, gotStatus)
 			require.Equal(t, testCase.wantErr, gotErr)
 		})
@@ -112,10 +112,10 @@ func TestMetricsConsumer(t *testing.T) {
 		base.ResourceMetrics().AppendEmpty()
 		rc := recordConsumer{}
 		mc := &metricsConsumer{
-			unmarshaler: unmarshalertest.NewWithMetrics(base),
+			unmarshaler: unmarshalertest.NewNopMetrics(base, nil),
 			consumer:    &rc,
 		}
-		gotStatus, gotErr := mc.Consume(context.TODO(), "", nil, map[string]string{
+		gotStatus, gotErr := mc.Consume(context.TODO(), nil, map[string]string{
 			"CommonAttributes": "Test",
 		})
 		require.Equal(t, http.StatusOK, gotStatus)

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog/compression"
 	"io"
 	"net"
@@ -263,23 +264,13 @@ func (fmr *firehoseReceiver) transformRecords(records []firehoseRecord, decompre
 
 		data, err := base64.StdEncoding.DecodeString(record.Data)
 		if err != nil {
-			fmr.settings.Logger.Error(
-				"Unable to base64 decode the record data",
-				zap.Int("index", index),
-				zap.Error(err),
-			)
-			continue
+			return transformed, fmt.Errorf("unable to base64 decode the record at index %d: %w", index, err)
 		}
 
 		if decompress {
 			data, err = compression.Unzip(data)
 			if err != nil {
-				fmr.settings.Logger.Error(
-					"Failed to unzip record data",
-					zap.Int("index", index),
-					zap.Error(err),
-				)
-				continue
+				return transformed, fmt.Errorf("unable to unzip decoded record at index %d: %w", index, err)
 			}
 		}
 

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -217,7 +217,7 @@ func (fmr *firehoseReceiver) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// decode records
+	// transform records
 	encoding := r.Header.Get(headerContentEncoding)
 	records, err := fmr.transformRecords(fr.Records, encoding == "gzip")
 	if err != nil {

--- a/receiver/awsfirehosereceiver/receiver.go
+++ b/receiver/awsfirehosereceiver/receiver.go
@@ -27,7 +27,7 @@ const (
 	headerFirehoseCommonAttributes = "X-Amz-Firehose-Common-Attributes"
 	headerContentType              = "Content-Type"
 	headerContentLength            = "Content-Length"
-	headerContentEncoding          = " Content-Encoding"
+	headerContentEncoding          = "Content-Encoding"
 )
 
 var (

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -162,7 +163,8 @@ func TestFirehoseRequest(t *testing.T) {
 			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
 				{Data: "XXXXXaGVsbG8="},
 			}),
-			wantStatusCode: http.StatusOK, // having an invalid record does not stop the request
+			wantStatusCode: http.StatusBadRequest,
+			wantErr:        fmt.Errorf("unable to base64 decode the record at index 0: %w", base64.CorruptInputError(12)),
 		},
 		"WithValidRecords": {
 			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -158,6 +158,12 @@ func TestFirehoseRequest(t *testing.T) {
 			wantStatusCode: http.StatusInternalServerError,
 			wantErr:        firehoseConsumerErr,
 		},
+		"WithCorruptBase64Records": {
+			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
+				{Data: "XXXXXaGVsbG8="},
+			}),
+			wantStatusCode: http.StatusOK, // having an invalid record does not stop the request
+		},
 		"WithValidRecords": {
 			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
 				testFirehoseRecord("test"),

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -40,7 +40,7 @@ func newNopFirehoseConsumer(statusCode int, err error) *nopFirehoseConsumer {
 	return &nopFirehoseConsumer{statusCode, err}
 }
 
-func (nfc *nopFirehoseConsumer) Consume(context.Context, [][]byte, map[string]string) (int, error) {
+func (nfc *nopFirehoseConsumer) Consume(context.Context, string, [][]byte, map[string]string) (int, error) {
 	return nfc.statusCode, nfc.err
 }
 

--- a/receiver/awsfirehosereceiver/receiver_test.go
+++ b/receiver/awsfirehosereceiver/receiver_test.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -40,7 +39,7 @@ func newNopFirehoseConsumer(statusCode int, err error) *nopFirehoseConsumer {
 	return &nopFirehoseConsumer{statusCode, err}
 }
 
-func (nfc *nopFirehoseConsumer) Consume(context.Context, string, [][]byte, map[string]string) (int, error) {
+func (nfc *nopFirehoseConsumer) Consume(context.Context, [][]byte, map[string]string) (int, error) {
 	return nfc.statusCode, nfc.err
 }
 
@@ -158,13 +157,6 @@ func TestFirehoseRequest(t *testing.T) {
 			consumer:       newNopFirehoseConsumer(http.StatusInternalServerError, firehoseConsumerErr),
 			wantStatusCode: http.StatusInternalServerError,
 			wantErr:        firehoseConsumerErr,
-		},
-		"WithCorruptBase64Records": {
-			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{
-				{Data: "XXXXXaGVsbG8="},
-			}),
-			wantStatusCode: http.StatusBadRequest,
-			wantErr:        fmt.Errorf("unable to base64 decode the record at index 0: %w", base64.CorruptInputError(12)),
 		},
 		"WithValidRecords": {
 			body: testFirehoseRequest(testFirehoseRequestID, []firehoseRecord{


### PR DESCRIPTION
Please see the issue https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/35988#issuecomment-2504983187.

This new `record_type` does the exact same thing as the other record types, but is capable of distinguishing between them:

- If it is JSON:
  - If it is a metrics receiver, parses it as cloudwatch metric.
  - If it is a logs receiver, parses it as a cloudwatch log.
- If it is protobuf:
  - If it is a metric, parses it as OTLP metric.

I have used the exact same tests for this record type as the ones that are present for the other record types so there isn't any doubt that the new record type works. 
