### PR TITLE
[extension/sigv4authextension] Add support for endpoint based names for logs and traces

### DIFF
--- a/.chloggen/sigv4_logs_traces_support.yaml
+++ b/.chloggen/sigv4_logs_traces_support.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: sigv4authextension
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add support for endpoint based names for logs and traces"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36828]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/extension/sigv4authextension/README.md
+++ b/extension/sigv4authextension/README.md
@@ -26,7 +26,7 @@ The configuration fields are as follows:
     * Note that an attempt will be made to obtain a valid region from the endpoint of the service you are exporting to
     * [List of AWS regions](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RegionsAndAvailabilityZones.html)
 * `service`: **Optional**. The AWS service for AWS Sigv4
-    * Note that an attempt will be made to obtain a valid service from the endpoint of the service you are exporting to
+    * Note for supported services an attempt will be made to obtain a valid service from the endpoint of the service you are exporting to. Supported services include - workspaces, es, logs and traces.
 
 
 ```yaml

--- a/extension/sigv4authextension/signingroundtripper.go
+++ b/extension/sigv4authextension/signingroundtripper.go
@@ -114,27 +114,32 @@ func (si *signingRoundTripper) inferServiceAndRegion(r *http.Request) (service s
 	service = si.service
 	region = si.region
 
-	h := r.Host
-	if strings.HasPrefix(h, "aps-workspaces") {
-		if service == "" {
-			service = "aps"
-		}
-		rest := h[strings.Index(h, ".")+1:]
-		if region == "" {
-			region = rest[0:strings.Index(rest, ".")]
-		}
-	} else if strings.HasPrefix(h, "search-") {
-		if service == "" {
-			service = "es"
-		}
-		rest := h[strings.Index(h, ".")+1:]
-		if region == "" {
-			region = rest[0:strings.Index(rest, ".")]
-		}
+	host := r.Host
+	switch {
+	case strings.HasPrefix(host, "aps-workspaces"):
+		service, region = extractServiceAndRegion(service, region, host, "aps")
+	case strings.HasPrefix(host, "search-"):
+		service, region = extractServiceAndRegion(service, region, host, "es")
+	case strings.HasPrefix(host, "logs"):
+		service, region = extractServiceAndRegion(service, region, host, "logs")
+	case strings.HasPrefix(host, "xray"):
+		service, region = extractServiceAndRegion(service, region, host, "xray")
 	}
 
 	if service == "" || region == "" {
 		si.logger.Warn("Unable to infer region and/or service from the URL. Please provide values for region and/or service in the collector configuration.")
+	}
+
+	return service, region
+}
+
+func extractServiceAndRegion(service, region, host, defaultService string) (string, string) {
+	if service == "" {
+		service = defaultService
+	}
+	rest := host[strings.Index(host, ".")+1:]
+	if region == "" {
+		region = rest[0:strings.Index(rest, ".")]
 	}
 	return service, region
 }

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -110,6 +110,12 @@ func TestInferServiceAndRegion(t *testing.T) {
 	req5, err := http.NewRequest(http.MethodGet, "https://aps-workspaces.us-east-1.amazonaws.com/workspaces/ws-XXX/api/v1/remote_write", nil)
 	assert.NoError(t, err)
 
+	req6, err := http.NewRequest(http.MethodGet, "https://logs.us-east-1.amazonaws.com/v1/logs", nil)
+	assert.NoError(t, err)
+
+	req7, err := http.NewRequest(http.MethodGet, "https://xray.us-east-1.amazonaws.com/v1/traces", nil)
+	assert.NoError(t, err)
+
 	tests := []struct {
 		name            string
 		request         *http.Request
@@ -148,6 +154,20 @@ func TestInferServiceAndRegion(t *testing.T) {
 		{
 			"match_with_config",
 			req5,
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
+			"service",
+			"region",
+		},
+		{
+			"match_with_config",
+			req6,
+			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
+			"service",
+			"region",
+		},
+		{
+			"match_with_config",
+			req7,
 			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
 			"service",
 			"region",

--- a/extension/sigv4authextension/signingroundtripper_test.go
+++ b/extension/sigv4authextension/signingroundtripper_test.go
@@ -159,18 +159,18 @@ func TestInferServiceAndRegion(t *testing.T) {
 			"region",
 		},
 		{
-			"match_with_config",
+			"logs_service_and_region_match_with_no_config",
 			req6,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
-			"service",
-			"region",
+			createDefaultConfig().(*Config),
+			"logs",
+			"us-east-1",
 		},
 		{
-			"match_with_config",
+			"xray_service_and_region_match_with_no_config",
 			req7,
-			&Config{Region: "region", Service: "service", AssumeRole: AssumeRole{ARN: "rolearn", STSRegion: "region"}},
-			"service",
-			"region",
+			createDefaultConfig().(*Config),
+			"xray",
+			"us-east-1",
 		},
 	}
 


### PR DESCRIPTION
#### Description

Adds support for default endpoint based service name and region detection for AWS CloudWatchLogs and Traces endpoints

#### Link to tracking issue
Fixes

#### Testing
* Added unit tests
