### PR TITLE
[internal/filter] Add filterottl functions with additional options

### DIFF
--- a/internal/filter/filterottl/filter.go
+++ b/internal/filter/filterottl/filter.go
@@ -20,7 +20,12 @@ import (
 // The passed in functions should use the ottlspan.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlspan.TransformContext], error) {
-	parser, err := ottlspan.NewParser(functions, set)
+	return NewBoolExprForSpanWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForSpanWithOptions is like NewBoolExprForSpan, but with additional options.
+func NewBoolExprForSpanWithOptions(conditions []string, functions map[string]ottl.Factory[ottlspan.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottlspan.Option) (*ottl.ConditionSequence[ottlspan.TransformContext], error) {
+	parser, err := ottlspan.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +41,12 @@ func NewBoolExprForSpan(conditions []string, functions map[string]ottl.Factory[o
 // The passed in functions should use the ottlspanevent.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlspanevent.TransformContext], error) {
-	parser, err := ottlspanevent.NewParser(functions, set)
+	return NewBoolExprForSpanEventWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForSpanEventWithOptions is like NewBoolExprForSpanEvent, but with additional options.
+func NewBoolExprForSpanEventWithOptions(conditions []string, functions map[string]ottl.Factory[ottlspanevent.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottlspanevent.Option) (*ottl.ConditionSequence[ottlspanevent.TransformContext], error) {
+	parser, err := ottlspanevent.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -52,7 +62,12 @@ func NewBoolExprForSpanEvent(conditions []string, functions map[string]ottl.Fact
 // The passed in functions should use the ottlmetric.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlmetric.TransformContext], error) {
-	parser, err := ottlmetric.NewParser(functions, set)
+	return NewBoolExprForMetricWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForMetricWithOptions is like NewBoolExprForMetric, but with additional options.
+func NewBoolExprForMetricWithOptions(conditions []string, functions map[string]ottl.Factory[ottlmetric.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottlmetric.Option) (*ottl.ConditionSequence[ottlmetric.TransformContext], error) {
+	parser, err := ottlmetric.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +83,12 @@ func NewBoolExprForMetric(conditions []string, functions map[string]ottl.Factory
 // The passed in functions should use the ottldatapoint.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottldatapoint.TransformContext], error) {
-	parser, err := ottldatapoint.NewParser(functions, set)
+	return NewBoolExprForDataPointWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForDataPointWithOptions is like NewBoolExprForDataPoint, but with additional options.
+func NewBoolExprForDataPointWithOptions(conditions []string, functions map[string]ottl.Factory[ottldatapoint.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottldatapoint.Option) (*ottl.ConditionSequence[ottldatapoint.TransformContext], error) {
+	parser, err := ottldatapoint.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +104,12 @@ func NewBoolExprForDataPoint(conditions []string, functions map[string]ottl.Fact
 // The passed in functions should use the ottllog.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottllog.TransformContext], error) {
-	parser, err := ottllog.NewParser(functions, set)
+	return NewBoolExprForLogWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForLogWithOptions is like NewBoolExprForLog, but with additional options.
+func NewBoolExprForLogWithOptions(conditions []string, functions map[string]ottl.Factory[ottllog.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottllog.Option) (*ottl.ConditionSequence[ottllog.TransformContext], error) {
+	parser, err := ottllog.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +125,12 @@ func NewBoolExprForLog(conditions []string, functions map[string]ottl.Factory[ot
 // The passed in functions should use the ottlresource.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForResource(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlresource.TransformContext], error) {
-	parser, err := ottlresource.NewParser(functions, set)
+	return NewBoolExprForResourceWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForResourceWithOptions is like NewBoolExprForResource, but with additional options.
+func NewBoolExprForResourceWithOptions(conditions []string, functions map[string]ottl.Factory[ottlresource.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottlresource.Option) (*ottl.ConditionSequence[ottlresource.TransformContext], error) {
+	parser, err := ottlresource.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
 	}
@@ -116,7 +146,12 @@ func NewBoolExprForResource(conditions []string, functions map[string]ottl.Facto
 // The passed in functions should use the ottlresource.TransformContext.
 // If a function named `match` is not present in the function map it will be added automatically so that parsing works as expected
 func NewBoolExprForScope(conditions []string, functions map[string]ottl.Factory[ottlscope.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings) (*ottl.ConditionSequence[ottlscope.TransformContext], error) {
-	parser, err := ottlscope.NewParser(functions, set)
+	return NewBoolExprForScopeWithOptions(conditions, functions, errorMode, set, nil)
+}
+
+// NewBoolExprForScopeWithOptions is like NewBoolExprForScope, but with additional options.
+func NewBoolExprForScopeWithOptions(conditions []string, functions map[string]ottl.Factory[ottlscope.TransformContext], errorMode ottl.ErrorMode, set component.TelemetrySettings, parserOptions []ottlscope.Option) (*ottl.ConditionSequence[ottlscope.TransformContext], error) {
+	parser, err := ottlscope.NewParser(functions, set, parserOptions...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/filter/filterottl/filter_test.go
+++ b/internal/filter/filterottl/filter_test.go
@@ -62,6 +62,17 @@ func Test_NewBoolExprForSpan(t *testing.T) {
 	}
 }
 
+func Test_NewBoolExprForSpanWithOptions(t *testing.T) {
+	_, err := NewBoolExprForSpanWithOptions(
+		[]string{`span.name == "foo"`},
+		StandardSpanFuncs(),
+		ottl.PropagateError,
+		componenttest.NewNopTelemetrySettings(),
+		[]ottlspan.Option{ottlspan.EnablePathContextNames()},
+	)
+	assert.NoError(t, err)
+}
+
 func Test_NewBoolExprForSpanEvent(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -102,6 +113,17 @@ func Test_NewBoolExprForSpanEvent(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func Test_NewBoolExprForSpanEventWithOptions(t *testing.T) {
+	_, err := NewBoolExprForSpanEventWithOptions(
+		[]string{`spanevent.name == "foo"`},
+		StandardSpanEventFuncs(),
+		ottl.PropagateError,
+		componenttest.NewNopTelemetrySettings(),
+		[]ottlspanevent.Option{ottlspanevent.EnablePathContextNames()},
+	)
+	assert.NoError(t, err)
 }
 
 func Test_NewBoolExprForMetric(t *testing.T) {
@@ -146,6 +168,17 @@ func Test_NewBoolExprForMetric(t *testing.T) {
 	}
 }
 
+func Test_NewBoolExprForMetricWithOptions(t *testing.T) {
+	_, err := NewBoolExprForMetricWithOptions(
+		[]string{`metric.name == "foo"`},
+		StandardMetricFuncs(),
+		ottl.PropagateError,
+		componenttest.NewNopTelemetrySettings(),
+		[]ottlmetric.Option{ottlmetric.EnablePathContextNames()},
+	)
+	assert.NoError(t, err)
+}
+
 func Test_NewBoolExprForDataPoint(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -186,6 +219,17 @@ func Test_NewBoolExprForDataPoint(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func Test_NewBoolExprForDataPointWithOptions(t *testing.T) {
+	_, err := NewBoolExprForDataPointWithOptions(
+		[]string{"datapoint.count > 0"},
+		StandardDataPointFuncs(),
+		ottl.PropagateError,
+		componenttest.NewNopTelemetrySettings(),
+		[]ottldatapoint.Option{ottldatapoint.EnablePathContextNames()},
+	)
+	assert.NoError(t, err)
 }
 
 func Test_NewBoolExprForLog(t *testing.T) {
@@ -230,6 +274,17 @@ func Test_NewBoolExprForLog(t *testing.T) {
 	}
 }
 
+func Test_NewBoolExprForLogWithOptions(t *testing.T) {
+	_, err := NewBoolExprForLogWithOptions(
+		[]string{`log.body != ""`},
+		StandardLogFuncs(),
+		ottl.PropagateError,
+		componenttest.NewNopTelemetrySettings(),
+		[]ottllog.Option{ottllog.EnablePathContextNames()},
+	)
+	assert.NoError(t, err)
+}
+
 func Test_NewBoolExprForResource(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -270,6 +325,17 @@ func Test_NewBoolExprForResource(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func Test_NewBoolExprForResourceWithOptions(t *testing.T) {
+	_, err := NewBoolExprForResourceWithOptions(
+		[]string{`resource.dropped_attributes_count == 0`},
+		StandardResourceFuncs(),
+		ottl.PropagateError,
+		componenttest.NewNopTelemetrySettings(),
+		[]ottlresource.Option{ottlresource.EnablePathContextNames()},
+	)
+	assert.NoError(t, err)
 }
 
 func Test_NewBoolExprForScope(t *testing.T) {
@@ -320,4 +386,15 @@ func Test_NewBoolExprForScope(t *testing.T) {
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}
+}
+
+func Test_NewBoolExprForScopeWithOptions(t *testing.T) {
+	_, err := NewBoolExprForScopeWithOptions(
+		[]string{`scope.name != ""`},
+		StandardScopeFuncs(),
+		ottl.PropagateError,
+		componenttest.NewNopTelemetrySettings(),
+		[]ottlscope.Option{ottlscope.EnablePathContextNames()},
+	)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The `transformprocessor` is currently using the `internal/filter/filterottl` to create `conditions` expressions. In order to support path's with context prefix, it needs to configure the underline `ottl.Parser` using their `EnablePathContextNames` options. This PR changes this internal API adding new functions that accepts the parsers options as argument.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29017

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests

<!--Please delete paragraphs that you did not use before submitting.-->
