### PR TITLE
[chore][exporter/doris] Fix lint on doris exporter

### DIFF
--- a/exporter/dorisexporter/exporter_common.go
+++ b/exporter/dorisexporter/exporter_common.go
@@ -124,7 +124,7 @@ type metric interface {
 	dMetricGauge | dMetricSum | dMetricHistogram | dMetricExponentialHistogram | dMetricSummary
 }
 
-func toJsonLines[T dLog | dTrace | metric](data []*T) ([]byte, error) {
+func toJSONLines[T dLog | dTrace | metric](data []*T) ([]byte, error) {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	for _, d := range data {

--- a/exporter/dorisexporter/exporter_common_test.go
+++ b/exporter/dorisexporter/exporter_common_test.go
@@ -63,7 +63,7 @@ func findRandomPort() (int, error) {
 }
 
 func TestToJsonLines(t *testing.T) {
-	logs, err := toJsonLines([]*dLog{
+	logs, err := toJSONLines([]*dLog{
 		{}, {},
 	})
 	require.NoError(t, err)

--- a/exporter/dorisexporter/exporter_logs.go
+++ b/exporter/dorisexporter/exporter_logs.go
@@ -122,7 +122,7 @@ func (e *logsExporter) pushLogData(ctx context.Context, ld plog.Logs) error {
 }
 
 func (e *logsExporter) pushLogDataInternal(ctx context.Context, logs []*dLog) error {
-	marshal, err := toJsonLines(logs)
+	marshal, err := toJSONLines(logs)
 	if err != nil {
 		return err
 	}

--- a/exporter/dorisexporter/exporter_traces.go
+++ b/exporter/dorisexporter/exporter_traces.go
@@ -180,7 +180,7 @@ func (e *tracesExporter) pushTraceData(ctx context.Context, td ptrace.Traces) er
 }
 
 func (e *tracesExporter) pushTraceDataInternal(ctx context.Context, traces []*dTrace) error {
-	marshal, err := toJsonLines(traces)
+	marshal, err := toJSONLines(traces)
 	if err != nil {
 		return err
 	}

--- a/exporter/dorisexporter/metrics_exponential_histogram.go
+++ b/exporter/dorisexporter/metrics_exponential_histogram.go
@@ -117,5 +117,5 @@ func (m *metricModelExponentialHistogram) size() int {
 }
 
 func (m *metricModelExponentialHistogram) bytes() ([]byte, error) {
-	return toJsonLines(m.data)
+	return toJSONLines(m.data)
 }

--- a/exporter/dorisexporter/metrics_gauge.go
+++ b/exporter/dorisexporter/metrics_gauge.go
@@ -83,5 +83,5 @@ func (m *metricModelGauge) size() int {
 }
 
 func (m *metricModelGauge) bytes() ([]byte, error) {
-	return toJsonLines(m.data)
+	return toJSONLines(m.data)
 }

--- a/exporter/dorisexporter/metrics_histogram.go
+++ b/exporter/dorisexporter/metrics_histogram.go
@@ -107,5 +107,5 @@ func (m *metricModelHistogram) size() int {
 }
 
 func (m *metricModelHistogram) bytes() ([]byte, error) {
-	return toJsonLines(m.data)
+	return toJSONLines(m.data)
 }

--- a/exporter/dorisexporter/metrics_sum.go
+++ b/exporter/dorisexporter/metrics_sum.go
@@ -87,5 +87,5 @@ func (m *metricModelSum) size() int {
 }
 
 func (m *metricModelSum) bytes() ([]byte, error) {
-	return toJsonLines(m.data)
+	return toJSONLines(m.data)
 }

--- a/exporter/dorisexporter/metrics_summary.go
+++ b/exporter/dorisexporter/metrics_summary.go
@@ -88,5 +88,5 @@ func (m *metricModelSummary) size() int {
 }
 
 func (m *metricModelSummary) bytes() ([]byte, error) {
-	return toJsonLines(m.data)
+	return toJSONLines(m.data)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix main that is failing because of linting issues.

This is due to a race condition between PRs #36912 and one of the recent PRs related to linters (the spelling one?). The error this fixes is
```
dorisexporter/exporter_common.go:127:6: var-naming: func toJsonLines should be toJSONLines (revive)
func toJsonLines[T dLog | dTrace | metric](data []*T) ([]byte, error) {
     ^
```