### PR TITLE
[chore] explicitly use ubuntu 24.04 for runners to identify any breakage

### DIFF
--- a/.github/workflows/add-codeowners-to-pr.yml
+++ b/.github/workflows/add-codeowners-to-pr.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   add-owners-to-pr:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -7,7 +7,7 @@ jobs:
   add-labels:
     if: ${{ !github.event.issue.pull_request && startsWith(github.event.comment.body, '/label') && github.repository_owner == 'open-telemetry' }}
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/auto-assign-owners.yml
+++ b/.github/workflows/auto-assign-owners.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   add-owner:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: run

--- a/.github/workflows/auto-update-jmx-metrics-component.yml
+++ b/.github/workflows/auto-update-jmx-metrics-component.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-versions:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       latest-version: ${{ steps.check-versions.outputs.latest-version }}
       already-added: ${{ steps.check-versions.outputs.already-added }}
@@ -48,7 +48,7 @@ jobs:
           echo "already-opened=$already_opened" >> $GITHUB_OUTPUT
 
   update-jmx-metrics-component:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: |
       needs.check-versions.outputs.already-added != 'true' &&
       needs.check-versions.outputs.already-opened != 'true'

--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -71,7 +71,7 @@ jobs:
         run: make -j2 gotest GROUP=${{ matrix.group }}
   arm-unittest:
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run ARM') || github.event_name == 'push' || github.event_name == 'merge_group') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [arm-unittest-matrix]
     steps:
       - name: Print result

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   setup-environment:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make install-tools
   check-collector-module-version:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +53,7 @@ jobs:
       - name: Check Collector Module Version
         run: ./.github/workflows/scripts/check-collector-module-version.sh
   check-codeowners:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -88,7 +88,7 @@ jobs:
           - cmd-0
           - cmd-1
           - other
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -121,7 +121,7 @@ jobs:
         run: GOOS=${{ matrix.goos }} GOARCH=amd64 make -j2 golint GROUP=${{ matrix.group }}
   lint:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment, lint-matrix]
     steps:
       - name: Print result
@@ -156,7 +156,7 @@ jobs:
           - pkg
           - cmd-0
           - cmd-1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: Checkout Repo
@@ -182,7 +182,7 @@ jobs:
       - name: Run `govulncheck`
         run: make -j2 gogovulncheck GROUP=${{ matrix.group }}
   checks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -252,7 +252,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version: ["1.23.0", "1.22.8"] # 1.20 is interpreted as 1.2 without quotes
-        runner: [ubuntu-latest]
+        runner: [ubuntu-24.04]
         group:
           - receiver-0
           - receiver-1
@@ -313,7 +313,7 @@ jobs:
           path: ${{ matrix.group }}-coverage.txt
   unittest:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment, unittest-matrix]
     steps:
       - name: Print result
@@ -328,7 +328,7 @@ jobs:
             false
           fi
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [unittest]
     steps:
       - uses: actions/checkout@v4
@@ -362,7 +362,7 @@ jobs:
           - pkg
           - cmd-0
           - cmd-1
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -385,7 +385,7 @@ jobs:
 
   integration-tests:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment, integration-tests-matrix]
     steps:
       - name: Print result
@@ -401,7 +401,7 @@ jobs:
           fi
 
   correctness-traces:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -428,7 +428,7 @@ jobs:
       - name: Correctness
         run: make -C testbed run-correctness-traces-tests
   correctness-metrics:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -456,7 +456,7 @@ jobs:
         run: make -C testbed run-correctness-metrics-tests
 
   build-examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
@@ -465,7 +465,7 @@ jobs:
         run: make build-examples
 
   cross-compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     strategy:
       fail-fast: false
@@ -535,7 +535,7 @@ jobs:
           path: ./bin/*
 
   publish-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [lint, unittest, integration-tests]
     steps:
       - uses: actions/checkout@v4
@@ -549,7 +549,7 @@ jobs:
         id: check
         run: ./.github/workflows/scripts/verify-dist-files-exist.sh
   publish-dev:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [lint, unittest, integration-tests]
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     steps:
@@ -612,7 +612,7 @@ jobs:
           docker push otel/opentelemetry-collector-contrib-dev:$GITHUB_SHA
           docker push otel/opentelemetry-collector-contrib-dev:latest
   publish-stable:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [lint, unittest, integration-tests]
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     steps:
@@ -630,7 +630,7 @@ jobs:
     # This job updates the "next release" milestone
     # to the latest released version and creates a new milestone
     # named "next release" in its place
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [publish-stable]
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     steps:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   changelog:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -16,7 +16,7 @@ env:
 jobs:
   changedfiles:
     name: changed files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       PR_HEAD: ${{ github.event.pull_request.head.sha }}
     if: ${{ github.actor != 'dependabot[bot]' }}
@@ -31,7 +31,7 @@ jobs:
         run: |
           echo "md=$(git diff --name-only --diff-filter=ACMRTUXB $(git merge-base origin/main $PR_HEAD) $PR_HEAD | grep .md$ | xargs)" >> $GITHUB_OUTPUT
   check-links:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: changedfiles
     if: ${{needs.changedfiles.outputs.md}}
     steps:

--- a/.github/workflows/close-stale.yaml
+++ b/.github/workflows/close-stale.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
     steps:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -19,7 +19,7 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 jobs:
   collector-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
@@ -51,7 +51,7 @@ jobs:
           path: ./bin/*
 
   supervisor-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: collector-build
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +83,7 @@ jobs:
           go test -v --tags=e2e
 
   docker-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -131,7 +131,7 @@ jobs:
           - processor/k8sattributesprocessor
           - receiver/kubeletstatsreceiver
           - receiver/k8sobjectsreceiver
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: docker-build
     steps:
       - uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
 
   kubernetes-test:
     if: ${{ github.actor != 'dependabot[bot]' && always() }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [kubernetes-test-matrix]
     steps:
       - name: Print result

--- a/.github/workflows/generate-component-labels.yml
+++ b/.github/workflows/generate-component-labels.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   generate-component-labels:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/generate-weekly-report.yml
+++ b/.github/workflows/generate-weekly-report.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   get_issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -119,7 +119,7 @@ jobs:
           path: testbed/tests/results/${{steps.filename.outputs.name}}.json
 
   update-benchmarks:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [loadtest]
     if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/mark-issues-as-stale.yml
+++ b/.github/workflows/mark-issues-as-stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   mark-issues-as-stale:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/milestone-add-to-pr.yml
+++ b/.github/workflows/milestone-add-to-pr.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   update-pr:
     if: github.event.pull_request.merged
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/ping-codeowners-issues.yml
+++ b/.github/workflows/ping-codeowners-issues.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ping-owners:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ping-codeowners-on-new-issue.yml
+++ b/.github/workflows/ping-codeowners-on-new-issue.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ping-owners-on-new-issue:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ping-codeowners-prs.yml
+++ b/.github/workflows/ping-codeowners-prs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   ping-owners:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' && github.repository_owner == 'open-telemetry' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   # Releasing opentelemetry-collector-contrib
   prepare-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   prometheus-compliance-tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   shellcheck:
     name: shellcheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       VERSION: v0.10.0
     steps:

--- a/.github/workflows/telemetrygen.yml
+++ b/.github/workflows/telemetrygen.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   build-dev:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
@@ -59,7 +59,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 
   publish-latest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     permissions:
       packages: write
@@ -104,7 +104,7 @@ jobs:
           platforms: linux/amd64,linux/arm64,linux/s390x,linux/ppc64le
 
   publish-stable:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'open-telemetry/opentelemetry-collector-contrib'
     permissions:
       packages: write

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -13,7 +13,7 @@ env:
 jobs:
   setup-environment:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'dependency-major-update') && (github.actor == 'renovate[bot]' || contains(github.event.pull_request.labels.*.name, 'renovatebot')) }}
     steps:
       - uses: actions/checkout@v4

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -57,7 +57,7 @@ $(TOOLS_BIN_DIR):
 	mkdir -p $@
 
 $(TOOLS_BIN_NAMES): $(TOOLS_BIN_DIR) $(TOOLS_MOD_DIR)/go.mod
-	cd $(TOOLS_MOD_DIR) && GOOS="" $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
+	cd $(TOOLS_MOD_DIR) && GOOS="" GOARCH="" $(GOCMD) build -o $@ -trimpath $(filter %/$(notdir $@),$(TOOLS_PKG_NAMES))
 
 ADDLICENSE          := $(TOOLS_BIN_DIR)/addlicense
 MDLINKCHECK         := $(TOOLS_BIN_DIR)/markdown-link-check

--- a/cmd/opampsupervisor/e2e_test.go
+++ b/cmd/opampsupervisor/e2e_test.go
@@ -1348,13 +1348,14 @@ func TestSupervisorStopsAgentProcessWithEmptyConfigMap(t *testing.T) {
 	}
 
 	// Verify the collector is not running after 250 ms by checking the healthcheck endpoint
-	time.Sleep(1000 * time.Millisecond)
-	_, err := http.DefaultClient.Get("http://localhost:12345")
-	if runtime.GOOS != "windows" {
-		require.ErrorContains(t, err, "connection refused")
-	} else {
-		require.ErrorContains(t, err, "No connection could be made")
-	}
+	require.EventuallyWithT(t, func(tt *assert.CollectT) {
+		_, err := http.DefaultClient.Get("http://localhost:12345")
+		if runtime.GOOS != "windows" {
+			assert.ErrorContains(tt, err, "connection refused")
+		} else {
+			assert.ErrorContains(tt, err, "No connection could be made")
+		}
+	}, 3*time.Second, 250*time.Millisecond)
 }
 
 type LogEntry struct {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Rather than use ubuntu-latest, which will move over a period of time to ubuntu 24.04, directly move to ubuntu 24.04 to avoid having flaky or unexpected failures.

See https://github.com/actions/runner-images/issues/10636 for context.
