### PR TITLE
[cmd/opampsupervisor] report own metrics via OTLP

### DIFF
--- a/.chloggen/codeboten_opampsupervisor-emit-otlp.yaml
+++ b/.chloggen/codeboten_opampsupervisor-emit-otlp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: report own metrics via OTLP instead of prometheus receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37346]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -364,7 +364,6 @@ func Test_onMessage(t *testing.T) {
 		require.Equal(t, newID, s.persistentState.InstanceID)
 		t.Log(s.cfgState.Load())
 		mergedCfg := s.cfgState.Load().(*configState).mergedConfig
-		require.Contains(t, mergedCfg, "prometheus/own_metrics")
 		require.Contains(t, mergedCfg, newID.String())
 		require.Contains(t, mergedCfg, "runtime.type: test")
 	})
@@ -1137,8 +1136,8 @@ service:
         - periodic:
             exporter:
               otlp:
-			    protocol: http/protobuf
-				endpoint: "localhost"
+                protocol: http/protobuf
+                endpoint: localhost
 `
 
 		assert.True(t, configChanged)
@@ -1198,10 +1197,7 @@ func TestSupervisor_loadAndWriteInitialMergedConfig(t *testing.T) {
   debug/remote:
 `
 
-		const expectedMergedConfig = `exporters:
-    otlphttp/own_metrics:
-        metrics_endpoint: localhost
-extensions:
+		const expectedMergedConfig = `extensions:
     health_check:
         endpoint: ""
     opamp:
@@ -1215,30 +1211,20 @@ extensions:
                     insecure: true
 receiver:
     debug/remote: null
-receivers:
-    prometheus/own_metrics:
-        config:
-            scrape_configs:
-                - job_name: otel-collector
-                  scrape_interval: 10s
-                  static_configs:
-                    - targets:
-                        - 0.0.0.0:55555
 service:
     extensions:
         - health_check
         - opamp
-    pipelines:
-        metrics/own_metrics:
-            exporters:
-                - otlphttp/own_metrics
-            receivers:
-                - prometheus/own_metrics
     telemetry:
         logs:
             encoding: json
         metrics:
-            address: :55555
+            readers:
+                - periodic:
+                    exporter:
+                        otlp:
+                            endpoint: localhost
+                            protocol: http/protobuf
         resource:
             service.name: otelcol
 `

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -1129,27 +1129,16 @@ func TestSupervisor_setupOwnMetrics(t *testing.T) {
 			DestinationEndpoint: "localhost",
 		})
 
-		expectedOwnMetricsSection := `receivers:
-  # Collect own metrics
-  prometheus/own_metrics:
-    config:
-      scrape_configs:
-        - job_name: 'otel-collector'
-          scrape_interval: 10s
-          static_configs:
-            - targets: ['0.0.0.0:55555']  
-exporters:
-  otlphttp/own_metrics:
-    metrics_endpoint: "localhost"
-
+		expectedOwnMetricsSection := `
 service:
   telemetry:
     metrics:
-      address: ":55555"
-  pipelines:
-    metrics/own_metrics:
-      receivers: [prometheus/own_metrics]
-      exporters: [otlphttp/own_metrics]
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+			    protocol: http/protobuf
+				endpoint: "localhost"
 `
 
 		assert.True(t, configChanged)

--- a/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
@@ -1,21 +1,10 @@
-receivers:
-  # Collect own metrics
-  prometheus/own_metrics:
-    config:
-      scrape_configs:
-        - job_name: 'otel-collector'
-          scrape_interval: 10s
-          static_configs:
-            - targets: ['0.0.0.0:{{.PrometheusPort}}']  
-exporters:
-  otlphttp/own_metrics:
-    metrics_endpoint: "{{.MetricsEndpoint}}"
 
 service:
   telemetry:
     metrics:
-      address: ":{{.PrometheusPort}}"
-  pipelines:
-    metrics/own_metrics:
-      receivers: [prometheus/own_metrics]
-      exporters: [otlphttp/own_metrics]
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: {{.MetricsEndpoint}}


### PR DESCRIPTION
#### Description

This updates the configuration generated by the opampsupervisor to emit metrics using the OTLP exporter directly, rather than configuring a prom receiver.


#### Link to tracking issue
Fixes #37345

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
