### PR TITLE
[receiver/awss3receiver] Add support RFC3339 format for starttime and endtime

### DIFF
--- a/.chloggen/awss3receiver-add-support-rfc3339.yaml
+++ b/.chloggen/awss3receiver-add-support-rfc3339.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awss3receiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support RFC3339 format for starttime and endtime"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36787]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/awss3receiver/README.md
+++ b/receiver/awss3receiver/README.md
@@ -38,7 +38,7 @@ The following exporter configuration parameters are supported.
 
 ### Time format for `starttime` and `endtime`
 The `starttime` and `endtime` fields are used to specify the time range for which to retrieve data. 
-The time format is either `YYYY-MM-DD HH:MM` or simply `YYYY-MM-DD`, in which case the time is assumed to be `00:00`.
+The time format is either RFC3339,`YYYY-MM-DD HH:MM` or simply `YYYY-MM-DD`, in which case the time is assumed to be `00:00`.
 
 ### Encodings
 By default, the receiver understands the following encodings:

--- a/receiver/awss3receiver/config.go
+++ b/receiver/awss3receiver/config.go
@@ -85,7 +85,7 @@ func (c Config) Validate() error {
 }
 
 func parseTime(timeStr, configName string) (time.Time, error) {
-	layouts := []string{"2006-01-02 15:04", time.DateOnly}
+	layouts := []string{time.RFC3339, "2006-01-02 15:04", time.DateOnly}
 
 	for _, layout := range layouts {
 		if t, err := time.Parse(layout, timeStr); err == nil {

--- a/receiver/awss3receiver/config_test.go
+++ b/receiver/awss3receiver/config_test.go
@@ -53,7 +53,7 @@ func TestLoadConfig(t *testing.T) {
 		},
 		{
 			id:           component.NewIDWithName(metadata.Type, "1"),
-			errorMessage: "s3_partition must be either 'hour' or 'minute'; unable to parse starttime (a date), accepted formats: 2006-01-02 15:04, 2006-01-02; unable to parse endtime (2024-02-03a), accepted formats: 2006-01-02 15:04, 2006-01-02",
+			errorMessage: "s3_partition must be either 'hour' or 'minute'; unable to parse starttime (a date), accepted formats: 2006-01-02T15:04:05Z07:00, 2006-01-02 15:04, 2006-01-02; unable to parse endtime (2024-02-03a), accepted formats: 2006-01-02T15:04:05Z07:00, 2006-01-02 15:04, 2006-01-02",
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "2"),
@@ -92,6 +92,19 @@ func TestLoadConfig(t *testing.T) {
 				Notifications: Notifications{
 					OpAMP: &opampExtension,
 				},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "4"),
+			expected: &Config{
+				S3Downloader: S3DownloaderConfig{
+					Region:              "us-east-1",
+					S3Bucket:            "abucket",
+					S3Partition:         "minute",
+					EndpointPartitionID: "aws",
+				},
+				StartTime: "2024-01-31T15:00:00Z",
+				EndTime:   "2024-02-03T00:00:00Z",
 			},
 		},
 	}

--- a/receiver/awss3receiver/testdata/config.yaml
+++ b/receiver/awss3receiver/testdata/config.yaml
@@ -22,4 +22,8 @@ awss3/3:
       suffix: "nop"
   notifications:
     opampextension: "opamp/bar"
-
+awss3/4:
+  s3downloader:
+    s3_bucket: abucket
+  starttime: "2024-01-31T15:00:00Z"
+  endtime: "2024-02-03T00:00:00Z"


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds support RFC3339 (`"2006-01-02T15:04:05Z07:00"`) format for `starttime` and `endtime` fields.

Currently, those fields cannot specify timezone. It's depends on the situation.
This change makes clear the timezone.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

This PR adds a new test data `awss3/4` which tests specifying RFC3339.

<!--Describe the documentation added.-->
#### Documentation

This PR changes README.md to describe time format.

<!--Please delete paragraphs that you did not use before submitting.-->
