### PR TITLE
[receiver/sqlquery] sqlserver integration tests, improved coverage

### DIFF
--- a/receiver/sqlqueryreceiver/integration_test.go
+++ b/receiver/sqlqueryreceiver/integration_test.go
@@ -125,7 +125,7 @@ var (
 		},
 		Driver:                   "oracle",
 		CurrentTimestampFunction: "SYSTIMESTAMP",
-		ConvertColumnName:        func(name string) string { return strings.ToUpper(name) },
+		ConvertColumnName:        strings.ToUpper,
 		ContainerRequest: testcontainers.ContainerRequest{
 			FromDockerfile: testcontainers.FromDockerfile{
 				Context:    filepath.Join("testdata", "integration", "oracle"),
@@ -401,11 +401,10 @@ func insertSimpleLogs(t *testing.T, engine DbEngine, container testcontainers.Co
 	defer db.Close()
 
 	for newLogID := existingLogID + 1; newLogID <= existingLogID+newLogCount; newLogID++ {
-		query := fmt.Sprintf("insert into simple_logs (id, insert_time, body, attribute) values (%d, %s, 'another log %d', 'TLSv1.2')", newLogID, engine.CurrentTimestampFunction, newLogID)
+		query := fmt.Sprintf("insert into simple_logs (id, insert_time, body, attribute) values (%d, %s, 'another log %d', 'TLSv1.2')", newLogID, engine.CurrentTimestampFunction, newLogID) // nolint:gosec // Ignore, not possible to use prepared statements here for currentTimestampFunction
 		_, err := db.Exec(query)
 		require.NoError(t, err)
 	}
-
 }
 
 func createTestLogsReceiver(t *testing.T, driver, dataSource string, receiverCreateSettings receiver.Settings) (*logsReceiver, *Config, *consumertest.LogsSink) {

--- a/receiver/sqlqueryreceiver/testdata/integration/oracle/init.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/oracle/init.sql
@@ -1,9 +1,20 @@
+/* The alter session command is required to enable user creation in an Oracle docker container
+   This command shouldn't be used outside of test environments. */
+alter session set "_ORACLE_SCRIPT"=true;
+CREATE USER OTEL IDENTIFIED BY "p@ssw%rd";
+GRANT CREATE SESSION TO OTEL;
+GRANT ALL PRIVILEGES TO OTEL;
+ALTER USER OTEL QUOTA UNLIMITED ON USERS;
+-- Switch to the OTEL schema
+ALTER SESSION SET CURRENT_SCHEMA = OTEL;
+      
 create table movie
 (
     title       VARCHAR2(256),
     genre       VARCHAR(256),
     imdb_rating NUMBER
 );
+GRANT ALL ON movie TO OTEL;
 
 insert into movie (title, genre, imdb_rating)
 values ('E.T.', 'SciFi', 7.9);
@@ -16,13 +27,6 @@ values ('Die Hard', 'Action', 8.2);
 insert into movie (title, genre, imdb_rating)
 values ('Mission Impossible', 'Action', 7.1);
 
-/* The alter session command is required to enable user creation in an Oracle docker container
-   This command shouldn't be used outside of test environments. */
-alter session set "_ORACLE_SCRIPT"=true;
-CREATE USER OTEL IDENTIFIED BY "p@ssw%rd";
-GRANT CREATE SESSION TO OTEL;
-GRANT ALL ON movie TO OTEL;
-
 create table simple_logs
 (
     id number primary key,
@@ -30,7 +34,7 @@ create table simple_logs
     body varchar2(4000),
     attribute varchar2(100)
 );
-grant select on simple_logs to otel;
+GRANT ALL ON simple_logs TO OTEL;
 
 insert into simple_logs (id, insert_time, body, attribute) values
 (1, TIMESTAMP '2022-06-03 21:59:26 +00:00', '- - - [03/Jun/2022:21:59:26 +0000] "GET /api/health HTTP/1.1" 200 6197 4 "-" "-" 445af8e6c428303f -', 'TLSv1.2');

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/Dockerfile
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/mssql/server:2017-latest
+
+ENV ACCEPT_EULA=Y
+ENV SA_PASSWORD=YourStrong!Passw0rd
+
+COPY entrypoint.sh /usr/src/app/entrypoint.sh
+COPY configure-db.sh /usr/src/app/configure-db.sh
+COPY init.sql /usr/src/app/init.sql
+
+RUN chmod +x /usr/src/app/entrypoint.sh /usr/src/app/configure-db.sh
+
+ENTRYPOINT ["/bin/bash", "/usr/src/app/entrypoint.sh"]

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/Dockerfile
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/Dockerfile
@@ -1,12 +1,12 @@
-FROM mcr.microsoft.com/mssql/server:2017-latest
+FROM mcr.microsoft.com/mssql/server:2022-latest
 
 ENV ACCEPT_EULA=Y
 ENV SA_PASSWORD=YourStrong!Passw0rd
 
-COPY entrypoint.sh /usr/src/app/entrypoint.sh
-COPY configure-db.sh /usr/src/app/configure-db.sh
-COPY init.sql /usr/src/app/init.sql
+# Set the working directory
+WORKDIR /usr/src/app
 
-RUN chmod +x /usr/src/app/entrypoint.sh /usr/src/app/configure-db.sh
+# Copy the scripts and set the executable permissions before copying them into the image
+COPY entrypoint.sh configure-db.sh init.sql ./
 
 ENTRYPOINT ["/bin/bash", "/usr/src/app/entrypoint.sh"]

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/configure-db.sh
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/configure-db.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Run the SQL script to initialize the database
+/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd -d master -i /usr/src/app/init.sql

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/configure-db.sh
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/configure-db.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
 
 # Run the SQL script to initialize the database
 /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd -d master -i /usr/src/app/init.sql

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/configure-db.sh
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/configure-db.sh
@@ -5,6 +5,22 @@
 #
 #
 
+DBSTATUS=1
+ERRCODE=1
+i=0
 
-# Run the SQL script to initialize the database
-/opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P YourStrong!Passw0rd -d master -i /usr/src/app/init.sql
+
+while [[ $DBSTATUS -ne 0 ]] && [[ $i -lt 60 ]]; do
+	i=$((i + 1))
+	DBSTATUS=$(/opt/mssql-tools18/bin/sqlcmd -h -1 -t 1 -U sa -P "${SA_PASSWORD}" -C -Q "SET NOCOUNT ON; Select SUM(state) from sys.databases")
+	DBSTATUS=${DBSTATUS:-1}
+	sleep 1
+done
+
+if [[ $DBSTATUS -ne 0 ]]; then
+	echo "SQL Server took more than 60 seconds to start up or one or more databases are not in an ONLINE state"
+	exit 1
+fi
+
+# Run the setup script to create the DB and the schema in the DB
+/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "${SA_PASSWORD}" -C -d master -i /usr/src/app/init.sql

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/entrypoint.sh
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+#
+# Copyright The OpenTelemetry Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+
 
 # Start SQL Server in the background
 /opt/mssql/bin/sqlservr &

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/entrypoint.sh
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/entrypoint.sh
@@ -6,14 +6,8 @@
 #
 
 
-# Start SQL Server in the background
-/opt/mssql/bin/sqlservr &
+# Start the script to create the DB and user
+/usr/src/app/configure-db.sh &
 
-# Wait for SQL Server to start
-sleep 30s
-
-# Run the setup script to create the DB and the schema in the DB
-/usr/src/app/configure-db.sh
-
-# Call the original entrypoint script
-wait
+# Start SQL Server
+/opt/mssql/bin/sqlservr

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/entrypoint.sh
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Start SQL Server in the background
+/opt/mssql/bin/sqlservr &
+
+# Wait for SQL Server to start
+sleep 30s
+
+# Run the setup script to create the DB and the schema in the DB
+/usr/src/app/configure-db.sh
+
+# Call the original entrypoint script
+wait

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/expected.yaml
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/expected.yaml
@@ -1,0 +1,42 @@
+resourceMetrics:
+  - resource: {}
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asInt: "2"
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1734876925424574000"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asInt: "3"
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1734876925424574000"
+            name: genre.count
+          - gauge:
+              dataPoints:
+                - asDouble: 7.6499999999999995
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: Action
+                  timeUnixNano: "1734876925424574000"
+            name: genre.imdb
+          - gauge:
+              dataPoints:
+                - asDouble: 8.200000000000001
+                  attributes:
+                    - key: genre
+                      value:
+                        stringValue: SciFi
+                  timeUnixNano: "1734876925424574000"
+            name: genre.imdb
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlqueryreceiver

--- a/receiver/sqlqueryreceiver/testdata/integration/sqlserver/init.sql
+++ b/receiver/sqlqueryreceiver/testdata/integration/sqlserver/init.sql
@@ -1,0 +1,51 @@
+USE master;
+GO
+
+CREATE DATABASE otel;
+GO
+
+CREATE LOGIN otel WITH PASSWORD = 'YourStrong!Passw0rd';
+GO
+
+USE otel;
+GO
+
+CREATE USER otel FOR LOGIN otel;
+GO
+
+ALTER ROLE db_owner ADD MEMBER otel;
+GO
+
+CREATE TABLE movie
+(
+    title NVARCHAR(256),
+    genre NVARCHAR(256),
+    imdb_rating FLOAT
+);
+
+PRINT 'Inserting data into movie table...';
+INSERT INTO movie (title, genre, imdb_rating)
+VALUES ('E.T.', 'SciFi', 7.9),
+       ('Blade Runner', 'SciFi', 8.1),
+       ('Star Wars', 'SciFi', 8.6),
+       ('Die Hard', 'Action', 8.2),
+       ('Mission Impossible', 'Action', 7.1);
+PRINT 'Data inserted into movie table.';
+
+CREATE TABLE simple_logs
+(
+    id INT PRIMARY KEY,
+    insert_time DATETIME2,
+    body NVARCHAR(MAX),
+    attribute NVARCHAR(100)
+);
+
+PRINT 'Inserting data into simple_logs table...';
+INSERT INTO simple_logs (id, insert_time, body, attribute) VALUES
+                                                               (1, '2022-06-03 21:59:26', '- - - [03/Jun/2022:21:59:26 +0000] "GET /api/health HTTP/1.1" 200 6197 4 "-" "-" 445af8e6c428303f -', 'TLSv1.2'),
+                                                               (2, '2022-06-03 21:59:26.692991', '- - - [03/Jun/2022:21:59:26 +0000] "GET /api/health HTTP/1.1" 200 6205 5 "-" "-" 3285f43cd4baa202 -', 'TLSv1'),
+                                                               (3, '2022-06-03 21:59:29.212212', '- - - [03/Jun/2022:21:59:29 +0000] "GET /api/health HTTP/1.1" 200 6233 4 "-" "-" 579e8362d3185b61 -', 'TLSv1.2'),
+                                                               (4, '2022-06-03 21:59:31', '- - - [03/Jun/2022:21:59:31 +0000] "GET /api/health HTTP/1.1" 200 6207 5 "-" "-" 8c6ac61ae66e509f -', 'TLSv1'),
+                                                               (5, '2022-06-03 21:59:31.332121', '- - - [03/Jun/2022:21:59:31 +0000] "GET /api/health HTTP/1.1" 200 6200 4 "-" "-" c163495861e873d8 -', 'TLSv1.2');
+PRINT 'Data inserted into simple_logs table.';
+PRINT 'Initiation of otel database is complete';


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Mainly added test for sqlserver, plus added coverage for logs (as requested in [comment](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35195#pullrequestreview-2333553843))

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #29695

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Main changes:
* Added metrics tests for SqlServer
* Covered MySql, SqlServer and Oracle for logs

Improvements:

- To avoid repetitions, changed approach to "parameterized" tests - run the same test flow for different database engines (for logs only).
- Do not hardcode "localhost" and host port, get these values from testcontainers.
- Replaced inserting test values into the database from running CLI commands in the container to executing SQL commands.
- Updated Oracle init script to use `otel` schema instead of `sys`.

Important: For Oracle and SQL Server, tests are **skipped** (tested locally) - I expect them to fail due to #27577 (which was not fixed but closed due to inactivity).
<!--Describe the documentation added.-->
<!--Please delete paragraphs that you did not use before submitting.-->
