### PR TITLE
[pkg/ottl] remove support from accessing top-level objects

### DIFF
--- a/.chloggen/ottl-remove-top-level-paths.yaml
+++ b/.chloggen/ottl-remove-top-level-paths.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: removed the ability to reference entire parent objects.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36872]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+   Statements like `set(cache["resource"], resource)` in non-resource contexts will no longer work. 
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/pkg/ottl/contexts/internal/metric.go
+++ b/pkg/ottl/contexts/internal/metric.go
@@ -29,7 +29,7 @@ var MetricSymbolTable = map[ottl.EnumSymbol]ottl.Enum{
 
 func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
 	if path == nil {
-		return accessMetric[K](), nil
+		return nil, FormatDefaultErrorMessage("metric", "metric", "Metric", MetricRef)
 	}
 	switch path.Name() {
 	case "name":
@@ -48,20 +48,6 @@ func MetricPathGetSetter[K MetricContext](path ottl.Path[K]) (ottl.GetSetter[K],
 		return accessDataPoints[K](), nil
 	default:
 		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), "Metric", MetricRef)
-	}
-}
-
-func accessMetric[K MetricContext]() ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(_ context.Context, tCtx K) (any, error) {
-			return tCtx.GetMetric(), nil
-		},
-		Setter: func(_ context.Context, tCtx K, val any) error {
-			if newMetric, ok := val.(pmetric.Metric); ok {
-				newMetric.CopyTo(tCtx.GetMetric())
-			}
-			return nil
-		},
 	}
 }
 

--- a/pkg/ottl/contexts/internal/resource.go
+++ b/pkg/ottl/contexts/internal/resource.go
@@ -18,7 +18,7 @@ type ResourceContext interface {
 
 func ResourcePathGetSetter[K ResourceContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
 	if path == nil {
-		return accessResource[K](), nil
+		return nil, FormatDefaultErrorMessage("resource", "resource", "Resource", ResourceContextRef)
 	}
 	switch path.Name() {
 	case "attributes":
@@ -32,20 +32,6 @@ func ResourcePathGetSetter[K ResourceContext](path ottl.Path[K]) (ottl.GetSetter
 		return accessResourceSchemaURLItem[K](), nil
 	default:
 		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), "Resource", ResourceContextRef)
-	}
-}
-
-func accessResource[K ResourceContext]() ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(_ context.Context, tCtx K) (any, error) {
-			return tCtx.GetResource(), nil
-		},
-		Setter: func(_ context.Context, tCtx K, val any) error {
-			if newRes, ok := val.(pcommon.Resource); ok {
-				newRes.CopyTo(tCtx.GetResource())
-			}
-			return nil
-		},
 	}
 }
 

--- a/pkg/ottl/contexts/internal/resource_test.go
+++ b/pkg/ottl/contexts/internal/resource_test.go
@@ -29,15 +29,6 @@ func TestResourcePathGetSetter(t *testing.T) {
 		modified func(resource pcommon.Resource)
 	}{
 		{
-			name:   "resource",
-			path:   nil,
-			orig:   refResource,
-			newVal: pcommon.NewResource(),
-			modified: func(resource pcommon.Resource) {
-				pcommon.NewResource().CopyTo(resource)
-			},
-		},
-		{
 			name: "resource schema_url",
 			path: &TestPath[*resourceContext]{
 				N: "schema_url",

--- a/pkg/ottl/contexts/internal/scope.go
+++ b/pkg/ottl/contexts/internal/scope.go
@@ -18,7 +18,7 @@ type InstrumentationScopeContext interface {
 
 func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
 	if path == nil {
-		return accessInstrumentationScope[K](), nil
+		return nil, FormatDefaultErrorMessage("instrumentation_scope", "instrumentation_scope", "Instrumentation Scope", InstrumentationScopeRef)
 	}
 	switch path.Name() {
 	case "name":
@@ -37,20 +37,6 @@ func ScopePathGetSetter[K InstrumentationScopeContext](path ottl.Path[K]) (ottl.
 		return accessInstrumentationScopeSchemaURLItem[K](), nil
 	default:
 		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), "Instrumentation Scope", InstrumentationScopeRef)
-	}
-}
-
-func accessInstrumentationScope[K InstrumentationScopeContext]() ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(_ context.Context, tCtx K) (any, error) {
-			return tCtx.GetInstrumentationScope(), nil
-		},
-		Setter: func(_ context.Context, tCtx K, val any) error {
-			if newIl, ok := val.(pcommon.InstrumentationScope); ok {
-				newIl.CopyTo(tCtx.GetInstrumentationScope())
-			}
-			return nil
-		},
 	}
 }
 

--- a/pkg/ottl/contexts/internal/scope_test.go
+++ b/pkg/ottl/contexts/internal/scope_test.go
@@ -28,15 +28,6 @@ func TestScopePathGetSetter(t *testing.T) {
 		modified func(is pcommon.InstrumentationScope)
 	}{
 		{
-			name:   "instrumentation_scope",
-			path:   nil,
-			orig:   refIS,
-			newVal: pcommon.NewInstrumentationScope(),
-			modified: func(is pcommon.InstrumentationScope) {
-				pcommon.NewInstrumentationScope().CopyTo(is)
-			},
-		},
-		{
 			name: "instrumentation_scope name",
 			path: &TestPath[*instrumentationScopeContext]{
 				N: "name",

--- a/pkg/ottl/contexts/internal/span.go
+++ b/pkg/ottl/contexts/internal/span.go
@@ -39,7 +39,7 @@ var SpanSymbolTable = map[ottl.EnumSymbol]ottl.Enum{
 
 func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], error) {
 	if path == nil {
-		return accessSpan[K](), nil
+		return nil, FormatDefaultErrorMessage("span", "span", SpanContextName, SpanRef)
 	}
 	switch path.Name() {
 	case "trace_id":
@@ -129,20 +129,6 @@ func SpanPathGetSetter[K SpanContext](path ottl.Path[K]) (ottl.GetSetter[K], err
 		return accessStatus[K](), nil
 	default:
 		return nil, FormatDefaultErrorMessage(path.Name(), path.String(), SpanContextName, SpanRef)
-	}
-}
-
-func accessSpan[K SpanContext]() ottl.StandardGetSetter[K] {
-	return ottl.StandardGetSetter[K]{
-		Getter: func(_ context.Context, tCtx K) (any, error) {
-			return tCtx.GetSpan(), nil
-		},
-		Setter: func(_ context.Context, tCtx K, val any) error {
-			if newSpan, ok := val.(ptrace.Span); ok {
-				newSpan.CopyTo(tCtx.GetSpan())
-			}
-			return nil
-		},
 	}
 }
 

--- a/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
+++ b/pkg/ottl/contexts/ottldatapoint/datapoint_test.go
@@ -1923,8 +1923,6 @@ func createAttributeTelemetry(attributes pcommon.Map) {
 }
 
 func Test_newPathGetSetter_Metric(t *testing.T) {
-	refMetric := createMetricTelemetry()
-
 	newMetric := pmetric.NewMetric()
 	newMetric.SetName("new name")
 
@@ -1935,17 +1933,6 @@ func Test_newPathGetSetter_Metric(t *testing.T) {
 		newVal   any
 		modified func(metric pmetric.Metric)
 	}{
-		{
-			name: "metric",
-			path: &internal.TestPath[TransformContext]{
-				N: "metric",
-			},
-			orig:   refMetric,
-			newVal: newMetric,
-			modified: func(metric pmetric.Metric) {
-				newMetric.CopyTo(metric)
-			},
-		},
 		{
 			name: "metric name",
 			path: &internal.TestPath[TransformContext]{

--- a/pkg/ottl/contexts/ottllog/log_test.go
+++ b/pkg/ottl/contexts/ottllog/log_test.go
@@ -27,7 +27,7 @@ var (
 )
 
 func Test_newPathGetSetter(t *testing.T) {
-	refLog, refIS, refResource := createTelemetry("string")
+	refLog, _, _ := createTelemetry("string")
 
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
@@ -594,28 +594,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: int64(20),
 			modified: func(log plog.LogRecord, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				log.SetDroppedAttributesCount(20)
-			},
-		},
-		{
-			name: "instrumentation_scope",
-			path: &internal.TestPath[TransformContext]{
-				N: "instrumentation_scope",
-			},
-			orig:   refIS,
-			newVal: pcommon.NewInstrumentationScope(),
-			modified: func(_ plog.LogRecord, il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
-				pcommon.NewInstrumentationScope().CopyTo(il)
-			},
-		},
-		{
-			name: "resource",
-			path: &internal.TestPath[TransformContext]{
-				N: "resource",
-			},
-			orig:   refResource,
-			newVal: pcommon.NewResource(),
-			modified: func(_ plog.LogRecord, _ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
-				pcommon.NewResource().CopyTo(resource)
 			},
 		},
 	}

--- a/pkg/ottl/contexts/ottlscope/scope_test.go
+++ b/pkg/ottl/contexts/ottlscope/scope_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func Test_newPathGetSetter(t *testing.T) {
-	refIS, refResource := createTelemetry()
+	refIS, _ := createTelemetry()
 
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
@@ -380,17 +380,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: "next",
 			modified: func(is pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				is.SetVersion("next")
-			},
-		},
-		{
-			name: "resource",
-			path: &internal.TestPath[TransformContext]{
-				N: "resource",
-			},
-			orig:   refResource,
-			newVal: pcommon.NewResource(),
-			modified: func(_ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
-				pcommon.NewResource().CopyTo(resource)
 			},
 		},
 	}

--- a/pkg/ottl/contexts/ottlspan/span_test.go
+++ b/pkg/ottl/contexts/ottlspan/span_test.go
@@ -26,7 +26,7 @@ var (
 )
 
 func Test_newPathGetSetter(t *testing.T) {
-	refSpan, refIS, refResource := createTelemetry()
+	refSpan, _, _ := createTelemetry()
 
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
@@ -647,28 +647,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: "bad span",
 			modified: func(span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				span.Status().SetMessage("bad span")
-			},
-		},
-		{
-			name: "instrumentation_scope",
-			path: &internal.TestPath[TransformContext]{
-				N: "instrumentation_scope",
-			},
-			orig:   refIS,
-			newVal: pcommon.NewInstrumentationScope(),
-			modified: func(_ ptrace.Span, il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
-				pcommon.NewInstrumentationScope().CopyTo(il)
-			},
-		},
-		{
-			name: "resource",
-			path: &internal.TestPath[TransformContext]{
-				N: "resource",
-			},
-			orig:   refResource,
-			newVal: pcommon.NewResource(),
-			modified: func(_ ptrace.Span, _ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
-				pcommon.NewResource().CopyTo(resource)
 			},
 		},
 	}

--- a/pkg/ottl/contexts/ottlspanevent/span_events_test.go
+++ b/pkg/ottl/contexts/ottlspanevent/span_events_test.go
@@ -20,7 +20,7 @@ import (
 var spanID2 = [8]byte{8, 7, 6, 5, 4, 3, 2, 1}
 
 func Test_newPathGetSetter(t *testing.T) {
-	refSpanEvent, refSpan, refIS, refResource := createTelemetry()
+	refSpanEvent, _, _, _ := createTelemetry()
 
 	newAttrs := pcommon.NewMap()
 	newAttrs.PutStr("hello", "world")
@@ -403,39 +403,6 @@ func Test_newPathGetSetter(t *testing.T) {
 			newVal: int64(20),
 			modified: func(spanEvent ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
 				spanEvent.SetDroppedAttributesCount(20)
-			},
-		},
-		{
-			name: "instrumentation_scope",
-			path: &internal.TestPath[TransformContext]{
-				N: "instrumentation_scope",
-			},
-			orig:   refIS,
-			newVal: pcommon.NewInstrumentationScope(),
-			modified: func(_ ptrace.SpanEvent, _ ptrace.Span, il pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
-				pcommon.NewInstrumentationScope().CopyTo(il)
-			},
-		},
-		{
-			name: "resource",
-			path: &internal.TestPath[TransformContext]{
-				N: "resource",
-			},
-			orig:   refResource,
-			newVal: pcommon.NewResource(),
-			modified: func(_ ptrace.SpanEvent, _ ptrace.Span, _ pcommon.InstrumentationScope, resource pcommon.Resource, _ pcommon.Map) {
-				pcommon.NewResource().CopyTo(resource)
-			},
-		},
-		{
-			name: "span",
-			path: &internal.TestPath[TransformContext]{
-				N: "span",
-			},
-			orig:   refSpan,
-			newVal: ptrace.NewSpan(),
-			modified: func(_ ptrace.SpanEvent, span ptrace.Span, _ pcommon.InstrumentationScope, _ pcommon.Resource, _ pcommon.Map) {
-				ptrace.NewSpan().CopyTo(span)
 			},
 		},
 	}


### PR DESCRIPTION
#### Description

Removes the path accessors for the shared contexts that allowed getting top level objects for:
- resource
- instrumentation_scope
- metric
- span

While these accessors existed the grammar didn't actually let you use them and their presence makes future work problematic. At this time we don't want to provide accessors to entire parent objects directly.

#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36869