### PR TITLE
[elasticsearchexporter] Support for complex attributes for log records in OTel mode

### DIFF
--- a/.chloggen/elasticsearchexporter_complex-log-attributes.yaml
+++ b/.chloggen/elasticsearchexporter_complex-log-attributes.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Support for complex attributes for log records in OTel mode
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/elasticsearchexporter_complex-log-attributes.yaml
+++ b/.chloggen/elasticsearchexporter_complex-log-attributes.yaml
@@ -10,7 +10,7 @@ component: elasticsearchexporter
 note: Support for complex attributes for log records in OTel mode
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [37021]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel_test.go
@@ -58,7 +58,7 @@ func TestObjectModel_CreateMap(t *testing.T) {
 				m := pcommon.NewMap()
 				m.PutInt("i", 42)
 				m.PutStr("str", "test")
-				doc.AddAttributes("prefix", m)
+				doc.AddFlattenedAttributes("prefix", m)
 				return doc
 			},
 			want: Document{fields: []field{{"prefix.i", IntValue(42)}, {"prefix.str", StringValue("test")}}},

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -221,7 +221,7 @@ func TestEncodeAttributes(t *testing.T) {
 			mappingMode: MappingNone,
 			want: func() objmodel.Document {
 				doc := objmodel.Document{}
-				doc.AddAttributes("Attributes", attributes)
+				doc.AddFlattenedAttributes("Attributes", attributes)
 				return doc
 			},
 		},
@@ -229,7 +229,7 @@ func TestEncodeAttributes(t *testing.T) {
 			mappingMode: MappingECS,
 			want: func() objmodel.Document {
 				doc := objmodel.Document{}
-				doc.AddAttributes("Attributes", attributes)
+				doc.AddFlattenedAttributes("Attributes", attributes)
 				return doc
 			},
 		},


### PR DESCRIPTION
According to the [spec](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/logs/data-model.md#field-attributes):

> The log attribute model MUST support [any type](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37021#type-any), a superset of [standard Attribute](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.40.0/specification/common/README.md#attribute), to preserve the semantics of structured attributes emitted by the applications.
