### PR TITLE
[exporter/prometheusremotewrite] only append colliding attributes values if they are different

### DIFF
--- a/.chloggen/only-append-label-values-if-they-are-different-for-colliding-attributes.yaml
+++ b/.chloggen/only-append-label-values-if-they-are-different-for-colliding-attributes.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Only append label values if they are different for colliding OTel attributes"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35896]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change ensures that, when translating colliding attributes from OTel attributes to Prometheus label, the label values are only appended if their values are different. 
+  This is a breaking change as it changes the value of label outputted.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/translator/prometheusremotewrite/helper.go
+++ b/pkg/translator/prometheusremotewrite/helper.go
@@ -141,7 +141,10 @@ func createAttributes(resource pcommon.Resource, attributes pcommon.Map, externa
 	for _, label := range labels {
 		finalKey := prometheustranslator.NormalizeLabel(label.Name)
 		if existingValue, alreadyExists := l[finalKey]; alreadyExists {
-			l[finalKey] = existingValue + ";" + label.Value
+			// Only append to existing value if the new value is different
+			if existingValue != label.Value {
+				l[finalKey] = existingValue + ";" + label.Value
+			}
 		} else {
 			l[finalKey] = label.Value
 		}

--- a/pkg/translator/prometheusremotewrite/helper_test.go
+++ b/pkg/translator/prometheusremotewrite/helper_test.go
@@ -350,6 +350,14 @@ func Test_createLabelSet(t *testing.T) {
 			getPromLabels(collidingSanitized, value11+";"+value12, label31, value31, label32, value32),
 		},
 		{
+			"existing_attribute_value_is_the_same_as_the_new_label_value",
+			pcommon.NewResource(),
+			lbsCollidingSameValue,
+			nil,
+			[]string{label31, value31, label32, value32},
+			getPromLabels(collidingSanitized, value11, label31, value31, label32, value32),
+		},
+		{
 			"sanitize_labels_starts_with_underscore",
 			pcommon.NewResource(),
 			lbs3,

--- a/pkg/translator/prometheusremotewrite/testutils_test.go
+++ b/pkg/translator/prometheusremotewrite/testutils_test.go
@@ -58,10 +58,11 @@ var (
 	floatVal1       = 1.0
 	floatVal2       = 2.0
 
-	lbs1         = getAttributes(label11, value11, label12, value12)
-	lbs3         = getAttributes(label11, value11, label12, value12, label51, value51)
-	lbs1Dirty    = getAttributes(label11+dirty1, value11, dirty2+label12, value12)
-	lbsColliding = getAttributes(colliding1, value11, colliding2, value12)
+	lbs1                  = getAttributes(label11, value11, label12, value12)
+	lbs3                  = getAttributes(label11, value11, label12, value12, label51, value51)
+	lbs1Dirty             = getAttributes(label11+dirty1, value11, dirty2+label12, value12)
+	lbsColliding          = getAttributes(colliding1, value11, colliding2, value12)
+	lbsCollidingSameValue = getAttributes(colliding1, value11, colliding2, value11)
 
 	exlbs1 = map[string]string{label41: value41}
 	exlbs2 = map[string]string{label11: value41}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

While translating two OTel attributes into Prometheus Labels, if both attributes results in the same Prometheus label and both have the same value, they won't be appended.

**Example:**
- "bar.one": "foo"
- "bar/one": "foo"

The above two attributes when translated to Prometheus label would become
- Before the PR
    - "bar_one": "foo;foo"
- After the PR:
    - "bar_one": "foo"

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #35896

<!--Describe what testing was performed and which tests were added.-->
#### Testing

- Unit test added

<!--Describe the documentation added.-->
#### Documentation
- Change log entry added 

<!--Please delete paragraphs that you did not use before submitting.-->
