### PR TITLE
[chore] remove gosec exclusion rule for G402

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -223,9 +223,6 @@ issues:
     - text: "G404:"
       linters:
         - gosec
-    - text: "G402:"
-      linters:
-        - gosec
     - text: "G115:"
       linters:
         - gosec


### PR DESCRIPTION
Check if we are still hitting this gosec rule.