### PR TITLE
[chore] Remove flaky TestConfigString test in datasetexporter

### DIFF
--- a/exporter/datasetexporter/config_test.go
+++ b/exporter/datasetexporter/config_test.go
@@ -9,9 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"go.opentelemetry.io/collector/config/configretry"
 	"go.opentelemetry.io/collector/confmap"
-	"go.opentelemetry.io/collector/exporter/exporterhelper"
 )
 
 func TestConfigUnmarshalUnknownAttributes(t *testing.T) {
@@ -100,49 +98,6 @@ func TestConfigValidate(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestConfigString(t *testing.T) {
-	config := Config{
-		DatasetURL: "https://example.com",
-		APIKey:     "secret",
-		Debug:      true,
-		BufferSettings: BufferSettings{
-			MaxLifetime:    123,
-			PurgeOlderThan: 567,
-			GroupBy:        []string{"field1", "field2"},
-		},
-		TracesSettings: TracesSettings{
-			exportSettings: exportSettings{
-				ExportSeparator:            "TTT",
-				ExportDistinguishingSuffix: "UUU",
-			},
-		},
-		LogsSettings: LogsSettings{
-			ExportResourceInfo:             true,
-			ExportResourcePrefix:           "AAA",
-			ExportScopeInfo:                true,
-			ExportScopePrefix:              "BBB",
-			DecomposeComplexMessageField:   true,
-			DecomposedComplexMessagePrefix: "EEE",
-			exportSettings: exportSettings{
-				ExportSeparator:            "CCC",
-				ExportDistinguishingSuffix: "DDD",
-			},
-		},
-		ServerHostSettings: ServerHostSettings{
-			ServerHost:  "foo-bar",
-			UseHostName: false,
-		},
-		BackOffConfig:   configretry.NewDefaultBackOffConfig(),
-		QueueSettings:   exporterhelper.NewDefaultQueueConfig(),
-		TimeoutSettings: exporterhelper.NewDefaultTimeoutConfig(),
-	}
-
-	assert.Equal(t,
-		"DatasetURL: https://example.com; APIKey: [REDACTED] (6); Debug: true; BufferSettings: {MaxLifetime:123ns PurgeOlderThan:567ns GroupBy:[field1 field2] RetryInitialInterval:0s RetryMaxInterval:0s RetryMaxElapsedTime:0s RetryShutdownTimeout:0s MaxParallelOutgoing:0}; LogsSettings: {ExportResourceInfo:true ExportResourcePrefix:AAA ExportScopeInfo:true ExportScopePrefix:BBB DecomposeComplexMessageField:true DecomposedComplexMessagePrefix:EEE exportSettings:{ExportSeparator:CCC ExportDistinguishingSuffix:DDD}}; TracesSettings: {exportSettings:{ExportSeparator:TTT ExportDistinguishingSuffix:UUU}}; ServerHostSettings: {UseHostName:false ServerHost:foo-bar}; BackOffConfig: {Enabled:true InitialInterval:5s RandomizationFactor:0.5 Multiplier:1.5 MaxInterval:30s MaxElapsedTime:5m0s}; QueueSettings: {Enabled:true NumConsumers:10 QueueSize:1000 StorageID:<nil>}; TimeoutSettings: {Timeout:5s}",
-		config.String(),
-	)
 }
 
 func TestConfigUseProvidedExportResourceInfoValue(t *testing.T) {


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This test will break `contrib-test` in opentelemetry-collector repo when we add new features in exporter spec.
Removing this test as it seems not to be useful(only test string representation) and makes `contrib-test` flaky.
Link: https://github.com/open-telemetry/opentelemetry-collector/actions/runs/12786594498/job/35643968597

cc @bogdandrutu 
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relevant to https://github.com/open-telemetry/opentelemetry-collector/pull/12090

<!--Describe what testing was performed and which tests were added.-->
#### Testing
n/a

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->
