### PR TITLE
fix: replace private image parse for common implementation

### DIFF
--- a/processor/k8sattributesprocessor/go.mod
+++ b/processor/k8sattributesprocessor/go.mod
@@ -82,6 +82,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mostynb/go-grpc-compression v1.2.3 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.117.0
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/openshift/api v3.9.0+incompatible // indirect

--- a/processor/k8sattributesprocessor/go.sum
+++ b/processor/k8sattributesprocessor/go.sum
@@ -1139,6 +1139,8 @@ github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGV
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.35.1 h1:Cwbd75ZBPxFSuZ6T+rN/WCb/gOc6YgFBXLlZLhC7Ds4=
 github.com/onsi/gomega v1.35.1/go.mod h1:PvZbdDc8J6XJEpDK4HCuRBm8a6Fzp9/DmhC9C7yFlog=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.117.0 h1:vnZsHJhZci7rjhuQUjZ2Utm3hPdzQCxoqZSL56Ra4ME=
+github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.117.0/go.mod h1:ShQ4jr9t4tb11LqLpKw7WOoZUaebKHObOj4OZLvgY7I=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -671,7 +671,9 @@ func (c *WatchClient) extractPodContainersAttributes(pod *api_v1.Pod) PodContain
 		for _, spec := range append(pod.Spec.Containers, pod.Spec.InitContainers...) {
 			container := &Container{}
 			imageRef, err := dcommon.ParseImageName(spec.Image)
-			if err == nil {
+			if err != nil {
+				dcommon.LogParseError(err, spec.Image, c.logger)
+			} else {
 				if c.Rules.ContainerImageName {
 					container.ImageName = imageRef.Repository
 				}

--- a/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
+++ b/receiver/awsecscontainermetricsreceiver/internal/awsecscontainermetrics/resource.go
@@ -11,15 +11,15 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil"
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
+	dcommon "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
 )
 
 func containerResource(cm ecsutil.ContainerMetadata, logger *zap.Logger) pcommon.Resource {
 	resource := pcommon.NewResource()
 
-	image, err := docker.ParseImageName(cm.Image)
+	image, err := dcommon.ParseImageName(cm.Image)
 	if err != nil {
-		docker.LogParseError(err, cm.Image, logger)
+		dcommon.LogParseError(err, cm.Image, logger)
 	}
 
 	resource.Attributes().PutStr(conventions.AttributeContainerName, cm.ContainerName)

--- a/receiver/k8sclusterreceiver/internal/container/containers.go
+++ b/receiver/k8sclusterreceiver/internal/container/containers.go
@@ -11,7 +11,7 @@ import (
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
+	dcommon "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/docker"
 	metadataPkg "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/constants"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/k8sclusterreceiver/internal/metadata"
@@ -89,9 +89,9 @@ func RecordSpecMetrics(logger *zap.Logger, mb *metadata.MetricsBuilder, c corev1
 	rb.SetK8sNamespaceName(pod.Namespace)
 	rb.SetContainerID(utils.StripContainerID(containerID))
 	rb.SetK8sContainerName(c.Name)
-	image, err := docker.ParseImageName(imageStr)
+	image, err := dcommon.ParseImageName(imageStr)
 	if err != nil {
-		docker.LogParseError(err, imageStr, logger)
+		dcommon.LogParseError(err, imageStr, logger)
 	} else {
 		rb.SetContainerImageName(image.Repository)
 		rb.SetContainerImageTag(image.Tag)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Replaces the private image parse method with the public `common/docker` image parse method.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36418

Blocked by 
- https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36279

<!--Describe what testing was performed and which tests were added.-->
#### Testing
the existing test [Test_extractPodContainersAttributes](https://vscode.dev/github/vordimous/opentelemetry-collector-contrib/blob/36418-use-docker.ParseImageName/processor/k8sattributesprocessor/internal/kube/client_test.go#L1490) is used to verify behavior remained the same