### PR TITLE
[chore] Fix logzioexporter tests on Windows

### DIFF
--- a/exporter/logzioexporter/from_domain_test.go
+++ b/exporter/logzioexporter/from_domain_test.go
@@ -39,8 +39,10 @@ func TestFromDomainEmbedProcess(t *testing.T) {
 func loadModel(t *testing.T) ([]byte, []byte) {
 	inStr, err := os.ReadFile("./testdata/span.json")
 	require.NoError(t, err)
+	inStr = bytes.ReplaceAll(inStr, []byte("\r\n"), []byte("\n"))
 	outStr, err := os.ReadFile("./testdata/logziospan.json")
 	require.NoError(t, err)
+	outStr = bytes.ReplaceAll(outStr, []byte("\r\n"), []byte("\n"))
 	return inStr, outStr
 }
 


### PR DESCRIPTION
#### Description
The test doesn't account that depending on `git` config the endlines of the test files may change from `\n` to `\r\n`. Alternatively we could require/document how `core.autocrlf` should be configured for the repo, but, doing it on code ensures that works with any configuration.

This fixes test failures on `TestFromDomainEmbedProcess`, e.g.: https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/12651645455/job/35252663284#step:8:478

#### Testing
Local run.

#### Documentation
N/A