### PR TITLE
[chore] re-enable loopclosure, a noop with 1.22

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -75,7 +75,6 @@ linters-settings:
     # TODO: Enable this and fix the alignment issues.
     disable:
       - fieldalignment
-      - loopclosure
 
   revive:
     # minimal confidence for issues, default is 0.8


### PR DESCRIPTION
It doesn't appear disabling this linter is necessary anymore. 