### PR TITLE
event client should honor access_token_passthrough

### DIFF
--- a/.chloggen/fix-signalfxexporter-honorpassthrough.yaml
+++ b/.chloggen/fix-signalfxexporter-honorpassthrough.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: 'signalfxexporter'
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: 'Honor access_token_passthrough config option for sending events'
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37102]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/exporter/signalfxexporter/eventclient.go
+++ b/exporter/signalfxexporter/eventclient.go
@@ -105,6 +105,11 @@ func (s *sfxEventClient) encodeBody(events []*sfxpb.Event) (bodyReader io.Reader
 }
 
 func (s *sfxEventClient) retrieveAccessToken(rl plog.ResourceLogs) string {
+	if !s.accessTokenPassthrough {
+		// Nothing to do if token is pass through not configured or resource is nil.
+		return ""
+	}
+
 	attrs := rl.Resource().Attributes()
 	if accessToken, ok := attrs.Get(splunk.SFxAccessTokenLabel); ok && accessToken.Type() == pcommon.ValueTypeStr {
 		return accessToken.Str()


### PR DESCRIPTION
#### Description
Similar to the metric client in the signalfxexporter, the event client should honor access_token_passthrough

