### PR TITLE
[chore] Fix check-codeowners: path needs to be updated on its own step

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -46,16 +46,18 @@ jobs:
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4
+      - name: Gen githubgen tool
+        if: github.repository == 'open-telemetry/opentelemetry-collector-contrib'
+        run: |
+          make githubgen-install
+          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       - uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}
           path: pr
       - name: Gen CODEOWNERS
-        if: github.repository == 'open-telemetry/opentelemetry-collector-contrib'
         run: |
-          make githubgen-install
           cd pr
-          echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
           GITHUB_TOKEN=${{ secrets.READ_ORG_AND_USER_TOKEN }} githubgen
           git diff -s --exit-code || (echo 'Generated code is out of date, please apply this diff and commit the changes in this PR.' && git diff && exit 1)


### PR DESCRIPTION
Path for the tool needs to be updated on its own step, prior to using the tool.