### PR TITLE
Fix regex used to match docker SHA256

### DIFF
--- a/.chloggen/fix-sha256-regex-for-docker.yaml
+++ b/.chloggen/fix-sha256-regex-for-docker.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component:  'internal/docker'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix image matching regular expression to properly match SHA256 strings.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36239]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This affects the `docker_observer` extension.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/internal/common/docker/images.go
+++ b/internal/common/docker/images.go
@@ -10,7 +10,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var extractImageRegexp = regexp.MustCompile(`^(?P<repository>([^/\s]+/)?([^:\s]+))(:(?P<tag>[^@\s]+))?(@sha256:(?P<sha256>\d+))?$`)
+var extractImageRegexp = regexp.MustCompile(`^(?P<repository>([^/\s]+/)?([^:\s]+))(:(?P<tag>[^@\s]+))?(@sha256:(?P<sha256>[A-Fa-f0-9]{64}))?$`)
 
 type ImageRef struct {
 	Repository string

--- a/internal/common/docker/images_test.go
+++ b/internal/common/docker/images_test.go
@@ -45,11 +45,11 @@ func TestDockerImageToElements(t *testing.T) {
 		{
 			name: "image with sha256 hash",
 			args: args{
-				image: "alpine:test@sha256:00000000000000",
+				image: "alpine:test@sha256:dbc66f8c46d4cf4793527ca0737d73527a2bb830019953c2371b5f45f515f1a8",
 			},
 			wantRepository: "alpine",
 			wantTag:        "test",
-			wantSHA256:     "00000000000000",
+			wantSHA256:     "dbc66f8c46d4cf4793527ca0737d73527a2bb830019953c2371b5f45f515f1a8",
 			wantErr:        false,
 		},
 		{


### PR DESCRIPTION
#### Description
Fix the regex used to match docker SHA256.

#### Link to tracking issue
Fix #36239

#### Testing
Local run of `make` at `internal/docker` - caveat: if some other test code depending on this may fail if it is not using a SHA256 with exactly 64 chars it will be broken by this change. I will add any test fix for any such case detected via CI.

#### Documentation
N/A