### PR TITLE
[chore][lint]: Replace exportloopref with copyloopvar for golangci-lint 1.62

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -141,7 +141,7 @@ linters:
     - depguard
     - errcheck
     - errorlint
-    - exportloopref
+    - copyloopvar
     - exhaustive
     - gci
     - gocritic


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Fix a warning with golangci-lint 1.62 about using the deprecated linter `exportloopref`.

#### Link to tracking issue
Related: #36638

