### PR TITLE
[chore] don't reference testutil from non-test code

### DIFF
--- a/receiver/awsfirehosereceiver/factory.go
+++ b/receiver/awsfirehosereceiver/factory.go
@@ -13,7 +13,6 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	"go.uber.org/zap"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsfirehosereceiver/internal/unmarshaler/cwlog"
@@ -22,8 +21,7 @@ import (
 )
 
 const (
-	defaultEndpoint = "0.0.0.0:4433"
-	defaultPort     = 4433
+	defaultEndpoint = "localhost:4433"
 )
 
 var (
@@ -78,7 +76,7 @@ func defaultLogsUnmarshalers(logger *zap.Logger) map[string]unmarshaler.LogsUnma
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: testutil.EndpointForPort(defaultPort),
+			Endpoint: defaultEndpoint,
 		},
 	}
 }

--- a/receiver/awsfirehosereceiver/go.mod
+++ b/receiver/awsfirehosereceiver/go.mod
@@ -4,7 +4,6 @@ go 1.22.0
 
 require (
 	github.com/gogo/protobuf v1.3.2
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.117.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.117.0
 	go.opentelemetry.io/collector/component/componentstatus v0.117.0
@@ -33,7 +32,6 @@ require (
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
@@ -53,7 +51,6 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.117.0 // indirect
 	go.opentelemetry.io/collector/extension v0.117.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.117.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.23.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.117.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.117.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.117.0 // indirect
@@ -78,5 +75,3 @@ retract (
 	v0.76.1
 	v0.65.0
 )
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/awsfirehosereceiver/go.sum
+++ b/receiver/awsfirehosereceiver/go.sum
@@ -23,8 +23,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
-github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -100,8 +98,6 @@ go.opentelemetry.io/collector/extension/auth v0.117.0 h1:tXQdYIdcABXalWyFZP22pRE
 go.opentelemetry.io/collector/extension/auth v0.117.0/go.mod h1:ofrV2BuE46+k7Su/h0ccrMl5Zk5Y7NVlzOb3AwU7Dzw=
 go.opentelemetry.io/collector/extension/auth/authtest v0.117.0 h1:wV4OIiWrt7gteQrxL8MCmGvjGhMiu5TplKJHOfVZO6Y=
 go.opentelemetry.io/collector/extension/auth/authtest v0.117.0/go.mod h1:nHxcAOyo26JnuYwKIoQM9mDlSXpERQrbjIw3Dtp9hug=
-go.opentelemetry.io/collector/featuregate v1.23.0 h1:N033ROo85qKrsK16QzR6RV+3UWOWF7kpOO8FSnX99s0=
-go.opentelemetry.io/collector/featuregate v1.23.0/go.mod h1:3GaXqflNDVwWndNGBJ1+XJFy3Fv/XrFgjMN60N3z7yg=
 go.opentelemetry.io/collector/pdata v1.23.0 h1:tEk0dkfB8RdSukoOMfEa8duB938gfZowdfRkrJxGDrw=
 go.opentelemetry.io/collector/pdata v1.23.0/go.mod h1:I2jggpBMiO8A+7TXhzNpcJZkJtvi1cU0iVNIi+6bc+o=
 go.opentelemetry.io/collector/pdata/pprofile v0.117.0 h1:AyOK+rkNGeawmLGUqF84wYks22BSGJtEV++3YSfvD1I=

--- a/receiver/awsxrayreceiver/factory.go
+++ b/receiver/awsxrayreceiver/factory.go
@@ -12,12 +12,11 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/proxy"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver/internal/metadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awsxrayreceiver/internal/udppoller"
 )
 
-const defaultPort = 2000
+const defaultEndpoint = "localhost:2000"
 
 // NewFactory creates a factory for AWS receiver.
 func NewFactory() receiver.Factory {
@@ -33,7 +32,7 @@ func createDefaultConfig() component.Config {
 	// https://github.com/aws/aws-xray-daemon/blob/master/pkg/cfg/cfg.go#L99
 	return &Config{
 		AddrConfig: confignet.AddrConfig{
-			Endpoint:  testutil.EndpointForPort(defaultPort),
+			Endpoint:  defaultEndpoint,
 			Transport: udppoller.Transport,
 		},
 		ProxyServer: proxy.DefaultConfig(),

--- a/receiver/influxdbreceiver/factory.go
+++ b/receiver/influxdbreceiver/factory.go
@@ -11,11 +11,10 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/influxdbreceiver/internal/metadata"
 )
 
-const defaultPort = 8086
+const defaultEndpoint = "localhost:8086"
 
 func NewFactory() receiver.Factory {
 	return receiver.NewFactory(
@@ -28,7 +27,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: testutil.EndpointForPort(defaultPort),
+			Endpoint: defaultEndpoint,
 		},
 	}
 }

--- a/receiver/jaegerreceiver/factory.go
+++ b/receiver/jaegerreceiver/factory.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/featuregate"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/jaegerreceiver/internal/metadata"
 )
 
@@ -27,11 +26,11 @@ const (
 	protoThriftBinary  = "thrift_binary"
 	protoThriftCompact = "thrift_compact"
 
-	// Default ports to bind to.
-	defaultGRPCPort          = 14250
-	defaultHTTPPort          = 14268
-	defaultThriftCompactPort = 6831
-	defaultThriftBinaryPort  = 6832
+	// Default endpoints to bind to.
+	defaultGRPCEndpoint          = "localhost:14250"
+	defaultHTTPEndpoint          = "localhost:14268"
+	defaultThriftCompactEndpoint = "localhost:6831"
+	defaultThriftBinaryEndpoint  = "localhost:6832"
 )
 
 var disableJaegerReceiverRemoteSampling = featuregate.GlobalRegistry().MustRegister(
@@ -54,19 +53,19 @@ func createDefaultConfig() component.Config {
 		Protocols: Protocols{
 			GRPC: &configgrpc.ServerConfig{
 				NetAddr: confignet.AddrConfig{
-					Endpoint:  testutil.EndpointForPort(defaultGRPCPort),
+					Endpoint:  defaultGRPCEndpoint,
 					Transport: confignet.TransportTypeTCP,
 				},
 			},
 			ThriftHTTP: &confighttp.ServerConfig{
-				Endpoint: testutil.EndpointForPort(defaultHTTPPort),
+				Endpoint: defaultHTTPEndpoint,
 			},
 			ThriftBinary: &ProtocolUDP{
-				Endpoint:        testutil.EndpointForPort(defaultThriftBinaryPort),
+				Endpoint:        defaultThriftBinaryEndpoint,
 				ServerConfigUDP: defaultServerConfigUDP(),
 			},
 			ThriftCompact: &ProtocolUDP{
-				Endpoint:        testutil.EndpointForPort(defaultThriftCompactPort),
+				Endpoint:        defaultThriftCompactEndpoint,
 				ServerConfigUDP: defaultServerConfigUDP(),
 			},
 		},

--- a/receiver/lokireceiver/factory.go
+++ b/receiver/lokireceiver/factory.go
@@ -15,15 +15,12 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/lokireceiver/internal/metadata"
 )
 
 const (
-	defaultGRPCPort         = 3600
-	defaultHTTPPort         = 3500
-	defaultGRPCBindEndpoint = "0.0.0.0:3600"
-	defaultHTTPBindEndpoint = "0.0.0.0:3500"
+	defaultGRPCEndpoint = "localhost:3600"
+	defaultHTTPEndpoint = "localhost:3500"
 )
 
 // NewFactory return a new receiver.Factory for loki receiver.
@@ -39,12 +36,12 @@ func createDefaultConfig() component.Config {
 		Protocols: Protocols{
 			GRPC: &configgrpc.ServerConfig{
 				NetAddr: confignet.AddrConfig{
-					Endpoint:  testutil.EndpointForPort(defaultGRPCPort),
+					Endpoint:  defaultGRPCEndpoint,
 					Transport: confignet.TransportTypeTCP,
 				},
 			},
 			HTTP: &confighttp.ServerConfig{
-				Endpoint: testutil.EndpointForPort(defaultHTTPPort),
+				Endpoint: defaultHTTPEndpoint,
 			},
 		},
 	}

--- a/receiver/lokireceiver/factory_test.go
+++ b/receiver/lokireceiver/factory_test.go
@@ -27,7 +27,7 @@ func TestCreateReceiver(t *testing.T) {
 	cfg := factory.CreateDefaultConfig()
 	cfg.(*Config).Protocols.GRPC = &configgrpc.ServerConfig{
 		NetAddr: confignet.AddrConfig{
-			Endpoint:  defaultGRPCBindEndpoint,
+			Endpoint:  defaultGRPCEndpoint,
 			Transport: confignet.TransportTypeTCP,
 		},
 	}

--- a/receiver/opencensusreceiver/factory.go
+++ b/receiver/opencensusreceiver/factory.go
@@ -12,12 +12,11 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/opencensusreceiver/internal/metadata"
 )
 
-const grpcPort = 55678
+const grpcEndpoint = "localhost:55678"
 
 // NewFactory creates a new OpenCensus receiver factory.
 func NewFactory() receiver.Factory {
@@ -32,7 +31,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: configgrpc.ServerConfig{
 			NetAddr: confignet.AddrConfig{
-				Endpoint:  testutil.EndpointForPort(grpcPort),
+				Endpoint:  grpcEndpoint,
 				Transport: confignet.TransportTypeTCP,
 			},
 			// We almost write 0 bytes, so no need to tune WriteBufferSize.

--- a/receiver/sapmreceiver/factory.go
+++ b/receiver/sapmreceiver/factory.go
@@ -17,13 +17,12 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sapmreceiver/internal/metadata"
 )
 
 const (
-	// Default port to bind to.
-	defaultPort = 7276
+	// Default endpoint to bind to.
+	defaultEndpoint = "localhost:7276"
 )
 
 // NewFactory creates a factory for SAPM receiver.
@@ -37,7 +36,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: testutil.EndpointForPort(defaultPort),
+			Endpoint: defaultEndpoint,
 		},
 	}
 }

--- a/receiver/signalfxreceiver/factory.go
+++ b/receiver/signalfxreceiver/factory.go
@@ -16,7 +16,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/signalfxreceiver/internal/metadata"
 )
 
@@ -24,8 +23,8 @@ import (
 
 const (
 
-	// Default port to bind to.
-	defaultPort = 9943
+	// Default endpoint to bind to.
+	defaultEndpoint = "localhost:9943"
 )
 
 // NewFactory creates a factory for SignalFx receiver.
@@ -40,7 +39,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: testutil.EndpointForPort(defaultPort),
+			Endpoint: defaultEndpoint,
 		},
 	}
 }

--- a/receiver/skywalkingreceiver/factory.go
+++ b/receiver/skywalkingreceiver/factory.go
@@ -19,7 +19,6 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/skywalkingreceiver/internal/metadata"
 )
@@ -29,9 +28,9 @@ const (
 	protoGRPC = "grpc"
 	protoHTTP = "http"
 
-	// Default ports to bind to.
-	defaultGRPCPort = 11800
-	defaultHTTPPort = 12800
+	// Default endpoints to bind to.
+	defaultGRPCEndpoint = "localhost:11800"
+	defaultHTTPEndpoint = "localhost:12800"
 )
 
 // NewFactory creates a new Skywalking receiver factory.
@@ -49,12 +48,12 @@ func createDefaultConfig() component.Config {
 		Protocols: Protocols{
 			GRPC: &configgrpc.ServerConfig{
 				NetAddr: confignet.AddrConfig{
-					Endpoint:  testutil.EndpointForPort(defaultGRPCPort),
+					Endpoint:  defaultGRPCEndpoint,
 					Transport: confignet.TransportTypeTCP,
 				},
 			},
 			HTTP: &confighttp.ServerConfig{
-				Endpoint: testutil.EndpointForPort(defaultHTTPPort),
+				Endpoint: defaultHTTPEndpoint,
 			},
 		},
 	}

--- a/receiver/skywalkingreceiver/go.mod
+++ b/receiver/skywalkingreceiver/go.mod
@@ -4,7 +4,6 @@ go 1.22.0
 
 require (
 	github.com/gorilla/mux v1.8.1
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/skywalking v0.117.0
 	github.com/stretchr/testify v1.10.0
@@ -39,7 +38,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
@@ -62,7 +60,6 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.117.0 // indirect
 	go.opentelemetry.io/collector/extension v0.117.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.117.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.23.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.117.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.117.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.117.0 // indirect
@@ -90,5 +87,3 @@ retract (
 	v0.76.1
 	v0.65.0
 )
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common

--- a/receiver/skywalkingreceiver/go.sum
+++ b/receiver/skywalkingreceiver/go.sum
@@ -68,8 +68,6 @@ github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
-github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
-github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -157,8 +155,6 @@ go.opentelemetry.io/collector/extension/auth v0.117.0 h1:tXQdYIdcABXalWyFZP22pRE
 go.opentelemetry.io/collector/extension/auth v0.117.0/go.mod h1:ofrV2BuE46+k7Su/h0ccrMl5Zk5Y7NVlzOb3AwU7Dzw=
 go.opentelemetry.io/collector/extension/auth/authtest v0.117.0 h1:wV4OIiWrt7gteQrxL8MCmGvjGhMiu5TplKJHOfVZO6Y=
 go.opentelemetry.io/collector/extension/auth/authtest v0.117.0/go.mod h1:nHxcAOyo26JnuYwKIoQM9mDlSXpERQrbjIw3Dtp9hug=
-go.opentelemetry.io/collector/featuregate v1.23.0 h1:N033ROo85qKrsK16QzR6RV+3UWOWF7kpOO8FSnX99s0=
-go.opentelemetry.io/collector/featuregate v1.23.0/go.mod h1:3GaXqflNDVwWndNGBJ1+XJFy3Fv/XrFgjMN60N3z7yg=
 go.opentelemetry.io/collector/pdata v1.23.0 h1:tEk0dkfB8RdSukoOMfEa8duB938gfZowdfRkrJxGDrw=
 go.opentelemetry.io/collector/pdata v1.23.0/go.mod h1:I2jggpBMiO8A+7TXhzNpcJZkJtvi1cU0iVNIi+6bc+o=
 go.opentelemetry.io/collector/pdata/pprofile v0.117.0 h1:AyOK+rkNGeawmLGUqF84wYks22BSGJtEV++3YSfvD1I=

--- a/receiver/splunkhecreceiver/factory.go
+++ b/receiver/splunkhecreceiver/factory.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/collector/receiver"
 	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/splunk"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver/internal/metadata"
@@ -21,8 +20,8 @@ import (
 // This file implements factory for Splunk HEC receiver.
 
 const (
-	// Default endpoints to bind to.
-	defaultPort = 8088
+	// Default endpoint to bind to.
+	defaultEndpoint = "localhost:8088"
 )
 
 // NewFactory creates a factory for Splunk HEC receiver.
@@ -38,7 +37,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: testutil.EndpointForPort(defaultPort),
+			Endpoint: defaultEndpoint,
 		},
 		AccessTokenPassthroughConfig: splunk.AccessTokenPassthroughConfig{},
 		HecToOtelAttrs: splunk.HecToOtelAttrs{

--- a/receiver/zipkinreceiver/config_test.go
+++ b/receiver/zipkinreceiver/config_test.go
@@ -43,7 +43,7 @@ func TestLoadConfig(t *testing.T) {
 			id: component.NewIDWithName(metadata.Type, "parse_strings"),
 			expected: &Config{
 				ServerConfig: confighttp.ServerConfig{
-					Endpoint: defaultBindEndpoint,
+					Endpoint: defaultHTTPEndpoint,
 				},
 				ParseStringTags: true,
 			},

--- a/receiver/zipkinreceiver/factory.go
+++ b/receiver/zipkinreceiver/factory.go
@@ -11,15 +11,13 @@ import (
 	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/receiver"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zipkinreceiver/internal/metadata"
 )
 
 // This file implements factory for Zipkin receiver.
 
 const (
-	defaultHTTPPort     = 9411
-	defaultBindEndpoint = "localhost:9411"
+	defaultHTTPEndpoint = "localhost:9411"
 )
 
 // NewFactory creates a new Zipkin receiver factory
@@ -35,7 +33,7 @@ func NewFactory() receiver.Factory {
 func createDefaultConfig() component.Config {
 	return &Config{
 		ServerConfig: confighttp.ServerConfig{
-			Endpoint: testutil.EndpointForPort(defaultHTTPPort),
+			Endpoint: defaultHTTPEndpoint,
 		},
 		ParseStringTags: false,
 	}

--- a/receiver/zipkinreceiver/go.mod
+++ b/receiver/zipkinreceiver/go.mod
@@ -4,7 +4,6 @@ go 1.22.7
 
 require (
 	github.com/jaegertracing/jaeger v1.64.0
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.117.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin v0.117.0
 	github.com/openzipkin/zipkin-go v0.4.3
@@ -36,7 +35,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
@@ -58,7 +56,6 @@ require (
 	go.opentelemetry.io/collector/consumer/xconsumer v0.117.0 // indirect
 	go.opentelemetry.io/collector/extension v0.117.0 // indirect
 	go.opentelemetry.io/collector/extension/auth v0.117.0 // indirect
-	go.opentelemetry.io/collector/featuregate v1.23.0 // indirect
 	go.opentelemetry.io/collector/pdata/pprofile v0.117.0 // indirect
 	go.opentelemetry.io/collector/pipeline v0.117.0 // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.117.0 // indirect
@@ -79,8 +76,6 @@ require (
 )
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal => ../../internal/coreinternal
-
-replace github.com/open-telemetry/opentelemetry-collector-contrib/internal/common => ../../internal/common
 
 replace github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/zipkin => ../../pkg/translator/zipkin
 

--- a/receiver/zipkinreceiver/go.sum
+++ b/receiver/zipkinreceiver/go.sum
@@ -26,8 +26,6 @@ github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
-github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/jaegertracing/jaeger v1.64.0 h1:fc45qwaBZpBE2DeXwJlm8hK1q2PACrzGKXKgIcHLPMw=
 github.com/jaegertracing/jaeger v1.64.0/go.mod h1:9yVeL3z2Q9AGrW7j7TTeqohUy7Bbp9XWXgUDG3rVdO0=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -109,8 +107,6 @@ go.opentelemetry.io/collector/extension/auth v0.117.0 h1:tXQdYIdcABXalWyFZP22pRE
 go.opentelemetry.io/collector/extension/auth v0.117.0/go.mod h1:ofrV2BuE46+k7Su/h0ccrMl5Zk5Y7NVlzOb3AwU7Dzw=
 go.opentelemetry.io/collector/extension/auth/authtest v0.117.0 h1:wV4OIiWrt7gteQrxL8MCmGvjGhMiu5TplKJHOfVZO6Y=
 go.opentelemetry.io/collector/extension/auth/authtest v0.117.0/go.mod h1:nHxcAOyo26JnuYwKIoQM9mDlSXpERQrbjIw3Dtp9hug=
-go.opentelemetry.io/collector/featuregate v1.23.0 h1:N033ROo85qKrsK16QzR6RV+3UWOWF7kpOO8FSnX99s0=
-go.opentelemetry.io/collector/featuregate v1.23.0/go.mod h1:3GaXqflNDVwWndNGBJ1+XJFy3Fv/XrFgjMN60N3z7yg=
 go.opentelemetry.io/collector/pdata v1.23.0 h1:tEk0dkfB8RdSukoOMfEa8duB938gfZowdfRkrJxGDrw=
 go.opentelemetry.io/collector/pdata v1.23.0/go.mod h1:I2jggpBMiO8A+7TXhzNpcJZkJtvi1cU0iVNIi+6bc+o=
 go.opentelemetry.io/collector/pdata/pprofile v0.117.0 h1:AyOK+rkNGeawmLGUqF84wYks22BSGJtEV++3YSfvD1I=

--- a/receiver/zookeeperreceiver/factory.go
+++ b/receiver/zookeeperreceiver/factory.go
@@ -14,12 +14,11 @@ import (
 	"go.opentelemetry.io/collector/scraper"
 	"go.opentelemetry.io/collector/scraper/scraperhelper"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/zookeeperreceiver/internal/metadata"
 )
 
 const (
-	defaultPort               = 2181
+	defaultEndpoint           = "localhost:2181"
 	defaultCollectionInterval = 10 * time.Second
 	defaultTimeout            = 10 * time.Second
 )
@@ -40,7 +39,7 @@ func createDefaultConfig() component.Config {
 	return &Config{
 		ControllerConfig: cfg,
 		TCPAddrConfig: confignet.TCPAddrConfig{
-			Endpoint: testutil.EndpointForPort(defaultPort),
+			Endpoint: defaultEndpoint,
 		},
 		MetricsBuilderConfig: metadata.DefaultMetricsBuilderConfig(),
 	}


### PR DESCRIPTION
#### Description

Update various receiver factories to stop using testutil.EndpointForPort, and directly specify the default endpoint. This removes test-related packages from the main binary's dependency tree.

#### Link to tracking issue

N/A

#### Testing

N/A

#### Documentation

N/A