### PR TITLE
[chore] group otel-collector contrib dep update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -104,6 +104,12 @@
       },
       {
         "matchManagers": ["gomod"],
+        "matchSourceUrls": ["https://github.com/open-telemetry/opentelemetry-collector-contrib"],
+        "groupName": "All OpenTelemetry Collector Contrib packages",
+        "matchUpdateTypes": ["major", "minor", "patch"]
+      },
+      {
+        "matchManagers": ["gomod"],
         "matchSourceUrls": [
           "https://github.com/open-telemetry/opentelemetry-go-contrib"
         ],


### PR DESCRIPTION
This is to group together PRs that have been done separately and are annoying as they end up conflicting once one is merged.

See an example with the following 2 prs:
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36757
https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36756