### PR TITLE
[chore] Fix the job updating otelcol core dependency

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -29,8 +29,16 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           branch: opentelemetrybot/update-otel
+          path: opentelemetry-collector-contrib
+          base: main
+          author:
+            opentelemetrybot
+            <107717825+opentelemetrybot@users.noreply.github.com>
+          committer:
+            opentelemetrybot
+            <107717825+opentelemetrybot@users.noreply.github.com>
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
-          commit-message: Update to latest opentelemetry-collector release.
+          commit-message: [chore] Update to latest opentelemetry-collector release.
           title: "[chore] Update to latest opentelemetry-collector"
           body: |
               This PR updates the opentelemetry-collector dependency to the latest release.


### PR DESCRIPTION
Fix https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/12713829455/job/35445661001 by adding missing `path` field. Other additions are improvements
