### PR TITLE
[chore] Add Sven Rebhan to influxdb code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,7 +62,7 @@ exporter/googlecloudexporter/                     @open-telemetry/collector-cont
 exporter/googlecloudpubsubexporter/               @open-telemetry/collector-contrib-approvers @alexvanboxel
 exporter/googlemanagedprometheusexporter/         @open-telemetry/collector-contrib-approvers @aabmass @dashpole @jsuereth @punya @psx95
 exporter/honeycombmarkerexporter/                 @open-telemetry/collector-contrib-approvers @TylerHelmuth @fchikwekwe
-exporter/influxdbexporter/                        @open-telemetry/collector-contrib-approvers @jacobmarble
+exporter/influxdbexporter/                        @open-telemetry/collector-contrib-approvers @srebhan @jacobmarble
 exporter/kafkaexporter/                           @open-telemetry/collector-contrib-approvers @pavolloffay @MovieStoreGuy
 exporter/loadbalancingexporter/                   @open-telemetry/collector-contrib-approvers @jpkrohling
 exporter/logicmonitorexporter/                    @open-telemetry/collector-contrib-approvers @bogdandrutu @khyatigandhi6 @avadhut123pisal
@@ -234,7 +234,7 @@ receiver/hostmetricsreceiver/                     @open-telemetry/collector-cont
 receiver/httpcheckreceiver/                       @open-telemetry/collector-contrib-approvers @codeboten
 receiver/huaweicloudcesreceiver/                  @open-telemetry/collector-contrib-approvers @heitorganzeli @narcis96 @mwear
 receiver/iisreceiver/                             @open-telemetry/collector-contrib-approvers @Mrod1598 @pjanotti
-receiver/influxdbreceiver/                        @open-telemetry/collector-contrib-approvers @jacobmarble
+receiver/influxdbreceiver/                        @open-telemetry/collector-contrib-approvers @srebhan @jacobmarble
 receiver/jaegerreceiver/                          @open-telemetry/collector-contrib-approvers @yurishkuro
 receiver/journaldreceiver/                        @open-telemetry/collector-contrib-approvers @sumo-drosiek @djaglowski
 receiver/k8sclusterreceiver/                      @open-telemetry/collector-contrib-approvers @dmitryax @TylerHelmuth @povilasv @ChrsMark

--- a/exporter/influxdbexporter/README.md
+++ b/exporter/influxdbexporter/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: traces, metrics, logs   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Aexporter%2Finfluxdb%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Aexporter%2Finfluxdb) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Aexporter%2Finfluxdb%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Aexporter%2Finfluxdb) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@jacobmarble](https://www.github.com/jacobmarble) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@srebhan](https://www.github.com/srebhan), [@jacobmarble](https://www.github.com/jacobmarble) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/exporter/influxdbexporter/metadata.yaml
+++ b/exporter/influxdbexporter/metadata.yaml
@@ -6,7 +6,7 @@ status:
     beta: [traces, metrics, logs]
   distributions: [contrib]
   codeowners:
-    active: [jacobmarble]
+    active: [srebhan, jacobmarble]
 
 tests:
   expect_consumer_error: true

--- a/receiver/influxdbreceiver/README.md
+++ b/receiver/influxdbreceiver/README.md
@@ -6,7 +6,7 @@
 | Stability     | [beta]: metrics   |
 | Distributions | [contrib] |
 | Issues        | [![Open issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aopen%20label%3Areceiver%2Finfluxdb%20&label=open&color=orange&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aopen+is%3Aissue+label%3Areceiver%2Finfluxdb) [![Closed issues](https://img.shields.io/github/issues-search/open-telemetry/opentelemetry-collector-contrib?query=is%3Aissue%20is%3Aclosed%20label%3Areceiver%2Finfluxdb%20&label=closed&color=blue&logo=opentelemetry)](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues?q=is%3Aclosed+is%3Aissue+label%3Areceiver%2Finfluxdb) |
-| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@jacobmarble](https://www.github.com/jacobmarble) |
+| [Code Owners](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/CONTRIBUTING.md#becoming-a-code-owner)    | [@srebhan](https://www.github.com/srebhan), [@jacobmarble](https://www.github.com/jacobmarble) |
 
 [beta]: https://github.com/open-telemetry/opentelemetry-collector/blob/main/docs/component-stability.md#beta
 [contrib]: https://github.com/open-telemetry/opentelemetry-collector-releases/tree/main/distributions/otelcol-contrib

--- a/receiver/influxdbreceiver/metadata.yaml
+++ b/receiver/influxdbreceiver/metadata.yaml
@@ -6,4 +6,4 @@ status:
     beta: [metrics]
   distributions: [contrib]
   codeowners:
-    active: [jacobmarble]
+    active: [srebhan, jacobmarble]


### PR DESCRIPTION
#### Description

I'm the current owner, and I'm departing from InfluxData at the end of the week. @srebhan leads Telegraf at InfluxData, so he's the natural choice for in-house maintainer of these components.
