### PR TITLE
[chore] remove outdated comment

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -219,7 +219,6 @@ linters:
 issues:
   # Excluding configuration per-path, per-linter, per-text and per-source
   exclude-rules:
-    # Exclude some linters from running on tests files.
     - text: "G404:"
       linters:
         - gosec


### PR DESCRIPTION
This comment says that the rule exclusions are only applying to test files, but that doesn't appear to be the case as no selection is made over file types. I offer to delete that comment as outdated.