### PR TITLE
[extension/oauth2clientauth] Add Token expiry buffer for oauth2clientauthextension

### DIFF
--- a/.chloggen/oauth2-expiry-buffer.yaml
+++ b/.chloggen/oauth2-expiry-buffer.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: extension/oauth2clientauth
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `expiry_buffer` config to `oauth2client` extension, allowing token refresh before expiration with a default buffer of 5 minutes.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35148]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - Prevents authentication failures by refreshing the token early.
+  - The default expiry buffer is set to 5 minutes, and users can adjust it as needed.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/extension/oauth2clientauthextension/README.md
+++ b/extension/oauth2clientauthextension/README.md
@@ -38,6 +38,8 @@ extensions:
       key_file: keyfile
     # timeout for the token client
     timeout: 2s
+    # buffer time before token expiry to refresh
+    expiry_buffer: 10s
     
 receivers:
   hostmetrics:
@@ -84,5 +86,6 @@ Following are the configuration fields
 - [**scopes**](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3) - **Optional** optional requested permissions associated for the client.
 - [**timeout**](https://golang.org/src/net/http/client.go#L90) -  **Optional** specifies the timeout on the underlying client to authorization server for fetching the tokens (initial and while refreshing).
   This is optional and not setting this configuration implies there is no timeout on the client.
+- **expiry_buffer** -  **Optional** Specifies the time buffer to refresh the access token before it expires, preventing authentication failures due to token expiration. The default value is 5m.
 
 For more information on client side TLS settings, see [configtls README](https://github.com/open-telemetry/opentelemetry-collector/tree/main/config/configtls).

--- a/extension/oauth2clientauthextension/clientcredentialsconfig.go
+++ b/extension/oauth2clientauthextension/clientcredentialsconfig.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"go.uber.org/multierr"
 	"golang.org/x/oauth2"
@@ -36,6 +37,7 @@ type clientCredentialsConfig struct {
 
 	ClientIDFile     string
 	ClientSecretFile string
+	ExpiryBuffer     time.Duration
 }
 
 type clientCredentialsTokenSource struct {
@@ -90,7 +92,7 @@ func (c *clientCredentialsConfig) createConfig() (*clientcredentials.Config, err
 }
 
 func (c *clientCredentialsConfig) TokenSource(ctx context.Context) oauth2.TokenSource {
-	return oauth2.ReuseTokenSource(nil, clientCredentialsTokenSource{ctx: ctx, config: c})
+	return oauth2.ReuseTokenSourceWithExpiry(nil, clientCredentialsTokenSource{ctx: ctx, config: c}, c.ExpiryBuffer)
 }
 
 func (ts clientCredentialsTokenSource) Token() (*oauth2.Token, error) {

--- a/extension/oauth2clientauthextension/config.go
+++ b/extension/oauth2clientauthextension/config.go
@@ -53,6 +53,9 @@ type Config struct {
 	// Timeout parameter configures `http.Client.Timeout` for the underneath client to authorization
 	// server while fetching and refreshing tokens.
 	Timeout time.Duration `mapstructure:"timeout,omitempty"`
+
+	// ExpiryBuffer specifies the time buffer before token expiry to refresh it.
+	ExpiryBuffer time.Duration `mapstructure:"expiry_buffer,omitempty"`
 }
 
 var _ component.Config = (*Config)(nil)

--- a/extension/oauth2clientauthextension/config_test.go
+++ b/extension/oauth2clientauthextension/config_test.go
@@ -35,6 +35,7 @@ func TestLoadConfig(t *testing.T) {
 				Scopes:         []string{"api.metrics"},
 				TokenURL:       "https://example.com/oauth2/default/v1/token",
 				Timeout:        time.Second,
+				ExpiryBuffer:   5 * time.Minute,
 			},
 		},
 		{
@@ -55,6 +56,7 @@ func TestLoadConfig(t *testing.T) {
 					InsecureSkipVerify: false,
 					ServerName:         "",
 				},
+				ExpiryBuffer: 15 * time.Second,
 			},
 		},
 		{

--- a/extension/oauth2clientauthextension/extension.go
+++ b/extension/oauth2clientauthextension/extension.go
@@ -55,6 +55,7 @@ func newClientAuthenticator(cfg *Config, logger *zap.Logger) (*clientAuthenticat
 			},
 			ClientIDFile:     cfg.ClientIDFile,
 			ClientSecretFile: cfg.ClientSecretFile,
+			ExpiryBuffer:     cfg.ExpiryBuffer,
 		},
 		logger: logger,
 		client: &http.Client{

--- a/extension/oauth2clientauthextension/extension_test.go
+++ b/extension/oauth2clientauthextension/extension_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -42,6 +43,7 @@ func TestOAuthClientSettings(t *testing.T) {
 				TokenURL:       "https://example.com/v1/token",
 				Scopes:         []string{"resource.read"},
 				Timeout:        2,
+				ExpiryBuffer:   10 * time.Second,
 				TLSSetting: configtls.ClientConfig{
 					Config: configtls.Config{
 						CAFile:   testCAFile,
@@ -63,6 +65,7 @@ func TestOAuthClientSettings(t *testing.T) {
 				TokenURL:     "https://example.com/v1/token",
 				Scopes:       []string{"resource.read"},
 				Timeout:      2,
+				ExpiryBuffer: 15 * time.Second,
 				TLSSetting: configtls.ClientConfig{
 					Config: configtls.Config{
 						CAFile:   testCAFile,
@@ -91,6 +94,7 @@ func TestOAuthClientSettings(t *testing.T) {
 			assert.EqualValues(t, test.settings.ClientSecret, rc.clientCredentials.ClientSecret)
 			assert.Equal(t, test.settings.ClientID, rc.clientCredentials.ClientID)
 			assert.Equal(t, test.settings.Timeout, rc.client.Timeout)
+			assert.Equal(t, test.settings.ExpiryBuffer, rc.clientCredentials.ExpiryBuffer)
 			assert.Equal(t, test.settings.EndpointParams, rc.clientCredentials.EndpointParams)
 
 			// test tls settings

--- a/extension/oauth2clientauthextension/factory.go
+++ b/extension/oauth2clientauthextension/factory.go
@@ -5,6 +5,7 @@ package oauth2clientauthextension // import "github.com/open-telemetry/opentelem
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/extension"
@@ -24,7 +25,9 @@ func NewFactory() extension.Factory {
 }
 
 func createDefaultConfig() component.Config {
-	return &Config{}
+	return &Config{
+		ExpiryBuffer: 5 * time.Minute,
+	}
 }
 
 func createExtension(_ context.Context, set extension.Settings, cfg component.Config) (extension.Extension, error) {

--- a/extension/oauth2clientauthextension/factory_test.go
+++ b/extension/oauth2clientauthextension/factory_test.go
@@ -6,6 +6,7 @@ package oauth2clientauthextension
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/component/componenttest"
@@ -14,7 +15,9 @@ import (
 
 func TestCreateDefaultConfig(t *testing.T) {
 	// prepare and test
-	expected := &Config{}
+	expected := &Config{
+		ExpiryBuffer: 5 * time.Minute,
+	}
 
 	// test
 	cfg := createDefaultConfig()

--- a/extension/oauth2clientauthextension/testdata/config.yaml
+++ b/extension/oauth2clientauthextension/testdata/config.yaml
@@ -13,6 +13,7 @@ oauth2client/withtls:
   token_url: https://example2.com/oauth2/default/v1/token
   scopes: ["api.metrics"]
   timeout: 1s
+  expiry_buffer: 15s
   # tls settings for the token client
   tls:
     insecure: true


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds an expiry_buffer config to the oauth2client extension, allowing token refresh before expiration. The default buffer is set to 5 m, preventing authentication failures due to token expiration.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #35148 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

passes tests.

<!--Describe the documentation added.-->
#### Documentation

The README has been updated to include the expiry_buffer config option, with instructions on how to use it and its default value.

<!--Please delete paragraphs that you did not use before submitting.-->
