### PR TITLE
[chore] switch to ubuntu 24.04 to identify breaking changes

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   setup-environment:
     timeout-minutes: 30
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v4
@@ -42,7 +42,7 @@ jobs:
             ./.tools
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
   check-codeowners:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [setup-environment]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Two `ubuntu-latest` references seem to have been missed as part of this PR: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36709 and are still causing a warning in the CI jobs: [Example](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/12338649982)

/cc @atoulme 