### PR TITLE
[githubgen] Deprecate githubgen in favor of opentelemetry-go-build-tools

### DIFF
--- a/.chloggen/deprecate_githubgen.yaml
+++ b/.chloggen/deprecate_githubgen.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: githubgen
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate githubgen in this repository
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37294]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  githubgen has moved to opentelemetry-go-build-tools. Please change your scripts to use this new location.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/githubgen/README.md
+++ b/cmd/githubgen/README.md
@@ -1,3 +1,7 @@
+:warn: This executable has moved to [opentelemetry-go-build-tools](Deprecated: use https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/githubgen).
+
+This code is deprecated and will be removed soon. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37294.
+
 # githubgen
 
 This executable is used to generate the `.github/CODEOWNERS` and `.github/ALLOWLIST` files.

--- a/cmd/githubgen/go.mod
+++ b/cmd/githubgen/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: use https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/githubgen
 module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/githubgen
 
 go 1.22.0

--- a/cmd/githubgen/main.go
+++ b/cmd/githubgen/main.go
@@ -1,6 +1,7 @@
 // Copyright The OpenTelemetry Authors
 // SPDX-License-Identifier: Apache-2.0
 
+// Deprecated: use https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/githubgen
 package main
 
 import (


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Deprecates githubgen in favor of the new location of this code under opentelemetry-go-build-tools

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to #37294 
