### PR TITLE
[exporter/elasticsearch] support both go-elasticsearch v7 & v8

### DIFF
--- a/.chloggen/elasticsearchexporter-goelasticsearchv8.yaml
+++ b/.chloggen/elasticsearchexporter-goelasticsearchv8.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Use go-elasticsearch/v8 by default, add config to fall back to v7
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [32454]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -228,6 +228,21 @@ The Elasticsearch Exporter's own telemetry settings for testing and debugging pu
   - `log_request_body` (default=false): Logs Elasticsearch client request body as a field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
   - `log_response_body` (default=false): Logs Elasticsearch client response body as a field in a log line at DEBUG level. It requires `service::telemetry::logs::level` to be set to `debug`. WARNING: Enabling this config may expose sensitive data.
 
+### Elasticsearch version compatibility
+
+The Elasticsearch Exporter uses the [go-elasticsearch](https://github.com/elastic/go-elasticsearch)
+client for communicating with Elasticsearch, and has forward compatibility with Elasticsearch 8+ by
+default. It is possible to enable best-effort support for older Elasticsearch 7.x versions by
+setting the Elasticsearch exporter config `version` to `7`.
+
+Certain features of the exporter, such as the `otel` mapping mode, may require newer versions of
+Elasticsearch. In general it is recommended to use the exporter with the most recent supported,
+as this will have the most in-depth testing.
+
+> [!NOTE]
+> See https://www.elastic.co/support/eol for Elasticsearch's End Of Life policy.
+> Versions prior to 7.17.x are no longer supported by Elastic.
+
 ## Exporting metrics
 
 Metrics support is currently in development.

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -230,12 +230,14 @@ The Elasticsearch Exporter's own telemetry settings for testing and debugging pu
 
 ### Elasticsearch version compatibility
 
-- `version` (default=8): Version of target Elasticsearch
-
 The Elasticsearch Exporter uses the [go-elasticsearch](https://github.com/elastic/go-elasticsearch)
 client for communicating with Elasticsearch, and has forward compatibility with Elasticsearch 8+ by
-default. It is possible to enable best-effort support for older Elasticsearch 7.x versions by
-setting the Elasticsearch exporter config `version` to `7`.
+default. Settings related to Elasticsearch version compatibility are:
+
+- `version` (default=8): Version of target Elasticsearch
+
+It is possible to enable best-effort support for older Elasticsearch 7.x versions by setting the
+Elasticsearch exporter config `version` to `7`.
 
 Certain features of the exporter, such as the `otel` mapping mode, may require newer versions of
 Elasticsearch. In general it is recommended to use the exporter with the most recent supported,

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -230,6 +230,8 @@ The Elasticsearch Exporter's own telemetry settings for testing and debugging pu
 
 ### Elasticsearch version compatibility
 
+- `version` (default=8): Version of target Elasticsearch
+
 The Elasticsearch Exporter uses the [go-elasticsearch](https://github.com/elastic/go-elasticsearch)
 client for communicating with Elasticsearch, and has forward compatibility with Elasticsearch 8+ by
 default. It is possible to enable best-effort support for older Elasticsearch 7.x versions by

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -78,6 +78,10 @@ type Config struct {
 	// If Batcher.Enabled is non-nil (i.e. batcher::enabled is specified),
 	// then the Flush will be ignored even if Batcher.Enabled is false.
 	Batcher BatcherConfig `mapstructure:"batcher"`
+
+	// Version holds the major version of Elasticsearch that the exporter
+	// will target: 7 or 8.
+	Version int `mapstructure:"version"`
 }
 
 // BatcherConfig holds configuration for exporterbatcher.
@@ -271,6 +275,11 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.Retry.MaxRetries < 0 {
 		return errors.New("retry::max_retries should be non-negative")
+	}
+	switch cfg.Version {
+	case 7, 8:
+	default:
+		return fmt.Errorf("version must be 7 or 8, got %d", cfg.Version)
 	}
 
 	return nil

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -120,6 +120,7 @@ func TestConfig(t *testing.T) {
 						MaxSizeItems: 0,
 					},
 				},
+				Version: 8,
 			},
 		},
 		{
@@ -191,6 +192,7 @@ func TestConfig(t *testing.T) {
 						MaxSizeItems: 0,
 					},
 				},
+				Version: 8,
 			},
 		},
 		{
@@ -262,6 +264,7 @@ func TestConfig(t *testing.T) {
 						MaxSizeItems: 0,
 					},
 				},
+				Version: 8,
 			},
 		},
 		{

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -1769,6 +1769,7 @@ func TestExporterBatcher(t *testing.T) {
 	exporter := newUnstartedTestLogsExporter(t, "http://testing.invalid", func(cfg *Config) {
 		cfg.Batcher = BatcherConfig{Enabled: &batcherEnabled}
 		cfg.Auth = &configauth.Authentication{AuthenticatorID: testauthID}
+		cfg.Retry.Enabled = false
 	})
 	err := exporter.Start(context.Background(), &mockHost{
 		extensions: map[component.ID]component.Component{

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -97,6 +97,7 @@ func createDefaultConfig() component.Config {
 			Bytes:    5e+6,
 			Interval: 30 * time.Second,
 		},
+		Version: 8,
 	}
 }
 

--- a/exporter/elasticsearchexporter/go.mod
+++ b/exporter/elasticsearchexporter/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/elastic/go-docappender/v2 v2.3.3
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
+	github.com/elastic/go-elasticsearch/v8 v8.17.0
 	github.com/elastic/go-structform v0.0.12
 	github.com/klauspost/compress v1.17.11
 	github.com/lestrrat-go/strftime v1.1.0
@@ -34,7 +35,6 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/elastic/elastic-transport-go/v8 v8.6.0 // indirect
-	github.com/elastic/go-elasticsearch/v8 v8.17.0 // indirect
 	github.com/elastic/go-sysinfo v1.7.1 // indirect
 	github.com/elastic/go-windows v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect


### PR DESCRIPTION
#### Description

Use go-elasticsearch/v8 (which is being actively developed) by default, and add a `version` configuration setting that can be set to `7` to use go-elasticsearch/v7.

(Note that I think it's worth having a discussion about whether this is worthwhile, since v8 will support 7.17.x, and older version of Elasticsearch are EOL. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32454#issuecomment-2588842642)

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/32454

#### Testing

TODO

#### Documentation

Updated README with a new section on Elasticsearch version compatibility.