### PR TITLE
fix(azuremonitorexporter): Fix flushes on each single Span

### DIFF
--- a/.chloggen/fix_azure-monitor-exporter-flush-ddos.yaml
+++ b/.chloggen/fix_azure-monitor-exporter-flush-ddos.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix flushes on each single Span
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37214]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/azuremonitorexporter/azuremonitor_exporter.go
+++ b/exporter/azuremonitorexporter/azuremonitor_exporter.go
@@ -122,8 +122,6 @@ func (v *traceVisitor) visit(
 		v.exporter.transportChannel.Send(envelope)
 	}
 
-	// Flush the transport channel to force the telemetry to be sent
-	v.exporter.transportChannel.Flush()
 	v.processed++
 
 	return true
@@ -137,5 +135,11 @@ func (exporter *azureMonitorExporter) consumeTraces(_ context.Context, traceData
 
 	visitor := &traceVisitor{exporter: exporter}
 	accept(traceData, visitor)
+
+	// Flush the transport channel to force the telemetry to be sent
+	if visitor.processed > 0 {
+		exporter.transportChannel.Flush()
+	}
+
 	return visitor.err
 }


### PR DESCRIPTION
#### Description
This commit fixes AzureMonitorExporter issue when it calls Flush on each Span

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37214 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests updated or introduced new coverage to track number of calls to the Flush method

<!--Describe the documentation added.-->
#### Documentation
No documentation added

<!--Please delete paragraphs that you did not use before submitting.-->
