### PR TITLE
[chore] `make tidylist`

### DIFF
--- a/internal/tidylist/tidylist.txt
+++ b/internal/tidylist/tidylist.txt
@@ -287,6 +287,7 @@ processor/coralogixprocessor
 processor/logstransformprocessor
 processor/schemaprocessor
 receiver/awscloudwatchmetricsreceiver
+receiver/gitlabreceiver
 receiver/netflowreceiver
 receiver/osqueryreceiver
 receiver/prometheusremotewritereceiver


### PR DESCRIPTION
#### Description

The new CI job checking that `internal/tidylist/tidylist.txt` is up-to-date, introduced in #37142, is failing on main because #36838 which was merged just before causes changes to said file. This PR just runs `make tidylist` to fix this.
