### PR TITLE
Trigger windows e2e tests when windows-related files change

### DIFF
--- a/.github/workflows/e2e-tests-windows.yml
+++ b/.github/workflows/e2e-tests-windows.yml
@@ -19,6 +19,17 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
 jobs:
+  get-changed-files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Get changed files
+        id: get_changed_files
+        run: echo "::set-output name=files::$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})"
+      - name: Print changed files
+        run: echo "${{ steps.get_changed_files.outputs.files }}"
+
   collector-build:
     runs-on: windows-latest
     if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}

--- a/.github/workflows/e2e-tests-windows.yml
+++ b/.github/workflows/e2e-tests-windows.yml
@@ -19,20 +19,22 @@ env:
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 2
 
 jobs:
-  get-changed-files:
+  windows-file-changed:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Get changed files
-        id: get_changed_files
-        run: echo "::set-output name=files::$(git diff --name-only ${{ github.event.before }} ${{ github.sha }})"
-      - name: Print changed files
-        run: echo "${{ steps.get_changed_files.outputs.files }}"
+        with:
+          fetch-depth: 0
+      - name: Did windows files changed
+        run: echo "changed=$(./.github/workflows/scripts/is_changed_file_windows.sh )" >> "$GITHUB_OUTPUT"
+      - run: echo $(./.github/workflows/scripts/is_changed_file_windows.sh ${{ github.event.pull_request.base.sha }} ${{ github.sha }} )
 
   collector-build:
     runs-on: windows-latest
-    if: ${{ github.actor != 'dependabot[bot]' && (contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') }}
+    needs: [windows-file-changed]
+    if: ${{ github.actor != 'dependabot[bot]' && ((contains(github.event.pull_request.labels.*.name, 'Run Windows') || github.event_name == 'push' || github.event_name == 'merge_group') || needs.windows-file-changed.outputs.changed == 'true') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/scripts/is_changed_file_windows.sh
+++ b/.github/workflows/scripts/is_changed_file_windows.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+
+#
+# verifies if any changed file is related to windows architecture.
+# this script is used to determine if e2e tests should be run on windows.
+#
+# It's intended to be used in a GitHub Actions workflow:
+# bash .github/workflows/scripts/is_changed_file_windows.sh ${{ github.event.pull_request.base.sha }} ${{ github.sha }}
+
+
+# Get changed files
+base_sha=$1
+head_sha=$2
+changed_files=$(git diff --name-only $base_sha $head_sha)
+
+# Find windows related files
+windows_files=$(find * -regex ".*windows.*.go")
+
+
+# Loop over changed files and check if they exist in windows_files
+found_windows_file=false
+for file in $changed_files; do
+  for windows_file in $windows_files; do
+    if [[ $file == "$windows_file" ]]; then
+      found_windows_file=true
+      break
+    fi
+  done
+done
+
+echo "$found_windows_file"


### PR DESCRIPTION
#### Description
We've noticed that many of the CI failures on main come from Windows e2e tests. We want to be more proactive in catching those failures, so this PR changes the workflow triggering Windows e2e tests to ensure they run on Pull Requests that change Windows-related files, even if the label `Run Windows` is absent.

It does so by looking at changed files. If the word `windows` is present in the file name, it triggers the workflow.

#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36788


