### PR TITLE
[chore] fieldalignment for internal/splunk

### DIFF
--- a/exporter/splunkhecexporter/client_test.go
+++ b/exporter/splunkhecexporter/client_test.go
@@ -533,7 +533,7 @@ func TestReceiveTracesBatches(t *testing.T) {
 						z.Close()
 						require.NoError(t, err)
 					}
-					timeStr := fmt.Sprintf(`"time":%d,`, i+1)
+					timeStr := fmt.Sprintf(`"time":%d}`, i+1)
 					if strings.Contains(string(batchBody), timeStr) {
 						assert.False(t, eventFound, "span event %d found in multiple batches", i)
 						eventFound = true

--- a/internal/splunk/common.go
+++ b/internal/splunk/common.go
@@ -48,13 +48,20 @@ type AccessTokenPassthroughConfig struct {
 
 // Event represents a metric in Splunk HEC format
 type Event struct {
-	Time       float64        `json:"time,omitempty"`       // optional epoch time - set to zero if the event timestamp is missing or unknown (will be added at indexing time)
-	Host       string         `json:"host"`                 // hostname
-	Source     string         `json:"source,omitempty"`     // optional description of the source of the event; typically the app's name
-	SourceType string         `json:"sourcetype,omitempty"` // optional name of a Splunk parsing configuration; this is usually inferred by Splunk
-	Index      string         `json:"index,omitempty"`      // optional name of the Splunk index to store the event in; not required if the token has a default index set in Splunk
-	Event      any            `json:"event"`                // type of event: set to "metric" or nil if the event represents a metric, or is the payload of the event.
-	Fields     map[string]any `json:"fields,omitempty"`     // dimensions and metric data
+	// type of event: set to "metric" or nil if the event represents a metric, or is the payload of the event.
+	Event any `json:"event"`
+	// dimensions and metric data
+	Fields map[string]any `json:"fields,omitempty"`
+	// hostname
+	Host string `json:"host"`
+	// optional description of the source of the event; typically the app's name
+	Source string `json:"source,omitempty"`
+	// optional name of a Splunk parsing configuration; this is usually inferred by Splunk
+	SourceType string `json:"sourcetype,omitempty"`
+	// optional name of the Splunk index to store the event in; not required if the token has a default index set in Splunk
+	Index string `json:"index,omitempty"`
+	// optional epoch time - set to zero if the event timestamp is missing or unknown (will be added at indexing time)
+	Time float64 `json:"time,omitempty"`
 }
 
 // IsMetric returns true if the Splunk event is a metric.
@@ -93,12 +100,12 @@ func (e *Event) GetMetricValues() map[string]any {
 func (e *Event) UnmarshalJSON(b []byte) error {
 	rawEvent := struct {
 		Time       any            `json:"time,omitempty"`
+		Event      any            `json:"event"`
+		Fields     map[string]any `json:"fields,omitempty"`
 		Host       string         `json:"host"`
 		Source     string         `json:"source,omitempty"`
 		SourceType string         `json:"sourcetype,omitempty"`
 		Index      string         `json:"index,omitempty"`
-		Event      any            `json:"event"`
-		Fields     map[string]any `json:"fields,omitempty"`
 	}{}
 	err := json.Unmarshal(b, &rawEvent)
 	if err != nil {


### PR DESCRIPTION
```
opentelemetry-collector-contrib/internal/splunk/common.go:50:12: struct with 96 pointer bytes could be 80
opentelemetry-collector-contrib/internal/splunk/common.go:94:14: struct with 104 pointer bytes could be 96
```