### PR TITLE
[googlecloudpubsubreceiver] add configs to specify credentials info

### DIFF
--- a/.chloggen/gcppubsubreceiver-add-credentials-config.yaml
+++ b/.chloggen/gcppubsubreceiver-add-credentials-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: googlecloudpubsubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add additional config to specify credentials to be used to connector to GCP PubSub
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37255]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/gcppubsubreceiver-add-credentials-config.yaml
+++ b/.chloggen/gcppubsubreceiver-add-credentials-config.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: googlecloudpubsubreceiver
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add additional config to specify credentials to be used to connector to GCP PubSub
+note: Add additional config to specify credentials to be used to connect to GCP PubSub
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [37255]

--- a/receiver/googlecloudpubsubreceiver/README.md
+++ b/receiver/googlecloudpubsubreceiver/README.md
@@ -30,6 +30,8 @@ The following configuration options are supported:
   or switching between [global and regional service endpoints](https://cloud.google.com/pubsub/docs/reference/service_apis_overview#service_endpoints).
 * `insecure` (Optional): allows performing “insecure” SSL connections and transfers, useful when connecting to a local
    emulator instance. Only has effect if Endpoint is not ""
+* `credentials_file_path` (Optional): Path to a credentials file to use to connect.
+* `credentials_json` (Optional): Credentials JSON to use to connect.
 
 ```yaml
 receivers:

--- a/receiver/googlecloudpubsubreceiver/config_test.go
+++ b/receiver/googlecloudpubsubreceiver/config_test.go
@@ -136,7 +136,7 @@ func TestConfigCredentialsValidation(t *testing.T) {
 	c := factory.CreateDefaultConfig().(*Config)
 	c.Subscription = "projects/my-project/subscriptions/my-subscription"
 
-	dummyCredentialsJSON := `{
+	dummyCredentialsJSON := `{ 
 		"type": "service_account",
 		"project_id": "my-project",
 		"private_key_id": "d41d8cd98f00b204e9800998ecf8427e",
@@ -148,7 +148,7 @@ func TestConfigCredentialsValidation(t *testing.T) {
 		"auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
 		"client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/my-project.iam.gserviceaccount.com",
 		"universe_domain": "googleapis.com"
-	  }`
+	  }` // #nosec G101 -- this is not real/functional credentials
 
 	c.CredentialsFilePath = "/home/service-principal-01ba5c7dde9b.json"
 	c.CredentialsJSON = ""

--- a/receiver/googlecloudpubsubreceiver/receiver.go
+++ b/receiver/googlecloudpubsubreceiver/receiver.go
@@ -84,6 +84,13 @@ func (receiver *pubsubReceiver) generateClientOptions() (copts []option.ClientOp
 			copts = append(copts, option.WithEndpoint(receiver.config.Endpoint))
 		}
 	}
+	if receiver.config.CredentialsFilePath != "" {
+		copts = append(copts, option.WithCredentialsFile(receiver.config.CredentialsFilePath))
+	}
+	if receiver.config.CredentialsJSON != "" {
+		copts = append(copts, option.WithCredentialsJSON([]byte(receiver.config.CredentialsJSON)))
+	}
+
 	return copts
 }
 
@@ -100,6 +107,7 @@ func (receiver *pubsubReceiver) Start(ctx context.Context, _ component.Host) err
 			startErr = fmt.Errorf("failed creating the gRPC client to Pubsub: %w", err)
 			return
 		}
+
 		receiver.client = client
 
 		err = receiver.createReceiverHandler(ctx)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Add 2 new configs to specify credentials information to be used by the client to connect to GCP PubSub.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

[Fixes](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37255)

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Manually tested locally, verifying the code does use the passed credentials to connect.

<!--Describe the documentation added.-->
#### Documentation

Added new configs to the README
<!--Please delete paragraphs that you did not use before submitting.-->
