### PR TITLE
[chore] Build test tools in scoped tests action

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -59,6 +59,9 @@ jobs:
             ./.tools
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
+      - name: Build test tools
+        run: make "$(${PWD} -replace '\\', '/')/.tools/gotestsum"
+
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests
         env:


### PR DESCRIPTION
**Description:**
The new GH action is breaking because `gotestsum` is not being built. I guess that in my fork the cache was always available when I tested. Anyway, building the tool to ensure the test works.

**Testing:**
The same step is already in other actions I will be testing this concurrently in my fork.

**Documentation:**
N/A