### PR TITLE
[chore][workflow] only run for main repository

### DIFF
--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -24,7 +24,7 @@ jobs:
   setup-environment:
     timeout-minutes: 30
     runs-on: ubuntu-24.04
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: ${{ github.actor != 'dependabot[bot]' && github.repository == 'open-telemetry/opentelemetry-collector-contrib' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -47,7 +47,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Gen githubgen tool
-        if: github.repository == 'open-telemetry/opentelemetry-collector-contrib'
         run: |
           make githubgen-install
           echo "$(go env GOPATH)/bin" >> $GITHUB_PATH


### PR DESCRIPTION
#### Description

Without this change, when someone makes a PR to `main` in a fork of this repository, this [workflow fails](https://github.com/check-spelling-sandbox/opentelemetry-collector-contrib/actions/runs/12663292988)

#### Testing

https://github.com/check-spelling-sandbox/opentelemetry-collector-contrib/actions/runs/12663466736
