### PR TITLE
[pkg/stanza] Log the entry in `HandleEntryError` when the transformer on_error mode is send_quiet or drop_quiet

### DIFF
--- a/.chloggen/handle-error-log-entry.yaml
+++ b/.chloggen/handle-error-log-entry.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/stanza
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Log the entry in HandleEntryError when the transformer on_error mode is send_quiet or drop_quiet.
+
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36899]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/stanza/operator/helper/transformer.go
+++ b/pkg/stanza/operator/helper/transformer.go
@@ -95,7 +95,7 @@ func (t *TransformerOperator) ProcessWith(ctx context.Context, entry *entry.Entr
 // HandleEntryError will handle an entry error using the on_error strategy.
 func (t *TransformerOperator) HandleEntryError(ctx context.Context, entry *entry.Entry, err error) error {
 	if t.OnError == SendOnErrorQuiet || t.OnError == DropOnErrorQuiet {
-		t.Logger().Debug("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError))
+		t.Logger().Debug("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError), zap.Any("entry", entry))
 	} else {
 		t.Logger().Error("Failed to process entry", zap.Any("error", err), zap.Any("action", t.OnError))
 	}

--- a/pkg/stanza/operator/helper/transformer_test.go
+++ b/pkg/stanza/operator/helper/transformer_test.go
@@ -151,6 +151,7 @@ func TestTransformerDropOnErrorQuiet(t *testing.T) {
 			Context: []zapcore.Field{
 				{Key: "error", Type: 26, Interface: fmt.Errorf("Failure")},
 				zap.Any("action", "drop_quiet"),
+				zap.Any("entry", testEntry),
 			},
 		},
 	}
@@ -241,6 +242,7 @@ func TestTransformerSendOnErrorQuiet(t *testing.T) {
 			Context: []zapcore.Field{
 				{Key: "error", Type: 26, Interface: fmt.Errorf("Failure")},
 				zap.Any("action", "send_quiet"),
+				zap.Any("entry", testEntry),
 			},
 		},
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The `HandleEntryError` is used in many places for handling parsing errors. Sometimes the error itself is not very helpful, e.g. the syslog parser return errors like "parsing error [col 66]", which is quite hard to understand without seeing the actual entry.

This PR logs the entry when the error mode is `send_quiet` or `drop_quiet` in debug level. It shouldn't add too much noise and could be very helpful in debugging.
