### PR TITLE
[chore][connector/routing] Fix versions noted in deprecation of match_once field

### DIFF
--- a/connector/routingconnector/README.md
+++ b/connector/routingconnector/README.md
@@ -32,7 +32,7 @@ The `match_once` field is deprecated as of `v0.116.0`. The deprecation schedule 
 
 - `v0.116.0`: The field is deprecated. If `false` is used, a warning will be logged.
 - `v0.117.0`: The default value will change from `false` to `true`. If `false` is used, an error will be logged.
-- `v0.118.0`: The field will be disconnected from behavior of the connector. If used (either `false` or `true`), an error will be logged.
+- `v0.118.0`: The field will be disconnected from behavior of the connector.
 - `v0.120.0`: The field will be removed.
 
 ### Migration

--- a/connector/routingconnector/README.md
+++ b/connector/routingconnector/README.md
@@ -28,16 +28,16 @@ Routes logs, metrics or traces based on resource attributes to specific pipeline
 
 ## Notice
 
-The `match_once` field is deprecated as of `v0.115.0`. The deprecation schedule is planned as follows:
+The `match_once` field is deprecated as of `v0.116.0`. The deprecation schedule is planned as follows:
 
-- `v0.115.0`: The field is deprecated. If `false` is used, a warning will be logged.
-- `v0.116.0`: The default value will change from `false` to `true`. If `false` is used, an error will be logged.
-- `v0.117.0`: The field will be disconnected from behavior of the connector. If used (either `false` or `true`), an error will be logged.
-- `v0.119.0`: The field will be removed.
+- `v0.116.0`: The field is deprecated. If `false` is used, a warning will be logged.
+- `v0.117.0`: The default value will change from `false` to `true`. If `false` is used, an error will be logged.
+- `v0.118.0`: The field will be disconnected from behavior of the connector. If used (either `false` or `true`), an error will be logged.
+- `v0.120.0`: The field will be removed.
 
 ### Migration
 
-It is recommended to set `match_once: true` until `v0.116.0` and then remove all usage of the field before `v0.119.0`.
+It is recommended to set `match_once: true` until `v0.117.0` and then remove all usage of the field before `v0.120.0`.
 
 For detailed guidance on how to migrate configuration from `match_once: false` to `match_once: true`, see [Config Migration](#config-migration.md).
 


### PR DESCRIPTION
I mistook the current version of the collector in #36824. This PR bumps all referenced versions so the schedule begins with the next release of the collector. It also removes a note about erroring if the field is used after v0.118.0.