### PR TITLE
[chore]: use testify instead of testing.Fatal or testing.Error in extension and internal

### DIFF
--- a/extension/encoding/avrologencodingextension/avro_test.go
+++ b/extension/encoding/avrologencodingextension/avro_test.go
@@ -8,20 +8,17 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewAvroLogsUnmarshaler(t *testing.T) {
 	schema, data := createAVROTestData(t)
 
 	deserializer, err := newAVROStaticSchemaDeserializer(schema)
-	if err != nil {
-		t.Errorf("Did not expect an error, got %q", err.Error())
-	}
+	require.NoError(t, err, "Did not expect an error")
 
 	logMap, err := deserializer.Deserialize(data)
-	if err != nil {
-		t.Fatalf("Did not expect an error, got %q", err.Error())
-	}
+	require.NoError(t, err, "Did not expect an error")
 
 	assert.Equal(t, int64(1697187201488000000), logMap["timestamp"].(time.Time).UnixNano())
 	assert.Equal(t, "host1", logMap["hostname"])

--- a/extension/encoding/avrologencodingextension/extension_test.go
+++ b/extension/encoding/avrologencodingextension/extension_test.go
@@ -41,9 +41,8 @@ func TestInvalidUnmarshal(t *testing.T) {
 	t.Parallel()
 
 	schema, err := loadAVROSchemaFromFile("testdata/schema1.avro")
-	if err != nil {
-		t.Fatalf("Failed to read avro schema file: %q", err.Error())
-	}
+
+	require.NoError(t, err, "Failed to read avro schema file")
 
 	e, err := newExtension(&Config{Schema: string(schema)})
 	assert.NoError(t, err)

--- a/extension/encoding/avrologencodingextension/testutil.go
+++ b/extension/encoding/avrologencodingextension/testutil.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/linkedin/goavro/v2"
+	"github.com/stretchr/testify/require"
 )
 
 func encodeAVROLogTestData(codec *goavro.Codec, data string) []byte {
@@ -41,14 +42,10 @@ func createAVROTestData(t *testing.T) (string, []byte) {
 	t.Helper()
 
 	schema, err := loadAVROSchemaFromFile("testdata/schema1.avro")
-	if err != nil {
-		t.Fatalf("Failed to read avro schema file: %q", err.Error())
-	}
+	require.NoError(t, err, "Failed to read avro schema file")
 
 	codec, err := goavro.NewCodec(string(schema))
-	if err != nil {
-		t.Fatalf("Failed to create avro code from schema: %q", err.Error())
-	}
+	require.NoError(t, err, "Failed to create avro code from schema")
 
 	data := encodeAVROLogTestData(codec, `{
 		"timestamp": 1697187201488,

--- a/extension/observer/dockerobserver/extension_test.go
+++ b/extension/observer/dockerobserver/extension_test.go
@@ -23,10 +23,7 @@ func containerJSON(t *testing.T) dtypes.ContainerJSON {
 	require.NoError(t, err)
 
 	var container dtypes.ContainerJSON
-	err = json.Unmarshal(containerRaw, &container)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, json.Unmarshal(containerRaw, &container))
 	return container
 }
 

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/cloudwatchlogs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
@@ -185,10 +186,7 @@ func TestAddLogEventWithValidation(t *testing.T) {
 	logEvent := NewEvent(timestampMs, largeEventContent)
 	expectedTruncatedContent := (*logEvent.InputLogEvent.Message)[0:(defaultMaxEventPayloadBytes-perEventHeaderBytes-len(truncatedSuffix))] + truncatedSuffix
 
-	err := p.AddLogEntry(logEvent)
-	if err != nil {
-		t.Errorf("Error adding log entry: %v", err)
-	}
+	require.NoError(t, p.AddLogEntry(logEvent), "Error adding log entry")
 	assert.Equal(t, expectedTruncatedContent, *logEvent.InputLogEvent.Message)
 
 	logEvent = NewEvent(timestampMs, "")

--- a/internal/aws/k8s/k8sclient/helpers_test.go
+++ b/internal/aws/k8s/k8sclient/helpers_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -49,12 +50,8 @@ users:
       provideClusterInfo: true
 `
 	tmpfile, err := os.CreateTemp("", "kubeconfig")
-	if err != nil {
-		t.Error(err)
-	}
-	if err := os.WriteFile(tmpfile.Name(), []byte(content), 0o600); err != nil {
-		t.Error(err)
-	}
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(tmpfile.Name(), []byte(content), 0o600))
 	// overwrite the default kube config path
 	kubeConfigPath = tmpfile.Name()
 	return kubeConfigPath

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -278,7 +278,5 @@ func TestSweep(t *testing.T) {
 	require.NoError(t, mwe.Shutdown())
 	for range sweepEvent { // nolint
 	}
-	if !closed.Load() {
-		t.Errorf("Sweeper did not terminate.")
-	}
+	assert.True(t, closed.Load(), "Sweeper did not terminate.")
 }

--- a/internal/common/docker/images_test.go
+++ b/internal/common/docker/images_test.go
@@ -5,6 +5,9 @@ package docker
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDockerImageToElements(t *testing.T) {
@@ -133,18 +136,13 @@ func TestDockerImageToElements(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			image, err := ParseImageName(tt.args.image)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseImageName() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if image.Repository != tt.wantRepository {
-				t.Errorf("ParseImageName() repository = %v, want %v", image.Repository, tt.wantRepository)
-			}
-			if image.Tag != tt.wantTag {
-				t.Errorf("ParseImageName() tag = %v, want %v", image.Tag, tt.wantTag)
-			}
-			if image.SHA256 != tt.wantSHA256 {
-				t.Errorf("ParseImageName() hash = %v, want %v", image.SHA256, tt.wantSHA256)
+			if !tt.wantErr {
+				assert.NoError(t, err, "ParseImageName() error = %v, wantErr %v", err, tt.wantErr)
+				assert.Equal(t, tt.wantRepository, image.Repository, "ParseImageName() repository = %v, want %v", image.Repository, tt.wantRepository)
+				assert.Equal(t, tt.wantTag, image.Tag, "ParseImageName() tag = %v, want %v", image.Tag, tt.wantTag)
+				assert.Equal(t, tt.wantSHA256, image.SHA256, "ParseImageName() hash = %v, want %v", image.SHA256, tt.wantSHA256)
+			} else {
+				require.Error(t, err)
 			}
 		})
 	}

--- a/internal/coreinternal/parseutils/uri_test.go
+++ b/internal/coreinternal/parseutils/uri_test.go
@@ -455,9 +455,7 @@ func BenchmarkURLToMap(b *testing.B) {
 	m := make(map[string]any)
 	v := "https://dev:password@www.golang.org:8443/v1/app/stage?token=d9e28b1d-2c7b-4853-be6a-d94f34a5d4ab&env=prod&env=stage&token=c6fa29f9-a31b-4584-b98d-aa8473b0e18d&region=us-east1b&mode=fast"
 	u, err := url.ParseRequestURI(v)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 	for n := 0; n < b.N; n++ {
 		_, _ = urlToMap(u, m)
 	}
@@ -467,9 +465,7 @@ func BenchmarkQueryToMap(b *testing.B) {
 	m := make(map[string]any)
 	v := "?token=d9e28b1d-2c7b-4853-be6a-d94f34a5d4ab&env=prod&env=stage&token=c6fa29f9-a31b-4584-b98d-aa8473b0e18d&region=us-east1b&mode=fast"
 	u, err := url.ParseQuery(v)
-	if err != nil {
-		b.Fatal(err)
-	}
+	require.NoError(b, err)
 	for n := 0; n < b.N; n++ {
 		queryToMap(u, m)
 	}

--- a/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
+++ b/internal/coreinternal/timeutils/internal/ctimefmt/ctimefmt_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,36 +28,22 @@ var (
 
 func TestFormat(t *testing.T) {
 	s, err := Format(format1, dt1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if s != value1 {
-		t.Errorf("Given: %v, expected: %v", s, value1)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, s, value1, "Given: %v, expected: %v", s, value1)
 
 	s, err = Format(format2, dt1)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if s != value2 {
-		t.Errorf("Given: %v, expected: %v", s, value2)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, s, value2, "Given: %v, expected: %v", s, value2)
 }
 
 func TestParse(t *testing.T) {
 	dt, err := Parse(format1, value1)
-	if err != nil {
-		t.Error(err)
-	} else if dt != dt1 {
-		t.Errorf("Given: %v, expected: %v", dt, dt1)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, dt, dt1, "Given: %v, expected: %v", dt, dt1)
 
 	dt, err = Parse(format2, value2)
-	if err != nil {
-		t.Error(err)
-	} else if dt != dt2 {
-		t.Errorf("Given: %v, expected: %v", dt, dt2)
-	}
+	require.NoError(t, err)
+	assert.Equal(t, dt, dt2, "Given: %v, expected: %v", dt, dt2)
 }
 
 func TestZulu(t *testing.T) {
@@ -69,14 +56,11 @@ func TestZulu(t *testing.T) {
 	} {
 		t.Run(input, func(t *testing.T) {
 			dt, err := Parse(format, input)
-			if err != nil {
-				t.Error(err)
-			} else if dt.UnixNano() != dt1.UnixNano() {
-				// We compare the unix nanoseconds because Go has a subtle parsing difference between "Z" and "+0000".
-				// The former returns a Time with the UTC timezone, the latter returns a Time with a 0000 time zone offset.
-				// (See Go's documentation for `time.Parse`.)
-				t.Errorf("Given: %v, expected: %v", dt, dt1)
-			}
+			require.NoError(t, err)
+			// We compare the unix nanoseconds because Go has a subtle parsing difference between "Z" and "+0000".
+			// The former returns a Time with the UTC timezone, the latter returns a Time with a 0000 time zone offset.
+			// (See Go's documentation for `time.Parse`.)
+			assert.Equal(t, dt.UnixNano(), dt1.UnixNano(), "Given: %v, expected: %v", dt, dt1)
 		})
 	}
 }

--- a/internal/docker/docker_test_listener.go
+++ b/internal/docker/docker_test_listener.go
@@ -14,16 +14,12 @@ import (
 
 func testListener(t *testing.T) (net.Listener, string) {
 	f, err := os.CreateTemp(os.TempDir(), "testListener")
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	addr := f.Name()
 	require.NoError(t, os.Remove(addr))
 
 	listener, err := net.Listen("unix", addr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return listener, addr
 }


### PR DESCRIPTION
### Description

* uses testify instead of testing.Fatal or testing.Error in processor