### PR TITLE
[chore] 3 Improvements to scoped-tests action

### DIFF
--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -30,12 +30,13 @@ jobs:
               - '**/*_test.go'
 
   scoped-tests:
+    needs: changedfiles
+    if: needs.changedfiles.outputs.go_sources != '' || needs.changedfiles.outputs.go_tests != ''
     strategy:
       fail-fast: false
       matrix:
         os: [ windows-latest ]
     runs-on: ${{ matrix.os }}
-    needs: changedfiles
     steps:
       - name: Echo changed files
         shell: bash
@@ -59,8 +60,13 @@ jobs:
             ./.tools
           key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
 
-      - name: Build test tools
+      - name: Build gotestsum on Windows
+        if: runner.os == 'Windows'
         run: make "$(${PWD} -replace '\\', '/')/.tools/gotestsum"
+
+      - name: Build gotestsum
+        if: runner.os != 'Windows'
+        run: make "$PWD/.tools/gotestsum"
 
       - name: Run changed tests
         if: needs.changedfiles.outputs.go_tests

--- a/Makefile.Common
+++ b/Makefile.Common
@@ -279,7 +279,7 @@ for-affected-components:
 		if [ -z '$${DEPENDENT_PKGS}' ]; then \
 			echo "No other package depends on the one being changed."; \
 		else \
-			DEPENDENT_PKG_DIRS=$$(echo $${DEPENDENT_PKGS} | tr ' ' '\n' | xargs -I {} grep --include=go.mod -rl {} | xargs dirname | uniq); \
+			DEPENDENT_PKG_DIRS=$$(echo $${DEPENDENT_PKGS} | tr ' ' '\n' | xargs -I {} grep --include=go.mod -rl {} | xargs -r dirname | uniq); \
 			set -e; for dir in $$(echo $${DEPENDENT_PKG_DIRS}); do \
 			(cd "$${dir}" && \
 				echo "running $${CMD} in $${dir}" && \


### PR DESCRIPTION
#### Description

1. Completely skip the `scoped-tests` if there are no changes to go files (avoids checking out and setting the repo and not running any tests). Test on my fork: https://github.com/pjanotti/opentelemetry-service-contrib/actions/runs/12698095207/job/35395815043?pr=31
2. Make the step to build `gotestsum` work on non-Windows - this needs further investigation, since the `test` target depends on `gotestsum`, but, as seem yesterday it was failing to build the tool (at least on Windows GH runner, it didn't repro on my box). Test on my fork: https://github.com/pjanotti/opentelemetry-service-contrib/actions/runs/12697644120/job/35394429408
3. On `Makefile.Common` account for the case when an internal package is not used by any other package. 