### PR TITLE
[exporter/kafka] Enable Trace batch chunking before exporting to kafka

### DIFF
--- a/exporter/kafkaexporter/jaeger_marshaler.go
+++ b/exporter/kafkaexporter/jaeger_marshaler.go
@@ -5,6 +5,7 @@ package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collect
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/IBM/sarama"
 	"github.com/gogo/protobuf/jsonpb"
@@ -24,32 +25,69 @@ type jaegerMarshaler struct {
 var _ TracesMarshaler = (*jaegerMarshaler)(nil)
 
 func (j jaegerMarshaler) Marshal(traces ptrace.Traces, topic string) ([]*ProducerMessageChunks, error) {
-	// ToDo: implement partitionedByTraceID
+	if j.maxMessageBytes <= 0 {
+		return nil, fmt.Errorf("maxMessageBytes must be positive, got %d", j.maxMessageBytes)
+	}
 
 	batches := jaeger.ProtoFromTraces(traces)
+	if len(batches) == 0 {
+		return []*ProducerMessageChunks{}, nil
+	}
+
 	var messages []*sarama.ProducerMessage
-
-	// ToDo: effectively chunk the spans adhering to j.maxMessageBytes
 	var messageChunks []*ProducerMessageChunks
-
+	var packetSize int
 	var errs error
+
 	for _, batch := range batches {
 		for _, span := range batch.Spans {
 			span.Process = batch.Process
+
 			bts, err := j.marshaler.marshal(span)
 			if err != nil {
-				errs = multierr.Append(errs, err)
+				errs = multierr.Append(errs, fmt.Errorf("failed to marshal span %s: %w", span.SpanID.String(), err))
 				continue
 			}
+
 			key := []byte(span.TraceID.String())
-			messages = append(messages, &sarama.ProducerMessage{
+			msg := &sarama.ProducerMessage{
 				Topic: topic,
 				Value: sarama.ByteEncoder(bts),
 				Key:   sarama.ByteEncoder(key),
-			})
+			}
+
+			// Deriving version from sarama library
+			// https://github.com/IBM/sarama/blob/main/async_producer.go#L454
+			currentMsgSize := msg.ByteSize(2)
+
+			// Check if message itself exceeds size limit
+			if currentMsgSize > j.maxMessageBytes {
+				errs = multierr.Append(errs, fmt.Errorf("span %s exceeds maximum message size: %d > %d",
+					span.SpanID.String(), currentMsgSize, j.maxMessageBytes))
+				continue
+			}
+
+			// Check if adding this message would exceed the chunk size limit
+			if (packetSize + currentMsgSize) <= j.maxMessageBytes {
+				packetSize += currentMsgSize
+				messages = append(messages, msg)
+			} else {
+				// Current chunk is full, create new chunk
+				if len(messages) > 0 {
+					messageChunks = append(messageChunks, &ProducerMessageChunks{messages})
+					messages = make([]*sarama.ProducerMessage, 0, len(messages)) // Preallocate with previous size
+				}
+				messages = append(messages, msg)
+				packetSize = currentMsgSize
+			}
 		}
 	}
-	messageChunks = append(messageChunks, &ProducerMessageChunks{messages})
+
+	// Add final chunk if there are remaining messages
+	if len(messages) > 0 {
+		messageChunks = append(messageChunks, &ProducerMessageChunks{messages})
+	}
+
 	return messageChunks, errs
 }
 

--- a/exporter/kafkaexporter/jaeger_marshaler_test.go
+++ b/exporter/kafkaexporter/jaeger_marshaler_test.go
@@ -61,9 +61,9 @@ func TestJaegerMarshaler(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.encoding, func(t *testing.T) {
-			messages, err := test.unmarshaler.Marshal(td, "topic")
+			msg, err := test.unmarshaler.Marshal(td, "topic")
 			require.NoError(t, err)
-			assert.Equal(t, test.messages, messages)
+			assert.Equal(t, test.messages, msg[0])
 			assert.Equal(t, test.encoding, test.unmarshaler.Encoding())
 		})
 	}

--- a/exporter/kafkaexporter/kafka_exporter.go
+++ b/exporter/kafkaexporter/kafka_exporter.go
@@ -53,7 +53,7 @@ func (e *kafkaTracesProducer) tracesPusher(ctx context.Context, td ptrace.Traces
 	var allErrors []string
 
 	for i, chunk := range messageChunks {
-		sendErr := e.producer.SendMessages(chunk.msg)
+		sendErr := e.producer.SendMessages(chunk.Messages)
 		if sendErr == nil {
 			continue
 		}

--- a/exporter/kafkaexporter/kafka_exporter_test.go
+++ b/exporter/kafkaexporter/kafka_exporter_test.go
@@ -174,7 +174,7 @@ func TestTracesPusher(t *testing.T) {
 
 	p := kafkaTracesProducer{
 		producer:  producer,
-		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false),
+		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false, 0),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -193,7 +193,7 @@ func TestTracesPusher_attr(t *testing.T) {
 			TopicFromAttribute: "kafka_topic",
 		},
 		producer:  producer,
-		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false),
+		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false, 0),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -209,7 +209,7 @@ func TestTracesPusher_ctx(t *testing.T) {
 
 	p := kafkaTracesProducer{
 		producer:  producer,
-		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false),
+		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false, 0),
 	}
 	t.Cleanup(func() {
 		require.NoError(t, p.Close(context.Background()))
@@ -226,7 +226,7 @@ func TestTracesPusher_err(t *testing.T) {
 
 	p := kafkaTracesProducer{
 		producer:  producer,
-		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false),
+		marshaler: newPdataTracesMarshaler(&ptrace.ProtoMarshaler{}, defaultEncoding, false, 0),
 		logger:    zap.NewNop(),
 	}
 	t.Cleanup(func() {
@@ -432,7 +432,7 @@ func (e metricsErrorMarshaler) Encoding() string {
 
 var _ TracesMarshaler = (*tracesErrorMarshaler)(nil)
 
-func (e tracesErrorMarshaler) Marshal(_ ptrace.Traces, _ string) ([]*sarama.ProducerMessage, error) {
+func (e tracesErrorMarshaler) Marshal(_ ptrace.Traces, _ string) ([]*ProducerMessageChunks, error) {
 	return nil, e.err
 }
 

--- a/exporter/kafkaexporter/marshaler_test.go
+++ b/exporter/kafkaexporter/marshaler_test.go
@@ -466,7 +466,7 @@ func TestOTLPTracesJsonMarshaling(t *testing.T) {
 		require.NoError(t, err, "Must have marshaled the data without error")
 		require.Len(t, msg, test.numExpectedMessages, "Expected number of messages in the message")
 
-		for idx, singleMsg := range msg {
+		for idx, singleMsg := range msg[0].msg {
 			data, err := singleMsg.Value.Encode()
 			require.NoError(t, err, "Must not error when encoding value")
 			require.NotNil(t, data, "Must have valid data to test")

--- a/exporter/kafkaexporter/pdata_marshaler.go
+++ b/exporter/kafkaexporter/pdata_marshaler.go
@@ -4,6 +4,8 @@
 package kafkaexporter // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter"
 
 import (
+	"fmt"
+
 	"github.com/IBM/sarama"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -12,6 +14,7 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal/traceutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/batchpersignal"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil"
+	"go.uber.org/multierr"
 )
 
 type pdataLogsMarshaler struct {
@@ -128,38 +131,154 @@ type pdataTracesMarshaler struct {
 	maxMessageBytes      int
 }
 
-func (p *pdataTracesMarshaler) Marshal(td ptrace.Traces, topic string) ([]*ProducerMessageChunks, error) {
+func (p *pdataTracesMarshaler) processTrace(
+	trace ptrace.Traces,
+	topic string,
+	key []byte,
+	messages *[]*sarama.ProducerMessage,
+	messageChunks *[]*ProducerMessageChunks,
+	packetSize *int) error {
 
-	// ToDo: effectively chunk the spans adhering to j.maxMessageBytes
-	var messageChunks []*ProducerMessageChunks
-
-	var msgs []*sarama.ProducerMessage
-	if p.partitionedByTraceID {
-		for _, trace := range batchpersignal.SplitTraces(td) {
-			bts, err := p.marshaler.MarshalTraces(trace)
-			if err != nil {
-				return nil, err
-			}
-			msgs = append(msgs, &sarama.ProducerMessage{
-				Topic: topic,
-				Value: sarama.ByteEncoder(bts),
-				Key:   sarama.ByteEncoder(traceutil.TraceIDToHexOrEmptyString(trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID())),
-			})
-		}
-	} else {
-		bts, err := p.marshaler.MarshalTraces(td)
-		if err != nil {
-			return nil, err
-		}
-		msgs = append(msgs, &sarama.ProducerMessage{
-			Topic: topic,
-			Value: sarama.ByteEncoder(bts),
-		})
+	if trace.ResourceSpans().Len() == 0 {
+		return nil
 	}
 
-	messageChunks = append(messageChunks, &ProducerMessageChunks{msg: msgs})
+	bts, err := p.marshaler.MarshalTraces(trace)
+	if err != nil {
+		return fmt.Errorf("failed to marshal traces: %w", err)
+	}
 
-	return messageChunks, nil
+	msg := &sarama.ProducerMessage{
+		Topic: topic,
+		Value: sarama.ByteEncoder(bts),
+		Key:   sarama.ByteEncoder(key),
+	}
+
+	// Deriving version from sarama library
+	// https://github.com/IBM/sarama/blob/main/async_producer.go#L454
+	currentMsgSize := msg.ByteSize(2)
+
+	if (*packetSize + currentMsgSize) <= p.maxMessageBytes {
+		*packetSize += currentMsgSize
+		*messages = append(*messages, msg)
+		return nil
+	}
+
+	if len(*messages) > 0 {
+		*messageChunks = append(*messageChunks, &ProducerMessageChunks{*messages})
+		*messages = make([]*sarama.ProducerMessage, 0)
+		*packetSize = 0
+	}
+
+	// If current message itself exceeds limit, split it
+	if currentMsgSize > p.maxMessageBytes {
+		remaining := trace
+		for {
+			splitPoint, err := p.findSplitPoint(remaining)
+			if err != nil {
+				return fmt.Errorf("failed to find split point: %w", err)
+			}
+
+			// If we can't split further (single span exceeds limit)
+			if splitPoint < 1 {
+				return fmt.Errorf("single span size %d exceeds maximum message size %d", currentMsgSize, p.maxMessageBytes)
+			}
+
+			// Split and process first half
+			firstHalf, secondHalf := p.splitTraceBySpans(remaining, 0, splitPoint)
+
+			bts, err := p.marshaler.MarshalTraces(firstHalf)
+			if err != nil {
+				return fmt.Errorf("failed to marshal first half: %w", err)
+			}
+
+			splitMsg := &sarama.ProducerMessage{
+				Topic: topic,
+				Value: sarama.ByteEncoder(bts),
+				Key:   sarama.ByteEncoder(key),
+			}
+
+			*messageChunks = append(*messageChunks, &ProducerMessageChunks{[]*sarama.ProducerMessage{splitMsg}})
+
+			remaining = secondHalf
+			if remaining.ResourceSpans().At(0).ScopeSpans().At(0).Spans().Len() == 0 {
+				break
+			}
+
+			bts, err = p.marshaler.MarshalTraces(remaining)
+			if err != nil {
+				return fmt.Errorf("failed to marshal remaining half: %w", err)
+			}
+
+			remainingSize := (&sarama.ProducerMessage{
+				Topic: topic,
+				Value: sarama.ByteEncoder(bts),
+				Key:   sarama.ByteEncoder(key),
+			}).ByteSize(2)
+
+			if remainingSize <= p.maxMessageBytes {
+				*messages = append(*messages, &sarama.ProducerMessage{
+					Topic: topic,
+					Value: sarama.ByteEncoder(bts),
+					Key:   sarama.ByteEncoder(key),
+				})
+				*packetSize = remainingSize
+				break
+			}
+		}
+		return nil
+	}
+
+	*messages = append(*messages, msg)
+	*packetSize = currentMsgSize
+	return nil
+}
+
+func (p *pdataTracesMarshaler) Marshal(td ptrace.Traces, topic string) ([]*ProducerMessageChunks, error) {
+	if td.ResourceSpans().Len() == 0 {
+		return []*ProducerMessageChunks{}, nil
+	}
+
+	if p.maxMessageBytes <= 0 {
+		return nil, fmt.Errorf("maxMessageBytes must be positive, got %d", p.maxMessageBytes)
+	}
+
+	var messageChunks []*ProducerMessageChunks
+	var messages []*sarama.ProducerMessage
+	var packetSize int
+	var errs error
+
+	if p.partitionedByTraceID {
+		traces := batchpersignal.SplitTraces(td)
+		if len(traces) == 0 {
+			return []*ProducerMessageChunks{}, nil
+		}
+
+		for _, trace := range traces {
+			if trace.ResourceSpans().Len() == 0 ||
+				trace.ResourceSpans().At(0).ScopeSpans().Len() == 0 ||
+				trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().Len() == 0 {
+				continue
+			}
+
+			key := traceutil.TraceIDToHexOrEmptyString(trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).TraceID())
+			if err := p.processTrace(trace, topic, []byte(key), &messages, &messageChunks, &packetSize); err != nil {
+				errs = multierr.Append(errs, fmt.Errorf("failed to process trace with ID %s: %w", key, err))
+				continue
+			}
+		}
+	} else {
+		if err := p.processTrace(td, topic, nil, &messages, &messageChunks, &packetSize); err != nil {
+			errs = multierr.Append(errs, fmt.Errorf("failed to process batch: %w", err))
+		}
+	}
+
+	// Add any remaining messages as final chunk
+	if len(messages) > 0 {
+		messageChunks = append(messageChunks, &ProducerMessageChunks{messages})
+	}
+
+	return messageChunks, errs
 }
 
 func (p *pdataTracesMarshaler) Encoding() string {
@@ -173,4 +292,116 @@ func newPdataTracesMarshaler(marshaler ptrace.Marshaler, encoding string, partit
 		partitionedByTraceID: partitionedByTraceID,
 		maxMessageBytes:      maxMessageBytes,
 	}
+}
+
+// findSplitPoint uses binary search to find the maximum number of spans that can fit within maxMessageBytes
+func (p *pdataTracesMarshaler) findSplitPoint(trace ptrace.Traces) (int, error) {
+	if trace.ResourceSpans().Len() == 0 ||
+		trace.ResourceSpans().At(0).ScopeSpans().Len() == 0 {
+		return 0, fmt.Errorf("trace contains no spans")
+	}
+
+	spans := trace.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+	totalSpans := spans.Len()
+
+	if totalSpans == 0 {
+		return 0, fmt.Errorf("scope contains no spans")
+	}
+
+	// If single span, check if it fits
+	if totalSpans == 1 {
+		testTrace := ptrace.NewTraces()
+		trace.ResourceSpans().At(0).Resource().CopyTo(testTrace.ResourceSpans().AppendEmpty().Resource())
+		scope := testTrace.ResourceSpans().At(0).ScopeSpans().AppendEmpty()
+		trace.ResourceSpans().At(0).ScopeSpans().At(0).Scope().CopyTo(scope.Scope())
+		spans.At(0).CopyTo(scope.Spans().AppendEmpty())
+
+		bts, err := p.marshaler.MarshalTraces(testTrace)
+		if err != nil {
+			return 0, err
+		}
+
+		if (&sarama.ProducerMessage{Value: sarama.ByteEncoder(bts)}).ByteSize(2) <= p.maxMessageBytes {
+			return 1, nil
+		}
+		return 0, fmt.Errorf("single span exceeds maximum message size")
+	}
+
+	left := 1
+	right := totalSpans
+
+	// Binary search to find the largest number of spans that fits within maxMessageBytes
+	for left < right {
+		mid := (left + right + 1) / 2
+
+		testTrace := ptrace.NewTraces()
+		trace.ResourceSpans().At(0).Resource().CopyTo(testTrace.ResourceSpans().AppendEmpty().Resource())
+		scope := testTrace.ResourceSpans().At(0).ScopeSpans().AppendEmpty()
+		trace.ResourceSpans().At(0).ScopeSpans().At(0).Scope().CopyTo(scope.Scope())
+
+		for i := 0; i < mid; i++ {
+			spans.At(i).CopyTo(scope.Spans().AppendEmpty())
+		}
+
+		bts, err := p.marshaler.MarshalTraces(testTrace)
+		if err != nil {
+			return 0, err
+		}
+
+		msgSize := (&sarama.ProducerMessage{Value: sarama.ByteEncoder(bts)}).ByteSize(2)
+
+		if msgSize <= p.maxMessageBytes {
+			left = mid
+		} else {
+			right = mid - 1
+		}
+	}
+
+	if left == 0 {
+		return 0, fmt.Errorf("cannot find valid split point")
+	}
+
+	return left, nil
+}
+
+// splitTraceBySpans splits a trace into two parts based on span indices [0, splitPoint) and [splitPoint, end]
+func (p *pdataTracesMarshaler) splitTraceBySpans(trace ptrace.Traces, low, high int) (ptrace.Traces, ptrace.Traces) {
+	firstHalf := ptrace.NewTraces()
+	secondHalf := ptrace.NewTraces()
+
+	// Get the original resource spans
+	rSpans := trace.ResourceSpans()
+	if rSpans.Len() == 0 {
+		return firstHalf, secondHalf
+	}
+
+	// Copy resource to both traces
+	rSpans.At(0).Resource().CopyTo(firstHalf.ResourceSpans().AppendEmpty().Resource())
+	rSpans.At(0).Resource().CopyTo(secondHalf.ResourceSpans().AppendEmpty().Resource())
+
+	// For each scope spans in the original trace
+	originalScope := rSpans.At(0).ScopeSpans()
+	for i := 0; i < originalScope.Len(); i++ {
+		scope := originalScope.At(i)
+		spans := scope.Spans()
+
+		// Create scope spans in both halves
+		firstScope := firstHalf.ResourceSpans().At(0).ScopeSpans().AppendEmpty()
+		secondScope := secondHalf.ResourceSpans().At(0).ScopeSpans().AppendEmpty()
+
+		// Copy scope information
+		scope.Scope().CopyTo(firstScope.Scope())
+		scope.Scope().CopyTo(secondScope.Scope())
+
+		// Split spans between first and second half
+		for j := 0; j < spans.Len(); j++ {
+			if j < low || j >= high {
+				spans.At(j).CopyTo(secondScope.Spans().AppendEmpty())
+			} else {
+				spans.At(j).CopyTo(firstScope.Spans().AppendEmpty())
+			}
+		}
+	}
+
+	return firstHalf, secondHalf
 }

--- a/exporter/kafkaexporter/pdata_marshaler_test.go
+++ b/exporter/kafkaexporter/pdata_marshaler_test.go
@@ -1,0 +1,282 @@
+package kafkaexporter
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/ptrace"
+)
+
+func TestPdataTracesMarshaler_Marshal(t *testing.T) {
+	tests := []struct {
+		name                 string
+		maxMessageBytes      int
+		partitionedByTraceID bool
+		traces               ptrace.Traces
+		wantChunks           int
+		wantError            bool
+	}{
+		{
+			name:                 "empty_trace",
+			maxMessageBytes:      1000,
+			partitionedByTraceID: false,
+			traces:               ptrace.NewTraces(),
+			wantChunks:           0,
+			wantError:            false,
+		},
+		{
+			name:                 "single_small_trace",
+			maxMessageBytes:      1000,
+			partitionedByTraceID: false,
+			traces:               createTracesWithSize(1, 1, 10), // 1 resource, 1 span, small attributes
+			wantChunks:           1,
+			wantError:            false,
+		},
+		{
+			name:                 "single_large_trace_needs_splitting",
+			maxMessageBytes:      10000,
+			partitionedByTraceID: false,
+			traces:               createTracesWithSize(1, 10, 50), // 1 resource, 10 spans, larger attributes
+			wantChunks:           2,                               // Exact number depends on size
+			wantError:            false,
+		},
+		{
+			name:                 "multiple_traces_partitioned",
+			maxMessageBytes:      1000,
+			partitionedByTraceID: true,
+			traces:               createTracesWithMultipleTraceIDs(3, 1, 10), // 3 traces, 1 span each, small attributes
+			wantChunks:           1,
+			wantError:            false,
+		},
+		{
+			name:                 "oversized_single_span",
+			maxMessageBytes:      10,
+			partitionedByTraceID: false,
+			traces:               createTracesWithSize(1, 1, 1000), // 1 resource, 1 span, very large attributes
+			wantChunks:           0,
+			wantError:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marshaler := newPdataTracesMarshaler(
+				&ptrace.ProtoMarshaler{},
+				"proto",
+				tt.partitionedByTraceID,
+				tt.maxMessageBytes,
+			)
+
+			chunks, err := marshaler.Marshal(tt.traces, "test-topic")
+
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantChunks, len(chunks))
+
+			for _, chunk := range chunks {
+				for _, msg := range chunk.Messages {
+					assert.LessOrEqual(t, msg.ByteSize(2), tt.maxMessageBytes)
+				}
+			}
+		})
+	}
+}
+
+func TestPdataTracesMarshaler_FindSplitPoint(t *testing.T) {
+	tests := []struct {
+		name            string
+		maxMessageBytes int
+		trace           ptrace.Traces
+		wantSplitPoint  int
+		wantError       bool
+	}{
+		{
+			name:            "empty_trace",
+			maxMessageBytes: 1000,
+			trace:           ptrace.NewTraces(),
+			wantSplitPoint:  0,
+			wantError:       true,
+		},
+		{
+			name:            "single_span_fits",
+			maxMessageBytes: 1000,
+			trace:           createTracesWithSize(1, 1, 10),
+			wantSplitPoint:  1,
+			wantError:       false,
+		},
+		{
+			name:            "single_span_too_large",
+			maxMessageBytes: 10,
+			trace:           createTracesWithSize(1, 1, 1000),
+			wantSplitPoint:  0,
+			wantError:       true,
+		},
+		{
+			name:            "multiple_spans_partial_fit",
+			maxMessageBytes: 3000,
+			trace:           createTracesWithSize(1, 10, 100),
+			wantSplitPoint:  1,
+			wantError:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marshaler := newPdataTracesMarshaler(
+				&ptrace.ProtoMarshaler{},
+				"proto",
+				false,
+				tt.maxMessageBytes,
+			)
+
+			splitPoint, err := marshaler.(*pdataTracesMarshaler).findSplitPoint(tt.trace)
+
+			if tt.wantError {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.wantSplitPoint > 0 {
+				assert.Equal(t, tt.wantSplitPoint, splitPoint)
+			}
+
+			// Verify split point produces valid sized messages
+			protoMarshaler := &ptrace.ProtoMarshaler{}
+			if splitPoint > 0 {
+				firstHalf, _ := marshaler.(*pdataTracesMarshaler).splitTraceBySpans(tt.trace, 0, splitPoint)
+				bts, err := protoMarshaler.MarshalTraces(firstHalf)
+				require.NoError(t, err)
+
+				msgSize := (&sarama.ProducerMessage{
+					Value: sarama.ByteEncoder(bts),
+				}).ByteSize(2)
+
+				assert.LessOrEqual(t, msgSize, tt.maxMessageBytes)
+			}
+		})
+	}
+}
+
+func TestPdataTracesMarshaler_SplitTraceBySpans(t *testing.T) {
+	tests := []struct {
+		name       string
+		trace      ptrace.Traces
+		low        int
+		high       int
+		wantFirst  int
+		wantSecond int
+	}{
+		{
+			name:       "split_empty_trace",
+			trace:      ptrace.NewTraces(),
+			low:        0,
+			high:       0,
+			wantFirst:  0,
+			wantSecond: 0,
+		},
+		{
+			name:       "split_single_span",
+			trace:      createTracesWithSize(1, 1, 10),
+			low:        0,
+			high:       1,
+			wantFirst:  1,
+			wantSecond: 0,
+		},
+		{
+			name:       "split_multiple_spans",
+			trace:      createTracesWithSize(1, 10, 10),
+			low:        0,
+			high:       5,
+			wantFirst:  5,
+			wantSecond: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			marshaler := newPdataTracesMarshaler(
+				&ptrace.ProtoMarshaler{},
+				"proto",
+				false,
+				1000,
+			)
+
+			first, second := marshaler.(*pdataTracesMarshaler).splitTraceBySpans(tt.trace, tt.low, tt.high)
+
+			if tt.trace.ResourceSpans().Len() > 0 {
+				firstSpans := first.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+				secondSpans := second.ResourceSpans().At(0).ScopeSpans().At(0).Spans()
+				assert.Equal(t, tt.wantFirst, firstSpans.Len())
+				assert.Equal(t, tt.wantSecond, secondSpans.Len())
+
+				if tt.wantFirst > 0 {
+					assert.Equal(t,
+						tt.trace.ResourceSpans().At(0).Resource().Attributes().AsRaw(),
+						first.ResourceSpans().At(0).Resource().Attributes().AsRaw(),
+					)
+				}
+				if tt.wantSecond > 0 {
+					assert.Equal(t,
+						tt.trace.ResourceSpans().At(0).Resource().Attributes().AsRaw(),
+						second.ResourceSpans().At(0).Resource().Attributes().AsRaw(),
+					)
+				}
+			}
+		})
+	}
+}
+
+// Helper function
+
+func createTracesWithSize(resourceSpans, spansPerResource int, attrSize int) ptrace.Traces {
+	traces := ptrace.NewTraces()
+
+	for i := 0; i < resourceSpans; i++ {
+		rs := traces.ResourceSpans().AppendEmpty()
+		rs.Resource().Attributes().PutStr("resource", "resource-"+string(rune(i)))
+
+		ss := rs.ScopeSpans().AppendEmpty()
+		ss.Scope().SetName("scope-" + string(rune(i)))
+
+		for j := 0; j < spansPerResource; j++ {
+			span := ss.Spans().AppendEmpty()
+			span.SetName("span-" + string(rune(j)))
+			attrs := span.Attributes()
+			for k := 0; k < attrSize; k++ {
+				attrs.PutStr("key-"+string(rune(k)), "value-"+string(rune(k)))
+			}
+		}
+	}
+
+	return traces
+}
+
+func createTracesWithMultipleTraceIDs(numTraces, spansPerTrace, attrSize int) ptrace.Traces {
+	traces := ptrace.NewTraces()
+
+	for i := 0; i < numTraces; i++ {
+		rs := traces.ResourceSpans().AppendEmpty()
+		ss := rs.ScopeSpans().AppendEmpty()
+
+		for j := 0; j < spansPerTrace; j++ {
+			span := ss.Spans().AppendEmpty()
+			traceID := pcommon.TraceID([16]byte{byte(i), byte(j)})
+			span.SetTraceID(traceID)
+
+			attrs := span.Attributes()
+			for k := 0; k < attrSize; k++ {
+				attrs.PutStr("key-"+string(rune(k)), "value-"+string(rune(k)))
+			}
+		}
+	}
+
+	return traces
+}


### PR DESCRIPTION
Resolves #36982

Currently kafka exporter is not exporting messaging by adhering to the limits set by `MaxMessageBytes`, which can cause trace packets to drop when exceeding the limit.

This PR aims to fix that by effectively dividing the spans into chunks which have size under the limit set by `MaxMessageBytes`, and then individually send these chunks.