### PR TITLE
[processor/logdedup] fix config validation not working

### DIFF
--- a/.chloggen/logdedupprocessor-config-validate.yaml
+++ b/.chloggen/logdedupprocessor-config-validate.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: logdedupprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix config validation not working when creating a processor.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37278]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/logdedupprocessor/factory.go
+++ b/processor/logdedupprocessor/factory.go
@@ -32,6 +32,10 @@ func createLogsProcessor(_ context.Context, settings processor.Settings, cfg com
 		return nil, fmt.Errorf("invalid config type: %+v", cfg)
 	}
 
+	if err := processorCfg.Validate(); err != nil {
+		return nil, err
+	}
+
 	processor, err := newProcessor(processorCfg, consumer, settings)
 	if err != nil {
 		return nil, fmt.Errorf("error creating processor: %w", err)

--- a/processor/logdedupprocessor/processor_test.go
+++ b/processor/logdedupprocessor/processor_test.go
@@ -308,3 +308,24 @@ func TestProcessorConsumeMultipleConditions(t *testing.T) {
 	err = p.Shutdown(context.Background())
 	require.NoError(t, err)
 }
+
+func TestProcessorConfigValidate(t *testing.T) {
+	t.Parallel()
+	invalidCfg := &Config{
+		LogCountAttribute: defaultLogCountAttribute,
+		Interval:          -1,
+		Timezone:          "",
+	}
+
+	_, err := createLogsProcessor(context.Background(), processortest.NewNopSettings(), invalidCfg, consumertest.NewNop())
+	require.Error(t, err)
+
+	validCfg := &Config{
+		LogCountAttribute: defaultLogCountAttribute,
+		Interval:          defaultInterval,
+		Timezone:          defaultTimezone,
+	}
+
+	_, err = createLogsProcessor(context.Background(), processortest.NewNopSettings(), validCfg, consumertest.NewNop())
+	require.NoError(t, err)
+}


### PR DESCRIPTION
#### Description

The Config struct has a Validate method but it is only used in tests.
Ensure we validate the configuration when creating the processor.
