### PR TITLE
[cmd/opampsupervisor] update types

### DIFF
--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -13,24 +13,26 @@ import (
 )
 
 type flattenedSettings struct {
-	onMessageFunc         func(conn serverTypes.Connection, message *protobufs.AgentToServer)
-	onConnectingFunc      func(request *http.Request) (shouldConnect bool, rejectStatusCode int)
-	onConnectionCloseFunc func(conn serverTypes.Connection)
-	endpoint              string
+	onMessage         func(conn serverTypes.Connection, message *protobufs.AgentToServer)
+	onConnecting      func(request *http.Request) (shouldConnect bool, rejectStatusCode int)
+	onConnectionClose func(conn serverTypes.Connection)
+	endpoint          string
 }
 
 func (fs flattenedSettings) toServerSettings() server.StartSettings {
 	return server.StartSettings{
 		Settings: server.Settings{
-			Callbacks: fs,
+			Callbacks: serverTypes.Callbacks{
+				OnConnecting: fs.OnConnecting,
+			},
 		},
 		ListenEndpoint: fs.endpoint,
 	}
 }
 
 func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.ConnectionResponse {
-	if fs.onConnectingFunc != nil {
-		shouldConnect, rejectStatusCode := fs.onConnectingFunc(request)
+	if fs.onConnecting != nil {
+		shouldConnect, rejectStatusCode := fs.onConnecting(request)
 		if !shouldConnect {
 			return serverTypes.ConnectionResponse{
 				Accept:         false,
@@ -40,23 +42,25 @@ func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.Conn
 	}
 
 	return serverTypes.ConnectionResponse{
-		Accept:              true,
-		ConnectionCallbacks: fs,
+		Accept: true,
+		ConnectionCallbacks: serverTypes.ConnectionCallbacks{
+			OnMessage: fs.OnMessage,
+		},
 	}
 }
 
 func (fs flattenedSettings) OnConnected(_ context.Context, _ serverTypes.Connection) {}
 
 func (fs flattenedSettings) OnMessage(_ context.Context, conn serverTypes.Connection, message *protobufs.AgentToServer) *protobufs.ServerToAgent {
-	if fs.onMessageFunc != nil {
-		fs.onMessageFunc(conn, message)
+	if fs.onMessage != nil {
+		fs.onMessage(conn, message)
 	}
 
 	return &protobufs.ServerToAgent{}
 }
 
 func (fs flattenedSettings) OnConnectionClose(conn serverTypes.Connection) {
-	if fs.onConnectionCloseFunc != nil {
-		fs.onConnectionCloseFunc(conn)
+	if fs.onConnectionClose != nil {
+		fs.onConnectionClose(conn)
 	}
 }

--- a/cmd/opampsupervisor/supervisor/server_test.go
+++ b/cmd/opampsupervisor/supervisor/server_test.go
@@ -28,7 +28,7 @@ func Test_flattenedSettings_OnConnecting(t *testing.T) {
 	t.Run("accept connection", func(t *testing.T) {
 		onConnectingFuncCalled := false
 		fs := flattenedSettings{
-			onConnectingFunc: func(_ *http.Request) (shouldConnect bool, rejectStatusCode int) {
+			onConnecting: func(_ *http.Request) (shouldConnect bool, rejectStatusCode int) {
 				onConnectingFuncCalled = true
 				return true, 0
 			},
@@ -43,7 +43,7 @@ func Test_flattenedSettings_OnConnecting(t *testing.T) {
 	t.Run("do not accept connection", func(t *testing.T) {
 		onConnectingFuncCalled := false
 		fs := flattenedSettings{
-			onConnectingFunc: func(_ *http.Request) (shouldConnect bool, rejectStatusCode int) {
+			onConnecting: func(_ *http.Request) (shouldConnect bool, rejectStatusCode int) {
 				onConnectingFuncCalled = true
 				return false, 500
 			},
@@ -60,7 +60,7 @@ func Test_flattenedSettings_OnConnecting(t *testing.T) {
 func Test_flattenedSettings_OnMessage(t *testing.T) {
 	onMessageFuncCalled := false
 	fs := flattenedSettings{
-		onMessageFunc: func(_ serverTypes.Connection, _ *protobufs.AgentToServer) {
+		onMessage: func(_ serverTypes.Connection, _ *protobufs.AgentToServer) {
 			onMessageFuncCalled = true
 		},
 	}
@@ -74,7 +74,7 @@ func Test_flattenedSettings_OnMessage(t *testing.T) {
 func Test_flattenedSettings_OnConnectionClose(t *testing.T) {
 	onConnectionCloseFuncCalled := false
 	fs := flattenedSettings{
-		onConnectionCloseFunc: func(_ serverTypes.Connection) {
+		onConnectionClose: func(_ serverTypes.Connection) {
 			onConnectionCloseFuncCalled = true
 		},
 	}

--- a/extension/opampextension/opamp_agent.go
+++ b/extension/opampextension/opamp_agent.go
@@ -118,20 +118,20 @@ func (o *opampAgent) Start(ctx context.Context, host component.Host) error {
 		TLSConfig:      tls,
 		OpAMPServerURL: o.cfg.Server.GetEndpoint(),
 		InstanceUid:    types.InstanceUid(o.instanceID),
-		Callbacks: types.CallbacksStruct{
-			OnConnectFunc: func(_ context.Context) {
+		Callbacks: types.Callbacks{
+			OnConnect: func(_ context.Context) {
 				o.logger.Debug("Connected to the OpAMP server")
 			},
-			OnConnectFailedFunc: func(_ context.Context, err error) {
+			OnConnectFailed: func(_ context.Context, err error) {
 				o.logger.Error("Failed to connect to the OpAMP server", zap.Error(err))
 			},
-			OnErrorFunc: func(_ context.Context, err *protobufs.ServerErrorResponse) {
+			OnError: func(_ context.Context, err *protobufs.ServerErrorResponse) {
 				o.logger.Error("OpAMP server returned an error response", zap.String("message", err.ErrorMessage))
 			},
-			GetEffectiveConfigFunc: func(_ context.Context) (*protobufs.EffectiveConfig, error) {
+			GetEffectiveConfig: func(_ context.Context) (*protobufs.EffectiveConfig, error) {
 				return o.composeEffectiveConfig(), nil
 			},
-			OnMessageFunc: o.onMessage,
+			OnMessage: o.onMessage,
 		},
 		Capabilities: o.capabilities.toAgentCapabilities(),
 	}


### PR DESCRIPTION
This change addresses the breaking changes in https://github.com/open-telemetry/opamp-go/releases/tag/v0.18.0
