### PR TITLE
[chore] Add replace for `redisstorageextension` to `builder-config.yaml`

### DIFF
--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -509,3 +509,4 @@ replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/status => ../../pkg/status
   - github.com/open-telemetry/opentelemetry-collector-contrib/receiver/awss3receiver => ../../receiver/awss3receiver
   - github.com/open-telemetry/opentelemetry-collector-contrib/exporter/dorisexporter => ../../exporter/dorisexporter
+  - github.com/open-telemetry/opentelemetry-collector-contrib/extension/storage/redisstorageextension => ../../extension/storage/redisstorageextension


### PR DESCRIPTION
#### Description

A `replace` statement is missing in `cmd/otelcontribcol/builder-config.yaml` for the `redisstorageextension` component, which breaks releases. This PR fixes that.
