### PR TITLE
[processor/k8sattributes] Automatic resource attributes

### DIFF
--- a/.chloggen/operator-resource-attributes.yaml
+++ b/.chloggen/operator-resource-attributes.yaml
@@ -10,3 +10,4 @@ subtext: |
   If you are using the file log receiver, you can now create the same resource attributes as traces (via OTLP) received
   from an application instrumented with the OpenTelemetry Operator -
   simply by adding the `extract: { operator_rules: { enabled: true } }` configuration to the `k8sattributesprocessor` processor.
+  See the [documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#config-example) for more details.

--- a/.chloggen/operator-resource-attributes.yaml
+++ b/.chloggen/operator-resource-attributes.yaml
@@ -9,5 +9,5 @@ issues: [37114]
 subtext: |
   If you are using the file log receiver, you can now create the same resource attributes as traces (via OTLP) received
   from an application instrumented with the OpenTelemetry Operator -
-  simply by adding the `extract: { operator_rules: { enabled: true } }` configuration to the `k8sattributesprocessor` processor.
+  simply by adding the `extract: { automatic_attributes: {}}` configuration to the `k8sattributesprocessor` processor.
   See the [documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#config-example) for more details.

--- a/.chloggen/operator-resource-attributes.yaml
+++ b/.chloggen/operator-resource-attributes.yaml
@@ -9,5 +9,5 @@ issues: [37114]
 subtext: |
   If you are using the file log receiver, you can now create the same resource attributes as traces (via OTLP) received
   from an application instrumented with the OpenTelemetry Operator -
-  simply by adding the `extract: { automatic_attributes: {}}` configuration to the `k8sattributesprocessor` processor.
+  simply by adding the `extract: { automatic_attributes: { enabled: true }}` configuration to the `k8sattributesprocessor` processor.
   See the [documentation](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/processor/k8sattributesprocessor/README.md#config-example) for more details.

--- a/.chloggen/operator-resource-attributes.yaml
+++ b/.chloggen/operator-resource-attributes.yaml
@@ -1,0 +1,12 @@
+change_type: enhancement
+
+component: k8sattributesprocessor
+
+note: Add option to configure resource attributes using the same logic as the OTel operator
+
+issues: [37114]
+
+subtext: |
+  If you are using the file log receiver, you can now create the same resource attributes as traces (via OTLP) received
+  from an application instrumented with the OpenTelemetry Operator -
+  simply by adding the `extract: { operator_rules: { enabled: true } }` configuration to the `k8sattributesprocessor` processor.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -281,7 +281,6 @@ k8sattributes/2:
       # Also translate the following labels to the specified resource attributes: 
       # app.kubernetes.io/name    => service.name
       # app.kubernetes.io/version => service.version
-      # app.kubernetes.io/part-of => service.namespace
       # This setting is ignored if 'enabled' is set to false
       labels: true 
   pod_association:

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -276,11 +276,12 @@ k8sattributes/2:
         key: app.kubernetes.io/component
         from: pod
     operator_rules:
-      # Apply the operator rules - see https://github.com/open-telemetry/opentelemetry-operator#configure-resource-attributes
+      # Apply the operator rules - see https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/k8s-attributes.md
       enabled: true
       # Also translate the following labels to the specified resource attributes: 
-      # app.kubernetes.io/name    => service.name
-      # app.kubernetes.io/version => service.version
+      # app.kubernetes.io/instance => service.name (higher priority than app.kubernetes.io/name)
+      # app.kubernetes.io/name     => service.name
+      # app.kubernetes.io/version  => service.version
       # This setting is ignored if 'enabled' is set to false
       labels: true 
   pod_association:

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -277,6 +277,7 @@ k8sattributes/2:
         from: pod
     automatic_attributes:
       # Apply the operator rules - see https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/k8s-attributes.md
+      enabled: true
       well_known_labels: true # default is false
       annotation_prefixes: ["foo/"] # default is ["resource.opentelemetry.io/"] - use empty list to disable
       exclude: ["service.version"] # default is empty list

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -271,10 +271,19 @@ k8sattributes/2:
       - k8s.node.name
       - k8s.pod.start_time
     labels:
-     # This label extraction rule takes the value 'app.kubernetes.io/component' label and maps it to the 'app.label.component' attribute which will be added to the associated resources
-     - tag_name: app.label.component
-       key: app.kubernetes.io/component
-       from: pod
+      # This label extraction rule takes the value 'app.kubernetes.io/component' label and maps it to the 'app.label.component' attribute which will be added to the associated resources
+      - tag_name: app.label.component
+        key: app.kubernetes.io/component
+        from: pod
+    operator_rules:
+      # Apply the operator rules - see https://github.com/open-telemetry/opentelemetry-operator#configure-resource-attributes
+      enabled: true
+      # Also translate the following labels to the specified resource attributes: 
+      # app.kubernetes.io/name    => service.name
+      # app.kubernetes.io/version => service.version
+      # app.kubernetes.io/part-of => service.namespace
+      # This setting is ignored if 'enabled' is set to false
+      labels: true 
   pod_association:
     - sources:
         # This rule associates all resources containing the 'k8s.pod.ip' attribute with the matching pods. If this attribute is not present in the resource, this rule will not be able to find the matching pod.

--- a/processor/k8sattributesprocessor/README.md
+++ b/processor/k8sattributesprocessor/README.md
@@ -275,15 +275,11 @@ k8sattributes/2:
       - tag_name: app.label.component
         key: app.kubernetes.io/component
         from: pod
-    operator_rules:
+    automatic_attributes:
       # Apply the operator rules - see https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/k8s-attributes.md
-      enabled: true
-      # Also translate the following labels to the specified resource attributes: 
-      # app.kubernetes.io/instance => service.name (higher priority than app.kubernetes.io/name)
-      # app.kubernetes.io/name     => service.name
-      # app.kubernetes.io/version  => service.version
-      # This setting is ignored if 'enabled' is set to false
-      labels: true 
+      well_known_labels: true # default is false
+      annotation_prefixes: ["foo/"] # default is ["resource.opentelemetry.io/"] - use empty list to disable
+      exclude: ["service.version"] # default is empty list
   pod_association:
     - sources:
         # This rule associates all resources containing the 'k8s.pod.ip' attribute with the matching pods. If this attribute is not present in the resource, this rule will not be able to find the matching pod.

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -167,7 +167,7 @@ type ExtractConfig struct {
 	// documentation for more details.
 	Labels []FieldExtractConfig `mapstructure:"labels"`
 
-	AutomaticRules *kube.AntomaticRules `mapstructure:"automatic_attributes"`
+	AutomaticRules kube.AutomaticRules `mapstructure:"automatic_attributes"`
 }
 
 // FieldExtractConfig allows specifying an extraction rule to extract a resource attribute from pod (or namespace)

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -167,7 +167,7 @@ type ExtractConfig struct {
 	// documentation for more details.
 	Labels []FieldExtractConfig `mapstructure:"labels"`
 
-	OperatorRules kube.OperatorRules `mapstructure:"operator_rules"`
+	AutomaticRules *kube.AntomaticRules `mapstructure:"automatic_attributes"`
 }
 
 // FieldExtractConfig allows specifying an extraction rule to extract a resource attribute from pod (or namespace)

--- a/processor/k8sattributesprocessor/config.go
+++ b/processor/k8sattributesprocessor/config.go
@@ -166,6 +166,8 @@ type ExtractConfig struct {
 	// It is a list of FieldExtractConfig type. See FieldExtractConfig
 	// documentation for more details.
 	Labels []FieldExtractConfig `mapstructure:"labels"`
+
+	OperatorRules kube.OperatorRules `mapstructure:"operator_rules"`
 }
 
 // FieldExtractConfig allows specifying an extraction rule to extract a resource attribute from pod (or namespace)

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -192,6 +192,7 @@ func createProcessorOpts(cfg component.Config) []option {
 	opts = append(opts, withExtractMetadata(oCfg.Extract.Metadata...))
 	opts = append(opts, withExtractLabels(oCfg.Extract.Labels...))
 	opts = append(opts, withExtractAnnotations(oCfg.Extract.Annotations...))
+	opts = append(opts, withOperatorExtractRules(oCfg.Extract.OperatorRules))
 
 	// filters
 	opts = append(opts, withFilterNode(oCfg.Filter.Node, oCfg.Filter.NodeFromEnvVar))

--- a/processor/k8sattributesprocessor/factory.go
+++ b/processor/k8sattributesprocessor/factory.go
@@ -192,7 +192,7 @@ func createProcessorOpts(cfg component.Config) []option {
 	opts = append(opts, withExtractMetadata(oCfg.Extract.Metadata...))
 	opts = append(opts, withExtractLabels(oCfg.Extract.Labels...))
 	opts = append(opts, withExtractAnnotations(oCfg.Extract.Annotations...))
-	opts = append(opts, withOperatorExtractRules(oCfg.Extract.OperatorRules))
+	opts = append(opts, withAutomaticRules(oCfg.Extract.AutomaticRules))
 
 	// filters
 	opts = append(opts, withFilterNode(oCfg.Filter.Node, oCfg.Filter.NodeFromEnvVar))

--- a/processor/k8sattributesprocessor/go.mod
+++ b/processor/k8sattributesprocessor/go.mod
@@ -3,6 +3,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sat
 go 1.23.0
 
 require (
+	github.com/distribution/reference v0.6.0
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.122.0
@@ -38,6 +39,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/exp v0.0.0-20220827204233-334a2380cb91
 	k8s.io/api v0.32.3
 	k8s.io/apimachinery v0.32.3
 	k8s.io/client-go v0.32.3
@@ -47,7 +49,6 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/distribution/reference v0.6.0 // indirect
 	github.com/docker/docker v27.5.1+incompatible // indirect
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/processor/k8sattributesprocessor/go.sum
+++ b/processor/k8sattributesprocessor/go.sum
@@ -1369,6 +1369,7 @@ golang.org/x/exp v0.0.0-20191227195350-da58074b4299/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u096TMicItID8zy7Y6sNkU49FU4=
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
+golang.org/x/exp v0.0.0-20220827204233-334a2380cb91 h1:tnebWN09GYg9OLPss1KXj8txwZc6X6uMr6VFdcGNbHw=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -88,7 +88,7 @@ var rRegex = regexp.MustCompile(`^(.*)-[0-9a-zA-Z]+$`)
 // format: [cronjob-name]-[time-hash-int]
 var cronJobRegex = regexp.MustCompile(`^(.*)-[0-9]+$`)
 
-var cannotRetrieveImage = errors.New("cannot retrieve image name")
+var errCannotRetrieveImage = errors.New("cannot retrieve image name")
 
 // New initializes a new k8s Client.
 func New(
@@ -714,7 +714,7 @@ func parseServiceVersionFromImage(image string) (string, error) {
 
 	namedRef, ok := ref.(reference.Named)
 	if !ok {
-		return "", cannotRetrieveImage
+		return "", errCannotRetrieveImage
 	}
 	var tag, digest string
 	if taggedRef, ok := namedRef.(reference.Tagged); ok {
@@ -733,7 +733,7 @@ func parseServiceVersionFromImage(image string) (string, error) {
 		return tag, nil
 	}
 
-	return "", cannotRetrieveImage
+	return "", errCannotRetrieveImage
 }
 
 func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContainers {

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -644,7 +644,7 @@ func removeUnnecessaryPodData(pod *api_v1.Pod, rules ExtractionRules) *api_v1.Po
 		removeUnnecessaryContainerData := func(c api_v1.Container) api_v1.Container {
 			transformedContainer := api_v1.Container{}
 			transformedContainer.Name = c.Name // we always need the name, it's used for identification
-			if rules.ContainerImageName || rules.ContainerImageTag {
+			if rules.ContainerImageName || rules.ContainerImageTag || rules.OperatorRules.Enabled {
 				transformedContainer.Image = c.Image
 			}
 			return transformedContainer
@@ -685,7 +685,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 	if !needContainerAttributes(c.Rules) {
 		return containers
 	}
-	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag {
+	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag || c.Rules.OperatorRules.Enabled {
 		for _, spec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 			container := &Container{}
 			imageRef, err := dcommon.ParseImageName(spec.Image)
@@ -695,6 +695,9 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 				}
 				if c.Rules.ContainerImageTag {
 					container.ImageTag = imageRef.Tag
+				}
+				if c.Rules.OperatorRules.Enabled {
+					container.ServiceVersion = tag
 				}
 			}
 			containers.ByName[spec.Name] = container

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/distribution/reference"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
 
-	"github.com/distribution/reference"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -26,6 +26,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
+	dcommon "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/metadata"
 )
@@ -465,7 +466,7 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 	if c.Rules.PodName {
 		tags[conventions.AttributeK8SPodName] = pod.Name
 	}
-	if c.Rules.RecommendedRules.Enabled {
+	if c.Rules.AutomaticRules.Enabled {
 		serviceNames[conventions.AttributeK8SPodName] = pod.Name
 	}
 
@@ -506,7 +507,7 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 		c.Rules.JobUID || c.Rules.JobName ||
 		c.Rules.StatefulSetUID || c.Rules.StatefulSetName ||
 		c.Rules.DeploymentName || c.Rules.DeploymentUID ||
-		c.Rules.CronJobName || c.Rules.RecommendedRules.Enabled {
+		c.Rules.CronJobName || c.Rules.AutomaticRules.Enabled {
 		for _, ref := range pod.OwnerReferences {
 			switch ref.Kind {
 			case "ReplicaSet":
@@ -516,19 +517,20 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 				if c.Rules.ReplicaSetName {
 					tags[conventions.AttributeK8SReplicaSetName] = ref.Name
 				}
-				if c.Rules.RecommendedRules.Enabled {
+				if c.Rules.AutomaticRules.Enabled {
 					serviceNames[conventions.AttributeK8SReplicaSetName] = ref.Name
 				}
-				if c.Rules.DeploymentName {
-					name := c.deploymentName(ref)
-					if name != "" {
-						tags[conventions.AttributeK8SDeploymentName] = name
-					}
-				}
-				if c.Rules.RecommendedRules.Enabled {
-					name := c.deploymentName(ref)
-					if name != "" {
-						serviceNames[conventions.AttributeK8SDeploymentName] = name
+				if c.Rules.DeploymentName || c.Rules.AutomaticRules.Enabled {
+					if replicaset, ok := c.getReplicaSet(string(ref.UID)); ok {
+						name := replicaset.Deployment.Name
+						if name != "" {
+							if c.Rules.DeploymentName {
+								tags[conventions.AttributeK8SDeploymentName] = name
+							}
+							if c.Rules.AutomaticRules.Enabled {
+								serviceNames[conventions.AttributeK8SDeploymentName] = name
+							}
+						}
 					}
 				}
 				if c.Rules.DeploymentUID {
@@ -545,7 +547,7 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 				if c.Rules.DaemonSetName {
 					tags[conventions.AttributeK8SDaemonSetName] = ref.Name
 				}
-				if c.Rules.RecommendedRules.Enabled {
+				if c.Rules.AutomaticRules.Enabled {
 					serviceNames[conventions.AttributeK8SDaemonSetName] = ref.Name
 				}
 			case "StatefulSet":
@@ -555,18 +557,18 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 				if c.Rules.StatefulSetName {
 					tags[conventions.AttributeK8SStatefulSetName] = ref.Name
 				}
-				if c.Rules.RecommendedRules.Enabled {
+				if c.Rules.AutomaticRules.Enabled {
 					serviceNames[conventions.AttributeK8SStatefulSetName] = ref.Name
 				}
 			case "Job":
-				if c.Rules.CronJobName || c.Rules.RecommendedRules.Enabled {
+				if c.Rules.CronJobName || c.Rules.AutomaticRules.Enabled {
 					parts := c.cronJobRegex.FindStringSubmatch(ref.Name)
 					if len(parts) == 2 {
 						name := parts[1]
 						if c.Rules.CronJobName {
 							tags[conventions.AttributeK8SCronJobName] = name
 						}
-						if c.Rules.RecommendedRules.Enabled {
+						if c.Rules.AutomaticRules.Enabled {
 							serviceNames[conventions.AttributeK8SCronJobName] = name
 						}
 					}
@@ -577,7 +579,7 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 				if c.Rules.JobName {
 					tags[conventions.AttributeK8SJobName] = ref.Name
 				}
-				if c.Rules.RecommendedRules.Enabled {
+				if c.Rules.AutomaticRules.Enabled {
 					serviceNames[conventions.AttributeK8SJobName] = ref.Name
 				}
 			}
@@ -604,15 +606,6 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 		r.extractFromPodMetadata(pod.Annotations, tags, "k8s.pod.annotations.%s")
 	}
 	return tags, serviceNames
-}
-
-func (c *WatchClient) deploymentName(ref meta_v1.OwnerReference) string {
-	if replicaset, ok := c.getReplicaSet(string(ref.UID)); ok {
-		if replicaset.Deployment.Name != "" {
-			return replicaset.Deployment.Name
-		}
-	}
-	return ""
 }
 
 // This function removes all data from the Pod except what is required by extraction rules and pod association
@@ -677,7 +670,7 @@ func removeUnnecessaryPodData(pod *api_v1.Pod, rules ExtractionRules) *api_v1.Po
 		removeUnnecessaryContainerData := func(c api_v1.Container) api_v1.Container {
 			transformedContainer := api_v1.Container{}
 			transformedContainer.Name = c.Name // we always need the name, it's used for identification
-			if rules.ContainerImageName || rules.ContainerImageTag || rules.RecommendedRules.Enabled {
+			if rules.ContainerImageName || rules.ContainerImageTag || rules.AutomaticRules.Enabled {
 				transformedContainer.Image = c.Image
 			}
 			return transformedContainer
@@ -708,30 +701,6 @@ func removeUnnecessaryPodData(pod *api_v1.Pod, rules ExtractionRules) *api_v1.Po
 	}
 
 	return &transformedPod
-}
-
-// parseNameAndTagFromImage parses the image name and tag for differently-formatted image names.
-// returns "latest" as the default if tag not present. also checks if the image contains a digest.
-// if it does, no latest tag is assumed.
-func parseNameAndTagFromImage(image string) (name, tag string, err error) {
-	ref, err := reference.Parse(image)
-	if err != nil {
-		return
-	}
-	namedRef, ok := ref.(reference.Named)
-	if !ok {
-		return "", "", cannotRetrieveImage
-	}
-	name = namedRef.Name()
-	if taggedRef, ok := namedRef.(reference.Tagged); ok {
-		tag = taggedRef.Tag()
-	}
-	if tag == "" {
-		if digestedRef, ok := namedRef.(reference.Digested); !ok || digestedRef.String() == "" {
-			tag = "latest"
-		}
-	}
-	return
 }
 
 // parseServiceVersionFromImage parses the service version for differently-formatted image names
@@ -774,25 +743,24 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 	if !needContainerAttributes(c.Rules) {
 		return containers
 	}
-	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag || c.Rules.RecommendedRules.Enabled {
+	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag || c.Rules.AutomaticRules.Enabled {
 		for _, spec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 			container := &Container{}
-			name, tag, err := parseNameAndTagFromImage(spec.Image)
+			imageRef, err := dcommon.ParseImageName(spec.Image)
 			if err == nil {
 				if c.Rules.ContainerImageName {
-					container.ImageName = name
+					container.ImageName = imageRef.Repository
 				}
 				if c.Rules.ContainerImageTag {
-					container.ImageTag = tag
+					container.ImageTag = imageRef.Tag
+				}
+				serviceVersion, err := parseServiceVersionFromImage(spec.Image)
+				if err == nil {
+					if c.Rules.AutomaticRules.Enabled {
+						container.ServiceVersion = serviceVersion
+					}
 				}
 			}
-			serviceVersion, err := parseServiceVersionFromImage(spec.Image)
-			if err == nil {
-				if c.Rules.RecommendedRules.Enabled {
-					container.ServiceVersion = serviceVersion
-				}
-			}
-
 			containers.ByName[spec.Name] = container
 		}
 	}
@@ -806,7 +774,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 		if c.Rules.ContainerName {
 			container.Name = containerName
 		}
-		if c.Rules.RecommendedRules.Enabled {
+		if c.Rules.AutomaticRules.Enabled {
 			container.ServiceInstanceID = operatorServiceInstanceID(pod, containerName)
 			container.ServiceName = containerName
 		}
@@ -1146,7 +1114,7 @@ func needContainerAttributes(rules ExtractionRules) bool {
 		rules.ContainerImageTag ||
 		rules.ContainerImageRepoDigests ||
 		rules.ContainerID ||
-		rules.RecommendedRules.Enabled
+		rules.AutomaticRules.Enabled
 }
 
 func (c *WatchClient) handleReplicaSetAdd(obj any) {

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -518,10 +518,16 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, 
 					serviceNames[conventions.AttributeK8SReplicaSetName] = ref.Name
 				}
 				if c.Rules.DeploymentName {
-					tags[conventions.AttributeK8SDeploymentName] = c.deploymentName(ref)
+					name := c.deploymentName(ref)
+					if name != "" {
+						tags[conventions.AttributeK8SDeploymentName] = name
+					}
 				}
 				if c.Rules.OperatorRules.Enabled {
-					serviceNames[conventions.AttributeK8SDeploymentName] = c.deploymentName(ref)
+					name := c.deploymentName(ref)
+					if name != "" {
+						serviceNames[conventions.AttributeK8SDeploymentName] = name
+					}
 				}
 				if c.Rules.DeploymentUID {
 					if replicaset, ok := c.getReplicaSet(string(ref.UID)); ok {

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -739,7 +739,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 			container.Name = containerName
 		}
 		if c.Rules.OperatorRules.Enabled {
-			container.ServiceInstanceID = createServiceInstanceID(pod, containerName)
+			container.ServiceInstanceID = operatorServiceInstanceID(pod, containerName)
 			container.ServiceName = containerName
 		}
 		containerID := apiStatus.ContainerID

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.opentelemetry.io/otel/attribute"
 	"regexp"
 	"strings"
 	"sync"
@@ -710,7 +709,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 		if c.Rules.ContainerName {
 			container.Name = apiStatus.Name
 		}
-		if c.Rules.AutoAnnotations {
+		if c.Rules.OperatorRules.Enabled {
 			container.ServiceInstanceID = createServiceInstanceID(pod, apiStatus.Name)
 		}
 		containerID := apiStatus.ContainerID
@@ -1045,8 +1044,7 @@ func needContainerAttributes(rules ExtractionRules) bool {
 		rules.ContainerImageTag ||
 		rules.ContainerImageRepoDigests ||
 		rules.ContainerID ||
-		rules.AutoAnnotations ||
-		rules.AutoAll
+		rules.OperatorRules.Enabled
 }
 
 func (c *WatchClient) handleReplicaSetAdd(obj any) {

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -457,10 +457,14 @@ func (c *WatchClient) GetNode(nodeName string) (*Node, bool) {
 	return nil, false
 }
 
-func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
+func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) (map[string]string, map[string]string) {
 	tags := map[string]string{}
+	serviceNames := map[string]string{}
 	if c.Rules.PodName {
 		tags[conventions.AttributeK8SPodName] = pod.Name
+	}
+	if c.Rules.OperatorRules.Enabled {
+		serviceNames[conventions.AttributeK8SPodName] = pod.Name
 	}
 
 	if c.Rules.PodHostName {
@@ -500,7 +504,7 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 		c.Rules.JobUID || c.Rules.JobName ||
 		c.Rules.StatefulSetUID || c.Rules.StatefulSetName ||
 		c.Rules.DeploymentName || c.Rules.DeploymentUID ||
-		c.Rules.CronJobName {
+		c.Rules.CronJobName || c.Rules.OperatorRules.Enabled {
 		for _, ref := range pod.OwnerReferences {
 			switch ref.Kind {
 			case "ReplicaSet":
@@ -510,12 +514,14 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 				if c.Rules.ReplicaSetName {
 					tags[conventions.AttributeK8SReplicaSetName] = ref.Name
 				}
+				if c.Rules.OperatorRules.Enabled {
+					serviceNames[conventions.AttributeK8SReplicaSetName] = ref.Name
+				}
 				if c.Rules.DeploymentName {
-					if replicaset, ok := c.getReplicaSet(string(ref.UID)); ok {
-						if replicaset.Deployment.Name != "" {
-							tags[conventions.AttributeK8SDeploymentName] = replicaset.Deployment.Name
-						}
-					}
+					tags[conventions.AttributeK8SDeploymentName] = c.deploymentName(ref)
+				}
+				if c.Rules.OperatorRules.Enabled {
+					serviceNames[conventions.AttributeK8SDeploymentName] = c.deploymentName(ref)
 				}
 				if c.Rules.DeploymentUID {
 					if replicaset, ok := c.getReplicaSet(string(ref.UID)); ok {
@@ -531,6 +537,9 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 				if c.Rules.DaemonSetName {
 					tags[conventions.AttributeK8SDaemonSetName] = ref.Name
 				}
+				if c.Rules.OperatorRules.Enabled {
+					serviceNames[conventions.AttributeK8SDaemonSetName] = ref.Name
+				}
 			case "StatefulSet":
 				if c.Rules.StatefulSetUID {
 					tags[conventions.AttributeK8SStatefulSetUID] = string(ref.UID)
@@ -538,11 +547,20 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 				if c.Rules.StatefulSetName {
 					tags[conventions.AttributeK8SStatefulSetName] = ref.Name
 				}
+				if c.Rules.OperatorRules.Enabled {
+					serviceNames[conventions.AttributeK8SStatefulSetName] = ref.Name
+				}
 			case "Job":
-				if c.Rules.CronJobName {
+				if c.Rules.CronJobName || c.Rules.OperatorRules.Enabled {
 					parts := c.cronJobRegex.FindStringSubmatch(ref.Name)
 					if len(parts) == 2 {
-						tags[conventions.AttributeK8SCronJobName] = parts[1]
+						name := parts[1]
+						if c.Rules.CronJobName {
+							tags[conventions.AttributeK8SCronJobName] = name
+						}
+						if c.Rules.OperatorRules.Enabled {
+							serviceNames[conventions.AttributeK8SCronJobName] = name
+						}
 					}
 				}
 				if c.Rules.JobUID {
@@ -550,6 +568,9 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 				}
 				if c.Rules.JobName {
 					tags[conventions.AttributeK8SJobName] = ref.Name
+				}
+				if c.Rules.OperatorRules.Enabled {
+					serviceNames[conventions.AttributeK8SJobName] = ref.Name
 				}
 			}
 		}
@@ -574,12 +595,16 @@ func (c *WatchClient) extractPodAttributes(pod *api_v1.Pod) map[string]string {
 	for _, r := range c.Rules.Annotations {
 		r.extractFromPodMetadata(pod.Annotations, tags, "k8s.pod.annotations.%s")
 	}
-	return tags
+	return tags, serviceNames
 }
 
-func createServiceInstanceID(pod *api_v1.Pod, containerName string) string {
-	resNames := []string{pod.Namespace, pod.Name, containerName}
-	return strings.Join(resNames, ".")
+func (c *WatchClient) deploymentName(ref meta_v1.OwnerReference) string {
+	if replicaset, ok := c.getReplicaSet(string(ref.UID)); ok {
+		if replicaset.Deployment.Name != "" {
+			return replicaset.Deployment.Name
+		}
+	}
+	return ""
 }
 
 // This function removes all data from the Pod except what is required by extraction rules and pod association
@@ -704,16 +729,18 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 		}
 	}
 	for _, apiStatus := range append(pod.Status.ContainerStatuses, pod.Status.InitContainerStatuses...) {
-		container, ok := containers.ByName[apiStatus.Name]
+		containerName := apiStatus.Name
+		container, ok := containers.ByName[containerName]
 		if !ok {
 			container = &Container{}
-			containers.ByName[apiStatus.Name] = container
+			containers.ByName[containerName] = container
 		}
 		if c.Rules.ContainerName {
-			container.Name = apiStatus.Name
+			container.Name = containerName
 		}
 		if c.Rules.OperatorRules.Enabled {
-			container.ServiceInstanceID = createServiceInstanceID(pod, apiStatus.Name)
+			container.ServiceInstanceID = createServiceInstanceID(pod, containerName)
+			container.ServiceName = containerName
 		}
 		containerID := apiStatus.ContainerID
 		// Remove container runtime prefix
@@ -785,7 +812,7 @@ func (c *WatchClient) podFromAPI(pod *api_v1.Pod) *Pod {
 	if c.shouldIgnorePod(pod) {
 		newPod.Ignore = true
 	} else {
-		newPod.Attributes = c.extractPodAttributes(pod)
+		newPod.Attributes, newPod.ServiceNames = c.extractPodAttributes(pod)
 		if needContainerAttributes(c.Rules) {
 			newPod.Containers = c.extractPodContainersAttributes(pod)
 		}

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/distribution/reference"
-
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/distribution/reference"
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
@@ -25,7 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
-	dcommon "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/metadata"
 )
@@ -85,6 +85,8 @@ var rRegex = regexp.MustCompile(`^(.*)-[0-9a-zA-Z]+$`)
 // Extract CronJob name from the Job name. Job name is created using
 // format: [cronjob-name]-[time-hash-int]
 var cronJobRegex = regexp.MustCompile(`^(.*)-[0-9]+$`)
+
+var cannotRetrieveImage = errors.New("cannot retrieve image name")
 
 // New initializes a new k8s Client.
 func New(
@@ -708,6 +710,62 @@ func removeUnnecessaryPodData(pod *api_v1.Pod, rules ExtractionRules) *api_v1.Po
 	return &transformedPod
 }
 
+// parseNameAndTagFromImage parses the image name and tag for differently-formatted image names.
+// returns "latest" as the default if tag not present. also checks if the image contains a digest.
+// if it does, no latest tag is assumed.
+func parseNameAndTagFromImage(image string) (name, tag string, err error) {
+	ref, err := reference.Parse(image)
+	if err != nil {
+		return
+	}
+	namedRef, ok := ref.(reference.Named)
+	if !ok {
+		return "", "", cannotRetrieveImage
+	}
+	name = namedRef.Name()
+	if taggedRef, ok := namedRef.(reference.Tagged); ok {
+		tag = taggedRef.Tag()
+	}
+	if tag == "" {
+		if digestedRef, ok := namedRef.(reference.Digested); !ok || digestedRef.String() == "" {
+			tag = "latest"
+		}
+	}
+	return
+}
+
+// parseServiceVersionFromImage parses the service version for differently-formatted image names
+// according to https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/k8s-attributes.md#how-serviceversion-should-be-calculated
+func parseServiceVersionFromImage(image string) (string, error) {
+	ref, err := reference.Parse(image)
+	if err != nil {
+		return "", err
+	}
+
+	namedRef, ok := ref.(reference.Named)
+	if !ok {
+		return "", cannotRetrieveImage
+	}
+	var tag, digest string
+	if taggedRef, ok := namedRef.(reference.Tagged); ok {
+		tag = taggedRef.Tag()
+	}
+	if digestedRef, ok := namedRef.(reference.Digested); ok {
+		digest = digestedRef.Digest().String()
+	}
+	if digest != "" {
+		if tag != "" {
+			return fmt.Sprintf("%s@%s", tag, digest), nil
+		}
+		return digest, nil
+	}
+	if tag != "" {
+		return tag, nil
+	}
+
+	return "", cannotRetrieveImage
+}
+
 func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContainers {
 	containers := PodContainers{
 		ByID:   map[string]*Container{},
@@ -719,18 +777,22 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 	if c.Rules.ContainerImageName || c.Rules.ContainerImageTag || c.Rules.OperatorRules.Enabled {
 		for _, spec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 			container := &Container{}
-			imageRef, err := dcommon.ParseImageName(spec.Image)
+			name, tag, err := parseNameAndTagFromImage(spec.Image)
 			if err == nil {
 				if c.Rules.ContainerImageName {
-					container.ImageName = imageRef.Repository
+					container.ImageName = name
 				}
 				if c.Rules.ContainerImageTag {
-					container.ImageTag = imageRef.Tag
-				}
-				if c.Rules.OperatorRules.Enabled {
-					container.ServiceVersion = tag
+					container.ImageTag = tag
 				}
 			}
+			serviceVersion, err := parseServiceVersionFromImage(spec.Image)
+			if err == nil {
+				if c.Rules.OperatorRules.Enabled {
+					container.ServiceVersion = serviceVersion
+				}
+			}
+
 			containers.ByName[spec.Name] = container
 		}
 	}
@@ -765,8 +827,12 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 			}
 
 			if c.Rules.ContainerImageRepoDigests {
-				if canonicalRef, err := dcommon.CanonicalImageRef(apiStatus.ImageID); err == nil {
-					containerStatus.ImageRepoDigest = canonicalRef
+				if parsed, err := reference.ParseAnyReference(apiStatus.ImageID); err == nil {
+					switch parsed.(type) {
+					case reference.Canonical:
+						containerStatus.ImageRepoDigest = parsed.String()
+					default:
+					}
 				}
 			}
 

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -775,7 +775,7 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 			container.Name = containerName
 		}
 		if c.Rules.AutomaticRules.Enabled {
-			container.ServiceInstanceID = operatorServiceInstanceID(pod, containerName)
+			container.ServiceInstanceID = automaticServiceInstanceID(pod, containerName)
 			container.ServiceName = containerName
 		}
 		containerID := apiStatus.ContainerID

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -7,11 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/distribution/reference"
 	"regexp"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/distribution/reference"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/featuregate"

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -703,7 +703,7 @@ func TestExtractionRules(t *testing.T) {
 	}
 
 	automaticRules := ExtractionRules{
-		RecommendedRules: AntomaticRules{
+		AutomaticRules: AutomaticRules{
 			Enabled: true,
 			Labels:  true,
 		},
@@ -1632,7 +1632,7 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 		{
 			name: "operator-container-level-attributes",
 			rules: ExtractionRules{
-				RecommendedRules: AntomaticRules{Enabled: true},
+				AutomaticRules: AutomaticRules{Enabled: true},
 			},
 			pod: &pod,
 			want: PodContainers{

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -9,11 +9,10 @@ import (
 	"testing"
 	"time"
 
-	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -705,7 +705,8 @@ func TestExtractionRules(t *testing.T) {
 	operatorRules := ExtractionRules{
 		OperatorRules: OperatorRules{
 			Enabled: true,
-			Labels:  true},
+			Labels:  true,
+		},
 		Annotations: []FieldExtractionRule{OperatorAnnotationRule},
 		Labels:      OperatorLabelRules,
 	}

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1019,18 +1019,18 @@ func TestExtractionRules(t *testing.T) {
 
 			// manually call the data removal functions here
 			// normally the informer does this, but fully emulating the informer in this test is annoying
-			pod := pod.DeepCopy()
+			podCopy := pod.DeepCopy()
 			for k, v := range tc.additionalAnnotations {
-				pod.Annotations[k] = v
+				podCopy.Annotations[k] = v
 			}
 			for k, v := range tc.additionalLabels {
-				pod.Labels[k] = v
+				podCopy.Labels[k] = v
 			}
-			transformedPod := removeUnnecessaryPodData(pod, c.Rules)
+			transformedPod := removeUnnecessaryPodData(podCopy, c.Rules)
 			transformedReplicaset := removeUnnecessaryReplicaSetData(replicaset)
 			c.handleReplicaSetAdd(transformedReplicaset)
 			c.handlePodAdd(transformedPod)
-			p, ok := c.GetPod(newPodIdentifier("connection", "", pod.Status.PodIP))
+			p, ok := c.GetPod(newPodIdentifier("connection", "", podCopy.Status.PodIP))
 			require.True(t, ok)
 
 			assert.Equal(t, tc.attributes, p.Attributes)

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1607,23 +1607,23 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			want:  PodContainers{ByID: map[string]*Container{}, ByName: map[string]*Container{}},
 		},
 		{
-			name: "service-instance-id-only",
+			name: "operator-container-level-attributes",
 			rules: ExtractionRules{
 				OperatorRules: OperatorRules{Enabled: true},
 			},
 			pod: &pod,
 			want: PodContainers{
 				ByID: map[string]*Container{
-					"container1-id-123":     {ServiceInstanceID: "test-namespace.test-pod.container1"},
+					"container1-id-123":     {ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
 					"container2-id-456":     {ServiceInstanceID: "test-namespace.test-pod.container2"},
-					"container3-id-abc":     {ServiceInstanceID: "test-namespace.test-pod.container3"},
-					"init-container-id-789": {ServiceInstanceID: "test-namespace.test-pod.init_container"},
+					"container3-id-abc":     {ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
+					"init-container-id-789": {ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
 				},
 				ByName: map[string]*Container{
-					"container1":     {ServiceInstanceID: "test-namespace.test-pod.container1"},
+					"container1":     {ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
 					"container2":     {ServiceInstanceID: "test-namespace.test-pod.container2"},
-					"container3":     {ServiceInstanceID: "test-namespace.test-pod.container3"},
-					"init_container": {ServiceInstanceID: "test-namespace.test-pod.init_container"},
+					"container3":     {ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
+					"init_container": {ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
 				},
 			},
 		},

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1638,15 +1638,15 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			want: PodContainers{
 				ByID: map[string]*Container{
 					"container1-id-123":     {ServiceName: "container1", ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
-					"container2-id-456":     {ServiceName: "container2", ServiceInstanceID: "test-namespace.test-pod.container2"},
-					"container3-id-abc":     {ServiceName: "container3", ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
-					"init-container-id-789": {ServiceName: "init_container", ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
+					"container2-id-456":     {ServiceName: "container2", ServiceInstanceID: "test-namespace.test-pod.container2", ServiceVersion: "sha256:430ac608abaa332de4ce45d68534447c7a206edc5e98aaff9923ecc12f8a80d9"},
+					"container3-id-abc":     {ServiceName: "container3", ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0@sha256:4b0b1b6f6cdd3e5b9e55f74a1e8d19ed93a3f5a04c6b6c3c57c4e6d19f6b7c4d"},
+					"init-container-id-789": {ServiceName: "init_container", ServiceInstanceID: "test-namespace.test-pod.init_container"},
 				},
 				ByName: map[string]*Container{
 					"container1":     {ServiceName: "container1", ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
-					"container2":     {ServiceName: "container2", ServiceInstanceID: "test-namespace.test-pod.container2"},
-					"container3":     {ServiceName: "container3", ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
-					"init_container": {ServiceName: "init_container", ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
+					"container2":     {ServiceName: "container2", ServiceInstanceID: "test-namespace.test-pod.container2", ServiceVersion: "sha256:430ac608abaa332de4ce45d68534447c7a206edc5e98aaff9923ecc12f8a80d9"},
+					"container3":     {ServiceName: "container3", ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0@sha256:4b0b1b6f6cdd3e5b9e55f74a1e8d19ed93a3f5a04c6b6c3c57c4e6d19f6b7c4d"},
+					"init_container": {ServiceName: "init_container", ServiceInstanceID: "test-namespace.test-pod.init_container"},
 				},
 			},
 		},

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -988,12 +988,10 @@ func TestExtractionRules(t *testing.T) {
 			additionalLabels: map[string]string{
 				"app.kubernetes.io/name":    "label-service",
 				"app.kubernetes.io/version": "label-version",
-				"app.kubernetes.io/part-of": "label-namespace",
 			},
 			attributes: map[string]string{
-				"service.name":      "label-service",
-				"service.version":   "label-version",
-				"service.namespace": "label-namespace",
+				"service.name":    "label-service",
+				"service.version": "label-version",
 			},
 		},
 		{

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -707,8 +707,8 @@ func TestExtractionRules(t *testing.T) {
 			Enabled: true,
 			Labels:  true,
 		},
-		Annotations: []FieldExtractionRule{OperatorAnnotationRule},
-		Labels:      OperatorLabelRules,
+		Annotations: []FieldExtractionRule{AutomaticAnnotationRule(DefaultAnnotationPrefix)},
+		Labels:      AutomaticLabelRules,
 	}
 
 	testCases := []struct {
@@ -1046,7 +1046,7 @@ func TestExtractionRules(t *testing.T) {
 
 			assert.Equal(t, tc.attributes, p.Attributes)
 			if tc.serviceName != "" {
-				assert.Equal(t, tc.serviceName, OperatorServiceName("containerName", p.ServiceNames))
+				assert.Equal(t, tc.serviceName, AutomaticServiceName("containerName", p.ServiceNames))
 			}
 		})
 	}

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -1489,6 +1489,10 @@ func TestPodIgnorePatterns(t *testing.T) {
 
 func Test_extractPodContainersAttributes(t *testing.T) {
 	pod := api_v1.Pod{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-namespace",
+		},
 		Spec: api_v1.PodSpec{
 			Containers: []api_v1.Container{
 				{
@@ -1563,6 +1567,27 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			rules: ExtractionRules{},
 			pod:   &pod,
 			want:  PodContainers{ByID: map[string]*Container{}, ByName: map[string]*Container{}},
+		},
+		{
+			name: "service-instance-id-only",
+			rules: ExtractionRules{
+				OperatorRules: OperatorRules{Enabled: true},
+			},
+			pod: &pod,
+			want: PodContainers{
+				ByID: map[string]*Container{
+					"container1-id-123":     {ServiceInstanceID: "test-namespace.test-pod.container1"},
+					"container2-id-456":     {ServiceInstanceID: "test-namespace.test-pod.container2"},
+					"container3-id-abc":     {ServiceInstanceID: "test-namespace.test-pod.container3"},
+					"init-container-id-789": {ServiceInstanceID: "test-namespace.test-pod.init_container"},
+				},
+				ByName: map[string]*Container{
+					"container1":     {ServiceInstanceID: "test-namespace.test-pod.container1"},
+					"container2":     {ServiceInstanceID: "test-namespace.test-pod.container2"},
+					"container3":     {ServiceInstanceID: "test-namespace.test-pod.container3"},
+					"init_container": {ServiceInstanceID: "test-namespace.test-pod.init_container"},
+				},
+			},
 		},
 		{
 			name: "image-name-only",

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -5,10 +5,11 @@ package kube
 
 import (
 	"fmt"
-	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"regexp"
 	"testing"
 	"time"
+
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -995,6 +995,19 @@ func TestExtractionRules(t *testing.T) {
 			},
 		},
 		{
+			name:  "operator-rules-label-values-instance",
+			rules: operatorRules,
+			additionalLabels: map[string]string{
+				"app.kubernetes.io/instance": "instance-service",
+				"app.kubernetes.io/name":     "label-service",
+				"app.kubernetes.io/version":  "label-version",
+			},
+			attributes: map[string]string{
+				"service.name":    "instance-service",
+				"service.version": "label-version",
+			},
+		},
+		{
 			name:  "operator-rules-annotation-override",
 			rules: operatorRules,
 			additionalAnnotations: map[string]string{

--- a/processor/k8sattributesprocessor/internal/kube/client_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/client_test.go
@@ -643,11 +643,8 @@ func TestExtractionRules(t *testing.T) {
 			Namespace:         "ns1",
 			CreationTimestamp: meta_v1.Now(),
 			Labels: map[string]string{
-				"label1":                    "lv1",
-				"label2":                    "k1=v1 k5=v5 extra!",
-				"app.kubernetes.io/name":    "auth-service",
-				"app.kubernetes.io/version": "1.0.0",
-				"app.kubernetes.io/part-of": "auth",
+				"label1": "lv1",
+				"label2": "k1=v1 k5=v5 extra!",
 			},
 			Annotations: map[string]string{
 				"annotation1": "av1",
@@ -705,16 +702,26 @@ func TestExtractionRules(t *testing.T) {
 		},
 	}
 
+	operatorRules := ExtractionRules{
+		OperatorRules: OperatorRules{
+			Enabled: true,
+			Labels:  true},
+		Annotations: []FieldExtractionRule{OperatorAnnotationRule},
+		Labels:      OperatorLabelRules,
+	}
+
 	testCases := []struct {
 		name                  string
 		rules                 ExtractionRules
 		additionalAnnotations map[string]string
+		additionalLabels      map[string]string
 		attributes            map[string]string
+		serviceName           string
 	}{
 		{
 			name:       "no-rules",
 			rules:      ExtractionRules{},
-			attributes: nil,
+			attributes: map[string]string{},
 		},
 		{
 			name: "deployment",
@@ -967,38 +974,41 @@ func TestExtractionRules(t *testing.T) {
 			},
 		},
 		{
-			name: "operator-rules",
-			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{OperatorAnnotationRule},
-				Labels:      OperatorLabelRules,
+			name:       "operator-rules-builtin",
+			rules:      operatorRules,
+			attributes: map[string]string{
+				// tested in operator-container-level-attributes below
 			},
-			additionalAnnotations: map[string]string{
-				"resource.opentelemetry.io/service.instance.id": "instance-id",
+			serviceName: "auth-service",
+		},
+		{
+			name:  "operator-rules-label-values",
+			rules: operatorRules,
+			additionalLabels: map[string]string{
+				"app.kubernetes.io/name":    "label-service",
+				"app.kubernetes.io/version": "label-version",
+				"app.kubernetes.io/part-of": "label-namespace",
 			},
 			attributes: map[string]string{
-				"service.instance.id": "instance-id",
-				"service.name":        "auth-service",
-				"service.version":     "1.0.0",
-				"service.namespace":   "auth",
+				"service.name":      "label-service",
+				"service.version":   "label-version",
+				"service.namespace": "label-namespace",
 			},
 		},
 		{
-			name: "operator-rules-annotation-override",
-			rules: ExtractionRules{
-				Annotations: []FieldExtractionRule{OperatorAnnotationRule},
-				Labels:      OperatorLabelRules,
-			},
+			name:  "operator-rules-annotation-override",
+			rules: operatorRules,
 			additionalAnnotations: map[string]string{
-				"resource.opentelemetry.io/service.instance.id": "instance-id",
-				"resource.opentelemetry.io/service.version":     "1.1.0",
-				"resource.opentelemetry.io/service.name":        "auth-service2",
-				"resource.opentelemetry.io/service.namespace":   "auth2",
+				"resource.opentelemetry.io/service.instance.id": "annotation-id",
+				"resource.opentelemetry.io/service.version":     "annotation-version",
+				"resource.opentelemetry.io/service.name":        "annotation-service",
+				"resource.opentelemetry.io/service.namespace":   "annotation-namespace",
 			},
 			attributes: map[string]string{
-				"service.instance.id": "instance-id",
-				"service.name":        "auth-service2",
-				"service.version":     "1.0.0",
-				"service.namespace":   "auth2",
+				"service.instance.id": "annotation-id",
+				"service.name":        "annotation-service",
+				"service.version":     "annotation-version",
+				"service.namespace":   "annotation-namespace",
 			},
 		},
 	}
@@ -1012,6 +1022,9 @@ func TestExtractionRules(t *testing.T) {
 			for k, v := range tc.additionalAnnotations {
 				pod.Annotations[k] = v
 			}
+			for k, v := range tc.additionalLabels {
+				pod.Labels[k] = v
+			}
 			transformedPod := removeUnnecessaryPodData(pod, c.Rules)
 			transformedReplicaset := removeUnnecessaryReplicaSetData(replicaset)
 			c.handleReplicaSetAdd(transformedReplicaset)
@@ -1020,6 +1033,9 @@ func TestExtractionRules(t *testing.T) {
 			require.True(t, ok)
 
 			assert.Equal(t, tc.attributes, p.Attributes)
+			if tc.serviceName != "" {
+				assert.Equal(t, tc.serviceName, OperatorServiceName("containerName", p.ServiceNames))
+			}
 		})
 	}
 }
@@ -1078,7 +1094,7 @@ func TestReplicaSetExtractionRules(t *testing.T) {
 		{
 			name:       "no-rules",
 			rules:      ExtractionRules{},
-			attributes: nil,
+			attributes: map[string]string{},
 		}, {
 			name: "one_deployment_is_controller",
 			ownerReferences: []meta_v1.OwnerReference{
@@ -1170,12 +1186,7 @@ func TestReplicaSetExtractionRules(t *testing.T) {
 			p, ok := c.GetPod(newPodIdentifier("connection", "", pod.Status.PodIP))
 			require.True(t, ok)
 
-			assert.Equal(t, len(tc.attributes), len(p.Attributes))
-			for k, v := range tc.attributes {
-				got, ok := p.Attributes[k]
-				assert.True(t, ok)
-				assert.Equal(t, v, got)
-			}
+			assert.Equal(t, tc.attributes, p.Attributes)
 		})
 	}
 }
@@ -1614,16 +1625,16 @@ func Test_extractPodContainersAttributes(t *testing.T) {
 			pod: &pod,
 			want: PodContainers{
 				ByID: map[string]*Container{
-					"container1-id-123":     {ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
-					"container2-id-456":     {ServiceInstanceID: "test-namespace.test-pod.container2"},
-					"container3-id-abc":     {ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
-					"init-container-id-789": {ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
+					"container1-id-123":     {ServiceName: "container1", ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
+					"container2-id-456":     {ServiceName: "container2", ServiceInstanceID: "test-namespace.test-pod.container2"},
+					"container3-id-abc":     {ServiceName: "container3", ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
+					"init-container-id-789": {ServiceName: "init_container", ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
 				},
 				ByName: map[string]*Container{
-					"container1":     {ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
-					"container2":     {ServiceInstanceID: "test-namespace.test-pod.container2"},
-					"container3":     {ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
-					"init_container": {ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
+					"container1":     {ServiceName: "container1", ServiceInstanceID: "test-namespace.test-pod.container1", ServiceVersion: "0.1.0"},
+					"container2":     {ServiceName: "container2", ServiceInstanceID: "test-namespace.test-pod.container2"},
+					"container3":     {ServiceName: "container3", ServiceInstanceID: "test-namespace.test-pod.container3", ServiceVersion: "1.0"},
+					"init_container": {ServiceName: "init_container", ServiceInstanceID: "test-namespace.test-pod.init_container", ServiceVersion: "latest"},
 				},
 			},
 		},

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -134,6 +134,7 @@ type Container struct {
 	ImageName         string
 	ImageTag          string
 	ServiceInstanceID string
+	ServiceVersion    string
 
 	// Statuses is a map of container k8s.container.restart_count attribute to ContainerStatus struct.
 	Statuses map[int]ContainerStatus

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -8,9 +8,8 @@ import (
 	"regexp"
 	"time"
 
-	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
-
 	"go.opentelemetry.io/collector/component"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -117,7 +117,8 @@ type Pod struct {
 	// Containers specifies all containers in this pod.
 	Containers PodContainers
 
-	DeletedAt time.Time
+	DeletedAt    time.Time
+	ServiceNames map[string]string
 }
 
 // PodContainers specifies a list of pod containers. It is not safe for concurrent use.
@@ -135,6 +136,7 @@ type Container struct {
 	ImageTag          string
 	ServiceInstanceID string
 	ServiceVersion    string
+	ServiceName       string
 
 	// Statuses is a map of container k8s.container.restart_count attribute to ContainerStatus struct.
 	Statuses map[int]ContainerStatus
@@ -272,7 +274,7 @@ func (rules *ExtractionRules) IncludesOwnerMetadata() bool {
 			return true
 		}
 	}
-	return false
+	return rules.OperatorRules.Enabled
 }
 
 // FieldExtractionRule is used to specify which fields to extract from pod fields

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -295,6 +295,31 @@ type FieldExtractionRule struct {
 	From string
 }
 
+var OperatorAnnotationRule = FieldExtractionRule{
+	Name:                 "$1",
+	KeyRegex:             regexp.MustCompile(`^resource.opentelemetry.io/(.+)$`),
+	HasKeyRegexReference: true,
+	From:                 MetadataFromPod,
+}
+
+var OperatorLabelRules = []FieldExtractionRule{
+	{
+		Name: "service.name",
+		Key:  "app.kubernetes.io/name",
+		From: MetadataFromPod,
+	},
+	{
+		Name: "service.version",
+		Key:  "app.kubernetes.io/version",
+		From: MetadataFromPod,
+	},
+	{
+		Name: "service.namespace",
+		Key:  "app.kubernetes.io/part-of",
+		From: MetadataFromPod,
+	},
+}
+
 func (r *FieldExtractionRule) extractFromPodMetadata(metadata map[string]string, tags map[string]string, formatter string) {
 	// By default if the From field is not set for labels and annotations we want to extract them from pod
 	if r.From == MetadataFromPod || r.From == "" {

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -130,9 +130,10 @@ type PodContainers struct {
 
 // Container stores resource attributes for a specific container defined by k8s pod spec.
 type Container struct {
-	Name      string
-	ImageName string
-	ImageTag  string
+	Name              string
+	ImageName         string
+	ImageTag          string
+	ServiceInstanceID string
 
 	// Statuses is a map of container k8s.container.restart_count attribute to ContainerStatus struct.
 	Statuses map[int]ContainerStatus
@@ -238,6 +239,8 @@ type ExtractionRules struct {
 	ContainerImageRepoDigests bool
 	ContainerImageTag         bool
 	ClusterUID                bool
+	AutoAnnotations           bool
+	AutoAll                   bool
 
 	Annotations []FieldExtractionRule
 	Labels      []FieldExtractionRule

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -214,11 +214,6 @@ type LabelFilter struct {
 	Op selection.Operator
 }
 
-type OperatorRules struct {
-	Enabled bool `mapstructure:"enabled"`
-	Labels  bool `mapstructure:"labels"`
-}
-
 // ExtractionRules is used to specify the information that needs to be extracted
 // from pods and added to the spans as tags.
 type ExtractionRules struct {
@@ -296,31 +291,6 @@ type FieldExtractionRule struct {
 	//  - namespace
 	//  - node
 	From string
-}
-
-var OperatorAnnotationRule = FieldExtractionRule{
-	Name:                 "$1",
-	KeyRegex:             regexp.MustCompile(`^resource.opentelemetry.io/(.+)$`),
-	HasKeyRegexReference: true,
-	From:                 MetadataFromPod,
-}
-
-var OperatorLabelRules = []FieldExtractionRule{
-	{
-		Name: "service.name",
-		Key:  "app.kubernetes.io/name",
-		From: MetadataFromPod,
-	},
-	{
-		Name: "service.version",
-		Key:  "app.kubernetes.io/version",
-		From: MetadataFromPod,
-	},
-	{
-		Name: "service.namespace",
-		Key:  "app.kubernetes.io/part-of",
-		From: MetadataFromPod,
-	},
 }
 
 func (r *FieldExtractionRule) extractFromPodMetadata(metadata map[string]string, tags map[string]string, formatter string) {

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -246,7 +246,7 @@ type ExtractionRules struct {
 	Annotations []FieldExtractionRule
 	Labels      []FieldExtractionRule
 
-	RecommendedRules *AntomaticRules
+	AutomaticRules AutomaticRules
 }
 
 // IncludesOwnerMetadata determines whether the ExtractionRules include metadata about Pod Owners
@@ -269,7 +269,7 @@ func (rules *ExtractionRules) IncludesOwnerMetadata() bool {
 			return true
 		}
 	}
-	return rules.RecommendedRules.Enabled
+	return rules.AutomaticRules.Enabled
 }
 
 // FieldExtractionRule is used to specify which fields to extract from pod fields

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -5,9 +5,10 @@ package kube // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"fmt"
-	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"regexp"
 	"time"
+
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 
 	"go.opentelemetry.io/collector/component"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -211,6 +211,11 @@ type LabelFilter struct {
 	Op selection.Operator
 }
 
+type OperatorRules struct {
+	Enabled bool `mapstructure:"enabled"`
+	Labels  bool `mapstructure:"labels"`
+}
+
 // ExtractionRules is used to specify the information that needs to be extracted
 // from pods and added to the spans as tags.
 type ExtractionRules struct {
@@ -239,11 +244,11 @@ type ExtractionRules struct {
 	ContainerImageRepoDigests bool
 	ContainerImageTag         bool
 	ClusterUID                bool
-	AutoAnnotations           bool
-	AutoAll                   bool
 
 	Annotations []FieldExtractionRule
 	Labels      []FieldExtractionRule
+
+	OperatorRules OperatorRules
 }
 
 // IncludesOwnerMetadata determines whether the ExtractionRules include metadata about Pod Owners

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -246,7 +246,7 @@ type ExtractionRules struct {
 	Annotations []FieldExtractionRule
 	Labels      []FieldExtractionRule
 
-	OperatorRules OperatorRules
+	RecommendedRules *AntomaticRules
 }
 
 // IncludesOwnerMetadata determines whether the ExtractionRules include metadata about Pod Owners
@@ -269,7 +269,7 @@ func (rules *ExtractionRules) IncludesOwnerMetadata() bool {
 			return true
 		}
 	}
-	return rules.OperatorRules.Enabled
+	return rules.RecommendedRules.Enabled
 }
 
 // FieldExtractionRule is used to specify which fields to extract from pod fields

--- a/processor/k8sattributesprocessor/internal/kube/kube.go
+++ b/processor/k8sattributesprocessor/internal/kube/kube.go
@@ -5,6 +5,7 @@ package kube // import "github.com/open-telemetry/opentelemetry-collector-contri
 
 import (
 	"fmt"
+	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
 	"regexp"
 	"time"
 
@@ -269,7 +270,7 @@ func (rules *ExtractionRules) IncludesOwnerMetadata() bool {
 			return true
 		}
 	}
-	return rules.AutomaticRules.Enabled
+	return rules.AutomaticRules.IsEnabled(conventions.AttributeServiceName)
 }
 
 // FieldExtractionRule is used to specify which fields to extract from pod fields

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -26,6 +26,11 @@ var OperatorAnnotationRule = FieldExtractionRule{
 var OperatorLabelRules = []FieldExtractionRule{
 	{
 		Name: "service.name",
+		Key:  "app.kubernetes.io/instance", // todo check that it takes precedence over app.kubernetes.io/name
+		From: MetadataFromPod,
+	},
+	{
+		Name: "service.name",
 		Key:  "app.kubernetes.io/name",
 		From: MetadataFromPod,
 	},

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -7,9 +7,8 @@ import (
 	"regexp"
 	"strings"
 
-	"golang.org/x/exp/slices"
-
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"golang.org/x/exp/slices"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -4,6 +4,7 @@
 package kube // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/kube"
 
 import (
+	"golang.org/x/exp/slices"
 	"regexp"
 	"strings"
 
@@ -16,6 +17,17 @@ type AutomaticRules struct {
 	Labels             bool     `mapstructure:"well_known_labels"`
 	AnnotationPrefixes []string `mapstructure:"annotation_prefixes"`
 	Exclude            []string `mapstructure:"exclude"`
+}
+
+func (r *AutomaticRules) IsEnabled(key string) bool {
+	b := r.Enabled && !slices.Contains(r.Exclude, key)
+	return b
+}
+
+func (r *AutomaticRules) NeedContainer() bool {
+	return r.IsEnabled(conventions.AttributeServiceName) ||
+		r.IsEnabled(conventions.AttributeServiceInstanceID) ||
+		r.IsEnabled(conventions.AttributeServiceVersion)
 }
 
 const DefaultAnnotationPrefix = "resource.opentelemetry.io/"

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -23,15 +23,16 @@ var OperatorAnnotationRule = FieldExtractionRule{
 	From:                 MetadataFromPod,
 }
 
+// OperatorLabelRules has rules where the last entry wins
 var OperatorLabelRules = []FieldExtractionRule{
 	{
 		Name: "service.name",
-		Key:  "app.kubernetes.io/instance", // todo check that it takes precedence over app.kubernetes.io/name
+		Key:  "app.kubernetes.io/name",
 		From: MetadataFromPod,
 	},
 	{
 		Name: "service.name",
-		Key:  "app.kubernetes.io/name",
+		Key:  "app.kubernetes.io/instance",
 		From: MetadataFromPod,
 	},
 	{

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -4,9 +4,10 @@
 package kube // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/kube"
 
 import (
-	"golang.org/x/exp/slices"
 	"regexp"
 	"strings"
+
+	"golang.org/x/exp/slices"
 
 	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
 	v1 "k8s.io/api/core/v1"

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -1,0 +1,31 @@
+package kube
+
+import (
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	"k8s.io/api/core/v1"
+	"strings"
+)
+
+var serviceNamePrecedence = []string{
+	conventions.AttributeK8SDeploymentName,
+	conventions.AttributeK8SReplicaSetName,
+	conventions.AttributeK8SStatefulSetName,
+	conventions.AttributeK8SDaemonSetName,
+	conventions.AttributeK8SCronJobName,
+	conventions.AttributeK8SJobName,
+	conventions.AttributeK8SPodName,
+}
+
+func OperatorServiceName(containerName string, names map[string]string) string {
+	for _, k := range serviceNamePrecedence {
+		if v, ok := names[k]; ok {
+			return v
+		}
+	}
+	return containerName
+}
+
+func createServiceInstanceID(pod *v1.Pod, containerName string) string {
+	resNames := []string{pod.Namespace, pod.Name, containerName}
+	return strings.Join(resNames, ".")
+}

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -1,4 +1,7 @@
-package kube
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package kube // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/k8sattributesprocessor/internal/kube"
 
 import (
 	"regexp"

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -11,7 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type OperatorRules struct {
+type AntomaticRules struct {
 	Enabled bool `mapstructure:"enabled"`
 	Labels  bool `mapstructure:"labels"`
 }

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -34,11 +34,6 @@ var OperatorLabelRules = []FieldExtractionRule{
 		Key:  "app.kubernetes.io/version",
 		From: MetadataFromPod,
 	},
-	{
-		Name: "service.namespace",
-		Key:  "app.kubernetes.io/part-of",
-		From: MetadataFromPod,
-	},
 }
 
 var serviceNamePrecedence = []string{

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -1,10 +1,11 @@
 package kube
 
 import (
-	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
-	"k8s.io/api/core/v1"
 	"regexp"
 	"strings"
+
+	conventions "go.opentelemetry.io/collector/semconv/v1.6.1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type OperatorRules struct {

--- a/processor/k8sattributesprocessor/internal/kube/operator.go
+++ b/processor/k8sattributesprocessor/internal/kube/operator.go
@@ -11,7 +11,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-type AntomaticRules struct {
+type AutomaticRules struct {
 	Enabled bool `mapstructure:"enabled"`
 	Labels  bool `mapstructure:"labels"`
 }

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -198,10 +198,10 @@ func withExtractMetadata(fields ...string) option {
 	}
 }
 
-func withAutomaticRules(rules *kube.AntomaticRules) option {
+func withAutomaticRules(rules kube.AutomaticRules) option {
 	return func(p *kubernetesprocessor) error {
-		if rules != nil {
-			p.rules.RecommendedRules = rules
+		if rules.Enabled {
+			p.rules.AutomaticRules = rules
 			p.rules.Annotations = append(p.rules.Annotations, kube.OperatorAnnotationRule)
 			if rules.Labels {
 				p.rules.Labels = append(p.rules.Labels, kube.OperatorLabelRules...)

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -202,12 +202,10 @@ func withOperatorExtractRules(rules kube.OperatorRules) option {
 	return func(p *kubernetesprocessor) error {
 		if rules.Enabled {
 			p.rules.OperatorRules = rules
-			p.rules.Annotations = append(p.rules.Annotations, kube.FieldExtractionRule{
-				Name:                 "$1",
-				KeyRegex:             regexp.MustCompile(`^resource.opentelemetry.io/(.+)$`),
-				HasKeyRegexReference: true,
-				From:                 kube.MetadataFromPod,
-			})
+			p.rules.Annotations = append(p.rules.Annotations, kube.OperatorAnnotationRule)
+			if rules.Labels {
+				p.rules.Labels = append(p.rules.Labels, kube.OperatorLabelRules...)
+			}
 		}
 		return nil
 	}

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -202,6 +202,12 @@ func withOperatorExtractRules(rules kube.OperatorRules) option {
 	return func(p *kubernetesprocessor) error {
 		if rules.Enabled {
 			p.rules.OperatorRules = rules
+			p.rules.Annotations = append(p.rules.Annotations, kube.FieldExtractionRule{
+				Name:                 "$1",
+				KeyRegex:             regexp.MustCompile(`^resource.opentelemetry.io/(.+)$`),
+				HasKeyRegexReference: true,
+				From:                 kube.MetadataFromPod,
+			})
 		}
 		return nil
 	}

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -198,6 +198,15 @@ func withExtractMetadata(fields ...string) option {
 	}
 }
 
+func withOperatorExtractRules(rules kube.OperatorRules) option {
+	return func(p *kubernetesprocessor) error {
+		if rules.Enabled {
+			p.rules.OperatorRules = rules
+		}
+		return nil
+	}
+}
+
 // withExtractLabels allows specifying options to control extraction of pod labels.
 func withExtractLabels(labels ...FieldExtractConfig) option {
 	return func(p *kubernetesprocessor) error {

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -210,7 +210,11 @@ func withAutomaticRules(rules kube.AutomaticRules) option {
 				p.rules.Annotations = append(p.rules.Annotations, kube.AutomaticAnnotationRule(prefix))
 			}
 			if rules.Labels {
-				p.rules.Labels = append(p.rules.Labels, kube.AutomaticLabelRules...)
+				for _, rule := range kube.AutomaticLabelRules {
+					if rules.IsEnabled(rule.Name) {
+						p.rules.Labels = append(p.rules.Labels, rule)
+					}
+				}
 			}
 		}
 		return nil

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -198,10 +198,10 @@ func withExtractMetadata(fields ...string) option {
 	}
 }
 
-func withOperatorExtractRules(rules kube.OperatorRules) option {
+func withAutomaticRules(rules *kube.AntomaticRules) option {
 	return func(p *kubernetesprocessor) error {
-		if rules.Enabled {
-			p.rules.OperatorRules = rules
+		if rules != nil {
+			p.rules.RecommendedRules = rules
 			p.rules.Annotations = append(p.rules.Annotations, kube.OperatorAnnotationRule)
 			if rules.Labels {
 				p.rules.Labels = append(p.rules.Labels, kube.OperatorLabelRules...)

--- a/processor/k8sattributesprocessor/options.go
+++ b/processor/k8sattributesprocessor/options.go
@@ -202,9 +202,15 @@ func withAutomaticRules(rules kube.AutomaticRules) option {
 	return func(p *kubernetesprocessor) error {
 		if rules.Enabled {
 			p.rules.AutomaticRules = rules
-			p.rules.Annotations = append(p.rules.Annotations, kube.OperatorAnnotationRule)
+			prefixes := rules.AnnotationPrefixes
+			if len(prefixes) == 0 {
+				prefixes = []string{kube.DefaultAnnotationPrefix}
+			}
+			for _, prefix := range prefixes {
+				p.rules.Annotations = append(p.rules.Annotations, kube.AutomaticAnnotationRule(prefix))
+			}
 			if rules.Labels {
-				p.rules.Labels = append(p.rules.Labels, kube.OperatorLabelRules...)
+				p.rules.Labels = append(p.rules.Labels, kube.AutomaticLabelRules...)
 			}
 		}
 		return nil

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -171,6 +171,11 @@ func (kp *kubernetesprocessor) processResource(ctx context.Context, resource pco
 		for key, val := range attrsToAdd {
 			setResourceAttribute(resource.Attributes(), key, val)
 		}
+
+		kp.rules.AutomaticRules.IsEnabled(conventions.AttributeServiceNamespace)
+		{
+			resource.Attributes().PutStr(conventions.AttributeServiceNamespace, namespace)
+		}
 	}
 
 	nodeName := getNodeName(pod, resource.Attributes())

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -241,14 +241,20 @@ func (kp *kubernetesprocessor) addContainerAttributes(attrs pcommon.Map, pod *ku
 	if containerSpec.Name != "" {
 		setResourceAttribute(attrs, conventions.AttributeK8SContainerName, containerSpec.Name)
 	}
-	if containerSpec.ServiceInstanceID != "" {
-		setResourceAttribute(attrs, conventions.AttributeServiceInstanceID, containerSpec.ServiceInstanceID)
-	}
 	if containerSpec.ImageName != "" {
 		setResourceAttribute(attrs, conventions.AttributeContainerImageName, containerSpec.ImageName)
 	}
 	if containerSpec.ImageTag != "" {
 		setResourceAttribute(attrs, conventions.AttributeContainerImageTag, containerSpec.ImageTag)
+	}
+	if containerSpec.ServiceInstanceID != "" {
+		setResourceAttribute(attrs, conventions.AttributeServiceInstanceID, containerSpec.ServiceInstanceID)
+	}
+	if containerSpec.ServiceVersion != "" {
+		setResourceAttribute(attrs, conventions.AttributeServiceVersion, containerSpec.ServiceVersion)
+	}
+	if containerSpec.ServiceName != "" {
+		setResourceAttribute(attrs, conventions.AttributeServiceName, kube.OperatorServiceName(containerSpec.ServiceName, pod.ServiceNames))
 	}
 	// attempt to get container ID from restart count
 	runID := -1

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -241,6 +241,9 @@ func (kp *kubernetesprocessor) addContainerAttributes(attrs pcommon.Map, pod *ku
 	if containerSpec.Name != "" {
 		setResourceAttribute(attrs, conventions.AttributeK8SContainerName, containerSpec.Name)
 	}
+	if containerSpec.ServiceInstanceID != "" {
+		setResourceAttribute(attrs, conventions.AttributeServiceInstanceID, containerSpec.ServiceInstanceID)
+	}
 	if containerSpec.ImageName != "" {
 		setResourceAttribute(attrs, conventions.AttributeContainerImageName, containerSpec.ImageName)
 	}

--- a/processor/k8sattributesprocessor/processor.go
+++ b/processor/k8sattributesprocessor/processor.go
@@ -254,7 +254,7 @@ func (kp *kubernetesprocessor) addContainerAttributes(attrs pcommon.Map, pod *ku
 		setResourceAttribute(attrs, conventions.AttributeServiceVersion, containerSpec.ServiceVersion)
 	}
 	if containerSpec.ServiceName != "" {
-		setResourceAttribute(attrs, conventions.AttributeServiceName, kube.OperatorServiceName(containerSpec.ServiceName, pod.ServiceNames))
+		setResourceAttribute(attrs, conventions.AttributeServiceName, kube.AutomaticServiceName(containerSpec.ServiceName, pod.ServiceNames))
 	}
 	// attempt to get container ID from restart count
 	runID := -1

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1403,7 +1403,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				t,
 				NewFactory().CreateDefaultConfig(),
 				nil,
-				withAutomaticRules(kube.AntomaticRules{
+				withAutomaticRules(kube.AutomaticRules{
 					Enabled: true,
 					Labels:  true,
 				}),

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1040,6 +1040,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 								ImageTag:          "1.0.1",
 								ServiceInstanceID: "instance-1",
 								ServiceVersion:    "1.0.1",
+								ServiceName:       "app",
 							},
 						},
 					},
@@ -1056,6 +1057,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				conventions.AttributeContainerImageTag:  "1.0.1",
 				conventions.AttributeServiceInstanceID:  "instance-1",
 				conventions.AttributeServiceVersion:     "1.0.1",
+				conventions.AttributeServiceName:        "app",
 			},
 		},
 		{
@@ -1076,10 +1078,9 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 					Containers: kube.PodContainers{
 						ByID: map[string]*kube.Container{
 							"767dc30d4fece77038e8ec2585a33471944d0b754659af7aa7e101181418f0dd": {
-								Name:              "app",
-								ImageName:         "test/app",
-								ImageTag:          "1.0.1",
-								ServiceInstanceID: "instance-1",
+								Name:      "app",
+								ImageName: "test/app",
+								ImageTag:  "1.0.1",
 							},
 						},
 					},
@@ -1095,13 +1096,10 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				conventions.AttributeK8SContainerName:   "app",
 				conventions.AttributeContainerImageName: "test/app",
 				conventions.AttributeContainerImageTag:  "1.0.1",
-				conventions.AttributeServiceInstanceID:  "instance-1",
-				conventions.AttributeServiceVersion:     "1.0.1",
-				conventions.AttributeServiceName:        "app",
 			},
 		},
 		{
-			name: "explicit-service-instance-id",
+			name: "operator-explicit-values-win",
 			op: func(kp *kubernetesprocessor) {
 				kp.podAssociations = []kube.Association{
 					{
@@ -1116,9 +1114,10 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				}
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "19f651bc-73e4-410f-b3e9-f0241679d3b8")] = &kube.Pod{
 					Attributes: map[string]string{
-						"service.instance.id": "explicit-1",
-						"service.version":     "1.0.2",
-						"service.name":        "test-app",
+						conventions.AttributeServiceInstanceID: "explicit-instance",
+						conventions.AttributeServiceVersion:    "explicit-version",
+						conventions.AttributeServiceName:       "explicit-name",
+						conventions.AttributeServiceNamespace:  "explicit-ns",
 					},
 					Containers: kube.PodContainers{
 						ByID: map[string]*kube.Container{
@@ -1127,6 +1126,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 								ImageName:         "test/app",
 								ImageTag:          "1.0.1",
 								ServiceInstanceID: "instance-1",
+								ServiceVersion:    "version-1",
 							},
 						},
 					},
@@ -1142,9 +1142,10 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				conventions.AttributeK8SContainerName:   "app",
 				conventions.AttributeContainerImageName: "test/app",
 				conventions.AttributeContainerImageTag:  "1.0.1",
-				conventions.AttributeServiceInstanceID:  "explicit-1",
-				conventions.AttributeServiceVersion:     "1.0.2",
-				conventions.AttributeServiceName:        "test-app",
+				conventions.AttributeServiceInstanceID:  "explicit-instance",
+				conventions.AttributeServiceVersion:     "explicit-version",
+				conventions.AttributeServiceName:        "explicit-name",
+				conventions.AttributeServiceNamespace:   "explicit-ns",
 			},
 		},
 		{

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1403,7 +1403,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				t,
 				NewFactory().CreateDefaultConfig(),
 				nil,
-				withOperatorExtractRules(kube.OperatorRules{
+				withAutomaticRules(kube.AntomaticRules{
 					Enabled: true,
 					Labels:  true,
 				}),

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -864,9 +864,10 @@ func TestAddNamespaceLabels(t *testing.T) {
 	m.assertBatchesLen(1)
 	m.assertResourceObjectLen(0)
 	m.assertResource(0, func(res pcommon.Resource) {
-		assert.Equal(t, 2, res.Attributes().Len())
+		assert.Equal(t, 3, res.Attributes().Len())
 		assertResourceHasStringAttribute(t, res, "k8s.pod.ip", podIP)
 		assertResourceHasStringAttribute(t, res, "nslabel", "1")
+		assertResourceHasStringAttribute(t, res, "service.namespace", "namespace-1")
 	})
 }
 
@@ -1099,7 +1100,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 			},
 		},
 		{
-			name: "operator-explicit-values-win",
+			name: "automatic-explicit-values-win",
 			op: func(kp *kubernetesprocessor) {
 				kp.podAssociations = []kube.Association{
 					{

--- a/processor/k8sattributesprocessor/processor_test.go
+++ b/processor/k8sattributesprocessor/processor_test.go
@@ -1039,6 +1039,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 								ImageName:         "test/app",
 								ImageTag:          "1.0.1",
 								ServiceInstanceID: "instance-1",
+								ServiceVersion:    "1.0.1",
 							},
 						},
 					},
@@ -1054,6 +1055,7 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				conventions.AttributeContainerImageName: "test/app",
 				conventions.AttributeContainerImageTag:  "1.0.1",
 				conventions.AttributeServiceInstanceID:  "instance-1",
+				conventions.AttributeServiceVersion:     "1.0.1",
 			},
 		},
 		{
@@ -1094,6 +1096,8 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				conventions.AttributeContainerImageName: "test/app",
 				conventions.AttributeContainerImageTag:  "1.0.1",
 				conventions.AttributeServiceInstanceID:  "instance-1",
+				conventions.AttributeServiceVersion:     "1.0.1",
+				conventions.AttributeServiceName:        "app",
 			},
 		},
 		{
@@ -1113,6 +1117,8 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				kp.kc.(*fakeClient).Pods[newPodIdentifier("resource_attribute", "k8s.pod.uid", "19f651bc-73e4-410f-b3e9-f0241679d3b8")] = &kube.Pod{
 					Attributes: map[string]string{
 						"service.instance.id": "explicit-1",
+						"service.version":     "1.0.2",
+						"service.name":        "test-app",
 					},
 					Containers: kube.PodContainers{
 						ByID: map[string]*kube.Container{
@@ -1137,6 +1143,8 @@ func TestProcessorAddContainerAttributes(t *testing.T) {
 				conventions.AttributeContainerImageName: "test/app",
 				conventions.AttributeContainerImageTag:  "1.0.1",
 				conventions.AttributeServiceInstanceID:  "explicit-1",
+				conventions.AttributeServiceVersion:     "1.0.2",
+				conventions.AttributeServiceName:        "test-app",
 			},
 		},
 		{


### PR DESCRIPTION
#### Description

Implements https://github.com/open-telemetry/semantic-conventions/blob/main/docs/non-normative/k8s-attributes.md#how-serviceversion-should-be-calculate

The OTel operator has a set of rules to create resource attributes - which is described [here](https://github.com/open-telemetry/opentelemetry-operator#configure-resource-attributes).

This PR allows the collector to create resource attributes with the same logic.

#### Why

If the operator supplies resource attributes (that are sent with OTLP), it seems redundant that the collector should be able to do the same - it will just overwrite the resource attribute with identical values.

This feature gets interesting if you are not only getting all data from OTLP - but some data elsewhere, e.g. from the file log receiver.

It's crucial to use the same values for resource attributes across signals - **this makes correlation possible**.
For example, it allows you to find **file based** the log entries on the same service instance as a trace you're viewing (around the same time).

#### Alternatives

The same result can be achieved using the transforprocessor - but it's a very long and hard-to-understand configuration.
It that way, it's similar to the [container parser](https://opentelemetry.io/blog/2024/otel-collector-container-log-parser/).

#### Testing

Unit tests were added - e2e tests later

#### Documentation

Added [here](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/61b534d13c0366fc3c533b2d8de287a62b312baa/processor/k8sattributesprocessor/README.md#config-example)
This also has a complete config.