### PR TITLE
[exporter/elasticsearch] [chore] fix lint issues with golangci-lint 1.62

### DIFF
--- a/exporter/elasticsearchexporter/internal/exphistogram/exphistogram.go
+++ b/exporter/elasticsearchexporter/internal/exphistogram/exphistogram.go
@@ -41,12 +41,12 @@ func ToTDigest(dp pmetric.ExponentialHistogramDataPoint) (counts []int64, values
 		}
 		lb := -LowerBoundary(offset+i+1, scale)
 		ub := -LowerBoundary(offset+i, scale)
-		counts = append(counts, int64(count))
+		counts = append(counts, safeUint64ToInt64(count))
 		values = append(values, lb+(ub-lb)/2)
 	}
 
 	if zeroCount := dp.ZeroCount(); zeroCount != 0 {
-		counts = append(counts, int64(zeroCount))
+		counts = append(counts, safeUint64ToInt64(zeroCount))
 		values = append(values, 0)
 	}
 
@@ -59,8 +59,16 @@ func ToTDigest(dp pmetric.ExponentialHistogramDataPoint) (counts []int64, values
 		}
 		lb := LowerBoundary(offset+i, scale)
 		ub := LowerBoundary(offset+i+1, scale)
-		counts = append(counts, int64(count))
+		counts = append(counts, safeUint64ToInt64(count))
 		values = append(values, lb+(ub-lb)/2)
 	}
 	return
+}
+
+func safeUint64ToInt64(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	} else {
+		return int64(v) // nolint:goset // overflow checked
+	}
 }

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -33,6 +33,7 @@ package objmodel // import "github.com/open-telemetry/opentelemetry-collector-co
 
 import (
 	"encoding/hex"
+	"errors"
 	"io"
 	"maps"
 	"math"
@@ -535,11 +536,10 @@ func (v *Value) iterJSON(w *json.Visitor, dedot bool, otel bool) error {
 	case KindBool:
 		return w.OnBool(v.primitive == 1)
 	case KindInt:
-		var i int64 = math.MaxInt64
-		if v.primitive < math.MaxInt64 {
-			i = int64(v.primitive) //nolint:gosec // overflow checked
+		if v.primitive > math.MaxInt64 {
+			return errors.New("integer value is higher than maximum int64")
 		}
-		return w.OnInt64(i)
+		return w.OnInt64(int64(v.primitive)) //nolint:gosec // overflow checked
 	case KindDouble:
 		if math.IsNaN(v.dbl) || math.IsInf(v.dbl, 0) {
 			// NaN and Inf are undefined for JSON. Let's serialize to "null"

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -78,6 +78,7 @@ const (
 	KindNil Kind = iota
 	KindBool
 	KindInt
+	KindUInt
 	KindDouble
 	KindString
 	KindArr
@@ -433,7 +434,7 @@ func StringValue(str string) Value { return Value{kind: KindString, str: str} }
 func IntValue(i int64) Value { return Value{kind: KindInt, i: i} }
 
 // UIntValue creates a new value from an unsigned integer.
-func UIntValue(i uint64) Value { return Value{kind: KindInt, ui: i} }
+func UIntValue(i uint64) Value { return Value{kind: KindUInt, ui: i} }
 
 // DoubleValue creates a new value from a double value..
 func DoubleValue(d float64) Value { return Value{kind: KindDouble, dbl: d} }
@@ -530,10 +531,9 @@ func (v *Value) iterJSON(w *json.Visitor, dedot bool, otel bool) error {
 	case KindBool:
 		return w.OnBool(v.ui == 1)
 	case KindInt:
-		if v.ui != 0 {
-			return w.OnUint64(v.ui)
-		}
 		return w.OnInt64(v.i)
+	case KindUInt:
+		return w.OnUint64(v.ui)
 	case KindDouble:
 		if math.IsNaN(v.dbl) || math.IsInf(v.dbl, 0) {
 			// NaN and Inf are undefined for JSON. Let's serialize to "null"

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -170,7 +170,7 @@ func (doc *Document) AddInt(key string, value int64) {
 	doc.Add(key, IntValue(value))
 }
 
-// AddInt adds an unsigned integer value to the document.
+// AddUInt adds an unsigned integer value to the document.
 func (doc *Document) AddUInt(key string, value uint64) {
 	doc.Add(key, UIntValue(value))
 }

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
@@ -4,7 +4,6 @@
 package objmodel
 
 import (
-	"errors"
 	"math"
 	"strings"
 	"testing"
@@ -377,15 +376,11 @@ func TestValue_Serialize(t *testing.T) {
 		want    string
 		wantErr error
 	}{
-		"nil value":         {value: nilValue, want: "null"},
-		"bool value: true":  {value: BoolValue(true), want: "true"},
-		"bool value: false": {value: BoolValue(false), want: "false"},
-		"int value":         {value: IntValue(42), want: "42"},
-		"large int value": {
-			value:   UIntValue(math.MaxInt64 + 1),
-			want:    "",
-			wantErr: errors.New("integer value is higher than maximum int64"),
-		},
+		"nil value":          {value: nilValue, want: "null"},
+		"bool value: true":   {value: BoolValue(true), want: "true"},
+		"bool value: false":  {value: BoolValue(false), want: "false"},
+		"int value":          {value: IntValue(42), want: "42"},
+		"uint value":         {value: UIntValue(42), want: "42"},
 		"double value: 3.14": {value: DoubleValue(3.14), want: "3.14"},
 		"double value: 1.0":  {value: DoubleValue(1.0), want: "1.0"},
 		"NaN is undefined":   {value: DoubleValue(math.NaN()), want: "null"},

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
@@ -372,9 +372,8 @@ func TestDocument_Serialize_Dedot(t *testing.T) {
 
 func TestValue_Serialize(t *testing.T) {
 	tests := map[string]struct {
-		value   Value
-		want    string
-		wantErr error
+		value Value
+		want  string
 	}{
 		"nil value":          {value: nilValue, want: "null"},
 		"bool value: true":   {value: BoolValue(true), want: "true"},
@@ -412,11 +411,7 @@ func TestValue_Serialize(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			var buf strings.Builder
 			err := test.value.iterJSON(newJSONVisitor(&buf), false, false)
-			if test.wantErr == nil {
-				require.NoError(t, err)
-			} else {
-				assert.Equal(t, test.wantErr, err)
-			}
+			require.NoError(t, err)
 			assert.Equal(t, test.want, buf.String())
 		})
 	}

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -349,7 +349,7 @@ func (m *encodeModel) upsertMetricDataPointValueOTelMode(documents map[uint32]ob
 
 	if dp.HasMappingHint(hintDocCount) {
 		docCount := dp.DocCount()
-		document.AddInt("_doc_count", int64(docCount))
+		document.AddUInt("_doc_count", docCount)
 	}
 
 	switch value.Type() {
@@ -387,7 +387,8 @@ func (dp summaryDataPoint) Value() (pcommon.Value, error) {
 	vm := pcommon.NewValueMap()
 	m := vm.Map()
 	m.PutDouble("sum", dp.Sum())
-	m.PutInt("value_count", int64(dp.Count()))
+
+	m.PutInt("value_count", safeUint64ToInt64(dp.Count()))
 	return vm, nil
 }
 
@@ -413,7 +414,7 @@ func (dp exponentialHistogramDataPoint) Value() (pcommon.Value, error) {
 		vm := pcommon.NewValueMap()
 		m := vm.Map()
 		m.PutDouble("sum", dp.Sum())
-		m.PutInt("value_count", int64(dp.Count()))
+		m.PutInt("value_count", safeUint64ToInt64(dp.Count()))
 		return vm, nil
 	}
 
@@ -460,7 +461,7 @@ func (dp histogramDataPoint) Value() (pcommon.Value, error) {
 		vm := pcommon.NewValueMap()
 		m := vm.Map()
 		m.PutDouble("sum", dp.Sum())
-		m.PutInt("value_count", int64(dp.Count()))
+		m.PutInt("value_count", safeUint64ToInt64(dp.Count()))
 		return vm, nil
 	}
 	return histogramToValue(dp.HistogramDataPoint)
@@ -518,7 +519,7 @@ func histogramToValue(dp pmetric.HistogramDataPoint) (pcommon.Value, error) {
 			value = explicitBounds.At(i-1) + (explicitBounds.At(i)-explicitBounds.At(i-1))/2.0
 		}
 
-		counts.AppendEmpty().SetInt(int64(count))
+		counts.AppendEmpty().SetInt(safeUint64ToInt64(count))
 		values.AppendEmpty().SetDouble(value)
 	}
 
@@ -674,7 +675,7 @@ func (m *encodeModel) encodeSpanOTelMode(resource pcommon.Resource, resourceSche
 	document.AddSpanID("parent_span_id", span.ParentSpanID())
 	document.AddString("name", span.Name())
 	document.AddString("kind", span.Kind().String())
-	document.AddInt("duration", int64(span.EndTimestamp()-span.StartTimestamp()))
+	document.AddInt("duration", safeUint64ToInt64(uint64(span.EndTimestamp()-span.StartTimestamp())))
 
 	m.encodeAttributesOTelMode(&document, span.Attributes())
 
@@ -985,7 +986,11 @@ func valueHash(h hash.Hash, v pcommon.Value) {
 		h.Write(buf)
 	case pcommon.ValueTypeInt:
 		buf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(buf, uint64(v.Int()))
+		var i uint64
+		if v.Int() > 0 {
+			i = uint64(v.Int()) //nolint:gosec // overflow checked
+		}
+		binary.LittleEndian.PutUint64(buf, i)
 		h.Write(buf)
 	case pcommon.ValueTypeBytes:
 		h.Write(v.Bytes().AsRaw())
@@ -1072,5 +1077,13 @@ func mergeGeolocation(attributes pcommon.Map) {
 			key := prefix + latKey
 			attributes.PutDouble(key, geo.lat)
 		}
+	}
+}
+
+func safeUint64ToInt64(v uint64) int64 {
+	if v > math.MaxInt64 {
+		return math.MaxInt64
+	} else {
+		return int64(v) // nolint:goset // overflow checked
 	}
 }

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -675,7 +675,7 @@ func (m *encodeModel) encodeSpanOTelMode(resource pcommon.Resource, resourceSche
 	document.AddSpanID("parent_span_id", span.ParentSpanID())
 	document.AddString("name", span.Name())
 	document.AddString("kind", span.Kind().String())
-	document.AddInt("duration", safeUint64ToInt64(uint64(span.EndTimestamp()-span.StartTimestamp())))
+	document.AddUint("duration", (span.EndTimestamp()-span.StartTimestamp()))
 
 	m.encodeAttributesOTelMode(&document, span.Attributes())
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -985,7 +985,7 @@ func valueHash(h hash.Hash, v pcommon.Value) {
 		h.Write(buf)
 	case pcommon.ValueTypeInt:
 		buf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(buf, uint64(v.Int())) // nolint:gosec // overflow assumed. We prefer having high integers than zero.
+		binary.LittleEndian.PutUint64(buf, uint64(v.Int())) // nolint:gosec // Overflow assumed. We prefer having high integers over zero.
 		h.Write(buf)
 	case pcommon.ValueTypeBytes:
 		h.Write(v.Bytes().AsRaw())

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -674,7 +674,7 @@ func (m *encodeModel) encodeSpanOTelMode(resource pcommon.Resource, resourceSche
 	document.AddSpanID("parent_span_id", span.ParentSpanID())
 	document.AddString("name", span.Name())
 	document.AddString("kind", span.Kind().String())
-	document.AddUint("duration", (span.EndTimestamp() - span.StartTimestamp()))
+	document.AddUInt("duration", uint64(span.EndTimestamp()-span.StartTimestamp()))
 
 	m.encodeAttributesOTelMode(&document, span.Attributes())
 

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -986,11 +986,7 @@ func valueHash(h hash.Hash, v pcommon.Value) {
 		h.Write(buf)
 	case pcommon.ValueTypeInt:
 		buf := make([]byte, 8)
-		var i uint64
-		if v.Int() > 0 {
-			i = uint64(v.Int()) //nolint:gosec // overflow checked
-		}
-		binary.LittleEndian.PutUint64(buf, i)
+		binary.LittleEndian.PutUint64(buf, uint64(v.Int())) // nolint:gosec // overflow assumed. We prefer having high integers than zero.
 		h.Write(buf)
 	case pcommon.ValueTypeBytes:
 		h.Write(v.Bytes().AsRaw())

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -387,7 +387,6 @@ func (dp summaryDataPoint) Value() (pcommon.Value, error) {
 	vm := pcommon.NewValueMap()
 	m := vm.Map()
 	m.PutDouble("sum", dp.Sum())
-
 	m.PutInt("value_count", safeUint64ToInt64(dp.Count()))
 	return vm, nil
 }
@@ -675,7 +674,7 @@ func (m *encodeModel) encodeSpanOTelMode(resource pcommon.Resource, resourceSche
 	document.AddSpanID("parent_span_id", span.ParentSpanID())
 	document.AddString("name", span.Name())
 	document.AddString("kind", span.Kind().String())
-	document.AddUint("duration", (span.EndTimestamp()-span.StartTimestamp()))
+	document.AddUint("duration", (span.EndTimestamp() - span.StartTimestamp()))
 
 	m.encodeAttributesOTelMode(&document, span.Attributes())
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1109,7 +1109,7 @@ func TestEncodeLogOtelMode(t *testing.T) {
 // helper function that creates the OTel LogRecord from the test structure
 func createTestOTelLogRecord(t *testing.T, rec OTelRecord) (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Resource) {
 	record := plog.NewLogRecord()
-	record.SetTimestamp(pcommon.Timestamp(uint64(rec.Timestamp.UnixNano())))                 //nolint:gosec // this input is controller from test
+	record.SetTimestamp(pcommon.Timestamp(uint64(rec.Timestamp.UnixNano())))                 //nolint:gosec // this input is controller by tests
 	record.SetObservedTimestamp(pcommon.Timestamp(uint64(rec.ObservedTimestamp.UnixNano()))) //nolint:gosec // this input is controller from test
 
 	record.SetTraceID(pcommon.TraceID(rec.TraceID))

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1109,7 +1109,7 @@ func TestEncodeLogOtelMode(t *testing.T) {
 // helper function that creates the OTel LogRecord from the test structure
 func createTestOTelLogRecord(t *testing.T, rec OTelRecord) (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Resource) {
 	record := plog.NewLogRecord()
-	record.SetTimestamp(pcommon.Timestamp(uint64(rec.Timestamp.UnixNano())))                 //nolint:gosec // this input is controller by tests
+	record.SetTimestamp(pcommon.Timestamp(uint64(rec.Timestamp.UnixNano())))                 //nolint:gosec // this input is controlled by tests
 	record.SetObservedTimestamp(pcommon.Timestamp(uint64(rec.ObservedTimestamp.UnixNano()))) //nolint:gosec // this input is controller from test
 
 	record.SetTraceID(pcommon.TraceID(rec.TraceID))

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1245,7 +1245,7 @@ func TestEncodeLogBodyMapMode(t *testing.T) {
 	resourceLogs := logs.ResourceLogs().AppendEmpty()
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
 	logRecords := scopeLogs.LogRecords()
-	observedTimestamp := pcommon.Timestamp(time.Now().UnixNano()) // nolint:gosec // time.Now is safe to convert to signed integer
+	observedTimestamp := pcommon.Timestamp(time.Now().UnixNano()) // nolint:gosec // UnixNano is positive and thus safe to convert to signed integer.
 
 	logRecord := logRecords.AppendEmpty()
 	logRecord.SetObservedTimestamp(observedTimestamp)

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1110,7 +1110,7 @@ func TestEncodeLogOtelMode(t *testing.T) {
 func createTestOTelLogRecord(t *testing.T, rec OTelRecord) (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Resource) {
 	record := plog.NewLogRecord()
 	record.SetTimestamp(pcommon.Timestamp(uint64(rec.Timestamp.UnixNano())))                 //nolint:gosec // this input is controlled by tests
-	record.SetObservedTimestamp(pcommon.Timestamp(uint64(rec.ObservedTimestamp.UnixNano()))) //nolint:gosec // this input is controller from test
+	record.SetObservedTimestamp(pcommon.Timestamp(uint64(rec.ObservedTimestamp.UnixNano()))) //nolint:gosec // this input is controlled by tests
 
 	record.SetTraceID(pcommon.TraceID(rec.TraceID))
 	record.SetSpanID(pcommon.SpanID(rec.SpanID))

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -1109,8 +1109,8 @@ func TestEncodeLogOtelMode(t *testing.T) {
 // helper function that creates the OTel LogRecord from the test structure
 func createTestOTelLogRecord(t *testing.T, rec OTelRecord) (plog.LogRecord, pcommon.InstrumentationScope, pcommon.Resource) {
 	record := plog.NewLogRecord()
-	record.SetTimestamp(pcommon.Timestamp(uint64(rec.Timestamp.UnixNano())))
-	record.SetObservedTimestamp(pcommon.Timestamp(uint64(rec.ObservedTimestamp.UnixNano())))
+	record.SetTimestamp(pcommon.Timestamp(uint64(rec.Timestamp.UnixNano())))                 //nolint:gosec // this input is controller from test
+	record.SetObservedTimestamp(pcommon.Timestamp(uint64(rec.ObservedTimestamp.UnixNano()))) //nolint:gosec // this input is controller from test
 
 	record.SetTraceID(pcommon.TraceID(rec.TraceID))
 	record.SetSpanID(pcommon.SpanID(rec.SpanID))
@@ -1245,7 +1245,7 @@ func TestEncodeLogBodyMapMode(t *testing.T) {
 	resourceLogs := logs.ResourceLogs().AppendEmpty()
 	scopeLogs := resourceLogs.ScopeLogs().AppendEmpty()
 	logRecords := scopeLogs.LogRecords()
-	observedTimestamp := pcommon.Timestamp(time.Now().UnixNano())
+	observedTimestamp := pcommon.Timestamp(time.Now().UnixNano()) // nolint:gosec // time.Now is safe to convert to signed integer
 
 	logRecord := logRecords.AppendEmpty()
 	logRecord.SetObservedTimestamp(observedTimestamp)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The golangci-lint upgrades causes a lot gosec issues due to a new check for integer conversion overflow.
This PR checks for integer overflows within the elasticsearch exporter package.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36638
