### PR TITLE
[chore]: use testify instead of testing.Fatal or testing.Error in exporter

### DIFF
--- a/exporter/alertmanagerexporter/alertmanager_exporter_test.go
+++ b/exporter/alertmanagerexporter/alertmanager_exporter_test.go
@@ -325,9 +325,7 @@ func TestAlertManagerPostAlert(t *testing.T) {
 
 	err = am.postAlert(context.Background(), alerts)
 	assert.NoError(t, err)
-	if mock.fooCalledSuccessfully == false {
-		t.Errorf("mock server wasn't called")
-	}
+	assert.True(t, mock.fooCalledSuccessfully, "mock server wasn't called")
 }
 
 func TestClientConfig(t *testing.T) {

--- a/exporter/clickhouseexporter/exporter_logs_test.go
+++ b/exporter/clickhouseexporter/exporter_logs_test.go
@@ -32,10 +32,7 @@ func TestLogsExporter_New(t *testing.T) {
 	_ = func(want error) validate {
 		return func(t *testing.T, exporter *logsExporter, err error) {
 			require.Nil(t, exporter)
-			require.Error(t, err)
-			if !errors.Is(err, want) {
-				t.Fatalf("Expected error '%v', but got '%v'", want, err)
-			}
+			require.ErrorIs(t, err, want, "Expected error '%v', but got '%v'", want, err)
 		}
 	}
 

--- a/exporter/datadogexporter/internal/logs/sender_test.go
+++ b/exporter/datadogexporter/internal/logs/sender_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/confighttp"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.uber.org/zap/zaptest"
@@ -192,9 +193,7 @@ func TestSubmitLogs(t *testing.T) {
 			})
 			defer server.Close()
 			s := NewSender(server.URL, logger, confighttp.ClientConfig{Timeout: time.Second * 10, TLSSetting: configtls.ClientConfig{InsecureSkipVerify: true}}, true, "")
-			if err := s.SubmitLogs(context.Background(), tt.payload); err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, s.SubmitLogs(context.Background(), tt.payload))
 			assert.Equal(t, calls, tt.numRequests)
 		})
 	}

--- a/exporter/datadogexporter/internal/metrics/sketches/sketches_test.go
+++ b/exporter/datadogexporter/internal/metrics/sketches/sketches_test.go
@@ -74,14 +74,10 @@ func TestSketchSeriesListMarshal(t *testing.T) {
 	}
 
 	b, err := sl.Marshal()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	pl := new(gogen.SketchPayload)
-	if err := pl.Unmarshal(b); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, pl.Unmarshal(b))
 
 	require.Len(t, pl.Sketches, len(sl))
 

--- a/exporter/datadogexporter/traces_exporter_test.go
+++ b/exporter/datadogexporter/traces_exporter_test.go
@@ -116,11 +116,10 @@ func TestTracesSource(t *testing.T) {
 			return
 		}
 		buf := new(bytes.Buffer)
-		if _, err := buf.ReadFrom(r.Body); err != nil {
-			t.Fatalf("Metrics server handler error: %v", err)
-		}
+		_, err := buf.ReadFrom(r.Body)
+		assert.NoError(t, err, "Metrics server handler error: %v", err)
 		reqs <- buf.Bytes()
-		_, err := w.Write([]byte("{\"status\": \"ok\"}"))
+		_, err = w.Write([]byte("{\"status\": \"ok\"}"))
 		assert.NoError(t, err)
 	}))
 	defer metricsServer.Close()

--- a/exporter/logzioexporter/jsonlog_test.go
+++ b/exporter/logzioexporter/jsonlog_test.go
@@ -111,10 +111,6 @@ func TestSetTimeStamp(t *testing.T) {
 	requests := strings.Split(string(decoded), "\n")
 	require.NoError(t, json.Unmarshal([]byte(requests[0]), &jsonLog))
 	require.NoError(t, json.Unmarshal([]byte(requests[1]), &jsonLogNoTimestamp))
-	if jsonLogNoTimestamp["@timestamp"] != nil {
-		t.Fatalf("did not expect @timestamp")
-	}
-	if jsonLog["@timestamp"] == nil {
-		t.Fatalf("@timestamp does not exist")
-	}
+	require.Nil(t, jsonLogNoTimestamp["@timestamp"], "did not expect @timestamp")
+	require.NotNil(t, jsonLog["@timestamp"], "@timestamp does not exist")
 }

--- a/exporter/logzioexporter/logziospan_test.go
+++ b/exporter/logzioexporter/logziospan_test.go
@@ -10,13 +10,12 @@ import (
 	"testing"
 
 	"github.com/jaegertracing/jaeger/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransformToLogzioSpanBytes(tester *testing.T) {
 	inStr, err := os.ReadFile("./testdata/span.json")
-	if err != nil {
-		tester.Fatalf("error opening sample span file %s", err.Error())
-	}
+	require.NoError(tester, err, "error opening sample span file")
 
 	var span model.Span
 	err = json.Unmarshal(inStr, &span)
@@ -24,14 +23,10 @@ func TestTransformToLogzioSpanBytes(tester *testing.T) {
 		fmt.Println("json.Unmarshal")
 	}
 	newSpan, err := transformToLogzioSpanBytes(&span)
-	if err != nil {
-		tester.Fatal(err.Error())
-	}
+	require.NoError(tester, err)
 	m := make(map[string]any)
 	err = json.Unmarshal(newSpan, &m)
-	if err != nil {
-		tester.Fatal(err.Error())
-	}
+	require.NoError(tester, err)
 	if _, ok := m["JaegerTag"]; !ok {
 		tester.Error("error converting span to logzioSpan, JaegerTag is not found")
 	}
@@ -39,25 +34,17 @@ func TestTransformToLogzioSpanBytes(tester *testing.T) {
 
 func TestTransformToDbModelSpan(tester *testing.T) {
 	inStr, err := os.ReadFile("./testdata/span.json")
-	if err != nil {
-		tester.Fatalf("error opening sample span file %s", err.Error())
-	}
+	require.NoError(tester, err, "error opening sample span file")
 	var span model.Span
 	err = json.Unmarshal(inStr, &span)
 	if err != nil {
 		fmt.Println("json.Unmarshal")
 	}
 	newSpan, err := transformToLogzioSpanBytes(&span)
-	if err != nil {
-		tester.Fatal(err.Error())
-	}
+	require.NoError(tester, err)
 	var testLogzioSpan logzioSpan
 	err = json.Unmarshal(newSpan, &testLogzioSpan)
-	if err != nil {
-		tester.Fatal(err.Error())
-	}
+	require.NoError(tester, err)
 	dbModelSpan := testLogzioSpan.transformToDbModelSpan()
-	if len(dbModelSpan.References) != 3 {
-		tester.Fatalf("Error converting logzio span to dbmodel span")
-	}
+	require.Len(tester, dbModelSpan.References, 3, "Error converting logzio span to dbmodel span")
 }

--- a/exporter/mezmoexporter/exporter_test.go
+++ b/exporter/mezmoexporter/exporter_test.go
@@ -122,9 +122,7 @@ type (
 func createHTTPServer(params *testServerParams) testServer {
 	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			params.t.Fatal(err)
-		}
+		assert.NoError(params.t, err)
 
 		var logBody mezmoLogBody
 		if err = json.Unmarshal(body, &logBody); err != nil {

--- a/exporter/otelarrowexporter/internal/arrow/exporter_test.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter_test.go
@@ -922,9 +922,7 @@ func benchmarkPrioritizer(b *testing.B, numStreams int, pname PrioritizerName) {
 
 	wg.Add(1)
 	defer func() {
-		if err := tc.exporter.Shutdown(bg); err != nil {
-			b.Errorf("shutdown failed: %v", err)
-		}
+		assert.NoError(b, tc.exporter.Shutdown(bg), "shutdown failed")
 		wg.Done()
 		wg.Wait()
 	}()

--- a/exporter/prometheusexporter/end_to_end_test.go
+++ b/exporter/prometheusexporter/end_to_end_test.go
@@ -48,9 +48,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	defer dropWizardServer.Close()
 
 	srvURL, err := url.Parse(dropWizardServer.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -67,12 +65,8 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	exporterFactory := NewFactory()
 	set := exportertest.NewNopSettings()
 	exporter, err := exporterFactory.CreateMetrics(ctx, set, exporterCfg)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = exporter.Start(ctx, nil); err != nil {
-		t.Fatalf("Failed to start the Prometheus exporter: %v", err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, exporter.Start(ctx, nil), "Failed to start the Prometheus exporter")
 	t.Cleanup(func() { require.NoError(t, exporter.Shutdown(ctx)) })
 
 	// 3. Create the Prometheus receiver scraping from the DropWizard mock server and
@@ -89,9 +83,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
                 - targets: ['%s']
         `, srvURL.Host))
 	receiverConfig := new(prometheusreceiver.PromConfig)
-	if err = yaml.Unmarshal(yamlConfig, receiverConfig); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, yaml.Unmarshal(yamlConfig, receiverConfig))
 
 	receiverFactory := prometheusreceiver.NewFactory()
 	receiverCreateSet := receivertest.NewNopSettings()
@@ -100,26 +92,18 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	}
 	// 3.5 Create the Prometheus receiver and pass in the previously created Prometheus exporter.
 	prometheusReceiver, err := receiverFactory.CreateMetrics(ctx, receiverCreateSet, rcvCfg, exporter)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err = prometheusReceiver.Start(ctx, nil); err != nil {
-		t.Fatalf("Failed to start the Prometheus receiver: %v", err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, prometheusReceiver.Start(ctx, nil), "Failed to start the Prometheus receiver")
 	t.Cleanup(func() { require.NoError(t, prometheusReceiver.Shutdown(ctx)) })
 
 	// 4. Scrape from the Prometheus receiver to ensure that we export summary metrics
 	wg.Wait()
 
 	res, err := http.Get("http://" + exporterCfg.Endpoint + "/metrics")
-	if err != nil {
-		t.Fatalf("Failed to scrape from the exporter: %v", err)
-	}
+	require.NoError(t, err, "Failed to scrape from the exporter")
 	prometheusExporterScrape, err := io.ReadAll(res.Body)
 	res.Body.Close()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	// 5. Verify that we have the summary metrics and that their values make sense.
 	wantLineRegexps := []string{
@@ -171,9 +155,7 @@ func TestEndToEndSummarySupport(t *testing.T) {
 	// After this replacement, there should ONLY be newlines present.
 	prometheusExporterScrape = bytes.ReplaceAll(prometheusExporterScrape, []byte("\n"), []byte(""))
 	// Now assert that NO output was left over.
-	if len(prometheusExporterScrape) != 0 {
-		t.Fatalf("Left-over unmatched Prometheus scrape content: %q\n", prometheusExporterScrape)
-	}
+	require.Empty(t, prometheusExporterScrape, "Left-over unmatched Prometheus scrape content: %q\n", prometheusExporterScrape)
 }
 
 // the following triggers G101: Potential hardcoded credentials

--- a/exporter/prometheusexporter/prometheus_test.go
+++ b/exporter/prometheusexporter/prometheus_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"testing"
 	"time"
 
@@ -149,9 +148,7 @@ func TestPrometheusExporter_WithTLS(t *testing.T) {
 	rsp, err := httpClient.Get("https://localhost:7777/metrics")
 	require.NoError(t, err, "Failed to perform a scrape")
 
-	if g, w := rsp.StatusCode, 200; g != w {
-		t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-	}
+	assert.Equal(t, http.StatusOK, rsp.StatusCode, "Mismatched HTTP response status code")
 
 	blob, _ := io.ReadAll(rsp.Body)
 	_ = rsp.Body.Close()
@@ -164,9 +161,7 @@ func TestPrometheusExporter_WithTLS(t *testing.T) {
 	}
 
 	for _, w := range want {
-		if !strings.Contains(string(blob), w) {
-			t.Errorf("Missing %v from response:\n%v", w, string(blob))
-		}
+		assert.Contains(t, string(blob), w, "Missing %v from response:\n%v", w, string(blob))
 	}
 }
 
@@ -208,9 +203,7 @@ func TestPrometheusExporter_endToEndMultipleTargets(t *testing.T) {
 		res, err1 := http.Get("http://localhost:7777/metrics")
 		require.NoError(t, err1, "Failed to perform a scrape")
 
-		if g, w := res.StatusCode, 200; g != w {
-			t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-		}
+		assert.Equal(t, http.StatusOK, res.StatusCode, "Mismatched HTTP response status code")
 		blob, _ := io.ReadAll(res.Body)
 		_ = res.Body.Close()
 		want := []string{
@@ -229,9 +222,7 @@ func TestPrometheusExporter_endToEndMultipleTargets(t *testing.T) {
 		}
 
 		for _, w := range want {
-			if !strings.Contains(string(blob), w) {
-				t.Errorf("Missing %v from response:\n%v", w, string(blob))
-			}
+			assert.Contains(t, string(blob), w, "Missing %v from response:\n%v", w, string(blob))
 		}
 	}
 
@@ -242,9 +233,7 @@ func TestPrometheusExporter_endToEndMultipleTargets(t *testing.T) {
 	res, err := http.Get("http://localhost:7777/metrics")
 	require.NoError(t, err, "Failed to perform a scrape")
 
-	if g, w := res.StatusCode, 200; g != w {
-		t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-	}
+	assert.Equal(t, http.StatusOK, res.StatusCode, "Mismatched HTTP response status code")
 	blob, _ := io.ReadAll(res.Body)
 	_ = res.Body.Close()
 	require.Emptyf(t, string(blob), "Metrics did not expire")
@@ -285,9 +274,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 		res, err1 := http.Get("http://localhost:7777/metrics")
 		require.NoError(t, err1, "Failed to perform a scrape")
 
-		if g, w := res.StatusCode, 200; g != w {
-			t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-		}
+		assert.Equal(t, http.StatusOK, res.StatusCode, "Mismatched HTTP response status code")
 		blob, _ := io.ReadAll(res.Body)
 		_ = res.Body.Close()
 		want := []string{
@@ -302,9 +289,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 		}
 
 		for _, w := range want {
-			if !strings.Contains(string(blob), w) {
-				t.Errorf("Missing %v from response:\n%v", w, string(blob))
-			}
+			assert.Contains(t, string(blob), w, "Missing %v from response:\n%v", w, string(blob))
 		}
 	}
 
@@ -315,9 +300,7 @@ func TestPrometheusExporter_endToEnd(t *testing.T) {
 	res, err := http.Get("http://localhost:7777/metrics")
 	require.NoError(t, err, "Failed to perform a scrape")
 
-	if g, w := res.StatusCode, 200; g != w {
-		t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-	}
+	assert.Equal(t, http.StatusOK, res.StatusCode, "Mismatched HTTP response status code")
 	blob, _ := io.ReadAll(res.Body)
 	_ = res.Body.Close()
 	require.Emptyf(t, string(blob), "Metrics did not expire")
@@ -359,9 +342,7 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 		res, err1 := http.Get("http://localhost:7777/metrics")
 		require.NoError(t, err1, "Failed to perform a scrape")
 
-		if g, w := res.StatusCode, 200; g != w {
-			t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-		}
+		assert.Equal(t, http.StatusOK, res.StatusCode, "Mismatched HTTP response status code")
 		blob, _ := io.ReadAll(res.Body)
 		_ = res.Body.Close()
 		want := []string{
@@ -376,9 +357,7 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 		}
 
 		for _, w := range want {
-			if !strings.Contains(string(blob), w) {
-				t.Errorf("Missing %v from response:\n%v", w, string(blob))
-			}
+			assert.Contains(t, string(blob), w, "Missing %v from response:\n%v", w, string(blob))
 		}
 	}
 
@@ -389,9 +368,7 @@ func TestPrometheusExporter_endToEndWithTimestamps(t *testing.T) {
 	res, err := http.Get("http://localhost:7777/metrics")
 	require.NoError(t, err, "Failed to perform a scrape")
 
-	if g, w := res.StatusCode, 200; g != w {
-		t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-	}
+	assert.Equal(t, http.StatusOK, res.StatusCode, "Mismatched HTTP response status code")
 	blob, _ := io.ReadAll(res.Body)
 	_ = res.Body.Close()
 	require.Emptyf(t, string(blob), "Metrics did not expire")
@@ -434,9 +411,7 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	rsp, err := http.Get("http://localhost:7777/metrics")
 	require.NoError(t, err, "Failed to perform a scrape")
 
-	if g, w := rsp.StatusCode, 200; g != w {
-		t.Errorf("Mismatched HTTP response status code: Got: %d Want: %d", g, w)
-	}
+	assert.Equal(t, http.StatusOK, rsp.StatusCode, "Mismatched HTTP response status code")
 
 	blob, _ := io.ReadAll(rsp.Body)
 	_ = rsp.Body.Close()
@@ -449,9 +424,7 @@ func TestPrometheusExporter_endToEndWithResource(t *testing.T) {
 	}
 
 	for _, w := range want {
-		if !strings.Contains(string(blob), w) {
-			t.Errorf("Missing %v from response:\n%v", w, string(blob))
-		}
+		assert.Contains(t, string(blob), w, "Missing %v from response:\n%v", w, string(blob))
 	}
 }
 

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -260,9 +260,7 @@ func Test_export(t *testing.T) {
 		// The following is a handler function that reads the sent httpRequest, unmarshal, and checks if the WriteRequest
 		// preserves the TimeSeries data correctly
 		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 		require.NotNil(t, body)
 		// Receives the http requests and unzip, unmarshalls, and extracts TimeSeries
 		assert.Equal(t, "0.1.0", r.Header.Get("X-Prometheus-Remote-Write-Version"))
@@ -452,9 +450,7 @@ func Test_PushMetrics(t *testing.T) {
 
 	checkFunc := func(t *testing.T, r *http.Request, expected int, isStaleMarker bool) {
 		body, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		buf := make([]byte, len(body))
 		dest, err := snappy.Decode(buf, body)

--- a/exporter/prometheusremotewriteexporter/helper_test.go
+++ b/exporter/prometheusremotewriteexporter/helper_test.go
@@ -242,10 +242,8 @@ func TestEnsureTimeseriesPointsAreSortedByTimestamp(t *testing.T) {
 			si := ts.Samples[i]
 			for j := 0; j < i; j++ {
 				sj := ts.Samples[j]
-				if sj.Timestamp > si.Timestamp {
-					t.Errorf("Timeseries[%d]: Sample[%d].Timestamp(%d) > Sample[%d].Timestamp(%d)",
-						ti, j, sj.Timestamp, i, si.Timestamp)
-				}
+				assert.LessOrEqual(t, sj.Timestamp, si.Timestamp, "Timeseries[%d]: Sample[%d].Timestamp(%d) > Sample[%d].Timestamp(%d)",
+					ti, j, sj.Timestamp, i, si.Timestamp)
 			}
 		}
 	}

--- a/exporter/signalfxexporter/internal/translation/converter_test.go
+++ b/exporter/signalfxexporter/internal/translation/converter_test.go
@@ -1358,9 +1358,8 @@ func TestMetricsConverter_ConvertDimension(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c, err := NewMetricsConverter(zap.NewNop(), tt.fields.metricTranslator, nil, nil, tt.fields.nonAlphanumericDimChars, false, true)
 			require.NoError(t, err)
-			if got := c.ConvertDimension(tt.args.dim); got != tt.want {
-				t.Errorf("ConvertDimension() = %v, want %v", got, tt.want)
-			}
+			got := c.ConvertDimension(tt.args.dim)
+			assert.Equal(t, tt.want, got, "ConvertDimension() = %v, want %v", got, tt.want)
 		})
 	}
 }

--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -194,8 +194,8 @@ type capturingData struct {
 func (c *capturingData) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	body, err := io.ReadAll(r.Body)
 
-	if c.checkCompression && r.Header.Get("Content-Encoding") != "gzip" {
-		c.testing.Fatal("No compression")
+	if c.checkCompression {
+		assert.Equal(c.testing, "gzip", r.Header.Get("Content-Encoding"), "No compression")
 	}
 
 	if err != nil {
@@ -535,9 +535,7 @@ func TestReceiveTracesBatches(t *testing.T) {
 					}
 					timeStr := fmt.Sprintf(`"time":%d,`, i+1)
 					if strings.Contains(string(batchBody), timeStr) {
-						if eventFound {
-							t.Errorf("span event %d found in multiple batches", i)
-						}
+						assert.False(t, eventFound, "span event %d found in multiple batches", i)
 						eventFound = true
 					}
 				}
@@ -827,9 +825,7 @@ func TestReceiveLogs(t *testing.T) {
 								require.NoError(t, err)
 							}
 							if strings.Contains(string(batchBody), fmt.Sprintf(`"%s"`, attrVal.Str())) {
-								if eventFound {
-									t.Errorf("log event %s found in multiple batches", attrVal.Str())
-								}
+								assert.False(t, eventFound, "log event %s found in multiple batches", attrVal.Str())
 								eventFound = true
 								droppedCount--
 							}
@@ -1203,9 +1199,7 @@ func TestReceiveBatchedMetrics(t *testing.T) {
 						}
 						time := float64(i) + 0.001*float64(i)
 						if strings.Contains(string(batchBody), fmt.Sprintf(`"time":%g`, time)) {
-							if eventFound {
-								t.Errorf("metric event %d found in multiple batches", i)
-							}
+							assert.False(t, eventFound, "metric event %d found in multiple batches", i)
 							eventFound = true
 						}
 					}


### PR DESCRIPTION
### Description

* uses testify instead of testing.Fatal or testing.Error in processor