### PR TITLE
[exporter/azuremonitor] fix not exporting to azure monitor when using instrumentaion key

### DIFF
--- a/.chloggen/36704.yaml
+++ b/.chloggen/36704.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: fix bug to remove default config of endpoint which causes failing to parse endpoint correctly.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36704]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/azuremonitorexporter/config_test.go
+++ b/exporter/azuremonitorexporter/config_test.go
@@ -36,7 +36,7 @@ func TestLoadConfig(t *testing.T) {
 		{
 			id: component.NewIDWithName(metadata.Type, "2"),
 			expected: &Config{
-				Endpoint:           defaultEndpoint,
+				Endpoint:           "https://dc.services.visualstudio.com/v2/track",
 				ConnectionString:   "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://ingestion.azuremonitor.com/",
 				InstrumentationKey: "00000000-0000-0000-0000-000000000000",
 				MaxBatchSize:       100,

--- a/exporter/azuremonitorexporter/factory.go
+++ b/exporter/azuremonitorexporter/factory.go
@@ -20,10 +20,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/azuremonitorexporter/internal/metadata"
 )
 
-const (
-	defaultEndpoint = "https://dc.services.visualstudio.com/v2/track"
-)
-
 var errUnexpectedConfigurationType = errors.New("failed to cast configuration to Azure Monitor Config")
 
 // NewFactory returns a factory for Azure Monitor exporter.
@@ -44,7 +40,6 @@ type factory struct {
 
 func createDefaultConfig() component.Config {
 	return &Config{
-		Endpoint:          defaultEndpoint,
 		MaxBatchSize:      1024,
 		MaxBatchInterval:  10 * time.Second,
 		SpanEventsEnabled: false,


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixed not exporting to azure monitor when using instrumentation key without endpoint. If default config is set, it'll never goto the branch
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/ab0f6a24521104e2e06c11673bc462aa4a5703e4/exporter/azuremonitorexporter/connection_string_parser.go#L47

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #36704 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

tested locally and can send metrics/logs/traces to `appinsights` successfully. And passes all tests.

<!--Describe the documentation added.-->
#### Documentation

no need to update.

<!--Please delete paragraphs that you did not use before submitting.-->
