### PR TITLE
[chore] Remove invalid fields from update-otel GH actions

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -31,12 +31,6 @@ jobs:
           branch: opentelemetrybot/update-otel
           path: opentelemetry-collector-contrib
           base: main
-          author:
-            opentelemetrybot
-            <107717825+opentelemetrybot@users.noreply.github.com>
-          committer:
-            opentelemetrybot
-            <107717825+opentelemetrybot@users.noreply.github.com>
           token: ${{ secrets.OPENTELEMETRYBOT_GITHUB_TOKEN }}
           commit-message: [chore] Update to latest opentelemetry-collector release.
           title: "[chore] Update to latest opentelemetry-collector"


### PR DESCRIPTION
I took them from another OTel project and added them in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37149, but the values are invalid. A multiline YAML flag is missing. I'm removing them for now since I don't think they are necessary.