### PR TITLE
Add back "[exporter/awsemfexporter]Split EMF log with larger than 100 buckets."

### DIFF
--- a/.chloggen/split-emf-log-when-buckets-larger-than-100.yaml
+++ b/.chloggen/split-emf-log-when-buckets-larger-than-100.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsemfexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Split EMF log to multiple log splits when buckets larger than 100.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [242]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/split-emf-log-when-buckets-larger-than-100.yaml
+++ b/.chloggen/split-emf-log-when-buckets-larger-than-100.yaml
@@ -10,7 +10,7 @@ component: awsemfexporter
 note: Split EMF log to multiple log splits when buckets larger than 100.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [242]
+issues: [36771]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -240,6 +241,65 @@ func generateTestExponentialHistogramMetricWithInfs(name string) pmetric.Metrics
 	exponentialHistogramDatapoint.Negative().BucketCounts().FromRaw([]uint64{
 		1, 0, 1,
 	})
+	exponentialHistogramDatapoint.Attributes().PutStr("label1", "value1")
+	return otelMetrics
+}
+
+func generateTestExponentialHistogramMetricWithLongBuckets(name string) pmetric.Metrics {
+	otelMetrics := pmetric.NewMetrics()
+	rs := otelMetrics.ResourceMetrics().AppendEmpty()
+	metrics := rs.ScopeMetrics().AppendEmpty().Metrics()
+	metric := metrics.AppendEmpty()
+	metric.SetName(name)
+	metric.SetUnit("Seconds")
+	exponentialHistogramMetric := metric.SetEmptyExponentialHistogram()
+
+	exponentialHistogramDatapoint := exponentialHistogramMetric.DataPoints().AppendEmpty()
+	exponentialHistogramDatapoint.SetCount(3662)
+	exponentialHistogramDatapoint.SetSum(1000)
+	exponentialHistogramDatapoint.SetMin(-9e+17)
+	exponentialHistogramDatapoint.SetMax(9e+17)
+	exponentialHistogramDatapoint.SetZeroCount(2)
+	posBucketCounts := make([]uint64, 60)
+	for i := range posBucketCounts {
+		posBucketCounts[i] = uint64(i + 1)
+	}
+	exponentialHistogramDatapoint.Positive().BucketCounts().FromRaw(posBucketCounts)
+	negBucketCounts := make([]uint64, 60)
+	for i := range negBucketCounts {
+		negBucketCounts[i] = uint64(i + 1)
+	}
+	exponentialHistogramDatapoint.Negative().BucketCounts().FromRaw(negBucketCounts)
+	exponentialHistogramDatapoint.Attributes().PutStr("label1", "value1")
+	return otelMetrics
+}
+
+func generateTestExponentialHistogramMetricWithSpecifiedNumberOfBuckets(name string, bucketLength int) pmetric.Metrics {
+	halfBucketLength := bucketLength / 2
+	otelMetrics := pmetric.NewMetrics()
+	rs := otelMetrics.ResourceMetrics().AppendEmpty()
+	metrics := rs.ScopeMetrics().AppendEmpty().Metrics()
+	metric := metrics.AppendEmpty()
+	metric.SetName(name)
+	metric.SetUnit("Seconds")
+	exponentialHistogramMetric := metric.SetEmptyExponentialHistogram()
+
+	exponentialHistogramDatapoint := exponentialHistogramMetric.DataPoints().AppendEmpty()
+	exponentialHistogramDatapoint.SetCount(250550)
+	exponentialHistogramDatapoint.SetSum(10000)
+	exponentialHistogramDatapoint.SetMin(-9e+20)
+	exponentialHistogramDatapoint.SetMax(9e+20)
+	exponentialHistogramDatapoint.SetZeroCount(50)
+	posBucketCounts := make([]uint64, halfBucketLength)
+	for i := range posBucketCounts {
+		posBucketCounts[i] = uint64(i + 1)
+	}
+	exponentialHistogramDatapoint.Positive().BucketCounts().FromRaw(posBucketCounts)
+	negBucketCounts := make([]uint64, halfBucketLength)
+	for i := range negBucketCounts {
+		negBucketCounts[i] = uint64(i + 1)
+	}
+	exponentialHistogramDatapoint.Negative().BucketCounts().FromRaw(negBucketCounts)
 	exponentialHistogramDatapoint.Attributes().PutStr("label1", "value1")
 	return otelMetrics
 }
@@ -841,7 +901,7 @@ func TestCalculateDeltaDatapoints_ExponentialHistogramDataPointSlice(t *testing.
 			}(),
 			expectedDatapoint: dataPoint{
 				name:   "foo",
-				value:  &cWMetricHistogram{Values: []float64{1.5, 3, 6, 0, -1.5, -3, -6}, Counts: []float64{1, 2, 3, 4, 1, 2, 3}},
+				value:  &cWMetricHistogram{Values: []float64{6, 3, 1.5, 0, -1.5, -3, -6}, Counts: []float64{3, 2, 1, 4, 1, 2, 3}, Count: 16},
 				labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
 			},
 		},
@@ -862,7 +922,7 @@ func TestCalculateDeltaDatapoints_ExponentialHistogramDataPointSlice(t *testing.
 			}(),
 			expectedDatapoint: dataPoint{
 				name:   "foo",
-				value:  &cWMetricHistogram{Values: []float64{0.625, 2.5, 10, 0, -0.625, -2.5, -10}, Counts: []float64{1, 2, 3, 4, 1, 2, 3}},
+				value:  &cWMetricHistogram{Values: []float64{10, 2.5, 0.625, 0, -0.625, -2.5, -10}, Counts: []float64{3, 2, 1, 4, 1, 2, 3}, Count: 16},
 				labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1", "label2": "value2"},
 			},
 		},
@@ -881,6 +941,543 @@ func TestCalculateDeltaDatapoints_ExponentialHistogramDataPointSlice(t *testing.
 			assert.True(t, retained)
 			assert.Equal(t, 1, exponentialHistogramDatapointSlice.Len())
 			assert.Equal(t, tc.expectedDatapoint, dps[0])
+		})
+	}
+}
+
+func TestCalculateDeltaDatapoints_ExponentialHistogramDataPointSliceWithSplitDataPoints(t *testing.T) {
+	dmd := generateDeltaMetricMetadata(false, "foo", false)
+
+	testCases := []struct {
+		name               string
+		histogramDPS       pmetric.ExponentialHistogramDataPointSlice
+		expectedDatapoints []dataPoint
+	}{
+		{
+			name: "Exponential histogram with more than 100 buckets, including positive, negative and zero buckets",
+			histogramDPS: func() pmetric.ExponentialHistogramDataPointSlice {
+				histogramDPS := pmetric.NewExponentialHistogramDataPointSlice()
+				histogramDP := histogramDPS.AppendEmpty()
+				posBucketCounts := make([]uint64, 60)
+				for i := range posBucketCounts {
+					posBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Positive().BucketCounts().FromRaw(posBucketCounts)
+				histogramDP.SetZeroCount(2)
+				negBucketCounts := make([]uint64, 60)
+				for i := range negBucketCounts {
+					negBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Negative().BucketCounts().FromRaw(negBucketCounts)
+				histogramDP.SetSum(1000)
+				histogramDP.SetMin(-9e+17)
+				histogramDP.SetMax(9e+17)
+				histogramDP.SetCount(uint64(3662))
+				histogramDP.Attributes().PutStr("label1", "value1")
+				return histogramDPS
+			}(),
+			expectedDatapoints: []dataPoint{
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							8.646911284551352e+17, 4.323455642275676e+17, 2.161727821137838e+17, 1.080863910568919e+17, 5.404319552844595e+16, 2.7021597764222976e+16,
+							1.3510798882111488e+16, 6.755399441055744e+15, 3.377699720527872e+15, 1.688849860263936e+15, 8.44424930131968e+14, 4.22212465065984e+14,
+							2.11106232532992e+14, 1.05553116266496e+14, 5.2776558133248e+13, 2.6388279066624e+13, 1.3194139533312e+13, 6.597069766656e+12, 3.298534883328e+12,
+							1.649267441664e+12, 8.24633720832e+11, 4.12316860416e+11, 2.06158430208e+11, 1.03079215104e+11, 5.1539607552e+10, 2.5769803776e+10,
+							1.2884901888e+10, 6.442450944e+09, 3.221225472e+09, 1.610612736e+09, 8.05306368e+08, 4.02653184e+08, 2.01326592e+08, 1.00663296e+08,
+							5.0331648e+07, 2.5165824e+07, 1.2582912e+07, 6.291456e+06, 3.145728e+06, 1.572864e+06, 786432, 393216, 196608, 98304, 49152, 24576,
+							12288, 6144, 3072, 1536, 768, 384, 192, 96, 48, 24, 12, 6, 3, 1.5, 0, -1.5, -3, -6, -12, -24, -48, -96, -192, -384, -768, -1536, -3072,
+							-6144, -12288, -24576, -49152, -98304, -196608, -393216, -786432, -1.572864e+06, -3.145728e+06, -6.291456e+06, -1.2582912e+07, -2.5165824e+07,
+							-5.0331648e+07, -1.00663296e+08, -2.01326592e+08, -4.02653184e+08, -8.05306368e+08, -1.610612736e+09, -3.221225472e+09, -6.442450944e+09,
+							-1.2884901888e+10, -2.5769803776e+10, -5.1539607552e+10, -1.03079215104e+11, -2.06158430208e+11, -4.12316860416e+11,
+						},
+						Counts: []float64{
+							60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7,
+							6, 5, 4, 3, 2, 1, 2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+							34, 35, 36, 37, 38, 39,
+						},
+						Sum: 1000, Count: 2612, Min: -5.49755813888e+11, Max: 9e+17,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							-8.24633720832e+11, -1.649267441664e+12, -3.298534883328e+12, -6.597069766656e+12, -1.3194139533312e+13, -2.6388279066624e+13, -5.2776558133248e+13,
+							-1.05553116266496e+14, -2.11106232532992e+14, -4.22212465065984e+14, -8.44424930131968e+14, -1.688849860263936e+15, -3.377699720527872e+15,
+							-6.755399441055744e+15, -1.3510798882111488e+16, -2.7021597764222976e+16, -5.404319552844595e+16, -1.080863910568919e+17, -2.161727821137838e+17,
+							-4.323455642275676e+17, -8.646911284551352e+17,
+						},
+						Counts: []float64{40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60},
+						Sum:    0, Count: 1050, Min: -9e+17, Max: -5.49755813888e+11,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+			},
+		},
+		{
+			name: "Exponential histogram with more than 100 buckets, including positive and zero buckets",
+			histogramDPS: func() pmetric.ExponentialHistogramDataPointSlice {
+				histogramDPS := pmetric.NewExponentialHistogramDataPointSlice()
+				histogramDP := histogramDPS.AppendEmpty()
+				posBucketCounts := make([]uint64, 120)
+				for i := range posBucketCounts {
+					posBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Positive().BucketCounts().FromRaw(posBucketCounts)
+				histogramDP.SetZeroCount(2)
+				histogramDP.SetSum(10000)
+				histogramDP.SetMin(0)
+				histogramDP.SetMax(9e+36)
+				histogramDP.SetCount(uint64(7262))
+				histogramDP.Attributes().PutStr("label1", "value1")
+				return histogramDPS
+			}(),
+			expectedDatapoints: []dataPoint{
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							9.969209968386869e+35, 4.9846049841934345e+35, 2.4923024920967173e+35, 1.2461512460483586e+35, 6.230756230241793e+34,
+							3.1153781151208966e+34, 1.5576890575604483e+34, 7.788445287802241e+33, 3.894222643901121e+33, 1.9471113219505604e+33,
+							9.735556609752802e+32, 4.867778304876401e+32, 2.4338891524382005e+32, 1.2169445762191002e+32, 6.084722881095501e+31,
+							3.0423614405477506e+31, 1.5211807202738753e+31, 7.605903601369376e+30, 3.802951800684688e+30, 1.901475900342344e+30,
+							9.50737950171172e+29, 4.75368975085586e+29, 2.37684487542793e+29, 1.188422437713965e+29, 5.942112188569825e+28,
+							2.9710560942849127e+28, 1.4855280471424563e+28, 7.427640235712282e+27, 3.713820117856141e+27, 1.8569100589280704e+27,
+							9.284550294640352e+26, 4.642275147320176e+26, 2.321137573660088e+26, 1.160568786830044e+26, 5.80284393415022e+25,
+							2.90142196707511e+25, 1.450710983537555e+25, 7.253554917687775e+24, 3.6267774588438875e+24, 1.8133887294219438e+24,
+							9.066943647109719e+23, 4.5334718235548594e+23, 2.2667359117774297e+23, 1.1333679558887149e+23, 5.666839779443574e+22,
+							2.833419889721787e+22, 1.4167099448608936e+22, 7.083549724304468e+21, 3.541774862152234e+21, 1.770887431076117e+21,
+							8.854437155380585e+20, 4.4272185776902924e+20, 2.2136092888451462e+20, 1.1068046444225731e+20, 5.5340232221128655e+19,
+							2.7670116110564327e+19, 1.3835058055282164e+19, 6.917529027641082e+18, 3.458764513820541e+18, 1.7293822569102705e+18,
+							8.646911284551352e+17, 4.323455642275676e+17, 2.161727821137838e+17, 1.080863910568919e+17, 5.404319552844595e+16,
+							2.7021597764222976e+16, 1.3510798882111488e+16, 6.755399441055744e+15, 3.377699720527872e+15, 1.688849860263936e+15,
+							8.44424930131968e+14, 4.22212465065984e+14, 2.11106232532992e+14, 1.05553116266496e+14, 5.2776558133248e+13,
+							2.6388279066624e+13, 1.3194139533312e+13, 6.597069766656e+12, 3.298534883328e+12, 1.649267441664e+12, 8.24633720832e+11,
+							4.12316860416e+11, 2.06158430208e+11, 1.03079215104e+11, 5.1539607552e+10, 2.5769803776e+10, 1.2884901888e+10,
+							6.442450944e+09, 3.221225472e+09, 1.610612736e+09, 8.05306368e+08, 4.02653184e+08, 2.01326592e+08, 1.00663296e+08,
+							5.0331648e+07, 2.5165824e+07, 1.2582912e+07, 6.291456e+06, 3.145728e+06, 1.572864e+06,
+						},
+						Counts: []float64{
+							120, 119, 118, 117, 116, 115, 114, 113, 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 100, 99,
+							98, 97, 96, 95, 94, 93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68,
+							67, 66, 65, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37,
+							36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21,
+						},
+						Sum: 10000, Count: 7050, Min: 1.048576e+06, Max: 9e+36,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{786432, 393216, 196608, 98304, 49152, 24576, 12288, 6144, 3072, 1536, 768, 384, 192, 96, 48, 24, 12, 6, 3, 1.5, 0},
+						Counts: []float64{20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 2},
+						Sum:    0, Count: 212, Min: 0, Max: 1.048576e+06,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+			},
+		},
+		{
+			name: "Exponential histogram with more than 100 buckets, including negative and zero buckets",
+			histogramDPS: func() pmetric.ExponentialHistogramDataPointSlice {
+				histogramDPS := pmetric.NewExponentialHistogramDataPointSlice()
+				histogramDP := histogramDPS.AppendEmpty()
+				negBucketCounts := make([]uint64, 120)
+				for i := range negBucketCounts {
+					negBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Negative().BucketCounts().FromRaw(negBucketCounts)
+				histogramDP.SetZeroCount(2)
+				histogramDP.SetSum(10000)
+				histogramDP.SetMin(-9e+36)
+				histogramDP.SetMax(0)
+				histogramDP.SetCount(uint64(7262))
+				histogramDP.Attributes().PutStr("label1", "value1")
+				return histogramDPS
+			}(),
+			expectedDatapoints: []dataPoint{
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							0, -1.5, -3, -6, -12, -24, -48, -96, -192, -384, -768, -1536, -3072, -6144, -12288, -24576,
+							-49152, -98304, -196608, -393216, -786432, -1.572864e+06, -3.145728e+06, -6.291456e+06, -1.2582912e+07,
+							-2.5165824e+07, -5.0331648e+07, -1.00663296e+08, -2.01326592e+08, -4.02653184e+08, -8.05306368e+08,
+							-1.610612736e+09, -3.221225472e+09, -6.442450944e+09, -1.2884901888e+10, -2.5769803776e+10,
+							-5.1539607552e+10, -1.03079215104e+11, -2.06158430208e+11, -4.12316860416e+11, -8.24633720832e+11,
+							-1.649267441664e+12, -3.298534883328e+12, -6.597069766656e+12, -1.3194139533312e+13, -2.6388279066624e+13,
+							-5.2776558133248e+13, -1.05553116266496e+14, -2.11106232532992e+14, -4.22212465065984e+14, -8.44424930131968e+14,
+							-1.688849860263936e+15, -3.377699720527872e+15, -6.755399441055744e+15, -1.3510798882111488e+16,
+							-2.7021597764222976e+16, -5.404319552844595e+16, -1.080863910568919e+17, -2.161727821137838e+17,
+							-4.323455642275676e+17, -8.646911284551352e+17, -1.7293822569102705e+18, -3.458764513820541e+18,
+							-6.917529027641082e+18, -1.3835058055282164e+19, -2.7670116110564327e+19, -5.5340232221128655e+19,
+							-1.1068046444225731e+20, -2.2136092888451462e+20, -4.4272185776902924e+20, -8.854437155380585e+20,
+							-1.770887431076117e+21, -3.541774862152234e+21, -7.083549724304468e+21, -1.4167099448608936e+22,
+							-2.833419889721787e+22, -5.666839779443574e+22, -1.1333679558887149e+23, -2.2667359117774297e+23,
+							-4.5334718235548594e+23, -9.066943647109719e+23, -1.8133887294219438e+24, -3.6267774588438875e+24,
+							-7.253554917687775e+24, -1.450710983537555e+25, -2.90142196707511e+25, -5.80284393415022e+25,
+							-1.160568786830044e+26, -2.321137573660088e+26, -4.642275147320176e+26, -9.284550294640352e+26,
+							-1.8569100589280704e+27, -3.713820117856141e+27, -7.427640235712282e+27, -1.4855280471424563e+28,
+							-2.9710560942849127e+28, -5.942112188569825e+28, -1.188422437713965e+29, -2.37684487542793e+29, -4.75368975085586e+29,
+						},
+						Counts: []float64{
+							2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24,
+							25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
+							47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72,
+							73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99,
+						},
+						Sum: 10000, Count: 4952, Min: -6.338253001141147e+29, Max: 0,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							-9.50737950171172e+29, -1.901475900342344e+30, -3.802951800684688e+30, -7.605903601369376e+30,
+							-1.5211807202738753e+31, -3.0423614405477506e+31, -6.084722881095501e+31, -1.2169445762191002e+32,
+							-2.4338891524382005e+32, -4.867778304876401e+32, -9.735556609752802e+32, -1.9471113219505604e+33, -3.894222643901121e+33,
+							-7.788445287802241e+33, -1.5576890575604483e+34, -3.1153781151208966e+34, -6.230756230241793e+34, -1.2461512460483586e+35,
+							-2.4923024920967173e+35, -4.9846049841934345e+35, -9.969209968386869e+35,
+						},
+						Counts: []float64{100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120},
+						Sum:    0, Count: 2310, Min: -9e+36, Max: -6.338253001141147e+29,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+			},
+		},
+		{
+			name: "Exponential histogram with more than 100 buckets, including positive and negative buckets",
+			histogramDPS: func() pmetric.ExponentialHistogramDataPointSlice {
+				histogramDPS := pmetric.NewExponentialHistogramDataPointSlice()
+				histogramDP := histogramDPS.AppendEmpty()
+				posBucketCounts := make([]uint64, 60)
+				for i := range posBucketCounts {
+					posBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Positive().BucketCounts().FromRaw(posBucketCounts)
+				negBucketCounts := make([]uint64, 60)
+				for i := range negBucketCounts {
+					negBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Negative().BucketCounts().FromRaw(negBucketCounts)
+				histogramDP.SetSum(1000)
+				histogramDP.SetMin(-9e+17)
+				histogramDP.SetMax(9e+17)
+				histogramDP.SetCount(uint64(3660))
+				histogramDP.Attributes().PutStr("label1", "value1")
+				return histogramDPS
+			}(),
+			expectedDatapoints: []dataPoint{
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							8.646911284551352e+17, 4.323455642275676e+17, 2.161727821137838e+17, 1.080863910568919e+17, 5.404319552844595e+16, 2.7021597764222976e+16,
+							1.3510798882111488e+16, 6.755399441055744e+15, 3.377699720527872e+15, 1.688849860263936e+15, 8.44424930131968e+14, 4.22212465065984e+14,
+							2.11106232532992e+14, 1.05553116266496e+14, 5.2776558133248e+13, 2.6388279066624e+13, 1.3194139533312e+13, 6.597069766656e+12, 3.298534883328e+12,
+							1.649267441664e+12, 8.24633720832e+11, 4.12316860416e+11, 2.06158430208e+11, 1.03079215104e+11, 5.1539607552e+10, 2.5769803776e+10,
+							1.2884901888e+10, 6.442450944e+09, 3.221225472e+09, 1.610612736e+09, 8.05306368e+08, 4.02653184e+08, 2.01326592e+08, 1.00663296e+08,
+							5.0331648e+07, 2.5165824e+07, 1.2582912e+07, 6.291456e+06, 3.145728e+06, 1.572864e+06, 786432, 393216, 196608, 98304, 49152, 24576,
+							12288, 6144, 3072, 1536, 768, 384, 192, 96, 48, 24, 12, 6, 3, 1.5, -1.5, -3, -6, -12, -24, -48, -96, -192, -384, -768, -1536, -3072,
+							-6144, -12288, -24576, -49152, -98304, -196608, -393216, -786432, -1.572864e+06, -3.145728e+06, -6.291456e+06, -1.2582912e+07, -2.5165824e+07,
+							-5.0331648e+07, -1.00663296e+08, -2.01326592e+08, -4.02653184e+08, -8.05306368e+08, -1.610612736e+09, -3.221225472e+09, -6.442450944e+09,
+							-1.2884901888e+10, -2.5769803776e+10, -5.1539607552e+10, -1.03079215104e+11, -2.06158430208e+11, -4.12316860416e+11, -8.24633720832e+11,
+						},
+						Counts: []float64{
+							60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7,
+							6, 5, 4, 3, 2, 1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+							34, 35, 36, 37, 38, 39, 40,
+						},
+						Sum: 1000, Count: 2650, Min: -1.099511627776e+12, Max: 9e+17,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							-1.649267441664e+12, -3.298534883328e+12, -6.597069766656e+12, -1.3194139533312e+13, -2.6388279066624e+13, -5.2776558133248e+13,
+							-1.05553116266496e+14, -2.11106232532992e+14, -4.22212465065984e+14, -8.44424930131968e+14, -1.688849860263936e+15, -3.377699720527872e+15,
+							-6.755399441055744e+15, -1.3510798882111488e+16, -2.7021597764222976e+16, -5.404319552844595e+16, -1.080863910568919e+17, -2.161727821137838e+17,
+							-4.323455642275676e+17, -8.646911284551352e+17,
+						},
+						Counts: []float64{41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60},
+						Sum:    0, Count: 1010, Min: -9e+17, Max: -1.099511627776e+12,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+			},
+		},
+		{
+			name: "Exponential histogram with exact 200 buckets, including positive, negative buckets",
+			histogramDPS: func() pmetric.ExponentialHistogramDataPointSlice {
+				histogramDPS := pmetric.NewExponentialHistogramDataPointSlice()
+				histogramDP := histogramDPS.AppendEmpty()
+				posBucketCounts := make([]uint64, 100)
+				for i := range posBucketCounts {
+					posBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Positive().BucketCounts().FromRaw(posBucketCounts)
+				negBucketCounts := make([]uint64, 100)
+				for i := range negBucketCounts {
+					negBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Negative().BucketCounts().FromRaw(negBucketCounts)
+				histogramDP.SetSum(100000)
+				histogramDP.SetMin(-9e+36)
+				histogramDP.SetMax(9e+36)
+				histogramDP.SetCount(uint64(3662))
+				histogramDP.Attributes().PutStr("label1", "value1")
+				return histogramDPS
+			}(),
+			expectedDatapoints: []dataPoint{
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							9.50737950171172e+29, 4.75368975085586e+29, 2.37684487542793e+29, 1.188422437713965e+29, 5.942112188569825e+28,
+							2.9710560942849127e+28, 1.4855280471424563e+28, 7.427640235712282e+27, 3.713820117856141e+27, 1.8569100589280704e+27,
+							9.284550294640352e+26, 4.642275147320176e+26, 2.321137573660088e+26, 1.160568786830044e+26, 5.80284393415022e+25,
+							2.90142196707511e+25, 1.450710983537555e+25, 7.253554917687775e+24, 3.6267774588438875e+24, 1.8133887294219438e+24,
+							9.066943647109719e+23, 4.5334718235548594e+23, 2.2667359117774297e+23, 1.1333679558887149e+23, 5.666839779443574e+22,
+							2.833419889721787e+22, 1.4167099448608936e+22, 7.083549724304468e+21, 3.541774862152234e+21, 1.770887431076117e+21,
+							8.854437155380585e+20, 4.4272185776902924e+20, 2.2136092888451462e+20, 1.1068046444225731e+20, 5.5340232221128655e+19,
+							2.7670116110564327e+19, 1.3835058055282164e+19, 6.917529027641082e+18, 3.458764513820541e+18, 1.7293822569102705e+18,
+							8.646911284551352e+17, 4.323455642275676e+17, 2.161727821137838e+17, 1.080863910568919e+17, 5.404319552844595e+16,
+							2.7021597764222976e+16, 1.3510798882111488e+16, 6.755399441055744e+15, 3.377699720527872e+15, 1.688849860263936e+15,
+							8.44424930131968e+14, 4.22212465065984e+14, 2.11106232532992e+14, 1.05553116266496e+14, 5.2776558133248e+13,
+							2.6388279066624e+13, 1.3194139533312e+13, 6.597069766656e+12, 3.298534883328e+12, 1.649267441664e+12, 8.24633720832e+11,
+							4.12316860416e+11, 2.06158430208e+11, 1.03079215104e+11, 5.1539607552e+10, 2.5769803776e+10, 1.2884901888e+10, 6.442450944e+09,
+							3.221225472e+09, 1.610612736e+09, 8.05306368e+08, 4.02653184e+08, 2.01326592e+08, 1.00663296e+08, 5.0331648e+07,
+							2.5165824e+07, 1.2582912e+07, 6.291456e+06, 3.145728e+06, 1.572864e+06, 786432, 393216, 196608, 98304, 49152, 24576, 12288,
+							6144, 3072, 1536, 768, 384, 192, 96, 48, 24, 12, 6, 3, 1.5,
+						},
+						Counts: []float64{
+							100, 99, 98, 97, 96, 95, 94,
+							93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61,
+							60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28,
+							27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1,
+						},
+						Sum: 100000, Count: 5050, Min: 1, Max: 9e+36,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							-1.5, -3, -6, -12, -24, -48, -96, -192, -384, -768, -1536, -3072, -6144, -12288, -24576, -49152, -98304, -196608, -393216,
+							-786432, -1.572864e+06, -3.145728e+06, -6.291456e+06, -1.2582912e+07, -2.5165824e+07, -5.0331648e+07, -1.00663296e+08,
+							-2.01326592e+08, -4.02653184e+08, -8.05306368e+08, -1.610612736e+09, -3.221225472e+09, -6.442450944e+09, -1.2884901888e+10,
+							-2.5769803776e+10, -5.1539607552e+10, -1.03079215104e+11, -2.06158430208e+11, -4.12316860416e+11, -8.24633720832e+11,
+							-1.649267441664e+12, -3.298534883328e+12, -6.597069766656e+12, -1.3194139533312e+13, -2.6388279066624e+13, -5.2776558133248e+13,
+							-1.05553116266496e+14, -2.11106232532992e+14, -4.22212465065984e+14, -8.44424930131968e+14, -1.688849860263936e+15,
+							-3.377699720527872e+15, -6.755399441055744e+15, -1.3510798882111488e+16, -2.7021597764222976e+16,
+							-5.404319552844595e+16, -1.080863910568919e+17, -2.161727821137838e+17, -4.323455642275676e+17, -8.646911284551352e+17,
+							-1.7293822569102705e+18, -3.458764513820541e+18, -6.917529027641082e+18, -1.3835058055282164e+19, -2.7670116110564327e+19,
+							-5.5340232221128655e+19, -1.1068046444225731e+20, -2.2136092888451462e+20, -4.4272185776902924e+20, -8.854437155380585e+20,
+							-1.770887431076117e+21, -3.541774862152234e+21, -7.083549724304468e+21, -1.4167099448608936e+22, -2.833419889721787e+22,
+							-5.666839779443574e+22, -1.1333679558887149e+23, -2.2667359117774297e+23, -4.5334718235548594e+23, -9.066943647109719e+23,
+							-1.8133887294219438e+24, -3.6267774588438875e+24, -7.253554917687775e+24, -1.450710983537555e+25, -2.90142196707511e+25,
+							-5.80284393415022e+25, -1.160568786830044e+26, -2.321137573660088e+26, -4.642275147320176e+26, -9.284550294640352e+26,
+							-1.8569100589280704e+27, -3.713820117856141e+27, -7.427640235712282e+27, -1.4855280471424563e+28, -2.9710560942849127e+28,
+							-5.942112188569825e+28, -1.188422437713965e+29, -2.37684487542793e+29, -4.75368975085586e+29, -9.50737950171172e+29,
+						},
+						Counts: []float64{
+							1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+							36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68,
+							69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100,
+						},
+						Sum: 0, Count: 5050, Min: -9e+36, Max: -1,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+			},
+		},
+		{
+			name: "Exponential histogram with more than 200 buckets, including positive, negative and zero buckets",
+			histogramDPS: func() pmetric.ExponentialHistogramDataPointSlice {
+				histogramDPS := pmetric.NewExponentialHistogramDataPointSlice()
+				histogramDP := histogramDPS.AppendEmpty()
+				posBucketCounts := make([]uint64, 120)
+				for i := range posBucketCounts {
+					posBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Positive().BucketCounts().FromRaw(posBucketCounts)
+				histogramDP.SetZeroCount(2)
+				negBucketCounts := make([]uint64, 120)
+				for i := range negBucketCounts {
+					negBucketCounts[i] = uint64(i + 1)
+				}
+				histogramDP.Negative().BucketCounts().FromRaw(negBucketCounts)
+				histogramDP.SetSum(100000)
+				histogramDP.SetMin(-9e+36)
+				histogramDP.SetMax(9e+36)
+				histogramDP.SetCount(uint64(3662))
+				histogramDP.Attributes().PutStr("label1", "value1")
+				return histogramDPS
+			}(),
+			expectedDatapoints: []dataPoint{
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							9.969209968386869e+35, 4.9846049841934345e+35, 2.4923024920967173e+35, 1.2461512460483586e+35, 6.230756230241793e+34,
+							3.1153781151208966e+34, 1.5576890575604483e+34, 7.788445287802241e+33, 3.894222643901121e+33, 1.9471113219505604e+33,
+							9.735556609752802e+32, 4.867778304876401e+32, 2.4338891524382005e+32, 1.2169445762191002e+32, 6.084722881095501e+31,
+							3.0423614405477506e+31, 1.5211807202738753e+31, 7.605903601369376e+30, 3.802951800684688e+30, 1.901475900342344e+30,
+							9.50737950171172e+29, 4.75368975085586e+29, 2.37684487542793e+29, 1.188422437713965e+29, 5.942112188569825e+28,
+							2.9710560942849127e+28, 1.4855280471424563e+28, 7.427640235712282e+27, 3.713820117856141e+27, 1.8569100589280704e+27,
+							9.284550294640352e+26, 4.642275147320176e+26, 2.321137573660088e+26, 1.160568786830044e+26, 5.80284393415022e+25,
+							2.90142196707511e+25, 1.450710983537555e+25, 7.253554917687775e+24, 3.6267774588438875e+24, 1.8133887294219438e+24,
+							9.066943647109719e+23, 4.5334718235548594e+23, 2.2667359117774297e+23, 1.1333679558887149e+23, 5.666839779443574e+22,
+							2.833419889721787e+22, 1.4167099448608936e+22, 7.083549724304468e+21, 3.541774862152234e+21, 1.770887431076117e+21,
+							8.854437155380585e+20, 4.4272185776902924e+20, 2.2136092888451462e+20, 1.1068046444225731e+20, 5.5340232221128655e+19,
+							2.7670116110564327e+19, 1.3835058055282164e+19, 6.917529027641082e+18, 3.458764513820541e+18, 1.7293822569102705e+18,
+							8.646911284551352e+17, 4.323455642275676e+17, 2.161727821137838e+17, 1.080863910568919e+17, 5.404319552844595e+16,
+							2.7021597764222976e+16, 1.3510798882111488e+16, 6.755399441055744e+15, 3.377699720527872e+15, 1.688849860263936e+15,
+							8.44424930131968e+14, 4.22212465065984e+14, 2.11106232532992e+14, 1.05553116266496e+14, 5.2776558133248e+13,
+							2.6388279066624e+13, 1.3194139533312e+13, 6.597069766656e+12, 3.298534883328e+12, 1.649267441664e+12, 8.24633720832e+11,
+							4.12316860416e+11, 2.06158430208e+11, 1.03079215104e+11, 5.1539607552e+10, 2.5769803776e+10, 1.2884901888e+10,
+							6.442450944e+09, 3.221225472e+09, 1.610612736e+09, 8.05306368e+08, 4.02653184e+08, 2.01326592e+08, 1.00663296e+08, 5.0331648e+07,
+							2.5165824e+07, 1.2582912e+07, 6.291456e+06, 3.145728e+06, 1.572864e+06,
+						},
+						Counts: []float64{
+							120, 119, 118, 117, 116, 115, 114, 113, 112, 111, 110, 109, 108, 107, 106, 105, 104, 103, 102, 101, 100, 99, 98, 97, 96, 95, 94,
+							93, 92, 91, 90, 89, 88, 87, 86, 85, 84, 83, 82, 81, 80, 79, 78, 77, 76, 75, 74, 73, 72, 71, 70, 69, 68, 67, 66, 65, 64, 63, 62, 61,
+							60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28,
+							27, 26, 25, 24, 23, 22, 21,
+						},
+						Sum: 100000, Count: 7050, Min: 1048576, Max: 9e+36,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							786432, 393216, 196608, 98304, 49152, 24576, 12288, 6144, 3072, 1536, 768, 384, 192, 96, 48, 24,
+							12, 6, 3, 1.5, 0, -1.5, -3, -6, -12, -24, -48, -96, -192, -384, -768, -1536,
+							-3072, -6144, -12288, -24576, -49152, -98304, -196608, -393216, -786432, -1.572864e+06, -3.145728e+06, -6.291456e+06,
+							-1.2582912e+07, -2.5165824e+07, -5.0331648e+07, -1.00663296e+08, -2.01326592e+08, -4.02653184e+08, -8.05306368e+08,
+							-1.610612736e+09, -3.221225472e+09, -6.442450944e+09, -1.2884901888e+10, -2.5769803776e+10, -5.1539607552e+10,
+							-1.03079215104e+11, -2.06158430208e+11, -4.12316860416e+11, -8.24633720832e+11, -1.649267441664e+12,
+							-3.298534883328e+12, -6.597069766656e+12, -1.3194139533312e+13, -2.6388279066624e+13, -5.2776558133248e+13,
+							-1.05553116266496e+14, -2.11106232532992e+14, -4.22212465065984e+14, -8.44424930131968e+14,
+							-1.688849860263936e+15, -3.377699720527872e+15, -6.755399441055744e+15, -1.3510798882111488e+16,
+							-2.7021597764222976e+16, -5.404319552844595e+16, -1.080863910568919e+17, -2.161727821137838e+17,
+							-4.323455642275676e+17, -8.646911284551352e+17, -1.7293822569102705e+18, -3.458764513820541e+18,
+							-6.917529027641082e+18, -1.3835058055282164e+19, -2.7670116110564327e+19, -5.5340232221128655e+19,
+							-1.1068046444225731e+20, -2.2136092888451462e+20, -4.4272185776902924e+20, -8.854437155380585e+20,
+							-1.770887431076117e+21, -3.541774862152234e+21, -7.083549724304468e+21, -1.4167099448608936e+22,
+							-2.833419889721787e+22, -5.666839779443574e+22, -1.1333679558887149e+23, -2.2667359117774297e+23,
+							-4.5334718235548594e+23,
+						},
+						Counts: []float64{
+							20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 2, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+							11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
+							37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62,
+							63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79,
+						},
+						Sum: 0, Count: 3372, Min: -6.044629098073146e+23, Max: 1048576,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							-9.066943647109719e+23, -1.8133887294219438e+24, -3.6267774588438875e+24, -7.253554917687775e+24, -1.450710983537555e+25,
+							-2.90142196707511e+25, -5.80284393415022e+25, -1.160568786830044e+26, -2.321137573660088e+26, -4.642275147320176e+26,
+							-9.284550294640352e+26, -1.8569100589280704e+27, -3.713820117856141e+27, -7.427640235712282e+27, -1.4855280471424563e+28,
+							-2.9710560942849127e+28, -5.942112188569825e+28, -1.188422437713965e+29, -2.37684487542793e+29, -4.75368975085586e+29,
+							-9.50737950171172e+29, -1.901475900342344e+30, -3.802951800684688e+30, -7.605903601369376e+30, -1.5211807202738753e+31,
+							-3.0423614405477506e+31, -6.084722881095501e+31, -1.2169445762191002e+32, -2.4338891524382005e+32, -4.867778304876401e+32,
+							-9.735556609752802e+32, -1.9471113219505604e+33, -3.894222643901121e+33, -7.788445287802241e+33, -1.5576890575604483e+34,
+							-3.1153781151208966e+34, -6.230756230241793e+34, -1.2461512460483586e+35, -2.4923024920967173e+35, -4.9846049841934345e+35,
+							-9.969209968386869e+35,
+						},
+						Counts: []float64{
+							80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109,
+							110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120,
+						},
+						Sum: 0, Count: 4100, Min: -9e+36, Max: -6.044629098073146e+23,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+			},
+		},
+		{
+			name: "Exponential histogram with more than 100 buckets, including positive, negative and zero buckets with zero counts",
+			histogramDPS: func() pmetric.ExponentialHistogramDataPointSlice {
+				histogramDPS := pmetric.NewExponentialHistogramDataPointSlice()
+				histogramDP := histogramDPS.AppendEmpty()
+				posBucketCounts := make([]uint64, 60)
+				for i := range posBucketCounts {
+					posBucketCounts[i] = uint64(i % 5)
+				}
+				histogramDP.Positive().BucketCounts().FromRaw(posBucketCounts)
+				histogramDP.SetZeroCount(2)
+				negBucketCounts := make([]uint64, 60)
+				for i := range negBucketCounts {
+					negBucketCounts[i] = uint64(i % 5)
+				}
+				histogramDP.Negative().BucketCounts().FromRaw(negBucketCounts)
+				histogramDP.SetSum(1000)
+				histogramDP.SetMin(-9e+17)
+				histogramDP.SetMax(9e+17)
+				histogramDP.SetCount(uint64(3662))
+				histogramDP.Attributes().PutStr("label1", "value1")
+				return histogramDPS
+			}(),
+			expectedDatapoints: []dataPoint{
+				{
+					name: "foo",
+					value: &cWMetricHistogram{
+						Values: []float64{
+							8.646911284551352e+17, 4.323455642275676e+17, 2.161727821137838e+17, 1.080863910568919e+17, 2.7021597764222976e+16,
+							1.3510798882111488e+16, 6.755399441055744e+15, 3.377699720527872e+15, 8.44424930131968e+14, 4.22212465065984e+14, 2.11106232532992e+14,
+							1.05553116266496e+14, 2.6388279066624e+13, 1.3194139533312e+13, 6.597069766656e+12, 3.298534883328e+12, 8.24633720832e+11, 4.12316860416e+11,
+							2.06158430208e+11, 1.03079215104e+11, 2.5769803776e+10, 1.2884901888e+10, 6.442450944e+09, 3.221225472e+09, 8.05306368e+08, 4.02653184e+08,
+							2.01326592e+08, 1.00663296e+08, 2.5165824e+07, 1.2582912e+07, 6.291456e+06, 3.145728e+06, 786432, 393216, 196608, 98304, 24576, 12288, 6144, 3072,
+							768, 384, 192, 96, 24, 12, 6, 3, 0, -3, -6, -12, -24, -96, -192, -384, -768, -3072, -6144, -12288, -24576, -98304, -196608, -393216, -786432,
+							-3.145728e+06, -6.291456e+06, -1.2582912e+07, -2.5165824e+07, -1.00663296e+08, -2.01326592e+08, -4.02653184e+08, -8.05306368e+08, -3.221225472e+09,
+							-6.442450944e+09, -1.2884901888e+10, -2.5769803776e+10, -1.03079215104e+11, -2.06158430208e+11, -4.12316860416e+11, -8.24633720832e+11, -3.298534883328e+12,
+							-6.597069766656e+12, -1.3194139533312e+13, -2.6388279066624e+13, -1.05553116266496e+14, -2.11106232532992e+14, -4.22212465065984e+14, -8.44424930131968e+14,
+							-3.377699720527872e+15, -6.755399441055744e+15, -1.3510798882111488e+16, -2.7021597764222976e+16, -1.080863910568919e+17, -2.161727821137838e+17,
+							-4.323455642275676e+17, -8.646911284551352e+17,
+						},
+						Counts: []float64{
+							4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3, 2, 1, 4, 3,
+							2, 1, 2, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4,
+						},
+						Sum: 1000, Count: 242, Min: -9e+17, Max: 9e+17,
+					},
+					labels: map[string]string{oTellibDimensionKey: instrLibName, "label1": "value1"},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(_ *testing.T) {
+			exponentialHistogramDatapointSlice := exponentialHistogramDataPointSlice{dmd, tc.histogramDPS}
+			emfCalcs := setupEmfCalculators()
+			defer require.NoError(t, shutdownEmfCalculators(emfCalcs))
+			dps, retained := exponentialHistogramDatapointSlice.CalculateDeltaDatapoints(0, instrLibName, false, emfCalcs)
+
+			assert.True(t, retained)
+			assert.Equal(t, 1, exponentialHistogramDatapointSlice.Len())
+			assert.Equal(t, len(tc.expectedDatapoints), len(dps))
+			for i, expectedDP := range tc.expectedDatapoints {
+				assert.Equal(t, expectedDP, dps[i], "datapoint mismatch at index %d", i)
+			}
 		})
 	}
 }
@@ -1521,12 +2118,14 @@ func TestGetDataPoints(t *testing.T) {
 	})
 }
 
-func BenchmarkGetAndCalculateDeltaDataPoints(b *testing.B) {
+func benchmarkGetAndCalculateDeltaDataPoints(b *testing.B, bucketLength int) {
 	generateMetrics := []pmetric.Metrics{
 		generateTestGaugeMetric("int-gauge", intValueType),
 		generateTestGaugeMetric("int-gauge", doubleValueType),
 		generateTestHistogramMetric("histogram"),
 		generateTestExponentialHistogramMetric("exponential-histogram"),
+		generateTestExponentialHistogramMetricWithSpecifiedNumberOfBuckets(
+			"exponential-histogram-buckets-"+strconv.Itoa(bucketLength), bucketLength),
 		generateTestSumMetric("int-sum", intValueType),
 		generateTestSumMetric("double-sum", doubleValueType),
 		generateTestSummaryMetric("summary"),
@@ -1548,4 +2147,20 @@ func BenchmarkGetAndCalculateDeltaDataPoints(b *testing.B) {
 			}
 		}
 	}
+}
+
+func BenchmarkGetAndCalculateDeltaDataPointsInclude100Buckets(b *testing.B) {
+	benchmarkGetAndCalculateDeltaDataPoints(b, 100)
+}
+
+func BenchmarkGetAndCalculateDeltaDataPointsInclude200Buckets(b *testing.B) {
+	benchmarkGetAndCalculateDeltaDataPoints(b, 200)
+}
+
+func BenchmarkGetAndCalculateDeltaDataPointsInclude300Buckets(b *testing.B) {
+	benchmarkGetAndCalculateDeltaDataPoints(b, 300)
+}
+
+func BenchmarkGetAndCalculateDeltaDataPointsInclude500Buckets(b *testing.B) {
+	benchmarkGetAndCalculateDeltaDataPoints(b, 500)
 }

--- a/exporter/awsemfexporter/datapoint_test.go
+++ b/exporter/awsemfexporter/datapoint_test.go
@@ -2035,7 +2035,7 @@ func TestGetDataPoints(t *testing.T) {
 		rm := tc.metric.ResourceMetrics().At(0)
 		metrics := rm.ScopeMetrics().At(0).Metrics()
 		metric := metrics.At(metrics.Len() - 1)
-		metadata := generateTestMetricMetadata("namespace", time.Now().UnixNano()/int64(time.Millisecond), "log-group", "log-stream", "cloudwatch-otel", metric.Type())
+		metadata := generateTestMetricMetadata("namespace", time.Now().UnixNano()/int64(time.Millisecond), "log-group", "log-stream", "cloudwatch-otel", metric.Type(), 0)
 
 		t.Run(tc.name, func(t *testing.T) {
 			if tc.isPrometheusMetrics {
@@ -2095,7 +2095,7 @@ func TestGetDataPoints(t *testing.T) {
 		metric := pmetric.NewMetric()
 		metric.SetName("foo")
 		metric.SetUnit("Count")
-		metadata := generateTestMetricMetadata("namespace", time.Now().UnixNano()/int64(time.Millisecond), "log-group", "log-stream", "cloudwatch-otel", pmetric.MetricTypeEmpty)
+		metadata := generateTestMetricMetadata("namespace", time.Now().UnixNano()/int64(time.Millisecond), "log-group", "log-stream", "cloudwatch-otel", pmetric.MetricTypeEmpty, 0)
 		obs, logs := observer.New(zap.WarnLevel)
 		logger := zap.New(obs)
 
@@ -2139,7 +2139,7 @@ func benchmarkGetAndCalculateDeltaDataPoints(b *testing.B, bucketLength int) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		for i := 0; i < metrics.Len(); i++ {
-			metadata := generateTestMetricMetadata("namespace", time.Now().UnixNano()/int64(time.Millisecond), "log-group", "log-stream", "cloudwatch-otel", metrics.At(i).Type())
+			metadata := generateTestMetricMetadata("namespace", time.Now().UnixNano()/int64(time.Millisecond), "log-group", "log-stream", "cloudwatch-otel", metrics.At(i).Type(), 0)
 			dps := getDataPoints(metrics.At(i), metadata, zap.NewNop())
 
 			for i := 0; i < dps.Len(); i++ {

--- a/exporter/awsemfexporter/grouped_metric.go
+++ b/exporter/awsemfexporter/grouped_metric.go
@@ -56,7 +56,7 @@ func addToGroupedMetric(
 			continue
 		}
 
-		for _, dp := range dps {
+		for i, dp := range dps {
 			labels := dp.labels
 
 			if metricType, ok := labels["Type"]; ok {
@@ -86,6 +86,7 @@ func addToGroupedMetric(
 			}
 
 			// Extra params to use when grouping metrics
+			metadata.groupedMetricMetadata.batchIndex = i
 			groupKey := aws.NewKey(metadata.groupedMetricMetadata, labels)
 			if _, ok := groupedMetrics[groupKey]; ok {
 				// if MetricName already exists in metrics map, print warning log

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -405,6 +405,47 @@ func TestAddToGroupedMetric(t *testing.T) {
 		assert.Equal(t, 1, logs.Len())
 		assert.Equal(t, expectedLogs, logs.AllUntimed())
 	})
+
+	t.Run("Duplicate metric names with different metricIndex", func(t *testing.T) {
+		emfCalcs := setupEmfCalculators()
+		defer require.NoError(t, shutdownEmfCalculators(emfCalcs))
+		groupedMetrics := make(map[any]*groupedMetric)
+		generateMetrics := []pmetric.Metrics{
+			generateTestExponentialHistogramMetricWithLongBuckets("test_multiBucket_metric"),
+		}
+		finalOtelMetrics := generateOtelTestMetrics(generateMetrics...)
+
+		rms := finalOtelMetrics.ResourceMetrics()
+		ilms := rms.At(0).ScopeMetrics()
+		metrics := ilms.At(0).Metrics()
+		assert.Equal(t, 1, metrics.Len())
+
+		for i := 0; i < metrics.Len(); i++ {
+			err := addToGroupedMetric(metrics.At(i),
+				groupedMetrics,
+				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type()),
+				true,
+				nil,
+				testCfg,
+				emfCalcs,
+			)
+			assert.NoError(t, err)
+		}
+		assert.Len(t, groupedMetrics, 2)
+		expectedLabels := map[string]string{oTellibDimensionKey: instrumentationLibName, "label1": "value1"}
+		expectedMetadata := map[int]cWMetricMetadata{
+			0: generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(0).Type(), 0),
+			1: generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(0).Type(), 1),
+		}
+		for _, v := range groupedMetrics {
+			assert.Len(t, v.metrics, 1)
+			assert.Len(t, v.labels, 2)
+			assert.Contains(t, expectedMetadata, v.metadata.groupedMetricMetadata.batchIndex)
+			assert.Equal(t, expectedMetadata[v.metadata.groupedMetricMetadata.batchIndex], v.metadata)
+			assert.Equal(t, expectedLabels, v.labels)
+			delete(expectedMetadata, v.metadata.groupedMetricMetadata.batchIndex)
+		}
+	})
 }
 
 func TestAddKubernetesWrapper(t *testing.T) {
@@ -509,7 +550,11 @@ func TestTranslateUnit(t *testing.T) {
 	assert.Equal(t, "Count", v)
 }
 
-func generateTestMetricMetadata(namespace string, timestamp int64, logGroup, logStreamName, instrumentationScopeName string, metricType pmetric.MetricType) cWMetricMetadata {
+func generateTestMetricMetadata(namespace string, timestamp int64, logGroup, logStreamName, instrumentationScopeName string, metricType pmetric.MetricType, batchIndex ...int) cWMetricMetadata {
+	mIndex := 0
+	if len(batchIndex) > 0 {
+		mIndex = batchIndex[0]
+	}
 	return cWMetricMetadata{
 		receiver: prometheusReceiver,
 		groupedMetricMetadata: groupedMetricMetadata{
@@ -518,6 +563,7 @@ func generateTestMetricMetadata(namespace string, timestamp int64, logGroup, log
 			logGroup:       logGroup,
 			logStream:      logStreamName,
 			metricDataType: metricType,
+			batchIndex:     mIndex,
 		},
 		instrumentationScopeName: instrumentationScopeName,
 	}

--- a/exporter/awsemfexporter/grouped_metric_test.go
+++ b/exporter/awsemfexporter/grouped_metric_test.go
@@ -108,7 +108,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 
 			for i := 0; i < metrics.Len(); i++ {
 				err := addToGroupedMetric(metrics.At(i), groupedMetrics,
-					generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type()),
+					generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type(), 0),
 					true,
 					nil,
 					testCfg,
@@ -121,7 +121,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 				assert.Equal(t, len(tc.expectedMetricInfo), len(v.metrics))
 				assert.Equal(t, tc.expectedMetricInfo, v.metrics)
 				assert.Len(t, v.labels, 2)
-				assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, tc.expectedMetricType), v.metadata)
+				assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, tc.expectedMetricType, 0), v.metadata)
 				assert.Equal(t, tc.expectedLabels, v.labels)
 			}
 		})
@@ -150,7 +150,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 		for i := 0; i < metrics.Len(); i++ {
 			err := addToGroupedMetric(metrics.At(i),
 				groupedMetrics,
-				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type()),
+				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type(), 0),
 				true,
 				nil,
 				testCfg,
@@ -165,19 +165,19 @@ func TestAddToGroupedMetric(t *testing.T) {
 				case "int-gauge", "double-gauge":
 					assert.Len(t, group.metrics, 2)
 					assert.Equal(t, "Count", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeGauge), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeGauge, 0), group.metadata)
 				case "int-sum", "double-sum":
 					assert.Len(t, group.metrics, 2)
 					assert.Equal(t, "Count", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSum), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSum, 0), group.metadata)
 				case "histogram":
 					assert.Len(t, group.metrics, 1)
 					assert.Equal(t, "Seconds", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeHistogram), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeHistogram, 0), group.metadata)
 				case "summary":
 					assert.Len(t, group.metrics, 1)
 					assert.Equal(t, "Seconds", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSummary), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSummary, 0), group.metadata)
 				default:
 					assert.Fail(t, fmt.Sprintf("Unhandled metric %s not expected", metricName))
 				}
@@ -222,7 +222,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 		for i := 0; i < metrics.Len(); i++ {
 			err := addToGroupedMetric(metrics.At(i),
 				groupedMetrics,
-				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type()),
+				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type(), 0),
 				true,
 				nil,
 				testCfg,
@@ -237,19 +237,19 @@ func TestAddToGroupedMetric(t *testing.T) {
 				case "int-gauge", "double-gauge":
 					assert.Len(t, group.metrics, 2)
 					assert.Equal(t, "Count", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeGauge), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeGauge, 0), group.metadata)
 				case "int-sum", "double-sum":
 					assert.Len(t, group.metrics, 2)
 					assert.Equal(t, "Count", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSum), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSum, 0), group.metadata)
 				case "histogram":
 					assert.Len(t, group.metrics, 1)
 					assert.Equal(t, "Seconds", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeHistogram), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeHistogram, 0), group.metadata)
 				case "summary":
 					assert.Len(t, group.metrics, 1)
 					assert.Equal(t, "Seconds", metricInfo.unit)
-					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSummary), group.metadata)
+					assert.Equal(t, generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeSummary, 0), group.metadata)
 				default:
 					assert.Fail(t, fmt.Sprintf("Unhandled metric %s not expected", metricName))
 				}
@@ -270,7 +270,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 		ilms := otelMetrics.ResourceMetrics().At(0).ScopeMetrics()
 		metric := ilms.At(0).Metrics().At(0)
 
-		metricMetadata1 := generateTestMetricMetadata(namespace, timestamp, "log-group-1", logStreamName, instrumentationLibName, metric.Type())
+		metricMetadata1 := generateTestMetricMetadata(namespace, timestamp, "log-group-1", logStreamName, instrumentationLibName, metric.Type(), 0)
 		err := addToGroupedMetric(metric,
 			groupedMetrics,
 			metricMetadata1,
@@ -286,6 +286,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 			logStreamName,
 			instrumentationLibName,
 			metric.Type(),
+			0,
 		)
 		err = addToGroupedMetric(metric, groupedMetrics, metricMetadata2, true, nil, testCfg, emfCalcs)
 		assert.NoError(t, err)
@@ -340,7 +341,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 		for i := 0; i < metrics.Len(); i++ {
 			err := addToGroupedMetric(metrics.At(i),
 				groupedMetrics,
-				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type()),
+				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type(), 0),
 				true,
 				nil,
 				testCfg,
@@ -382,7 +383,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 		testCfg.logger = zap.New(obs)
 		err := addToGroupedMetric(metric,
 			groupedMetrics,
-			generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeEmpty),
+			generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, pmetric.MetricTypeEmpty, 0),
 			true,
 			nil,
 			testCfg,
@@ -423,7 +424,7 @@ func TestAddToGroupedMetric(t *testing.T) {
 		for i := 0; i < metrics.Len(); i++ {
 			err := addToGroupedMetric(metrics.At(i),
 				groupedMetrics,
-				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type()),
+				generateTestMetricMetadata(namespace, timestamp, logGroup, logStreamName, instrumentationLibName, metrics.At(i).Type(), 0),
 				true,
 				nil,
 				testCfg,
@@ -500,7 +501,7 @@ func BenchmarkAddToGroupedMetric(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		groupedMetrics := make(map[any]*groupedMetric)
 		for i := 0; i < numMetrics; i++ {
-			metadata := generateTestMetricMetadata("namespace", int64(1596151098037), "log-group", "log-stream", "cloudwatch-otel", metrics.At(i).Type())
+			metadata := generateTestMetricMetadata("namespace", int64(1596151098037), "log-group", "log-stream", "cloudwatch-otel", metrics.At(i).Type(), 0)
 			err := addToGroupedMetric(metrics.At(i), groupedMetrics, metadata, true, nil, testCfg, emfCalcs)
 			assert.NoError(b, err)
 		}
@@ -550,11 +551,7 @@ func TestTranslateUnit(t *testing.T) {
 	assert.Equal(t, "Count", v)
 }
 
-func generateTestMetricMetadata(namespace string, timestamp int64, logGroup, logStreamName, instrumentationScopeName string, metricType pmetric.MetricType, batchIndex ...int) cWMetricMetadata {
-	mIndex := 0
-	if len(batchIndex) > 0 {
-		mIndex = batchIndex[0]
-	}
+func generateTestMetricMetadata(namespace string, timestamp int64, logGroup, logStreamName, instrumentationScopeName string, metricType pmetric.MetricType, batchIndex int) cWMetricMetadata {
 	return cWMetricMetadata{
 		receiver: prometheusReceiver,
 		groupedMetricMetadata: groupedMetricMetadata{
@@ -563,7 +560,7 @@ func generateTestMetricMetadata(namespace string, timestamp int64, logGroup, log
 			logGroup:       logGroup,
 			logStream:      logStreamName,
 			metricDataType: metricType,
-			batchIndex:     mIndex,
+			batchIndex:     batchIndex,
 		},
 		instrumentationScopeName: instrumentationScopeName,
 	}

--- a/exporter/awsemfexporter/metric_translator.go
+++ b/exporter/awsemfexporter/metric_translator.go
@@ -85,6 +85,7 @@ type groupedMetricMetadata struct {
 	logGroup                   string
 	logStream                  string
 	metricDataType             pmetric.MetricType
+	batchIndex                 int
 	retainInitialValueForDelta bool
 }
 
@@ -150,6 +151,7 @@ func (mt metricTranslator) translateOTelToGroupedMetric(rm pmetric.ResourceMetri
 					logGroup:                   logGroup,
 					logStream:                  logStream,
 					metricDataType:             metric.Type(),
+					batchIndex:                 0,
 					retainInitialValueForDelta: deltaInitialValue,
 				},
 				instrumentationScopeName: instrumentationScopeName,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR fix the flaky unit test in previous PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36336, and add back the implementation of splitting the emf log logic. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36727

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit test updated and passed with 10 count:
```
go test -run TestAddToGroupedMetric -count 10 -tags=always

PASS
ok  	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/awsemfexporter	0.016s

```
