### PR TITLE
[pkg/ottl/ottlfuncs] Added utf8 support to truncate_all function

### DIFF
--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -393,6 +393,8 @@ The `truncate_all` function truncates all string values in a `pcommon.Map` so th
 
 `target` is a path expression to a `pcommon.Map` type field. `limit` is a non-negative integer.
 
+If truncating at exactly the length results in a broken UTF-8 encoding, `truncate_all` will be truncated before the last UTF-8 character begins.
+
 The map will be mutated such that the number of characters in all string values is less than or equal to the limit. Non-string values are ignored.
 
 Examples:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Truncate_all will slice the string up to the given length. If truncating at exactly the length results in a broken UTF-8 encoding, it'll truncate before where the last UTF-8 character started.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36017 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Two UTF-8 characters were added to the end of the string and the limit was adjusted to match them and the truncation process was tested.

<!--Describe the documentation added.-->
#### Documentation
Updated pkg/ottl/ottfuncs/README.md with description.

