### PR TITLE
[exporter/awsxrayexporter] Merge in latest semconv for awsxrayexporter.

### DIFF
--- a/.chloggen/aws-xray-exporter-merge-in-latest-semconv.yaml
+++ b/.chloggen/aws-xray-exporter-merge-in-latest-semconv.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: awsxrayexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: merge in latest semantic conventions for awsxrayexporter.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [30935]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/aws-xray-exporter-merge-in-latest-semconv.yaml
+++ b/.chloggen/aws-xray-exporter-merge-in-latest-semconv.yaml
@@ -10,7 +10,7 @@ component: awsxrayexporter
 note: merge in latest semantic conventions for awsxrayexporter.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: [30935]
+issues: [36894]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/awsxrayexporter/awsxray_test.go
+++ b/exporter/awsxrayexporter/awsxray_test.go
@@ -19,7 +19,7 @@ import (
 	"go.opentelemetry.io/collector/exporter/exportertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/awsutil"
@@ -172,22 +172,22 @@ func constructW3CFormatTraceSpanData(ispans ptrace.ScopeSpans) {
 func constructResource() pcommon.Resource {
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeServiceName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeContainerName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "999999998")
-	attrs.PutStr(conventions.AttributeCloudRegion, "us-west-2")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-west-1b")
+	attrs.PutStr(conventionsv112.AttributeServiceName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "999999998")
+	attrs.PutStr(conventionsv112.AttributeCloudRegion, "us-west-2")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-west-1b")
 	return resource
 }
 
 func constructHTTPClientSpan(traceID pcommon.TraceID) ptrace.Span {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/users/junit"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	endTime := time.Now().Round(time.Second)
 	startTime := endTime.Add(-90 * time.Second)
 	spanAttributes := constructSpanAttributes(attributes)
@@ -212,10 +212,10 @@ func constructHTTPClientSpan(traceID pcommon.TraceID) ptrace.Span {
 
 func constructHTTPServerSpan(traceID pcommon.TraceID) ptrace.Span {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/users/junit"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	endTime := time.Now().Round(time.Second)
 	startTime := endTime.Add(-90 * time.Second)
 	spanAttributes := constructSpanAttributes(attributes)

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -90,7 +91,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 			sdkLanguage = value.Str()
 		case conventions.AttributeTelemetrySDKVersion:
 			sdkVersion = value.Str()
-		case conventions.AttributeTelemetryAutoVersion:
+		case conventions.AttributeTelemetryAutoVersion, conventionsv127.AttributeTelemetryDistroVersion:
 			autoVersion = value.Str()
 		case conventions.AttributeContainerID:
 			containerID = value.Str()

--- a/exporter/awsxrayexporter/internal/translator/aws.go
+++ b/exporter/awsxrayexporter/internal/translator/aws.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
-	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -59,57 +59,57 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 	filtered := make(map[string]pcommon.Value)
 	resource.Attributes().Range(func(key string, value pcommon.Value) bool {
 		switch key {
-		case conventions.AttributeCloudProvider:
+		case conventionsv112.AttributeCloudProvider:
 			cloud = value.Str()
-		case conventions.AttributeCloudPlatform:
+		case conventionsv112.AttributeCloudPlatform:
 			service = value.Str()
-		case conventions.AttributeCloudAccountID:
+		case conventionsv112.AttributeCloudAccountID:
 			account = value.Str()
-		case conventions.AttributeCloudAvailabilityZone:
+		case conventionsv112.AttributeCloudAvailabilityZone:
 			zone = value.Str()
-		case conventions.AttributeHostID:
+		case conventionsv112.AttributeHostID:
 			hostID = value.Str()
-		case conventions.AttributeHostType:
+		case conventionsv112.AttributeHostType:
 			hostType = value.Str()
-		case conventions.AttributeHostImageID:
+		case conventionsv112.AttributeHostImageID:
 			amiID = value.Str()
-		case conventions.AttributeContainerName:
+		case conventionsv112.AttributeContainerName:
 			if container == "" {
 				container = value.Str()
 			}
-		case conventions.AttributeK8SPodName:
+		case conventionsv112.AttributeK8SPodName:
 			podUID = value.Str()
-		case conventions.AttributeServiceNamespace:
+		case conventionsv112.AttributeServiceNamespace:
 			namespace = value.Str()
-		case conventions.AttributeServiceInstanceID:
+		case conventionsv112.AttributeServiceInstanceID:
 			deployID = value.Str()
-		case conventions.AttributeServiceVersion:
+		case conventionsv112.AttributeServiceVersion:
 			versionLabel = value.Str()
-		case conventions.AttributeTelemetrySDKName:
+		case conventionsv112.AttributeTelemetrySDKName:
 			sdkName = value.Str()
-		case conventions.AttributeTelemetrySDKLanguage:
+		case conventionsv112.AttributeTelemetrySDKLanguage:
 			sdkLanguage = value.Str()
-		case conventions.AttributeTelemetrySDKVersion:
+		case conventionsv112.AttributeTelemetrySDKVersion:
 			sdkVersion = value.Str()
-		case conventions.AttributeTelemetryAutoVersion, conventionsv127.AttributeTelemetryDistroVersion:
+		case conventionsv112.AttributeTelemetryAutoVersion, conventions.AttributeTelemetryDistroVersion:
 			autoVersion = value.Str()
-		case conventions.AttributeContainerID:
+		case conventionsv112.AttributeContainerID:
 			containerID = value.Str()
-		case conventions.AttributeK8SClusterName:
+		case conventionsv112.AttributeK8SClusterName:
 			clusterName = value.Str()
-		case conventions.AttributeAWSECSClusterARN:
+		case conventionsv112.AttributeAWSECSClusterARN:
 			clusterArn = value.Str()
-		case conventions.AttributeAWSECSContainerARN:
+		case conventionsv112.AttributeAWSECSContainerARN:
 			containerArn = value.Str()
-		case conventions.AttributeAWSECSTaskARN:
+		case conventionsv112.AttributeAWSECSTaskARN:
 			taskArn = value.Str()
-		case conventions.AttributeAWSECSTaskFamily:
+		case conventionsv112.AttributeAWSECSTaskFamily:
 			taskFamily = value.Str()
-		case conventions.AttributeAWSECSLaunchtype:
+		case conventionsv112.AttributeAWSECSLaunchtype:
 			launchType = value.Str()
-		case conventions.AttributeAWSLogGroupNames:
+		case conventionsv112.AttributeAWSLogGroupNames:
 			logGroups = normalizeToSlice(value)
-		case conventions.AttributeAWSLogGroupARNs:
+		case conventionsv112.AttributeAWSLogGroupARNs:
 			logGroupArns = normalizeToSlice(value)
 		}
 		return true
@@ -117,13 +117,13 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 
 	if awsOperation, ok := attributes[awsxray.AWSOperationAttribute]; ok {
 		operation = awsOperation.Str()
-	} else if rpcMethod, ok := attributes[conventions.AttributeRPCMethod]; ok {
+	} else if rpcMethod, ok := attributes[conventionsv112.AttributeRPCMethod]; ok {
 		operation = rpcMethod.Str()
 	}
 
 	for key, value := range attributes {
 		switch key {
-		case conventions.AttributeRPCMethod:
+		case conventionsv112.AttributeRPCMethod:
 			// Determinstically handled with if else above
 		case awsxray.AWSOperationAttribute:
 			// Determinstically handled with if else above
@@ -149,15 +149,15 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 			filtered[key] = value
 		}
 	}
-	if cloud != conventions.AttributeCloudProviderAWS && cloud != "" {
+	if cloud != conventionsv112.AttributeCloudProviderAWS && cloud != "" {
 		return filtered, nil // not AWS so return nil
 	}
 
 	// Favor Semantic Conventions for specific SQS and DynamoDB attributes.
-	if value, ok := attributes[conventions.AttributeMessagingURL]; ok {
+	if value, ok := attributes[conventionsv112.AttributeMessagingURL]; ok {
 		queueURL = value.Str()
 	}
-	if value, ok := attributes[conventions.AttributeAWSDynamoDBTableNames]; ok {
+	if value, ok := attributes[conventionsv112.AttributeAWSDynamoDBTableNames]; ok {
 		switch value.Type() {
 		case pcommon.ValueTypeSlice:
 			if value.Slice().Len() == 1 {
@@ -177,7 +177,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 	// EC2 - add ec2 metadata to xray request if
 	//       1. cloud.platfrom is set to "aws_ec2" or
 	//       2. there is an non-blank host/instance id found
-	if service == conventions.AttributeCloudPlatformAWSEC2 || hostID != "" {
+	if service == conventionsv112.AttributeCloudPlatformAWSEC2 || hostID != "" {
 		ec2 = &awsxray.EC2Metadata{
 			InstanceID:       awsxray.String(hostID),
 			AvailabilityZone: awsxray.String(zone),
@@ -187,7 +187,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 	}
 
 	// ECS
-	if service == conventions.AttributeCloudPlatformAWSECS {
+	if service == conventionsv112.AttributeCloudPlatformAWSECS {
 		ecs = &awsxray.ECSMetadata{
 			ContainerName:    awsxray.String(container),
 			ContainerID:      awsxray.String(containerID),
@@ -201,7 +201,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 	}
 
 	// Beanstalk
-	if service == conventions.AttributeCloudPlatformAWSElasticBeanstalk && deployID != "" {
+	if service == conventionsv112.AttributeCloudPlatformAWSElasticBeanstalk && deployID != "" {
 		deployNum, err := strconv.ParseInt(deployID, 10, 64)
 		if err != nil {
 			deployNum = 0
@@ -214,7 +214,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 	}
 
 	// EKS or native Kubernetes
-	if service == conventions.AttributeCloudPlatformAWSEKS || clusterName != "" {
+	if service == conventionsv112.AttributeCloudPlatformAWSEKS || clusterName != "" {
 		eks = &awsxray.EKSMetadata{
 			ClusterName: awsxray.String(clusterName),
 			Pod:         awsxray.String(podUID),
@@ -243,7 +243,7 @@ func makeAws(attributes map[string]pcommon.Value, resource pcommon.Resource, log
 
 	if sdkName != "" && sdkLanguage != "" {
 		// Convention for SDK name for xray SDK information is e.g., `X-Ray SDK for Java`, `X-Ray for Go`.
-		// We fill in with e.g, `opentelemetry for java` by using the conventions
+		// We fill in with e.g, `opentelemetry for java` by using the conventionsv112
 		sdk = sdkName + " for " + sdkLanguage
 	} else {
 		sdk = sdkName

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -408,21 +408,6 @@ func TestCustomSDK(t *testing.T) {
 	assert.Equal(t, "2.0.3", *awsData.XRay.SDKVersion)
 }
 
-func TestCustomSDKForLanguage(t *testing.T) {
-	attributes := make(map[string]pcommon.Value)
-	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "test for java")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "2.0.3")
-
-	filtered, awsData := makeAws(attributes, resource, nil)
-
-	assert.NotNil(t, filtered)
-	assert.NotNil(t, awsData)
-	assert.Equal(t, "test for java", *awsData.XRay.SDK)
-	assert.Equal(t, "2.0.3", *awsData.XRay.SDKVersion)
-}
-
 func TestLogGroups(t *testing.T) {
 	cwl1 := awsxray.LogGroupMetadata{
 		LogGroup: awsxray.String("group1"),

--- a/exporter/awsxrayexporter/internal/translator/aws_test.go
+++ b/exporter/awsxrayexporter/internal/translator/aws_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
-	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -21,13 +21,13 @@ func TestAwsFromEc2Resource(t *testing.T) {
 	imageID := "ami-0123456789"
 	resource := pcommon.NewResource()
 	attrs := pcommon.NewMap()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSEC2)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
-	attrs.PutStr(conventions.AttributeHostID, instanceID)
-	attrs.PutStr(conventions.AttributeHostType, hostType)
-	attrs.PutStr(conventions.AttributeHostImageID, imageID)
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSEC2)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventionsv112.AttributeHostID, instanceID)
+	attrs.PutStr(conventionsv112.AttributeHostType, hostType)
+	attrs.PutStr(conventionsv112.AttributeHostImageID, imageID)
 	attrs.CopyTo(resource.Attributes())
 
 	attributes := make(map[string]pcommon.Value)
@@ -61,21 +61,21 @@ func TestAwsFromEcsResource(t *testing.T) {
 	containerArn := "arn:aws:ecs:us-west-2:123456789123:container-instance/123"
 	resource := pcommon.NewResource()
 	attrs := pcommon.NewMap()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSECS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, az)
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerID, containerID)
-	attrs.PutStr(conventions.AttributeHostID, instanceID)
-	attrs.PutStr(conventions.AttributeAWSECSClusterARN, clusterArn)
-	attrs.PutStr(conventions.AttributeAWSECSContainerARN, containerArn)
-	attrs.PutStr(conventions.AttributeAWSECSTaskARN, taskArn)
-	attrs.PutStr(conventions.AttributeAWSECSTaskFamily, family)
-	attrs.PutStr(conventions.AttributeAWSECSLaunchtype, launchType)
-	attrs.PutStr(conventions.AttributeHostType, "m5.xlarge")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSECS)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, az)
+	attrs.PutStr(conventionsv112.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventionsv112.AttributeContainerName, containerName)
+	attrs.PutStr(conventionsv112.AttributeContainerID, containerID)
+	attrs.PutStr(conventionsv112.AttributeHostID, instanceID)
+	attrs.PutStr(conventionsv112.AttributeAWSECSClusterARN, clusterArn)
+	attrs.PutStr(conventionsv112.AttributeAWSECSContainerARN, containerArn)
+	attrs.PutStr(conventionsv112.AttributeAWSECSTaskARN, taskArn)
+	attrs.PutStr(conventionsv112.AttributeAWSECSTaskFamily, family)
+	attrs.PutStr(conventionsv112.AttributeAWSECSLaunchtype, launchType)
+	attrs.PutStr(conventionsv112.AttributeHostType, "m5.xlarge")
 
 	attrs.CopyTo(resource.Attributes())
 
@@ -106,13 +106,13 @@ func TestAwsFromBeanstalkResource(t *testing.T) {
 	versionLabel := "4"
 	resource := pcommon.NewResource()
 	attrs := pcommon.NewMap()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSElasticBeanstalk)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
-	attrs.PutStr(conventions.AttributeServiceNamespace, "production")
-	attrs.PutStr(conventions.AttributeServiceInstanceID, deployID)
-	attrs.PutStr(conventions.AttributeServiceVersion, versionLabel)
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSElasticBeanstalk)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventionsv112.AttributeServiceNamespace, "production")
+	attrs.PutStr(conventionsv112.AttributeServiceInstanceID, deployID)
+	attrs.PutStr(conventionsv112.AttributeServiceVersion, versionLabel)
 	attrs.CopyTo(resource.Attributes())
 
 	attributes := make(map[string]pcommon.Value)
@@ -138,20 +138,20 @@ func TestAwsFromEksResource(t *testing.T) {
 	containerID := "0123456789A"
 	resource := pcommon.NewResource()
 	attrs := pcommon.NewMap()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSEKS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeK8SClusterName, "production")
-	attrs.PutStr(conventions.AttributeK8SNamespaceName, "default")
-	attrs.PutStr(conventions.AttributeK8SDeploymentName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerID, containerID)
-	attrs.PutStr(conventions.AttributeHostID, instanceID)
-	attrs.PutStr(conventions.AttributeHostType, "m5.xlarge")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSEKS)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventionsv112.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventionsv112.AttributeK8SClusterName, "production")
+	attrs.PutStr(conventionsv112.AttributeK8SNamespaceName, "default")
+	attrs.PutStr(conventionsv112.AttributeK8SDeploymentName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
+	attrs.PutStr(conventionsv112.AttributeContainerName, containerName)
+	attrs.PutStr(conventionsv112.AttributeContainerID, containerID)
+	attrs.PutStr(conventionsv112.AttributeHostID, instanceID)
+	attrs.PutStr(conventionsv112.AttributeHostType, "m5.xlarge")
 	attrs.CopyTo(resource.Attributes())
 
 	attributes := make(map[string]pcommon.Value)
@@ -177,20 +177,20 @@ func TestAwsWithAwsSqsResources(t *testing.T) {
 	containerID := "0123456789A"
 	resource := pcommon.NewResource()
 	attrs := pcommon.NewMap()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeK8SClusterName, "production")
-	attrs.PutStr(conventions.AttributeK8SNamespaceName, "default")
-	attrs.PutStr(conventions.AttributeK8SDeploymentName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerID, containerID)
-	attrs.PutStr(conventions.AttributeHostID, instanceID)
-	attrs.PutStr(conventions.AttributeHostType, "m5.xlarge")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventionsv112.AttributeContainerName, containerName)
+	attrs.PutStr(conventionsv112.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventionsv112.AttributeK8SClusterName, "production")
+	attrs.PutStr(conventionsv112.AttributeK8SNamespaceName, "default")
+	attrs.PutStr(conventionsv112.AttributeK8SDeploymentName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
+	attrs.PutStr(conventionsv112.AttributeContainerName, containerName)
+	attrs.PutStr(conventionsv112.AttributeContainerID, containerID)
+	attrs.PutStr(conventionsv112.AttributeHostID, instanceID)
+	attrs.PutStr(conventionsv112.AttributeHostType, "m5.xlarge")
 
 	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
 	attributes := make(map[string]pcommon.Value)
@@ -211,7 +211,7 @@ func TestAwsWithAwsSqsResources(t *testing.T) {
 func TestAwsWithRpcAttributes(t *testing.T) {
 	resource := pcommon.NewResource()
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeRPCMethod] = pcommon.NewValueStr("ListBuckets")
+	attributes[conventionsv112.AttributeRPCMethod] = pcommon.NewValueStr("ListBuckets")
 
 	_, awsData := makeAws(attributes, resource, nil)
 
@@ -234,7 +234,7 @@ func TestAwsWithSqsAlternateAttribute(t *testing.T) {
 func TestAwsWithAwsSqsSemConvAttributes(t *testing.T) {
 	queueURL := "https://sqs.use1.amazonaws.com/Meltdown-Alerts"
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeMessagingURL] = pcommon.NewValueStr(queueURL)
+	attributes[conventionsv112.AttributeMessagingURL] = pcommon.NewValueStr(queueURL)
 
 	filtered, awsData := makeAws(attributes, pcommon.NewResource(), nil)
 
@@ -249,24 +249,24 @@ func TestAwsWithAwsDynamoDbResources(t *testing.T) {
 	containerID := "0123456789A"
 	resource := pcommon.NewResource()
 	attrs := pcommon.NewMap()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
-	attrs.PutStr(conventions.AttributeContainerName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeK8SClusterName, "production")
-	attrs.PutStr(conventions.AttributeK8SNamespaceName, "default")
-	attrs.PutStr(conventions.AttributeK8SDeploymentName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerID, containerID)
-	attrs.PutStr(conventions.AttributeHostID, instanceID)
-	attrs.PutStr(conventions.AttributeHostType, "m5.xlarge")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventionsv112.AttributeK8SClusterName, "production")
+	attrs.PutStr(conventionsv112.AttributeK8SNamespaceName, "default")
+	attrs.PutStr(conventionsv112.AttributeK8SDeploymentName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
+	attrs.PutStr(conventionsv112.AttributeContainerName, containerName)
+	attrs.PutStr(conventionsv112.AttributeContainerID, containerID)
+	attrs.PutStr(conventionsv112.AttributeHostID, instanceID)
+	attrs.PutStr(conventionsv112.AttributeHostType, "m5.xlarge")
 
 	tableName := "WIDGET_TYPES"
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeRPCMethod] = pcommon.NewValueStr("IncorrectAWSSDKOperation")
+	attributes[conventionsv112.AttributeRPCMethod] = pcommon.NewValueStr("IncorrectAWSSDKOperation")
 	attributes[awsxray.AWSOperationAttribute] = pcommon.NewValueStr("PutItem")
 	attributes[awsxray.AWSRequestIDAttribute] = pcommon.NewValueStr("75107C82-EC8A-4F75-883F-4440B491B0AB")
 	attributes[awsxray.AWSTableNameAttribute] = pcommon.NewValueStr(tableName)
@@ -295,8 +295,8 @@ func TestAwsWithDynamoDbAlternateAttribute(t *testing.T) {
 func TestAwsWithDynamoDbSemConvAttributes(t *testing.T) {
 	tableName := "MyTable"
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeAWSDynamoDBTableNames] = pcommon.NewValueSlice()
-	attributes[conventions.AttributeAWSDynamoDBTableNames].Slice().AppendEmpty().SetStr(tableName)
+	attributes[conventionsv112.AttributeAWSDynamoDBTableNames] = pcommon.NewValueSlice()
+	attributes[conventionsv112.AttributeAWSDynamoDBTableNames].Slice().AppendEmpty().SetStr(tableName)
 
 	filtered, awsData := makeAws(attributes, pcommon.NewResource(), nil)
 
@@ -308,7 +308,7 @@ func TestAwsWithDynamoDbSemConvAttributes(t *testing.T) {
 func TestAwsWithDynamoDbSemConvAttributesString(t *testing.T) {
 	tableName := "MyTable"
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeAWSDynamoDBTableNames] = pcommon.NewValueStr(tableName)
+	attributes[conventionsv112.AttributeAWSDynamoDBTableNames] = pcommon.NewValueStr(tableName)
 
 	filtered, awsData := makeAws(attributes, pcommon.NewResource(), nil)
 
@@ -332,9 +332,9 @@ func TestAwsWithRequestIdAlternateAttribute(t *testing.T) {
 func TestJavaSDK(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "opentelemetry")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.2.3")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKName, "opentelemetry")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKLanguage, "java")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKVersion, "1.2.3")
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -347,10 +347,10 @@ func TestJavaSDK(t *testing.T) {
 func TestJavaAutoInstrumentation(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "opentelemetry")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.2.3")
-	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "3.4.5")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKName, "opentelemetry")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKLanguage, "java")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKVersion, "1.2.3")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetryAutoVersion, "3.4.5")
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -364,10 +364,10 @@ func TestJavaAutoInstrumentation(t *testing.T) {
 func TestJavaAutoInstrumentationStable(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventionsv127.AttributeTelemetrySDKName, "opentelemetry")
-	resource.Attributes().PutStr(conventionsv127.AttributeTelemetrySDKLanguage, "java")
-	resource.Attributes().PutStr(conventionsv127.AttributeTelemetrySDKVersion, "1.2.3")
-	resource.Attributes().PutStr(conventionsv127.AttributeTelemetryDistroVersion, "3.4.5")
+	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "opentelemetry")
+	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
+	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.2.3")
+	resource.Attributes().PutStr(conventions.AttributeTelemetryDistroVersion, "3.4.5")
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -381,9 +381,9 @@ func TestJavaAutoInstrumentationStable(t *testing.T) {
 func TestGoSDK(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "opentelemetry")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "go")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "2.0.3")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKName, "opentelemetry")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKLanguage, "go")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKVersion, "2.0.3")
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -396,9 +396,9 @@ func TestGoSDK(t *testing.T) {
 func TestCustomSDK(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "opentracing")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "2.0.3")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKName, "opentracing")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKLanguage, "java")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKVersion, "2.0.3")
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -418,7 +418,7 @@ func TestLogGroups(t *testing.T) {
 
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	ava := resource.Attributes().PutEmptySlice(conventions.AttributeAWSLogGroupNames)
+	ava := resource.Attributes().PutEmptySlice(conventionsv112.AttributeAWSLogGroupNames)
 	ava.EnsureCapacity(2)
 	ava.AppendEmpty().SetStr("group1")
 	ava.AppendEmpty().SetStr("group2")
@@ -446,7 +446,7 @@ func TestLogGroupsFromArns(t *testing.T) {
 
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	ava := resource.Attributes().PutEmptySlice(conventions.AttributeAWSLogGroupARNs)
+	ava := resource.Attributes().PutEmptySlice(conventionsv112.AttributeAWSLogGroupARNs)
 	ava.EnsureCapacity(2)
 	ava.AppendEmpty().SetStr(group1)
 	ava.AppendEmpty().SetStr(group2)
@@ -468,7 +468,7 @@ func TestLogGroupsFromStringResourceAttribute(t *testing.T) {
 
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "group1")
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupNames, "group1")
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -490,7 +490,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	resource := pcommon.NewResource()
 
 	// normal cases
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "group1&group2")
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupNames, "group1&group2")
 	filtered, awsData := makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
@@ -499,7 +499,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
 	// with extra & at end
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "group1&group2&")
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupNames, "group1&group2&")
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
@@ -508,7 +508,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
 	// with extra & in the middle
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "group1&&group2")
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupNames, "group1&&group2")
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
@@ -517,7 +517,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
 	// with extra & at the beginning
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "&group1&group2")
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupNames, "&group1&group2")
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
@@ -526,7 +526,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 	assert.Contains(t, awsData.CWLogs, cwl2)
 
 	// with only &
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupNames, "&")
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupNames, "&")
 	filtered, awsData = makeAws(attributes, resource, nil)
 	assert.NotNil(t, filtered)
 	assert.NotNil(t, awsData)
@@ -536,7 +536,7 @@ func TestLogGroupsWithAmpersandFromStringResourceAttribute(t *testing.T) {
 func TestLogGroupsInvalidType(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutInt(conventions.AttributeAWSLogGroupNames, 1)
+	resource.Attributes().PutInt(conventionsv112.AttributeAWSLogGroupNames, 1)
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -556,7 +556,7 @@ func TestLogGroupsArnsFromStringResourceAttributes(t *testing.T) {
 
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupARNs, group1)
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupARNs, group1)
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 
@@ -581,7 +581,7 @@ func TestLogGroupsArnsWithAmpersandFromStringResourceAttributes(t *testing.T) {
 
 	attributes := make(map[string]pcommon.Value)
 	resource := pcommon.NewResource()
-	resource.Attributes().PutStr(conventions.AttributeAWSLogGroupARNs, "arn:aws:logs:us-east-1:123456789123:log-group:group1&arn:aws:logs:us-east-1:123456789123:log-group:group2")
+	resource.Attributes().PutStr(conventionsv112.AttributeAWSLogGroupARNs, "arn:aws:logs:us-east-1:123456789123:log-group:group1&arn:aws:logs:us-east-1:123456789123:log-group:group2")
 
 	filtered, awsData := makeAws(attributes, resource, nil)
 

--- a/exporter/awsxrayexporter/internal/translator/cause.go
+++ b/exporter/awsxrayexporter/internal/translator/cause.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
-	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -60,7 +60,7 @@ func makeCause(span ptrace.Span, attributes map[string]pcommon.Value, resource p
 	switch {
 	case hasExceptions:
 		language := ""
-		if val, ok := resource.Attributes().Get(conventions.AttributeTelemetrySDKLanguage); ok {
+		if val, ok := resource.Attributes().Get(conventionsv112.AttributeTelemetrySDKLanguage); ok {
 			language = val.Str()
 		}
 		isRemote := false
@@ -76,22 +76,22 @@ func makeCause(span ptrace.Span, attributes map[string]pcommon.Value, resource p
 				message = ""
 				stacktrace := ""
 
-				if val, ok := event.Attributes().Get(conventions.AttributeExceptionType); ok {
+				if val, ok := event.Attributes().Get(conventionsv112.AttributeExceptionType); ok {
 					exceptionType = val.Str()
 				}
 
-				if val, ok := event.Attributes().Get(conventions.AttributeExceptionMessage); ok {
+				if val, ok := event.Attributes().Get(conventionsv112.AttributeExceptionMessage); ok {
 					message = val.Str()
 				}
 
-				if val, ok := event.Attributes().Get(conventions.AttributeExceptionStacktrace); ok {
+				if val, ok := event.Attributes().Get(conventionsv112.AttributeExceptionStacktrace); ok {
 					stacktrace = val.Str()
 				}
 
 				parsed := parseException(exceptionType, message, stacktrace, isRemote, language)
 				exceptions = append(exceptions, parsed...)
 			} else if isAwsSdkSpan && event.Name() == AwsIndividualHTTPEventName {
-				errorCode, ok1 := event.Attributes().Get(conventionsv127.AttributeHTTPResponseStatusCode)
+				errorCode, ok1 := event.Attributes().Get(conventions.AttributeHTTPResponseStatusCode)
 				errorMessage, ok2 := event.Attributes().Get(AwsIndividualHTTPErrorMsgAttr)
 				if ok1 && ok2 {
 					eventEpochTime := event.Timestamp().AsTime().UnixMicro()
@@ -154,9 +154,9 @@ func makeCause(span ptrace.Span, attributes map[string]pcommon.Value, resource p
 		}
 	}
 
-	val, ok := span.Attributes().Get(conventions.AttributeHTTPStatusCode)
+	val, ok := span.Attributes().Get(conventionsv112.AttributeHTTPStatusCode)
 	if !ok {
-		val, ok = span.Attributes().Get(conventionsv127.AttributeHTTPResponseStatusCode)
+		val, ok = span.Attributes().Get(conventions.AttributeHTTPResponseStatusCode)
 	}
 
 	// The segment status for http spans will be based on their http.statuscode as we found some http

--- a/exporter/awsxrayexporter/internal/translator/cause_test.go
+++ b/exporter/awsxrayexporter/internal/translator/cause_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func TestCauseWithExceptions(t *testing.T) {
@@ -69,7 +70,7 @@ func TestMakeCauseAwsSdkSpan(t *testing.T) {
 
 	event1 := span.Events().AppendEmpty()
 	event1.SetName(AwsIndividualHTTPEventName)
-	event1.Attributes().PutStr(AwsIndividualHTTPErrorCodeAttr, "503")
+	event1.Attributes().PutStr(conventionsv127.AttributeHTTPResponseStatusCode, "503")
 	event1.Attributes().PutStr(AwsIndividualHTTPErrorMsgAttr, "service is temporarily unavailable")
 	timestamp := pcommon.NewTimestampFromTime(time.UnixMicro(1696954761000001))
 	event1.SetTimestamp(timestamp)
@@ -197,6 +198,31 @@ func TestCauseWithStatusMessage(t *testing.T) {
 	assert.Contains(t, jsonStr, errorMsg)
 }
 
+func TestCauseWithStatusMessageStable(t *testing.T) {
+	errorMsg := "this is a test"
+	attributes := make(map[string]any)
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 500
+	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
+	span.Status().SetMessage(errorMsg)
+	filtered, _ := makeHTTP(span)
+
+	res := pcommon.NewResource()
+	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
+
+	assert.True(t, isFault)
+	assert.False(t, isError)
+	assert.False(t, isThrottle)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, cause)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(cause))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.Contains(t, jsonStr, errorMsg)
+}
+
 func TestCauseWithHttpStatusMessage(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
@@ -222,12 +248,61 @@ func TestCauseWithHttpStatusMessage(t *testing.T) {
 	assert.Contains(t, jsonStr, errorMsg)
 }
 
+func TestCauseWithHttpStatusMessageStable(t *testing.T) {
+	errorMsg := "this is a test"
+	attributes := make(map[string]any)
+	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 500
+	attributes["http.status_text"] = errorMsg
+	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
+	filtered, _ := makeHTTP(span)
+
+	res := pcommon.NewResource()
+	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
+
+	assert.True(t, isFault)
+	assert.False(t, isError)
+	assert.False(t, isThrottle)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, cause)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(cause))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.Contains(t, jsonStr, errorMsg)
+}
+
 func TestCauseWithZeroStatusMessageAndFaultHttpCode(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
 	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes[conventions.AttributeHTTPStatusCode] = 500
+	attributes["http.status_text"] = errorMsg
+
+	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
+	filtered, _ := makeHTTP(span)
+	// Status is used to determine whether an error or not.
+	// This span illustrates incorrect instrumentation,
+	// marking a success status with an error http status code, and status wins.
+	// We do not expect to see such spans in practice.
+	res := pcommon.NewResource()
+	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
+
+	assert.False(t, isError)
+	assert.True(t, isFault)
+	assert.False(t, isThrottle)
+	assert.NotNil(t, filtered)
+	assert.Nil(t, cause)
+}
+
+func TestCauseWithZeroStatusMessageAndFaultHttpCodeStable(t *testing.T) {
+	errorMsg := "this is a test"
+	attributes := make(map[string]any)
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 500
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
@@ -339,6 +414,30 @@ func TestCauseWithZeroStatusMessageAndFaultErrorCode(t *testing.T) {
 	assert.Nil(t, cause)
 }
 
+func TestCauseWithZeroStatusMessageAndFaultErrorCodeStable(t *testing.T) {
+	errorMsg := "this is a test"
+	attributes := make(map[string]any)
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 400
+	attributes["http.status_text"] = errorMsg
+
+	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
+	filtered, _ := makeHTTP(span)
+	// Status is used to determine whether an error or not.
+	// This span illustrates incorrect instrumentation,
+	// marking a success status with an error http status code, and status wins.
+	// We do not expect to see such spans in practice.
+	res := pcommon.NewResource()
+	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
+
+	assert.True(t, isError)
+	assert.False(t, isFault)
+	assert.False(t, isThrottle)
+	assert.NotNil(t, filtered)
+	assert.Nil(t, cause)
+}
+
 func TestCauseWithClientErrorMessage(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
@@ -360,12 +459,54 @@ func TestCauseWithClientErrorMessage(t *testing.T) {
 	assert.NotNil(t, cause)
 }
 
+func TestCauseWithClientErrorMessageStable(t *testing.T) {
+	errorMsg := "this is a test"
+	attributes := make(map[string]any)
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 499
+	attributes["http.status_text"] = errorMsg
+
+	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
+	filtered, _ := makeHTTP(span)
+
+	res := pcommon.NewResource()
+	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
+
+	assert.True(t, isError)
+	assert.False(t, isFault)
+	assert.False(t, isThrottle)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, cause)
+}
+
 func TestCauseWithThrottled(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
 	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
 	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes[conventions.AttributeHTTPStatusCode] = 429
+	attributes["http.status_text"] = errorMsg
+
+	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
+	filtered, _ := makeHTTP(span)
+
+	res := pcommon.NewResource()
+	isError, isFault, isThrottle, filtered, cause := makeCause(span, filtered, res)
+
+	assert.True(t, isError)
+	assert.False(t, isFault)
+	assert.True(t, isThrottle)
+	assert.NotNil(t, filtered)
+	assert.NotNil(t, cause)
+}
+
+func TestCauseWithThrottledStable(t *testing.T) {
+	errorMsg := "this is a test"
+	attributes := make(map[string]any)
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 429
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)

--- a/exporter/awsxrayexporter/internal/translator/cause_test.go
+++ b/exporter/awsxrayexporter/internal/translator/cause_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
-	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func TestCauseWithExceptions(t *testing.T) {
@@ -26,9 +26,9 @@ func TestCauseWithExceptions(t *testing.T) {
 
 	event1 := span.Events().AppendEmpty()
 	event1.SetName(ExceptionEventName)
-	event1.Attributes().PutStr(conventions.AttributeExceptionType, "java.lang.IllegalStateException")
-	event1.Attributes().PutStr(conventions.AttributeExceptionMessage, "bad state")
-	event1.Attributes().PutStr(conventions.AttributeExceptionStacktrace, `java.lang.IllegalStateException: state is not legal
+	event1.Attributes().PutStr(conventionsv112.AttributeExceptionType, "java.lang.IllegalStateException")
+	event1.Attributes().PutStr(conventionsv112.AttributeExceptionMessage, "bad state")
+	event1.Attributes().PutStr(conventionsv112.AttributeExceptionStacktrace, `java.lang.IllegalStateException: state is not legal
 	at io.opentelemetry.sdk.trace.RecordEventsReadableSpanTest.recordException(RecordEventsReadableSpanTest.java:626)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
@@ -36,12 +36,12 @@ Caused by: java.lang.IllegalArgumentException: bad argument`)
 
 	event2 := span.Events().AppendEmpty()
 	event2.SetName(ExceptionEventName)
-	event2.Attributes().PutStr(conventions.AttributeExceptionType, "EmptyError")
+	event2.Attributes().PutStr(conventionsv112.AttributeExceptionType, "EmptyError")
 
 	filtered, _ := makeHTTP(span)
 
 	res := pcommon.NewResource()
-	res.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
+	res.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKLanguage, "java")
 	isError, isFault, isThrottle, filteredResult, cause := makeCause(span, filtered, res)
 
 	assert.True(t, isFault)
@@ -64,13 +64,13 @@ Caused by: java.lang.IllegalArgumentException: bad argument`)
 func TestMakeCauseAwsSdkSpan(t *testing.T) {
 	errorMsg := "this is a test"
 	attributeMap := make(map[string]any)
-	attributeMap[conventions.AttributeRPCSystem] = "aws-api"
+	attributeMap[conventionsv112.AttributeRPCSystem] = "aws-api"
 	span := constructExceptionServerSpan(attributeMap, ptrace.StatusCodeError)
 	span.Status().SetMessage(errorMsg)
 
 	event1 := span.Events().AppendEmpty()
 	event1.SetName(AwsIndividualHTTPEventName)
-	event1.Attributes().PutStr(conventionsv127.AttributeHTTPResponseStatusCode, "503")
+	event1.Attributes().PutStr(conventions.AttributeHTTPResponseStatusCode, "503")
 	event1.Attributes().PutStr(AwsIndividualHTTPErrorMsgAttr, "service is temporarily unavailable")
 	timestamp := pcommon.NewTimestampFromTime(time.UnixMicro(1696954761000001))
 	event1.SetTimestamp(timestamp)
@@ -118,14 +118,14 @@ Caused by: java.lang.IllegalArgumentException: bad argument`
 
 	event1 := span.Events().AppendEmpty()
 	event1.SetName(ExceptionEventName)
-	event1.Attributes().PutStr(conventions.AttributeExceptionType, "java.lang.IllegalStateException")
-	event1.Attributes().PutStr(conventions.AttributeExceptionMessage, "bad state")
-	event1.Attributes().PutStr(conventions.AttributeExceptionStacktrace, exceptionStack)
+	event1.Attributes().PutStr(conventionsv112.AttributeExceptionType, "java.lang.IllegalStateException")
+	event1.Attributes().PutStr(conventionsv112.AttributeExceptionMessage, "bad state")
+	event1.Attributes().PutStr(conventionsv112.AttributeExceptionStacktrace, exceptionStack)
 
 	filtered, _ := makeHTTP(span)
 
 	res := pcommon.NewResource()
-	res.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
+	res.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKLanguage, "java")
 	isError, isFault, isThrottle, filteredResult, cause := makeCause(span, filtered, res)
 
 	assert.False(t, isFault)
@@ -158,12 +158,12 @@ func EventWithoutExceptionWithoutErrorHelper(t *testing.T, statusCode ptrace.Sta
 
 	event1 := span.Events().AppendEmpty()
 	event1.SetName("NotException")
-	event1.Attributes().PutStr(conventions.AttributeHTTPMethod, "Post")
+	event1.Attributes().PutStr(conventionsv112.AttributeHTTPMethod, "Post")
 
 	filtered, _ := makeHTTP(span)
 
 	res := pcommon.NewResource()
-	res.Attributes().PutStr(conventions.AttributeTelemetrySDKLanguage, "java")
+	res.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKLanguage, "java")
 	isError, isFault, isThrottle, filteredResult, cause := makeCause(span, filtered, res)
 
 	assert.False(t, isFault)
@@ -176,9 +176,9 @@ func EventWithoutExceptionWithoutErrorHelper(t *testing.T, statusCode ptrace.Sta
 func TestCauseWithStatusMessage(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
-	attributes[conventions.AttributeHTTPStatusCode] = 500
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 500
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
 	span.Status().SetMessage(errorMsg)
 	filtered, _ := makeHTTP(span)
@@ -201,9 +201,9 @@ func TestCauseWithStatusMessage(t *testing.T) {
 func TestCauseWithStatusMessageStable(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 500
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 500
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
 	span.Status().SetMessage(errorMsg)
 	filtered, _ := makeHTTP(span)
@@ -226,9 +226,9 @@ func TestCauseWithStatusMessageStable(t *testing.T) {
 func TestCauseWithHttpStatusMessage(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
-	attributes[conventions.AttributeHTTPStatusCode] = 500
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 500
 	attributes["http.status_text"] = errorMsg
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
 	filtered, _ := makeHTTP(span)
@@ -251,9 +251,9 @@ func TestCauseWithHttpStatusMessage(t *testing.T) {
 func TestCauseWithHttpStatusMessageStable(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 500
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 500
 	attributes["http.status_text"] = errorMsg
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
 	filtered, _ := makeHTTP(span)
@@ -276,9 +276,9 @@ func TestCauseWithHttpStatusMessageStable(t *testing.T) {
 func TestCauseWithZeroStatusMessageAndFaultHttpCode(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
-	attributes[conventions.AttributeHTTPStatusCode] = 500
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 500
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
@@ -300,9 +300,9 @@ func TestCauseWithZeroStatusMessageAndFaultHttpCode(t *testing.T) {
 func TestCauseWithZeroStatusMessageAndFaultHttpCodeStable(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 500
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 500
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
@@ -324,8 +324,8 @@ func TestCauseWithZeroStatusMessageAndFaultHttpCodeStable(t *testing.T) {
 func TestNonHttpUnsetCodeSpan(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
@@ -347,8 +347,8 @@ func TestNonHttpUnsetCodeSpan(t *testing.T) {
 func TestNonHttpOkCodeSpan(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeOk)
@@ -370,8 +370,8 @@ func TestNonHttpOkCodeSpan(t *testing.T) {
 func TestNonHttpErrCodeSpan(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
@@ -393,9 +393,9 @@ func TestNonHttpErrCodeSpan(t *testing.T) {
 func TestCauseWithZeroStatusMessageAndFaultErrorCode(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
-	attributes[conventions.AttributeHTTPStatusCode] = 400
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 400
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
@@ -417,9 +417,9 @@ func TestCauseWithZeroStatusMessageAndFaultErrorCode(t *testing.T) {
 func TestCauseWithZeroStatusMessageAndFaultErrorCodeStable(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 400
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 400
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeUnset)
@@ -441,9 +441,9 @@ func TestCauseWithZeroStatusMessageAndFaultErrorCodeStable(t *testing.T) {
 func TestCauseWithClientErrorMessage(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
-	attributes[conventions.AttributeHTTPStatusCode] = 499
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 499
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
@@ -462,9 +462,9 @@ func TestCauseWithClientErrorMessage(t *testing.T) {
 func TestCauseWithClientErrorMessageStable(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 499
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 499
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
@@ -483,9 +483,9 @@ func TestCauseWithClientErrorMessageStable(t *testing.T) {
 func TestCauseWithThrottled(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/widgets"
-	attributes[conventions.AttributeHTTPStatusCode] = 429
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/widgets"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 429
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)
@@ -504,9 +504,9 @@ func TestCauseWithThrottled(t *testing.T) {
 func TestCauseWithThrottledStable(t *testing.T) {
 	errorMsg := "this is a test"
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodPost
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/widgets"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 429
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodPost
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/widgets"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 429
 	attributes["http.status_text"] = errorMsg
 
 	span := constructExceptionServerSpan(attributes, ptrace.StatusCodeError)

--- a/exporter/awsxrayexporter/internal/translator/http.go
+++ b/exporter/awsxrayexporter/internal/translator/http.go
@@ -10,8 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
-	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -36,57 +36,57 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 
 	span.Attributes().Range(func(key string, value pcommon.Value) bool {
 		switch key {
-		case conventions.AttributeHTTPMethod, conventionsv127.AttributeHTTPRequestMethod:
+		case conventionsv112.AttributeHTTPMethod, conventions.AttributeHTTPRequestMethod:
 			info.Request.Method = awsxray.String(value.Str())
 			hasHTTP = true
-		case conventions.AttributeHTTPClientIP:
+		case conventionsv112.AttributeHTTPClientIP:
 			info.Request.ClientIP = awsxray.String(value.Str())
 			hasHTTP = true
-		case conventions.AttributeHTTPUserAgent, conventionsv127.AttributeUserAgentOriginal:
+		case conventionsv112.AttributeHTTPUserAgent, conventions.AttributeUserAgentOriginal:
 			info.Request.UserAgent = awsxray.String(value.Str())
 			hasHTTP = true
-		case conventions.AttributeHTTPStatusCode, conventionsv127.AttributeHTTPResponseStatusCode:
+		case conventionsv112.AttributeHTTPStatusCode, conventions.AttributeHTTPResponseStatusCode:
 			info.Response.Status = aws.Int64(value.Int())
 			hasHTTP = true
-		case conventions.AttributeHTTPURL, conventionsv127.AttributeURLFull:
-			urlParts[conventions.AttributeHTTPURL] = value.Str()
+		case conventionsv112.AttributeHTTPURL, conventions.AttributeURLFull:
+			urlParts[conventionsv112.AttributeHTTPURL] = value.Str()
 			hasHTTP = true
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeHTTPScheme, conventionsv127.AttributeURLScheme:
-			urlParts[conventions.AttributeHTTPScheme] = value.Str()
+		case conventionsv112.AttributeHTTPScheme, conventions.AttributeURLScheme:
+			urlParts[conventionsv112.AttributeHTTPScheme] = value.Str()
 			hasHTTP = true
-		case conventions.AttributeHTTPHost:
+		case conventionsv112.AttributeHTTPHost:
 			urlParts[key] = value.Str()
 			hasHTTP = true
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeHTTPTarget, conventionsv127.AttributeURLQuery:
-			urlParts[conventions.AttributeHTTPTarget] = value.Str()
+		case conventionsv112.AttributeHTTPTarget, conventions.AttributeURLQuery:
+			urlParts[conventionsv112.AttributeHTTPTarget] = value.Str()
 			hasHTTP = true
-		case conventions.AttributeHTTPServerName:
+		case conventionsv112.AttributeHTTPServerName:
 			urlParts[key] = value.Str()
 			hasHTTP = true
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeNetHostPort:
+		case conventionsv112.AttributeNetHostPort:
 			urlParts[key] = value.Str()
 			hasHTTP = true
 			if len(urlParts[key]) == 0 {
 				urlParts[key] = strconv.FormatInt(value.Int(), 10)
 			}
-		case conventions.AttributeHostName:
+		case conventionsv112.AttributeHostName:
 			urlParts[key] = value.Str()
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeNetHostName:
+		case conventionsv112.AttributeNetHostName:
 			urlParts[key] = value.Str()
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeNetPeerName:
+		case conventionsv112.AttributeNetPeerName:
 			urlParts[key] = value.Str()
 			hasHTTPRequestURLAttributes = true
-		case conventions.AttributeNetPeerPort:
+		case conventionsv112.AttributeNetPeerPort:
 			urlParts[key] = value.Str()
 			if len(urlParts[key]) == 0 {
 				urlParts[key] = strconv.FormatInt(value.Int(), 10)
 			}
-		case conventions.AttributeNetPeerIP:
+		case conventionsv112.AttributeNetPeerIP:
 			// Prefer HTTP forwarded information (AttributeHTTPClientIP) when present.
 			if info.Request.ClientIP == nil {
 				info.Request.ClientIP = awsxray.String(value.Str())
@@ -94,7 +94,7 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 			urlParts[key] = value.Str()
 			hasHTTPRequestURLAttributes = true
 			hasNetPeerAddr = true
-		case conventionsv127.AttributeNetworkPeerAddress:
+		case conventions.AttributeNetworkPeerAddress:
 			// Prefer HTTP forwarded information (AttributeHTTPClientIP) when present.
 			if net.ParseIP(value.Str()) != nil {
 				if info.Request.ClientIP == nil {
@@ -103,17 +103,17 @@ func makeHTTP(span ptrace.Span) (map[string]pcommon.Value, *awsxray.HTTPData) {
 				hasHTTPRequestURLAttributes = true
 				hasNetPeerAddr = true
 			}
-		case conventionsv127.AttributeClientAddress:
+		case conventions.AttributeClientAddress:
 			if net.ParseIP(value.Str()) != nil {
 				info.Request.ClientIP = awsxray.String(value.Str())
 			}
-		case conventionsv127.AttributeURLPath:
+		case conventions.AttributeURLPath:
 			urlParts[key] = value.Str()
 			hasHTTP = true
-		case conventionsv127.AttributeServerAddress:
+		case conventions.AttributeServerAddress:
 			urlParts[key] = value.Str()
 			hasHTTPRequestURLAttributes = true
-		case conventionsv127.AttributeServerPort:
+		case conventions.AttributeServerPort:
 			urlParts[key] = value.Str()
 			if len(urlParts[key]) == 0 {
 				urlParts[key] = strconv.FormatInt(value.Int(), 10)
@@ -165,7 +165,7 @@ func extractResponseSizeFromEvents(span ptrace.Span) int64 {
 func extractResponseSizeFromAttributes(attributes pcommon.Map) int64 {
 	typeVal, ok := attributes.Get("message.type")
 	if ok && typeVal.Str() == "RECEIVED" {
-		if sizeVal, ok := attributes.Get(conventions.AttributeMessagingMessagePayloadSizeBytes); ok {
+		if sizeVal, ok := attributes.Get(conventionsv112.AttributeMessagingMessagePayloadSizeBytes); ok {
 			return sizeVal.Int()
 		}
 	}
@@ -174,26 +174,26 @@ func extractResponseSizeFromAttributes(attributes pcommon.Map) int64 {
 
 func constructClientURL(urlParts map[string]string) string {
 	// follows OpenTelemetry specification-defined combinations for client spans described in
-	// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#http-client
+	// https://github.com/open-telemetry/semantic-conventionsv112/blob/main/docs/http/http-spans.md#http-client
 
-	url, ok := urlParts[conventions.AttributeHTTPURL]
+	url, ok := urlParts[conventionsv112.AttributeHTTPURL]
 	if ok {
 		// full URL available so no need to assemble
 		return url
 	}
 
-	scheme, ok := urlParts[conventions.AttributeHTTPScheme]
+	scheme, ok := urlParts[conventionsv112.AttributeHTTPScheme]
 	if !ok {
 		scheme = "http"
 	}
 	port := ""
-	host, ok := urlParts[conventions.AttributeHTTPHost]
+	host, ok := urlParts[conventionsv112.AttributeHTTPHost]
 	if !ok {
-		host, ok = urlParts[conventions.AttributeNetPeerName]
+		host, ok = urlParts[conventionsv112.AttributeNetPeerName]
 		if !ok {
-			host = urlParts[conventions.AttributeNetPeerIP]
+			host = urlParts[conventionsv112.AttributeNetPeerIP]
 		}
-		port, ok = urlParts[conventions.AttributeNetPeerPort]
+		port, ok = urlParts[conventionsv112.AttributeNetPeerPort]
 		if !ok {
 			port = ""
 		}
@@ -202,7 +202,7 @@ func constructClientURL(urlParts map[string]string) string {
 	if len(port) > 0 && !(scheme == "http" && port == "80") && !(scheme == "https" && port == "443") {
 		url += ":" + port
 	}
-	target, ok := urlParts[conventions.AttributeHTTPTarget]
+	target, ok := urlParts[conventionsv112.AttributeHTTPTarget]
 	if ok {
 		url += target
 	} else {
@@ -213,34 +213,34 @@ func constructClientURL(urlParts map[string]string) string {
 
 func constructServerURL(urlParts map[string]string) string {
 	// follows OpenTelemetry specification-defined combinations for server spans described in
-	// https://github.com/open-telemetry/semantic-conventions/blob/main/docs/http/http-spans.md#http-server
+	// https://github.com/open-telemetry/semantic-conventionsv112/blob/main/docs/http/http-spans.md#http-server
 
-	url, ok := urlParts[conventions.AttributeHTTPURL]
+	url, ok := urlParts[conventionsv112.AttributeHTTPURL]
 	if ok {
 		// full URL available so no need to assemble
 		return url
 	}
 
-	scheme, ok := urlParts[conventions.AttributeHTTPScheme]
+	scheme, ok := urlParts[conventionsv112.AttributeHTTPScheme]
 	if !ok {
 		scheme = "http"
 	}
 	port := ""
-	host, ok := urlParts[conventions.AttributeHTTPHost]
+	host, ok := urlParts[conventionsv112.AttributeHTTPHost]
 	if !ok {
-		host, ok = urlParts[conventions.AttributeHTTPServerName]
+		host, ok = urlParts[conventionsv112.AttributeHTTPServerName]
 		if !ok {
-			host, ok = urlParts[conventions.AttributeNetHostName]
+			host, ok = urlParts[conventionsv112.AttributeNetHostName]
 			if !ok {
-				host, ok = urlParts[conventions.AttributeHostName]
+				host, ok = urlParts[conventionsv112.AttributeHostName]
 				if !ok {
-					host = urlParts[conventionsv127.AttributeServerAddress]
+					host = urlParts[conventions.AttributeServerAddress]
 				}
 			}
 		}
-		port, ok = urlParts[conventions.AttributeNetHostPort]
+		port, ok = urlParts[conventionsv112.AttributeNetHostPort]
 		if !ok {
-			port, ok = urlParts[conventionsv127.AttributeServerPort]
+			port, ok = urlParts[conventions.AttributeServerPort]
 			if !ok {
 				port = ""
 			}
@@ -250,11 +250,11 @@ func constructServerURL(urlParts map[string]string) string {
 	if len(port) > 0 && !(scheme == "http" && port == "80") && !(scheme == "https" && port == "443") {
 		url += ":" + port
 	}
-	target, ok := urlParts[conventions.AttributeHTTPTarget]
+	target, ok := urlParts[conventionsv112.AttributeHTTPTarget]
 	if ok {
 		url += target
 	} else {
-		path, ok := urlParts[conventionsv127.AttributeURLPath]
+		path, ok := urlParts[conventions.AttributeURLPath]
 		if ok {
 			url += path
 		} else {

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -78,7 +78,7 @@ func TestClientSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
 	attributes[conventionsv127.AttributeHTTPRequestMethod] = "GET"
 	attributes[conventionsv127.AttributeURLScheme] = "https"
-	attributes[conventionsv127.AttributeServerAddress] = "api.example.com"
+	attributes[conventions.AttributeHTTPHost] = "api.example.com"
 	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
 	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	attributes["user.id"] = "junit"
@@ -125,9 +125,9 @@ func TestClientSpanWithPeerAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
 	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
 	attributes[conventionsv127.AttributeURLScheme] = "http"
-	attributes[conventionsv127.AttributeServerAddress] = "kb234.example.com"
-	attributes[conventionsv127.AttributeServerPort] = 8080
-	attributes[conventionsv127.AttributeNetworkPeerAddress] = "10.8.17.36"
+	attributes[conventions.AttributeNetPeerName] = "kb234.example.com"
+	attributes[conventions.AttributeNetPeerPort] = 8080
+	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
 	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
 	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -14,6 +14,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func TestClientSpanWithURLAttribute(t *testing.T) {
@@ -36,9 +37,9 @@ func TestClientSpanWithURLAttribute(t *testing.T) {
 
 func TestClientSpanWithURLAttributeStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -59,6 +60,27 @@ func TestClientSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes[conventions.AttributeHTTPHost] = "api.example.com"
 	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
 	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes["user.id"] = "junit"
+	span := constructHTTPClientSpan(attributes)
+
+	filtered, httpData := makeHTTP(span)
+
+	assert.NotNil(t, httpData)
+	assert.NotNil(t, filtered)
+	w := testWriters.borrow()
+	require.NoError(t, w.Encode(httpData))
+	jsonStr := w.String()
+	testWriters.release(w)
+	assert.Contains(t, jsonStr, "https://api.example.com/users/junit")
+}
+
+func TestClientSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
+	attributes := make(map[string]any)
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = "GET"
+	attributes[conventionsv127.AttributeURLScheme] = "https"
+	attributes[conventionsv127.AttributeServerAddress] = "api.example.com"
+	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	attributes["user.id"] = "junit"
 	span := constructHTTPClientSpan(attributes)
 
@@ -101,13 +123,13 @@ func TestClientSpanWithPeerAttributes(t *testing.T) {
 
 func TestClientSpanWithPeerAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[AttributeURLScheme] = "http"
-	attributes[conventions.AttributeNetPeerName] = "kb234.example.com"
-	attributes[conventions.AttributeNetPeerPort] = 8080
-	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeURLScheme] = "http"
+	attributes[conventionsv127.AttributeServerAddress] = "kb234.example.com"
+	attributes[conventionsv127.AttributeServerPort] = 8080
+	attributes[conventionsv127.AttributeNetworkPeerAddress] = "10.8.17.36"
+	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -140,9 +162,9 @@ func TestClientSpanWithHttpPeerAttributes(t *testing.T) {
 
 func TestClientSpanWithHttpPeerAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[AttributeClientAddress] = "1.2.3.4"
-	attributes[AttributeNetworkPeerAddress] = "10.8.17.36"
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "1.2.3.4"
+	attributes[conventionsv127.AttributeNetworkPeerAddress] = "10.8.17.36"
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -213,11 +235,11 @@ func TestServerSpanWithURLAttribute(t *testing.T) {
 
 func TestServerSpanWithURLAttributeStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[AttributeClientAddress] = "192.168.15.32"
-	attributes[AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
-	attributes[AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -254,12 +276,12 @@ func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[AttributeURLScheme] = "https"
-	attributes[AttributeServerAddress] = "api.example.com"
-	attributes[AttributeURLPath] = "/users/junit"
-	attributes[AttributeClientAddress] = "192.168.15.32"
-	attributes[AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeURLScheme] = "https"
+	attributes[conventionsv127.AttributeServerAddress] = "api.example.com"
+	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -297,13 +319,13 @@ func TestServerSpanWithSchemeServernamePortTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeServernamePortTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[AttributeURLScheme] = "https"
-	attributes[AttributeServerAddress] = "api.example.com"
-	attributes[AttributeServerPort] = 443
-	attributes[AttributeURLPath] = "/users/junit"
-	attributes[AttributeClientAddress] = "192.168.15.32"
-	attributes[AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeURLScheme] = "https"
+	attributes[conventionsv127.AttributeServerAddress] = "api.example.com"
+	attributes[conventionsv127.AttributeServerPort] = 443
+	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -343,13 +365,13 @@ func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeNamePortTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[AttributeURLScheme] = "http"
-	attributes[AttributeServerAddress] = "kb234.example.com"
-	attributes[AttributeServerPort] = 8080
-	attributes[AttributeURLPath] = "/users/junit"
-	attributes[AttributeClientAddress] = "192.168.15.32"
-	attributes[AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeURLScheme] = "http"
+	attributes[conventionsv127.AttributeServerAddress] = "kb234.example.com"
+	attributes[conventionsv127.AttributeServerPort] = 8080
+	attributes[conventionsv127.AttributeURLPath] = "/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -393,13 +415,13 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributes(t *testing.T) {
 
 func TestSpanWithNotEnoughHTTPRequestURLAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[AttributeURLScheme] = "http"
-	attributes[AttributeClientAddress] = "192.168.15.32"
-	attributes[AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
-	attributes[AttributeURLPath] = "/users/junit"
-	attributes[AttributeServerPort] = 443
-	attributes[AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeURLScheme] = "http"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[conventionsv127.AttributeURLPath] = "/users/junit"
+	attributes[conventionsv127.AttributeServerPort] = 443
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -419,20 +441,20 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributesStable(t *testing.T) {
 func TestSpanWithNotEnoughHTTPRequestURLAttributesDuplicated(t *testing.T) {
 	attributes := make(map[string]any)
 	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
 	attributes[conventions.AttributeHTTPScheme] = "http"
-	attributes[AttributeURLScheme] = "http"
+	attributes[conventionsv127.AttributeURLScheme] = "http"
 	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
 	attributes[conventions.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
-	attributes[AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[conventionsv127.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
 	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[AttributeURLPath] = "/users/junit"
+	attributes[conventionsv127.AttributeURLPath] = "/users/junit"
 	attributes[conventions.AttributeNetHostPort] = 443
-	attributes[AttributeServerPort] = 443
+	attributes[conventionsv127.AttributeServerPort] = 443
 	attributes[conventions.AttributeNetPeerPort] = 8080
 	attributes[conventions.AttributeHTTPStatusCode] = 200
-	attributes[AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -451,8 +473,8 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributesDuplicated(t *testing.T) {
 
 func TestSpanWithClientAddrWithoutNetworkPeerAddr(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
 	span := constructHTTPServerSpan(attributes)
 
 	_, httpData := makeHTTP(span)
@@ -462,9 +484,9 @@ func TestSpanWithClientAddrWithoutNetworkPeerAddr(t *testing.T) {
 
 func TestSpanWithClientAddrAndNetworkPeerAddr(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[AttributeClientAddress] = "192.168.15.32"
-	attributes[AttributeNetworkPeerAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv127.AttributeNetworkPeerAddress] = "192.168.15.32"
 	span := constructHTTPServerSpan(attributes)
 
 	_, httpData := makeHTTP(span)
@@ -475,9 +497,9 @@ func TestSpanWithClientAddrAndNetworkPeerAddr(t *testing.T) {
 
 func TestSpanWithClientAddrNotIP(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[AttributeClientAddress] = "api.example.com"
-	attributes[AttributeNetworkPeerAddress] = "api.example.com"
+	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventionsv127.AttributeClientAddress] = "api.example.com"
+	attributes[conventionsv127.AttributeNetworkPeerAddress] = "api.example.com"
 	span := constructHTTPServerSpan(attributes)
 
 	_, httpData := makeHTTP(span)

--- a/exporter/awsxrayexporter/internal/translator/http_test.go
+++ b/exporter/awsxrayexporter/internal/translator/http_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
-	conventionsv127 "go.opentelemetry.io/collector/semconv/v1.27.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func TestClientSpanWithURLAttribute(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/users/junit"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -37,9 +37,9 @@ func TestClientSpanWithURLAttribute(t *testing.T) {
 
 func TestClientSpanWithURLAttributeStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -55,11 +55,11 @@ func TestClientSpanWithURLAttributeStable(t *testing.T) {
 
 func TestClientSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "api.example.com"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "api.example.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	attributes["user.id"] = "junit"
 	span := constructHTTPClientSpan(attributes)
 
@@ -76,11 +76,11 @@ func TestClientSpanWithSchemeHostTargetAttributes(t *testing.T) {
 
 func TestClientSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = "GET"
-	attributes[conventionsv127.AttributeURLScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "api.example.com"
-	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = "GET"
+	attributes[conventions.AttributeURLScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "api.example.com"
+	attributes[conventions.AttributeURLQuery] = "/users/junit"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	attributes["user.id"] = "junit"
 	span := constructHTTPClientSpan(attributes)
 
@@ -97,13 +97,13 @@ func TestClientSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 
 func TestClientSpanWithPeerAttributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "http"
-	attributes[conventions.AttributeNetPeerName] = "kb234.example.com"
-	attributes[conventions.AttributeNetPeerPort] = 8080
-	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "http"
+	attributes[conventionsv112.AttributeNetPeerName] = "kb234.example.com"
+	attributes[conventionsv112.AttributeNetPeerPort] = 8080
+	attributes[conventionsv112.AttributeNetPeerIP] = "10.8.17.36"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -123,13 +123,13 @@ func TestClientSpanWithPeerAttributes(t *testing.T) {
 
 func TestClientSpanWithPeerAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeURLScheme] = "http"
-	attributes[conventions.AttributeNetPeerName] = "kb234.example.com"
-	attributes[conventions.AttributeNetPeerPort] = 8080
-	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
-	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventions.AttributeURLScheme] = "http"
+	attributes[conventionsv112.AttributeNetPeerName] = "kb234.example.com"
+	attributes[conventionsv112.AttributeNetPeerPort] = 8080
+	attributes[conventionsv112.AttributeNetPeerIP] = "10.8.17.36"
+	attributes[conventions.AttributeURLQuery] = "/users/junit"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -148,8 +148,8 @@ func TestClientSpanWithPeerAttributesStable(t *testing.T) {
 
 func TestClientSpanWithHttpPeerAttributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPClientIP] = "1.2.3.4"
-	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "1.2.3.4"
+	attributes[conventionsv112.AttributeNetPeerIP] = "10.8.17.36"
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -162,9 +162,9 @@ func TestClientSpanWithHttpPeerAttributes(t *testing.T) {
 
 func TestClientSpanWithHttpPeerAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "1.2.3.4"
-	attributes[conventionsv127.AttributeNetworkPeerAddress] = "10.8.17.36"
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventions.AttributeClientAddress] = "1.2.3.4"
+	attributes[conventions.AttributeNetworkPeerAddress] = "10.8.17.36"
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -177,11 +177,11 @@ func TestClientSpanWithHttpPeerAttributesStable(t *testing.T) {
 
 func TestClientSpanWithPeerIp4Attributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "http"
-	attributes[conventions.AttributeNetPeerIP] = "10.8.17.36"
-	attributes[conventions.AttributeNetPeerPort] = "8080"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "http"
+	attributes[conventionsv112.AttributeNetPeerIP] = "10.8.17.36"
+	attributes[conventionsv112.AttributeNetPeerPort] = "8080"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -196,11 +196,11 @@ func TestClientSpanWithPeerIp4Attributes(t *testing.T) {
 
 func TestClientSpanWithPeerIp6Attributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeNetPeerIP] = "2001:db8:85a3::8a2e:370:7334"
-	attributes[conventions.AttributeNetPeerPort] = "443"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeNetPeerIP] = "2001:db8:85a3::8a2e:370:7334"
+	attributes[conventionsv112.AttributeNetPeerPort] = "443"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
 	span := constructHTTPClientSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -215,11 +215,11 @@ func TestClientSpanWithPeerIp6Attributes(t *testing.T) {
 
 func TestServerSpanWithURLAttribute(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/users/junit"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -235,11 +235,11 @@ func TestServerSpanWithURLAttribute(t *testing.T) {
 
 func TestServerSpanWithURLAttributeStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
-	attributes[conventionsv127.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -255,12 +255,12 @@ func TestServerSpanWithURLAttributeStable(t *testing.T) {
 
 func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "api.example.com"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "api.example.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -276,12 +276,12 @@ func TestServerSpanWithSchemeHostTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeURLScheme] = "https"
-	attributes[conventionsv127.AttributeServerAddress] = "api.example.com"
-	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventions.AttributeURLScheme] = "https"
+	attributes[conventions.AttributeServerAddress] = "api.example.com"
+	attributes[conventions.AttributeURLQuery] = "/users/junit"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -297,13 +297,13 @@ func TestServerSpanWithSchemeHostTargetAttributesStable(t *testing.T) {
 
 func TestServerSpanWithSchemeServernamePortTargetAttributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPServerName] = "api.example.com"
-	attributes[conventions.AttributeNetHostPort] = 443
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPServerName] = "api.example.com"
+	attributes[conventionsv112.AttributeNetHostPort] = 443
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -319,13 +319,13 @@ func TestServerSpanWithSchemeServernamePortTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeServernamePortTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeURLScheme] = "https"
-	attributes[conventionsv127.AttributeServerAddress] = "api.example.com"
-	attributes[conventionsv127.AttributeServerPort] = 443
-	attributes[conventionsv127.AttributeURLQuery] = "/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventions.AttributeURLScheme] = "https"
+	attributes[conventions.AttributeServerAddress] = "api.example.com"
+	attributes[conventions.AttributeServerPort] = 443
+	attributes[conventions.AttributeURLQuery] = "/users/junit"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 
 	filtered, httpData := makeHTTP(span)
@@ -341,13 +341,13 @@ func TestServerSpanWithSchemeServernamePortTargetAttributesStable(t *testing.T) 
 
 func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "http"
-	attributes[conventions.AttributeHostName] = "kb234.example.com"
-	attributes[conventions.AttributeNetHostPort] = 8080
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "http"
+	attributes[conventionsv112.AttributeHostName] = "kb234.example.com"
+	attributes[conventionsv112.AttributeNetHostPort] = 8080
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -365,13 +365,13 @@ func TestServerSpanWithSchemeNamePortTargetAttributes(t *testing.T) {
 
 func TestServerSpanWithSchemeNamePortTargetAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeURLScheme] = "http"
-	attributes[conventionsv127.AttributeServerAddress] = "kb234.example.com"
-	attributes[conventionsv127.AttributeServerPort] = 8080
-	attributes[conventionsv127.AttributeURLPath] = "/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventions.AttributeURLScheme] = "http"
+	attributes[conventions.AttributeServerAddress] = "kb234.example.com"
+	attributes[conventions.AttributeServerPort] = 8080
+	attributes[conventions.AttributeURLPath] = "/users/junit"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -389,14 +389,14 @@ func TestServerSpanWithSchemeNamePortTargetAttributesStable(t *testing.T) {
 
 func TestSpanWithNotEnoughHTTPRequestURLAttributes(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "http"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventions.AttributeNetHostPort] = 443
-	attributes[conventions.AttributeNetPeerPort] = 8080
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "http"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventionsv112.AttributeNetHostPort] = 443
+	attributes[conventionsv112.AttributeNetPeerPort] = 8080
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -415,13 +415,13 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributes(t *testing.T) {
 
 func TestSpanWithNotEnoughHTTPRequestURLAttributesStable(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeURLScheme] = "http"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
-	attributes[conventionsv127.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
-	attributes[conventionsv127.AttributeURLPath] = "/users/junit"
-	attributes[conventionsv127.AttributeServerPort] = 443
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventions.AttributeURLScheme] = "http"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[conventions.AttributeURLPath] = "/users/junit"
+	attributes[conventions.AttributeServerPort] = 443
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -440,21 +440,21 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributesStable(t *testing.T) {
 
 func TestSpanWithNotEnoughHTTPRequestURLAttributesDuplicated(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventionsv127.AttributeHTTPRequestMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "http"
-	attributes[conventionsv127.AttributeURLScheme] = "http"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
-	attributes[conventionsv127.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
-	attributes[conventions.AttributeHTTPTarget] = "/users/junit"
-	attributes[conventionsv127.AttributeURLPath] = "/users/junit"
-	attributes[conventions.AttributeNetHostPort] = 443
-	attributes[conventionsv127.AttributeServerPort] = 443
-	attributes[conventions.AttributeNetPeerPort] = 8080
-	attributes[conventions.AttributeHTTPStatusCode] = 200
-	attributes[conventionsv127.AttributeHTTPResponseStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventions.AttributeHTTPRequestMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "http"
+	attributes[conventions.AttributeURLScheme] = "http"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPUserAgent] = "PostmanRuntime/7.21.0"
+	attributes[conventions.AttributeUserAgentOriginal] = "PostmanRuntime/7.21.0"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/users/junit"
+	attributes[conventions.AttributeURLPath] = "/users/junit"
+	attributes[conventionsv112.AttributeNetHostPort] = 443
+	attributes[conventions.AttributeServerPort] = 443
+	attributes[conventionsv112.AttributeNetPeerPort] = 8080
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
+	attributes[conventions.AttributeHTTPResponseStatusCode] = 200
 	span := constructHTTPServerSpan(attributes)
 	timeEvents := constructTimedEventsWithReceivedMessageEvent(span.EndTimestamp())
 	timeEvents.CopyTo(span.Events())
@@ -473,8 +473,8 @@ func TestSpanWithNotEnoughHTTPRequestURLAttributesDuplicated(t *testing.T) {
 
 func TestSpanWithClientAddrWithoutNetworkPeerAddr(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
 	span := constructHTTPServerSpan(attributes)
 
 	_, httpData := makeHTTP(span)
@@ -484,9 +484,9 @@ func TestSpanWithClientAddrWithoutNetworkPeerAddr(t *testing.T) {
 
 func TestSpanWithClientAddrAndNetworkPeerAddr(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "192.168.15.32"
-	attributes[conventionsv127.AttributeNetworkPeerAddress] = "192.168.15.32"
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventions.AttributeClientAddress] = "192.168.15.32"
+	attributes[conventions.AttributeNetworkPeerAddress] = "192.168.15.32"
 	span := constructHTTPServerSpan(attributes)
 
 	_, httpData := makeHTTP(span)
@@ -497,9 +497,9 @@ func TestSpanWithClientAddrAndNetworkPeerAddr(t *testing.T) {
 
 func TestSpanWithClientAddrNotIP(t *testing.T) {
 	attributes := make(map[string]any)
-	attributes[conventionsv127.AttributeURLFull] = "https://api.example.com/users/junit"
-	attributes[conventionsv127.AttributeClientAddress] = "api.example.com"
-	attributes[conventionsv127.AttributeNetworkPeerAddress] = "api.example.com"
+	attributes[conventions.AttributeURLFull] = "https://api.example.com/users/junit"
+	attributes[conventions.AttributeClientAddress] = "api.example.com"
+	attributes[conventions.AttributeNetworkPeerAddress] = "api.example.com"
 	span := constructHTTPServerSpan(attributes)
 
 	_, httpData := makeHTTP(span)

--- a/exporter/awsxrayexporter/internal/translator/segment.go
+++ b/exporter/awsxrayexporter/internal/translator/segment.go
@@ -18,7 +18,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
@@ -306,7 +306,7 @@ func MakeDocumentFromSegment(segment *awsxray.Segment) (string, error) {
 
 func isAwsSdkSpan(span ptrace.Span) bool {
 	attributes := span.Attributes()
-	if rpcSystem, ok := attributes.Get(conventions.AttributeRPCSystem); ok {
+	if rpcSystem, ok := attributes.Get(conventionsv112.AttributeRPCSystem); ok {
 		return rpcSystem.Str() == awsAPIRPCSystem
 	}
 	return false
@@ -379,14 +379,14 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 	// peer.service should always be prioritized for segment names when it set by users and
 	// the new x-ray specific service name attributes are not found
 	if name == "" {
-		if peerService, ok := attributes.Get(conventions.AttributePeerService); ok {
+		if peerService, ok := attributes.Get(conventionsv112.AttributePeerService); ok {
 			name = peerService.Str()
 		}
 	}
 
 	if namespace == "" {
 		if isAwsSdkSpan(span) {
-			namespace = conventions.AttributeCloudProviderAWS
+			namespace = conventionsv112.AttributeCloudProviderAWS
 		}
 	}
 
@@ -397,16 +397,16 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 			name = awsService.Str()
 
 			if namespace == "" {
-				namespace = conventions.AttributeCloudProviderAWS
+				namespace = conventionsv112.AttributeCloudProviderAWS
 			}
 		}
 	}
 
 	if name == "" {
-		if dbInstance, ok := attributes.Get(conventions.AttributeDBName); ok {
+		if dbInstance, ok := attributes.Get(conventionsv112.AttributeDBName); ok {
 			// For database queries, the segment name convention is <db name>@<db host>
 			name = dbInstance.Str()
-			if dbURL, ok := attributes.Get(conventions.AttributeDBConnectionString); ok {
+			if dbURL, ok := attributes.Get(conventionsv112.AttributeDBConnectionString); ok {
 				// Trim JDBC connection string if starts with "jdbc:", otherwise no change
 				// jdbc:mysql://db.dev.example.com:3306
 				dbURLStr := strings.TrimPrefix(dbURL.Str(), "jdbc:")
@@ -421,25 +421,25 @@ func MakeSegment(span ptrace.Span, resource pcommon.Resource, indexedAttrs []str
 
 	if name == "" && span.Kind() == ptrace.SpanKindServer {
 		// Only for a server span, we can use the resource.
-		if service, ok := resource.Attributes().Get(conventions.AttributeServiceName); ok {
+		if service, ok := resource.Attributes().Get(conventionsv112.AttributeServiceName); ok {
 			name = service.Str()
 		}
 	}
 
 	if name == "" {
-		if rpcservice, ok := attributes.Get(conventions.AttributeRPCService); ok {
+		if rpcservice, ok := attributes.Get(conventionsv112.AttributeRPCService); ok {
 			name = rpcservice.Str()
 		}
 	}
 
 	if name == "" {
-		if host, ok := attributes.Get(conventions.AttributeHTTPHost); ok {
+		if host, ok := attributes.Get(conventionsv112.AttributeHTTPHost); ok {
 			name = host.Str()
 		}
 	}
 
 	if name == "" {
-		if peer, ok := attributes.Get(conventions.AttributeNetPeerName); ok {
+		if peer, ok := attributes.Get(conventionsv112.AttributeNetPeerName); ok {
 			name = peer.Str()
 		}
 	}
@@ -492,34 +492,34 @@ func determineAwsOrigin(resource pcommon.Resource) string {
 		return ""
 	}
 
-	if provider, ok := resource.Attributes().Get(conventions.AttributeCloudProvider); ok {
-		if provider.Str() != conventions.AttributeCloudProviderAWS {
+	if provider, ok := resource.Attributes().Get(conventionsv112.AttributeCloudProvider); ok {
+		if provider.Str() != conventionsv112.AttributeCloudProviderAWS {
 			return ""
 		}
 	}
 
-	if is, present := resource.Attributes().Get(conventions.AttributeCloudPlatform); present {
+	if is, present := resource.Attributes().Get(conventionsv112.AttributeCloudPlatform); present {
 		switch is.Str() {
-		case conventions.AttributeCloudPlatformAWSAppRunner:
+		case conventionsv112.AttributeCloudPlatformAWSAppRunner:
 			return OriginAppRunner
-		case conventions.AttributeCloudPlatformAWSEKS:
+		case conventionsv112.AttributeCloudPlatformAWSEKS:
 			return OriginEKS
-		case conventions.AttributeCloudPlatformAWSElasticBeanstalk:
+		case conventionsv112.AttributeCloudPlatformAWSElasticBeanstalk:
 			return OriginEB
-		case conventions.AttributeCloudPlatformAWSECS:
-			lt, present := resource.Attributes().Get(conventions.AttributeAWSECSLaunchtype)
+		case conventionsv112.AttributeCloudPlatformAWSECS:
+			lt, present := resource.Attributes().Get(conventionsv112.AttributeAWSECSLaunchtype)
 			if !present {
 				return OriginECS
 			}
 			switch lt.Str() {
-			case conventions.AttributeAWSECSLaunchtypeEC2:
+			case conventionsv112.AttributeAWSECSLaunchtypeEC2:
 				return OriginECSEC2
-			case conventions.AttributeAWSECSLaunchtypeFargate:
+			case conventionsv112.AttributeAWSECSLaunchtypeFargate:
 				return OriginECSFargate
 			default:
 				return OriginECS
 			}
-		case conventions.AttributeCloudPlatformAWSEC2:
+		case conventionsv112.AttributeCloudPlatformAWSEC2:
 			return OriginEC2
 
 		// If cloud_platform is defined with a non-AWS value, we should not assign it an AWS origin
@@ -608,10 +608,10 @@ func makeXRayAttributes(attributes map[string]pcommon.Value, resource pcommon.Re
 		metadata    = map[string]map[string]any{}
 		user        string
 	)
-	userid, ok := attributes[conventions.AttributeEnduserID]
+	userid, ok := attributes[conventionsv112.AttributeEnduserID]
 	if ok {
 		user = userid.Str()
-		delete(attributes, conventions.AttributeEnduserID)
+		delete(attributes, conventionsv112.AttributeEnduserID)
 	}
 
 	if len(attributes) == 0 && (!storeResource || resource.Attributes().Len() == 0) {

--- a/exporter/awsxrayexporter/internal/translator/segment_test.go
+++ b/exporter/awsxrayexporter/internal/translator/segment_test.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -37,13 +37,13 @@ func TestClientSpanWithRpcAwsSdkClientAttributes(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeRPCService] = "DynamoDB"
-	attributes[conventions.AttributeRPCMethod] = "GetItem"
-	attributes[conventions.AttributeRPCSystem] = "aws-api"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeRPCService] = "DynamoDB"
+	attributes[conventionsv112.AttributeRPCMethod] = "GetItem"
+	attributes[conventionsv112.AttributeRPCSystem] = "aws-api"
 	attributes[awsxray.AWSRequestIDAttribute] = "18BO1FEPJSSAOGNJEDPTPCMIU7VV4KQNSO5AEMVJF66Q9ASUAAJG"
 	attributes[awsxray.AWSTableNameAttribute] = "otel-dev-Testing"
 	resource := constructDefaultResource()
@@ -51,7 +51,7 @@ func TestClientSpanWithRpcAwsSdkClientAttributes(t *testing.T) {
 
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 	assert.Equal(t, "DynamoDB", *segment.Name)
-	assert.Equal(t, conventions.AttributeCloudProviderAWS, *segment.Namespace)
+	assert.Equal(t, conventionsv112.AttributeCloudProviderAWS, *segment.Namespace)
 	assert.Equal(t, "GetItem", *segment.AWS.Operation)
 	assert.Equal(t, "subsegment", *segment.Type)
 
@@ -70,12 +70,12 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
 	attributes[awsxray.AWSServiceAttribute] = "DynamoDB"
-	attributes[conventions.AttributeRPCMethod] = "IncorrectAWSSDKOperation"
+	attributes[conventionsv112.AttributeRPCMethod] = "IncorrectAWSSDKOperation"
 	attributes[awsxray.AWSOperationAttribute] = "GetItem"
 	attributes[awsxray.AWSRequestIDAttribute] = "18BO1FEPJSSAOGNJEDPTPCMIU7VV4KQNSO5AEMVJF66Q9ASUAAJG"
 	attributes[awsxray.AWSTableNameAttribute] = "otel-dev-Testing"
@@ -84,7 +84,7 @@ func TestClientSpanWithLegacyAwsSdkClientAttributes(t *testing.T) {
 
 	segment, _ := MakeSegment(span, resource, nil, false, nil, false)
 	assert.Equal(t, "DynamoDB", *segment.Name)
-	assert.Equal(t, conventions.AttributeCloudProviderAWS, *segment.Namespace)
+	assert.Equal(t, conventionsv112.AttributeCloudProviderAWS, *segment.Namespace)
 	assert.Equal(t, "GetItem", *segment.AWS.Operation)
 	assert.Equal(t, "subsegment", *segment.Type)
 
@@ -102,11 +102,11 @@ func TestClientSpanWithPeerService(t *testing.T) {
 	spanName := "AmazonDynamoDB.getItem"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributePeerService] = "cats-table"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "dynamodb.us-east-1.amazonaws.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributePeerService] = "cats-table"
 	attributes[awsxray.AWSServiceAttribute] = "DynamoDB"
 	attributes[awsxray.AWSOperationAttribute] = "GetItem"
 	attributes[awsxray.AWSRequestIDAttribute] = "18BO1FEPJSSAOGNJEDPTPCMIU7VV4KQNSO5AEMVJF66Q9ASUAAJG"
@@ -125,13 +125,13 @@ func TestServerSpanWithInternalServerError(t *testing.T) {
 	userAgent := "PostmanRuntime/7.21.0"
 	enduser := "go.tester@example.com"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.org/api/locations"
-	attributes[conventions.AttributeHTTPTarget] = "/api/locations"
-	attributes[conventions.AttributeHTTPStatusCode] = 500
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.org/api/locations"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/api/locations"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 500
 	attributes["http.status_text"] = "java.lang.NullPointerException"
-	attributes[conventions.AttributeHTTPUserAgent] = userAgent
-	attributes[conventions.AttributeEnduserID] = enduser
+	attributes[conventionsv112.AttributeHTTPUserAgent] = userAgent
+	attributes[conventionsv112.AttributeEnduserID] = enduser
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, errorMessage, attributes)
 	timeEvents := constructTimedEventsWithSentMessageEvent(span.StartTimestamp())
@@ -152,13 +152,13 @@ func TestServerSpanWithThrottle(t *testing.T) {
 	userAgent := "PostmanRuntime/7.21.0"
 	enduser := "go.tester@example.com"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.org/api/locations"
-	attributes[conventions.AttributeHTTPTarget] = "/api/locations"
-	attributes[conventions.AttributeHTTPStatusCode] = 429
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.org/api/locations"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/api/locations"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 429
 	attributes["http.status_text"] = "java.lang.NullPointerException"
-	attributes[conventions.AttributeHTTPUserAgent] = userAgent
-	attributes[conventions.AttributeEnduserID] = enduser
+	attributes[conventionsv112.AttributeHTTPUserAgent] = userAgent
+	attributes[conventionsv112.AttributeEnduserID] = enduser
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, errorMessage, attributes)
 	timeEvents := constructTimedEventsWithSentMessageEvent(span.StartTimestamp())
@@ -220,13 +220,13 @@ func TestClientSpanWithDbComponent(t *testing.T) {
 	parentSpanID := newSegmentID()
 	enterpriseAppID := "25F2E73B-4769-4C79-9DF3-7EBE85D571EA"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeDBSystem] = "mysql"
-	attributes[conventions.AttributeDBName] = "customers"
-	attributes[conventions.AttributeDBStatement] = spanName
-	attributes[conventions.AttributeDBUser] = "userprefsvc"
-	attributes[conventions.AttributeDBConnectionString] = "jdbc:mysql://db.dev.example.com:3306"
-	attributes[conventions.AttributeNetPeerName] = "db.dev.example.com"
-	attributes[conventions.AttributeNetPeerPort] = "3306"
+	attributes[conventionsv112.AttributeDBSystem] = "mysql"
+	attributes[conventionsv112.AttributeDBName] = "customers"
+	attributes[conventionsv112.AttributeDBStatement] = spanName
+	attributes[conventionsv112.AttributeDBUser] = "userprefsvc"
+	attributes[conventionsv112.AttributeDBConnectionString] = "jdbc:mysql://db.dev.example.com:3306"
+	attributes[conventionsv112.AttributeNetPeerName] = "db.dev.example.com"
+	attributes[conventionsv112.AttributeNetPeerPort] = "3306"
 	attributes["enterprise.app.id"] = enterpriseAppID
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, ptrace.StatusCodeUnset, "OK", attributes)
@@ -259,13 +259,13 @@ func TestClientSpanWithHttpHost(t *testing.T) {
 	spanName := "GET /"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
-	attributes[conventions.AttributeNetPeerPort] = "9443"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeHTTPHost] = "foo.com"
-	attributes[conventions.AttributeNetPeerName] = "bar.com"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
+	attributes[conventionsv112.AttributeNetPeerPort] = "9443"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeHTTPHost] = "foo.com"
+	attributes[conventionsv112.AttributeNetPeerName] = "bar.com"
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, ptrace.StatusCodeUnset, "OK", attributes)
 
@@ -279,12 +279,12 @@ func TestClientSpanWithoutHttpHost(t *testing.T) {
 	spanName := "GET /"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
-	attributes[conventions.AttributeNetPeerPort] = "9443"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeNetPeerName] = "bar.com"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
+	attributes[conventionsv112.AttributeNetPeerPort] = "9443"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeNetPeerName] = "bar.com"
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, ptrace.StatusCodeUnset, "OK", attributes)
 
@@ -298,13 +298,13 @@ func TestClientSpanWithRpcHost(t *testing.T) {
 	spanName := "GET /com.foo.AnimalService/GetCats"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
-	attributes[conventions.AttributeNetPeerPort] = "9443"
-	attributes[conventions.AttributeHTTPTarget] = "/com.foo.AnimalService/GetCats"
-	attributes[conventions.AttributeRPCService] = "com.foo.AnimalService"
-	attributes[conventions.AttributeNetPeerName] = "bar.com"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
+	attributes[conventionsv112.AttributeNetPeerPort] = "9443"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/com.foo.AnimalService/GetCats"
+	attributes[conventionsv112.AttributeRPCService] = "com.foo.AnimalService"
+	attributes[conventionsv112.AttributeNetPeerName] = "bar.com"
 	resource := constructDefaultResource()
 	span := constructClientSpan(parentSpanID, spanName, ptrace.StatusCodeUnset, "OK", attributes)
 
@@ -317,11 +317,11 @@ func TestClientSpanWithRpcHost(t *testing.T) {
 func TestSpanWithInvalidTraceId(t *testing.T) {
 	spanName := "platformapi.widgets.searchWidgets"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPScheme] = "ipv6"
-	attributes[conventions.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
-	attributes[conventions.AttributeNetPeerPort] = "9443"
-	attributes[conventions.AttributeHTTPTarget] = spanName
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPScheme] = "ipv6"
+	attributes[conventionsv112.AttributeNetPeerIP] = "2607:f8b0:4000:80c::2004"
+	attributes[conventionsv112.AttributeNetPeerPort] = "9443"
+	attributes[conventionsv112.AttributeHTTPTarget] = spanName
 	resource := constructDefaultResource()
 	span := constructClientSpan(pcommon.NewSpanIDEmpty(), spanName, ptrace.StatusCodeUnset, "OK", attributes)
 	timeEvents := constructTimedEventsWithSentMessageEvent(span.StartTimestamp())
@@ -352,11 +352,11 @@ func TestSpanWithInvalidTraceIdWithoutTimestampValidation(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "payment.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeRPCService] = "ABC"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "payment.amazonaws.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeRPCService] = "ABC"
 	attributes[awsRemoteService] = "ProducerService"
 
 	resource := constructDefaultResource()
@@ -676,11 +676,11 @@ func TestSpanWithSpecialAttributesAsListed(t *testing.T) {
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
 	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
-	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	attributes[conventionsv112.AttributeRPCMethod] = "rpc_method_val"
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, false, nil, false)
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventionsv112.AttributeRPCMethod}, false, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Len(t, segment.Annotations, 2)
@@ -696,16 +696,16 @@ func TestSpanWithSpecialAttributesAsListedWithAllowDot(t *testing.T) {
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
 	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
-	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	attributes[conventionsv112.AttributeRPCMethod] = "rpc_method_val"
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, false, nil, false)
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventionsv112.AttributeRPCMethod}, false, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Len(t, segment.Annotations, 2)
 	assert.Equal(t, "aws_operation_val", segment.Annotations[awsxray.AWSOperationAttribute])
-	assert.Equal(t, "rpc_method_val", segment.Annotations[conventions.AttributeRPCMethod])
+	assert.Equal(t, "rpc_method_val", segment.Annotations[conventionsv112.AttributeRPCMethod])
 }
 
 func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
@@ -716,11 +716,11 @@ func TestSpanWithSpecialAttributesAsListedAndIndexAll(t *testing.T) {
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
 	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
-	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	attributes[conventionsv112.AttributeRPCMethod] = "rpc_method_val"
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, true, nil, false)
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventionsv112.AttributeRPCMethod}, true, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "aws_operation_val", segment.Annotations["aws_operation"])
@@ -735,15 +735,15 @@ func TestSpanWithSpecialAttributesAsListedAndIndexAllWithAllowDot(t *testing.T) 
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
 	attributes[awsxray.AWSOperationAttribute] = "aws_operation_val"
-	attributes[conventions.AttributeRPCMethod] = "rpc_method_val"
+	attributes[conventionsv112.AttributeRPCMethod] = "rpc_method_val"
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
-	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventions.AttributeRPCMethod}, true, nil, false)
+	segment, _ := MakeSegment(span, resource, []string{awsxray.AWSOperationAttribute, conventionsv112.AttributeRPCMethod}, true, nil, false)
 
 	assert.NotNil(t, segment)
 	assert.Equal(t, "aws_operation_val", segment.Annotations[awsxray.AWSOperationAttribute])
-	assert.Equal(t, "rpc_method_val", segment.Annotations[conventions.AttributeRPCMethod])
+	assert.Equal(t, "rpc_method_val", segment.Annotations[conventionsv112.AttributeRPCMethod])
 }
 
 func TestSpanWithSpecialAttributesNotListedAndIndexAll(t *testing.T) {
@@ -751,7 +751,7 @@ func TestSpanWithSpecialAttributesNotListedAndIndexAll(t *testing.T) {
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
 	attributes[awsxray.AWSOperationAttribute] = "val1"
-	attributes[conventions.AttributeRPCMethod] = "val2"
+	attributes[conventionsv112.AttributeRPCMethod] = "val2"
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
@@ -768,8 +768,8 @@ func TestOriginNotAws(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderGCP)
-	attrs.PutStr(conventions.AttributeHostID, "instance-123")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderGCP)
+	attrs.PutStr(conventionsv112.AttributeHostID, "instance-123")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -784,9 +784,9 @@ func TestOriginEc2(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSEC2)
-	attrs.PutStr(conventions.AttributeHostID, "instance-123")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSEC2)
+	attrs.PutStr(conventionsv112.AttributeHostID, "instance-123")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -801,10 +801,10 @@ func TestOriginEcs(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSECS)
-	attrs.PutStr(conventions.AttributeHostID, "instance-123")
-	attrs.PutStr(conventions.AttributeContainerName, "container-123")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSECS)
+	attrs.PutStr(conventionsv112.AttributeHostID, "instance-123")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "container-123")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -819,11 +819,11 @@ func TestOriginEcsEc2(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSECS)
-	attrs.PutStr(conventions.AttributeAWSECSLaunchtype, conventions.AttributeAWSECSLaunchtypeEC2)
-	attrs.PutStr(conventions.AttributeHostID, "instance-123")
-	attrs.PutStr(conventions.AttributeContainerName, "container-123")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSECS)
+	attrs.PutStr(conventionsv112.AttributeAWSECSLaunchtype, conventionsv112.AttributeAWSECSLaunchtypeEC2)
+	attrs.PutStr(conventionsv112.AttributeHostID, "instance-123")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "container-123")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -838,11 +838,11 @@ func TestOriginEcsFargate(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSECS)
-	attrs.PutStr(conventions.AttributeAWSECSLaunchtype, conventions.AttributeAWSECSLaunchtypeFargate)
-	attrs.PutStr(conventions.AttributeHostID, "instance-123")
-	attrs.PutStr(conventions.AttributeContainerName, "container-123")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSECS)
+	attrs.PutStr(conventionsv112.AttributeAWSECSLaunchtype, conventionsv112.AttributeAWSECSLaunchtypeFargate)
+	attrs.PutStr(conventionsv112.AttributeHostID, "instance-123")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "container-123")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -857,11 +857,11 @@ func TestOriginEb(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSElasticBeanstalk)
-	attrs.PutStr(conventions.AttributeHostID, "instance-123")
-	attrs.PutStr(conventions.AttributeContainerName, "container-123")
-	attrs.PutStr(conventions.AttributeServiceInstanceID, "service-123")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSElasticBeanstalk)
+	attrs.PutStr(conventionsv112.AttributeHostID, "instance-123")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "container-123")
+	attrs.PutStr(conventionsv112.AttributeServiceInstanceID, "service-123")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -879,20 +879,20 @@ func TestOriginEks(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSEKS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeK8SClusterName, "production")
-	attrs.PutStr(conventions.AttributeK8SNamespaceName, "default")
-	attrs.PutStr(conventions.AttributeK8SDeploymentName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
-	attrs.PutStr(conventions.AttributeContainerName, containerName)
-	attrs.PutStr(conventions.AttributeContainerID, containerID)
-	attrs.PutStr(conventions.AttributeHostID, instanceID)
-	attrs.PutStr(conventions.AttributeHostType, "m5.xlarge")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSEKS)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventionsv112.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventionsv112.AttributeK8SClusterName, "production")
+	attrs.PutStr(conventionsv112.AttributeK8SNamespaceName, "default")
+	attrs.PutStr(conventionsv112.AttributeK8SDeploymentName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeK8SPodName, "my-deployment-65dcf7d447-ddjnl")
+	attrs.PutStr(conventionsv112.AttributeContainerName, containerName)
+	attrs.PutStr(conventionsv112.AttributeContainerID, containerID)
+	attrs.PutStr(conventionsv112.AttributeHostID, instanceID)
+	attrs.PutStr(conventionsv112.AttributeHostType, "m5.xlarge")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -907,8 +907,8 @@ func TestOriginAppRunner(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSAppRunner)
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSAppRunner)
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -923,7 +923,7 @@ func TestOriginBlank(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -938,12 +938,12 @@ func TestOriginPrefersInfraService(t *testing.T) {
 	attributes := make(map[string]any)
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudPlatform, conventions.AttributeCloudPlatformAWSEC2)
-	attrs.PutStr(conventions.AttributeK8SClusterName, "cluster-123")
-	attrs.PutStr(conventions.AttributeHostID, "instance-123")
-	attrs.PutStr(conventions.AttributeContainerName, "container-123")
-	attrs.PutStr(conventions.AttributeServiceInstanceID, "service-123")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudPlatform, conventionsv112.AttributeCloudPlatformAWSEC2)
+	attrs.PutStr(conventionsv112.AttributeK8SClusterName, "cluster-123")
+	attrs.PutStr(conventionsv112.AttributeHostID, "instance-123")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "container-123")
+	attrs.PutStr(conventionsv112.AttributeServiceInstanceID, "service-123")
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
 	segment, _ := MakeSegment(span, resource, []string{}, false, nil, false)
@@ -995,7 +995,7 @@ func TestSpanWithSingleDynamoDBTableHasTableName(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeAWSDynamoDBTableNames] = []string{"table1"}
+	attributes[conventionsv112.AttributeAWSDynamoDBTableNames] = []string{"table1"}
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
@@ -1004,14 +1004,14 @@ func TestSpanWithSingleDynamoDBTableHasTableName(t *testing.T) {
 	assert.NotNil(t, segment)
 	assert.Equal(t, "table1", *segment.AWS.TableName)
 	assert.Nil(t, segment.AWS.TableNames)
-	assert.Equal(t, []any{"table1"}, segment.Metadata["default"][conventions.AttributeAWSDynamoDBTableNames])
+	assert.Equal(t, []any{"table1"}, segment.Metadata["default"][conventionsv112.AttributeAWSDynamoDBTableNames])
 }
 
 func TestSpanWithMultipleDynamoDBTablesHasTableNames(t *testing.T) {
 	spanName := "/api/locations"
 	parentSpanID := newSegmentID()
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeAWSDynamoDBTableNames] = []string{"table1", "table2"}
+	attributes[conventionsv112.AttributeAWSDynamoDBTableNames] = []string{"table1", "table2"}
 	resource := constructDefaultResource()
 	span := constructServerSpan(parentSpanID, spanName, ptrace.StatusCodeError, "OK", attributes)
 
@@ -1020,7 +1020,7 @@ func TestSpanWithMultipleDynamoDBTablesHasTableNames(t *testing.T) {
 	assert.NotNil(t, segment)
 	assert.Nil(t, segment.AWS.TableName)
 	assert.Equal(t, []string{"table1", "table2"}, segment.AWS.TableNames)
-	assert.Equal(t, []any{"table1", "table2"}, segment.Metadata["default"][conventions.AttributeAWSDynamoDBTableNames])
+	assert.Equal(t, []any{"table1", "table2"}, segment.Metadata["default"][conventionsv112.AttributeAWSDynamoDBTableNames])
 }
 
 func TestSegmentWithLogGroupsFromConfig(t *testing.T) {
@@ -1068,11 +1068,11 @@ func TestClientSpanWithAwsRemoteServiceName(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "payment.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeRPCService] = "ABC"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "payment.amazonaws.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeRPCService] = "ABC"
 	attributes[awsRemoteService] = "PaymentService"
 
 	resource := constructDefaultResource()
@@ -1096,10 +1096,10 @@ func TestAwsSdkSpanWithDeprecatedAwsRemoteServiceName(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeRPCSystem] = "aws-api"
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeRPCService] = "DynamoDb"
+	attributes[conventionsv112.AttributeRPCSystem] = "aws-api"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeRPCService] = "DynamoDb"
 	attributes[awsRemoteService] = "AWS.SDK.DynamoDb"
 
 	resource := constructDefaultResource()
@@ -1124,10 +1124,10 @@ func TestAwsSdkSpanWithAwsRemoteServiceName(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeRPCSystem] = "aws-api"
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeRPCService] = "DynamoDb"
+	attributes[conventionsv112.AttributeRPCSystem] = "aws-api"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeRPCService] = "DynamoDb"
 	attributes[awsRemoteService] = "AWS::DynamoDB"
 
 	resource := constructDefaultResource()
@@ -1152,11 +1152,11 @@ func TestProducerSpanWithAwsRemoteServiceName(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "payment.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeRPCService] = "ABC"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "payment.amazonaws.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeRPCService] = "ABC"
 	attributes[awsRemoteService] = "ProducerService"
 
 	resource := constructDefaultResource()
@@ -1199,11 +1199,11 @@ func TestServerSpanWithAwsLocalServiceName(t *testing.T) {
 	parentSpanID := newSegmentID()
 	user := "testingT"
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeHTTPHost] = "payment.amazonaws.com"
-	attributes[conventions.AttributeHTTPTarget] = "/"
-	attributes[conventions.AttributeRPCService] = "ABC"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeHTTPHost] = "payment.amazonaws.com"
+	attributes[conventionsv112.AttributeHTTPTarget] = "/"
+	attributes[conventionsv112.AttributeRPCService] = "ABC"
 	attributes[awsLocalService] = "PaymentLocalService"
 	attributes[awsRemoteService] = "PaymentService"
 
@@ -1239,7 +1239,7 @@ func validateLocalRootDependencySubsegment(t *testing.T, segment *awsxray.Segmen
 	assert.Equal(t, "myAnnotationValue", segment.Annotations["myAnnotationKey"])
 
 	assert.Len(t, segment.Metadata["default"], 8)
-	assert.Equal(t, "receive", segment.Metadata["default"][conventions.AttributeMessagingOperation])
+	assert.Equal(t, "receive", segment.Metadata["default"][conventionsv112.AttributeMessagingOperation])
 	assert.Equal(t, "LOCAL_ROOT", segment.Metadata["default"][awsSpanKind])
 	assert.Equal(t, "myRemoteOperation", segment.Metadata["default"][awsRemoteOperation])
 	assert.Equal(t, "myTarget", segment.Metadata["default"][remoteTarget])
@@ -1291,8 +1291,8 @@ func validateLocalRootServiceSegment(t *testing.T, segment *awsxray.Segment, spa
 func getBasicAttributes() map[string]any {
 	attributes := make(map[string]any)
 
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeMessagingOperation] = "receive"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeMessagingOperation] = "receive"
 
 	attributes["otel.resource.attributes"] = "service.name=myTest"
 
@@ -1319,9 +1319,9 @@ func getBasicAttributes() map[string]any {
 func getBasicResource() pcommon.Resource {
 	resource := constructDefaultResource()
 
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKName, "MySDK")
-	resource.Attributes().PutStr(conventions.AttributeTelemetrySDKVersion, "1.20.0")
-	resource.Attributes().PutStr(conventions.AttributeTelemetryAutoVersion, "1.2.3")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKName, "MySDK")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetrySDKVersion, "1.20.0")
+	resource.Attributes().PutStr(conventionsv112.AttributeTelemetryAutoVersion, "1.2.3")
 
 	return resource
 }
@@ -1400,7 +1400,7 @@ func TestNonLocalRootConsumerProcess(t *testing.T) {
 	assert.Len(t, segments[0].Metadata["default"], 7)
 	assert.Equal(t, "Consumer", segments[0].Metadata["default"][awsSpanKind])
 	assert.Equal(t, "myLocalService", segments[0].Metadata["default"][awsLocalService])
-	assert.Equal(t, "receive", segments[0].Metadata["default"][conventions.AttributeMessagingOperation])
+	assert.Equal(t, "receive", segments[0].Metadata["default"][conventionsv112.AttributeMessagingOperation])
 	assert.Equal(t, "service.name=myTest", segments[0].Metadata["default"]["otel.resource.attributes"])
 	assert.Equal(t, "MySDK", *segments[0].AWS.XRay.SDK)
 	assert.Equal(t, "1.20.0", *segments[0].AWS.XRay.SDKVersion)
@@ -1415,7 +1415,7 @@ func TestLocalRootConsumerAWSNamespace(t *testing.T) {
 	parentSpanID := newSegmentID()
 
 	attributes := getBasicAttributes()
-	attributes[conventions.AttributeRPCSystem] = "aws-api"
+	attributes[conventionsv112.AttributeRPCSystem] = "aws-api"
 
 	span := constructConsumerSpan(parentSpanID, spanName, 200, "OK", attributes)
 
@@ -1474,10 +1474,10 @@ func TestLocalRootClientAwsServiceMetrics(t *testing.T) {
 
 	attributes := getBasicAttributes()
 	attributes[awsSpanKind] = "LOCAL_ROOT"
-	attributes[conventions.AttributeRPCSystem] = "aws-api"
-	attributes[conventions.AttributeHTTPMethod] = http.MethodPost
-	attributes[conventions.AttributeHTTPScheme] = "https"
-	attributes[conventions.AttributeRPCService] = "SQS"
+	attributes[conventionsv112.AttributeRPCSystem] = "aws-api"
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodPost
+	attributes[conventionsv112.AttributeHTTPScheme] = "https"
+	attributes[conventionsv112.AttributeRPCService] = "SQS"
 	attributes[awsRemoteService] = "AWS.SDK.SQS"
 
 	span := constructClientSpan(parentSpanID, spanName, 200, "OK", attributes)
@@ -1549,7 +1549,7 @@ func validateLocalRootWithoutDependency(t *testing.T, segment *awsxray.Segment, 
 	}
 
 	assert.Len(t, segment.Metadata["default"], numberOfMetadataKeys)
-	assert.Equal(t, "receive", segment.Metadata["default"][conventions.AttributeMessagingOperation])
+	assert.Equal(t, "receive", segment.Metadata["default"][conventionsv112.AttributeMessagingOperation])
 	assert.Equal(t, "LOCAL_ROOT", segment.Metadata["default"][awsSpanKind])
 	assert.Equal(t, "myRemoteOperation", segment.Metadata["default"][awsRemoteOperation])
 	assert.Equal(t, "myTarget", segment.Metadata["default"][remoteTarget])
@@ -1898,19 +1898,19 @@ func constructSpanAttributes(attributes map[string]any) pcommon.Map {
 func constructDefaultResource() pcommon.Resource {
 	resource := pcommon.NewResource()
 	attrs := resource.Attributes()
-	attrs.PutStr(conventions.AttributeServiceName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeServiceVersion, "semver:1.1.4")
-	attrs.PutStr(conventions.AttributeContainerName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeContainerImageName, "otel/signupaggregator")
-	attrs.PutStr(conventions.AttributeContainerImageTag, "v1")
-	attrs.PutStr(conventions.AttributeK8SClusterName, "production")
-	attrs.PutStr(conventions.AttributeK8SNamespaceName, "default")
-	attrs.PutStr(conventions.AttributeK8SDeploymentName, "signup_aggregator")
-	attrs.PutStr(conventions.AttributeK8SPodName, "signup_aggregator-x82ufje83")
-	attrs.PutStr(conventions.AttributeCloudProvider, conventions.AttributeCloudProviderAWS)
-	attrs.PutStr(conventions.AttributeCloudAccountID, "123456789")
-	attrs.PutStr(conventions.AttributeCloudRegion, "us-east-1")
-	attrs.PutStr(conventions.AttributeCloudAvailabilityZone, "us-east-1c")
+	attrs.PutStr(conventionsv112.AttributeServiceName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeServiceVersion, "semver:1.1.4")
+	attrs.PutStr(conventionsv112.AttributeContainerName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageName, "otel/signupaggregator")
+	attrs.PutStr(conventionsv112.AttributeContainerImageTag, "v1")
+	attrs.PutStr(conventionsv112.AttributeK8SClusterName, "production")
+	attrs.PutStr(conventionsv112.AttributeK8SNamespaceName, "default")
+	attrs.PutStr(conventionsv112.AttributeK8SDeploymentName, "signup_aggregator")
+	attrs.PutStr(conventionsv112.AttributeK8SPodName, "signup_aggregator-x82ufje83")
+	attrs.PutStr(conventionsv112.AttributeCloudProvider, conventionsv112.AttributeCloudProviderAWS)
+	attrs.PutStr(conventionsv112.AttributeCloudAccountID, "123456789")
+	attrs.PutStr(conventionsv112.AttributeCloudRegion, "us-east-1")
+	attrs.PutStr(conventionsv112.AttributeCloudAvailabilityZone, "us-east-1c")
 	attrs.PutStr(resourceStringKey, "string")
 	attrs.PutInt(resourceIntKey, 10)
 	attrs.PutDouble(resourceDoubleKey, 5.0)
@@ -1932,9 +1932,9 @@ func constructTimedEventsWithReceivedMessageEvent(tm pcommon.Timestamp) ptrace.S
 
 	eventAttr := event.Attributes()
 	eventAttr.PutStr("message.type", "RECEIVED")
-	eventAttr.PutInt(conventions.AttributeMessagingMessageID, 1)
-	eventAttr.PutInt(conventions.AttributeMessagingMessagePayloadCompressedSizeBytes, 6478)
-	eventAttr.PutInt(conventions.AttributeMessagingMessagePayloadSizeBytes, 12452)
+	eventAttr.PutInt(conventionsv112.AttributeMessagingMessageID, 1)
+	eventAttr.PutInt(conventionsv112.AttributeMessagingMessagePayloadCompressedSizeBytes, 6478)
+	eventAttr.PutInt(conventionsv112.AttributeMessagingMessagePayloadSizeBytes, 12452)
 
 	event.SetTimestamp(tm)
 	event.SetDroppedAttributesCount(0)
@@ -1948,8 +1948,8 @@ func constructTimedEventsWithSentMessageEvent(tm pcommon.Timestamp) ptrace.SpanE
 
 	eventAttr := event.Attributes()
 	eventAttr.PutStr("message.type", "SENT")
-	eventAttr.PutInt(conventions.AttributeMessagingMessageID, 1)
-	eventAttr.PutInt(conventions.AttributeMessagingMessagePayloadSizeBytes, 7480)
+	eventAttr.PutInt(conventionsv112.AttributeMessagingMessageID, 1)
+	eventAttr.PutInt(conventionsv112.AttributeMessagingMessagePayloadSizeBytes, 7480)
 
 	event.SetTimestamp(tm)
 	event.SetDroppedAttributesCount(0)

--- a/exporter/awsxrayexporter/internal/translator/service.go
+++ b/exporter/awsxrayexporter/internal/translator/service.go
@@ -5,7 +5,7 @@ package translator // import "github.com/open-telemetry/opentelemetry-collector-
 
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -13,9 +13,9 @@ import (
 func makeService(resource pcommon.Resource) *awsxray.ServiceData {
 	var service *awsxray.ServiceData
 
-	verStr, ok := resource.Attributes().Get(conventions.AttributeServiceVersion)
+	verStr, ok := resource.Attributes().Get(conventionsv112.AttributeServiceVersion)
 	if !ok {
-		verStr, ok = resource.Attributes().Get(conventions.AttributeContainerImageTag)
+		verStr, ok = resource.Attributes().Get(conventionsv112.AttributeContainerImageTag)
 	}
 	if ok {
 		service = &awsxray.ServiceData{

--- a/exporter/awsxrayexporter/internal/translator/service_test.go
+++ b/exporter/awsxrayexporter/internal/translator/service_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 )
 
 func TestServiceFromResource(t *testing.T) {
@@ -27,7 +27,7 @@ func TestServiceFromResource(t *testing.T) {
 
 func TestServiceFromResourceWithNoServiceVersion(t *testing.T) {
 	resource := constructDefaultResource()
-	resource.Attributes().Remove(conventions.AttributeServiceVersion)
+	resource.Attributes().Remove(conventionsv112.AttributeServiceVersion)
 	service := makeService(resource)
 
 	assert.NotNil(t, service)

--- a/exporter/awsxrayexporter/internal/translator/sql.go
+++ b/exporter/awsxrayexporter/internal/translator/sql.go
@@ -6,7 +6,7 @@ package translator // import "github.com/open-telemetry/opentelemetry-collector-
 import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 
 	awsxray "github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/xray"
 )
@@ -25,15 +25,15 @@ func makeSQL(span ptrace.Span, attributes map[string]pcommon.Value) (map[string]
 
 	for key, value := range attributes {
 		switch key {
-		case conventions.AttributeDBConnectionString:
+		case conventionsv112.AttributeDBConnectionString:
 			dbConnectionString = value.Str()
-		case conventions.AttributeDBSystem:
+		case conventionsv112.AttributeDBSystem:
 			dbSystem = value.Str()
-		case conventions.AttributeDBName:
+		case conventionsv112.AttributeDBName:
 			dbInstance = value.Str()
-		case conventions.AttributeDBStatement:
+		case conventionsv112.AttributeDBStatement:
 			dbStatement = value.Str()
-		case conventions.AttributeDBUser:
+		case conventionsv112.AttributeDBUser:
 			dbUser = value.Str()
 		default:
 			filtered[key] = value

--- a/exporter/awsxrayexporter/internal/translator/sql_test.go
+++ b/exporter/awsxrayexporter/internal/translator/sql_test.go
@@ -11,18 +11,18 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 )
 
 func TestClientSpanWithStatementAttribute(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeDBSystem] = pcommon.NewValueStr("mysql")
-	attributes[conventions.AttributeDBName] = pcommon.NewValueStr("customers")
-	attributes[conventions.AttributeDBStatement] = pcommon.NewValueStr("SELECT * FROM user WHERE user_id = ?")
-	attributes[conventions.AttributeDBUser] = pcommon.NewValueStr("readonly_user")
-	attributes[conventions.AttributeDBConnectionString] = pcommon.NewValueStr("mysql://db.example.com:3306")
-	attributes[conventions.AttributeNetPeerName] = pcommon.NewValueStr("db.example.com")
-	attributes[conventions.AttributeNetPeerPort] = pcommon.NewValueStr("3306")
+	attributes[conventionsv112.AttributeDBSystem] = pcommon.NewValueStr("mysql")
+	attributes[conventionsv112.AttributeDBName] = pcommon.NewValueStr("customers")
+	attributes[conventionsv112.AttributeDBStatement] = pcommon.NewValueStr("SELECT * FROM user WHERE user_id = ?")
+	attributes[conventionsv112.AttributeDBUser] = pcommon.NewValueStr("readonly_user")
+	attributes[conventionsv112.AttributeDBConnectionString] = pcommon.NewValueStr("mysql://db.example.com:3306")
+	attributes[conventionsv112.AttributeNetPeerName] = pcommon.NewValueStr("db.example.com")
+	attributes[conventionsv112.AttributeNetPeerPort] = pcommon.NewValueStr("3306")
 	span := constructSQLSpan(attributes)
 
 	filtered, sqlData := makeSQL(span, attributes)
@@ -39,13 +39,13 @@ func TestClientSpanWithStatementAttribute(t *testing.T) {
 
 func TestClientSpanWithNonSQLDatabase(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeDBSystem] = pcommon.NewValueStr("redis")
-	attributes[conventions.AttributeDBName] = pcommon.NewValueStr("0")
-	attributes[conventions.AttributeDBStatement] = pcommon.NewValueStr("SET key value")
-	attributes[conventions.AttributeDBUser] = pcommon.NewValueStr("readonly_user")
-	attributes[conventions.AttributeDBConnectionString] = pcommon.NewValueStr("redis://db.example.com:3306")
-	attributes[conventions.AttributeNetPeerName] = pcommon.NewValueStr("db.example.com")
-	attributes[conventions.AttributeNetPeerPort] = pcommon.NewValueStr("3306")
+	attributes[conventionsv112.AttributeDBSystem] = pcommon.NewValueStr("redis")
+	attributes[conventionsv112.AttributeDBName] = pcommon.NewValueStr("0")
+	attributes[conventionsv112.AttributeDBStatement] = pcommon.NewValueStr("SET key value")
+	attributes[conventionsv112.AttributeDBUser] = pcommon.NewValueStr("readonly_user")
+	attributes[conventionsv112.AttributeDBConnectionString] = pcommon.NewValueStr("redis://db.example.com:3306")
+	attributes[conventionsv112.AttributeNetPeerName] = pcommon.NewValueStr("db.example.com")
+	attributes[conventionsv112.AttributeNetPeerPort] = pcommon.NewValueStr("3306")
 	span := constructSQLSpan(attributes)
 
 	filtered, sqlData := makeSQL(span, attributes)
@@ -55,13 +55,13 @@ func TestClientSpanWithNonSQLDatabase(t *testing.T) {
 
 func TestClientSpanWithoutDBurlAttribute(t *testing.T) {
 	attributes := make(map[string]pcommon.Value)
-	attributes[conventions.AttributeDBSystem] = pcommon.NewValueStr("postgresql")
-	attributes[conventions.AttributeDBName] = pcommon.NewValueStr("customers")
-	attributes[conventions.AttributeDBStatement] = pcommon.NewValueStr("SELECT * FROM user WHERE user_id = ?")
-	attributes[conventions.AttributeDBUser] = pcommon.NewValueStr("readonly_user")
-	attributes[conventions.AttributeDBConnectionString] = pcommon.NewValueStr("")
-	attributes[conventions.AttributeNetPeerName] = pcommon.NewValueStr("db.example.com")
-	attributes[conventions.AttributeNetPeerPort] = pcommon.NewValueStr("3306")
+	attributes[conventionsv112.AttributeDBSystem] = pcommon.NewValueStr("postgresql")
+	attributes[conventionsv112.AttributeDBName] = pcommon.NewValueStr("customers")
+	attributes[conventionsv112.AttributeDBStatement] = pcommon.NewValueStr("SELECT * FROM user WHERE user_id = ?")
+	attributes[conventionsv112.AttributeDBUser] = pcommon.NewValueStr("readonly_user")
+	attributes[conventionsv112.AttributeDBConnectionString] = pcommon.NewValueStr("")
+	attributes[conventionsv112.AttributeNetPeerName] = pcommon.NewValueStr("db.example.com")
+	attributes[conventionsv112.AttributeNetPeerPort] = pcommon.NewValueStr("3306")
 	span := constructSQLSpan(attributes)
 
 	filtered, sqlData := makeSQL(span, attributes)

--- a/exporter/awsxrayexporter/internal/translator/writer_pool_test.go
+++ b/exporter/awsxrayexporter/internal/translator/writer_pool_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
-	conventions "go.opentelemetry.io/collector/semconv/v1.12.0"
+	conventionsv112 "go.opentelemetry.io/collector/semconv/v1.12.0"
 	"go.uber.org/zap"
 )
 
@@ -67,9 +67,9 @@ func BenchmarkWithPool(b *testing.B) {
 
 func constructWriterPoolSpan() ptrace.Span {
 	attributes := make(map[string]any)
-	attributes[conventions.AttributeHTTPMethod] = http.MethodGet
-	attributes[conventions.AttributeHTTPURL] = "https://api.example.com/users/junit"
-	attributes[conventions.AttributeHTTPClientIP] = "192.168.15.32"
-	attributes[conventions.AttributeHTTPStatusCode] = 200
+	attributes[conventionsv112.AttributeHTTPMethod] = http.MethodGet
+	attributes[conventionsv112.AttributeHTTPURL] = "https://api.example.com/users/junit"
+	attributes[conventionsv112.AttributeHTTPClientIP] = "192.168.15.32"
+	attributes[conventionsv112.AttributeHTTPStatusCode] = 200
 	return constructHTTPServerSpan(attributes)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The PR merge in latest semconv pkg and update existing semantic conventions utilization.  And further update `awsxrayexporter` to be able to handle following both new versions of http
span attributes:
`http.response.status_code` migrated from [http.status_code](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-status-code)
`url.query` migrated from [http.target](https://opentelemetry.io/docs/specs/semconv/attributes-registry/http/#http-target).

Otel Java SDK has renamed `telemetry.auto.version` to `telemetry.distro.version` ([Upstream PR](https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/9065)), update `awsxrayexporter` to be able to detect both attributes.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
N/A

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit test passed

<!--Describe the documentation added.-->
#### Documentation
N/A
