### PR TITLE
[exporter/elasticsearch][chore]: Fix copyloopvar issues

### DIFF
--- a/exporter/elasticsearchexporter/bulkindexer_test.go
+++ b/exporter/elasticsearchexporter/bulkindexer_test.go
@@ -85,7 +85,6 @@ func TestAsyncBulkIndexer_flush(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client, err := elasticsearch.NewClient(elasticsearch.Config{Transport: &mockTransport{
@@ -139,7 +138,6 @@ func TestAsyncBulkIndexer_requireDataStream(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			requireDataStreamCh := make(chan bool, 1)
@@ -215,7 +213,6 @@ func TestAsyncBulkIndexer_flush_error(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := Config{NumWorkers: 1, Flush: FlushSettings{Interval: time.Hour, Bytes: 1}}
@@ -269,7 +266,6 @@ func TestAsyncBulkIndexer_logRoundTrip(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -330,7 +330,6 @@ func TestConfig(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(strings.ReplaceAll(tt.id.String(), "/", "_"), func(t *testing.T) {
 			factory := NewFactory()
 			cfg := factory.CreateDefaultConfig()

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -562,11 +562,9 @@ func TestExporterLogs(t *testing.T) {
 		}
 
 		for name, handler := range handlers {
-			handler := handler
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 				for name, configurer := range configurations {
-					configurer := configurer
 					t.Run(name, func(t *testing.T) {
 						t.Parallel()
 						attempts := &atomic.Int64{}

--- a/exporter/elasticsearchexporter/mapping_hint_test.go
+++ b/exporter/elasticsearchexporter/mapping_hint_test.go
@@ -80,7 +80,6 @@ func TestHasHint(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, newMappingHintGetter(tt.attrsFunc()).HasMappingHint(tt.hint))
 		})


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Since Go 1.22, loop vars doesn't have to be explicitly created any more ([Go 1.22 release notes](https://tip.golang.org/doc/go1.22)). This PR cleans up the code.
