### PR TITLE
[pkg/ottl] Add support for non-element nodes in GetXML

### DIFF
--- a/.chloggen/get-xml-nonelements.yaml
+++ b/.chloggen/get-xml-nonelements.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: GetXML Converter now supports selecting text, CDATA, and attribute (value) content.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36821]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/ottlfuncs/README.md
+++ b/pkg/ottl/ottlfuncs/README.md
@@ -835,6 +835,18 @@ Get all elements in the document with tag "a" that have an attribute "b" with va
 
 - `GetXML(body, "//a[@b='c']")`
 
+Get `foo` from `<a>foo</a>`
+
+- `GetXML(body, "/a/text()")`
+
+Get `hello` from `<a><![CDATA[hello]]></a>`
+
+- `GetXML(body, "/a/text()")`
+
+Get `bar` from `<a foo="bar"/>`
+
+- `GetXML(body, "/a/@foo")`
+
 ### Hex
 
 `Hex(value)`

--- a/pkg/ottl/ottlfuncs/func_get_xml.go
+++ b/pkg/ottl/ottlfuncs/func_get_xml.go
@@ -52,10 +52,18 @@ func getXML[K any](target ottl.StringGetter[K], xPath string) ottl.ExprFunc[K] {
 
 		result := &xmlquery.Node{Type: xmlquery.DocumentNode}
 		for _, n := range nodes {
-			if n.Type != xmlquery.ElementNode {
+			switch n.Type {
+			case xmlquery.ElementNode, xmlquery.TextNode:
+				xmlquery.AddChild(result, n)
+			case xmlquery.AttributeNode, xmlquery.CharDataNode:
+				// get the value
+				xmlquery.AddChild(result, &xmlquery.Node{
+					Type: xmlquery.TextNode,
+					Data: n.InnerText(),
+				})
+			default:
 				continue
 			}
-			xmlquery.AddChild(result, n)
 		}
 		return result.OutputXML(false), nil
 	}

--- a/pkg/ottl/ottlfuncs/func_get_xml_test.go
+++ b/pkg/ottl/ottlfuncs/func_get_xml_test.go
@@ -74,22 +74,22 @@ func Test_GetXML(t *testing.T) {
 			want:     `<a></a>`,
 		},
 		{
-			name:     "ignore attribute selection",
+			name:     "get attribute selection",
 			document: `<a foo="bar"></a>`,
-			xPath:    "/@foo",
-			want:     ``,
+			xPath:    "/a/@foo",
+			want:     `bar`,
 		},
 		{
-			name:     "ignore text selection",
+			name:     "get text selection",
 			document: `<a>hello</a>`,
 			xPath:    "/a/text()",
-			want:     ``,
+			want:     `hello`,
 		},
 		{
-			name:     "ignore chardata selection",
+			name:     "get chardata selection",
 			document: `<a><![CDATA[hello]]></a>`,
 			xPath:    "/a/text()",
-			want:     ``,
+			want:     `hello`,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When originally implemented, only element nodes were selectable, but there doesn't seem to be any reason why we shouldn't be able to select these other types as well.