### PR TITLE
[wip][cmd/opampsupervisor] add ability to report own traces/logs

### DIFF
--- a/.chloggen/codeboten_add-support-for-headers.yaml
+++ b/.chloggen/codeboten_add-support-for-headers.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: add support for headers configuration for reporting own telemetry
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37353]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/codeboten_opampsupervisor-emit-otlp.yaml
+++ b/.chloggen/codeboten_opampsupervisor-emit-otlp.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: report own metrics via OTLP instead of prometheus receiver
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37346]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/examples/supervisor_darwin.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_darwin.yaml
@@ -9,6 +9,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/examples/supervisor_linux.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_linux.yaml
@@ -9,6 +9,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/examples/supervisor_windows.yaml
+++ b/cmd/opampsupervisor/examples/supervisor_windows.yaml
@@ -9,6 +9,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/specification/README.md
+++ b/cmd/opampsupervisor/specification/README.md
@@ -102,6 +102,10 @@ capabilities:
   # the Server.
   reports_own_logs: # true if unspecified
   
+  # The Collector will report own traces to the destination specified by
+  # the Server.
+  reports_own_traces: # true if unspecified
+  
   # The Collector will accept connections settings for exporters
   # from the Server.
   accepts_other_connection_settings: # false if unspecified

--- a/cmd/opampsupervisor/supervisor/config/config.go
+++ b/cmd/opampsupervisor/supervisor/config/config.go
@@ -93,6 +93,8 @@ type Capabilities struct {
 	AcceptsOpAMPConnectionSettings bool `mapstructure:"accepts_opamp_connection_settings"`
 	ReportsEffectiveConfig         bool `mapstructure:"reports_effective_config"`
 	ReportsOwnMetrics              bool `mapstructure:"reports_own_metrics"`
+	ReportsOwnLogs                 bool `mapstructure:"reports_own_logs"`
+	ReportsOwnTraces               bool `mapstructure:"reports_own_traces"`
 	ReportsHealth                  bool `mapstructure:"reports_health"`
 	ReportsRemoteConfig            bool `mapstructure:"reports_remote_config"`
 }
@@ -110,6 +112,14 @@ func (c Capabilities) SupportedCapabilities() protobufs.AgentCapabilities {
 
 	if c.ReportsOwnMetrics {
 		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics
+	}
+
+	if c.ReportsOwnLogs {
+		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnLogs
+	}
+
+	if c.ReportsOwnTraces {
+		supportedCapabilities |= protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnTraces
 	}
 
 	if c.AcceptsRemoteConfig {
@@ -243,6 +253,8 @@ func DefaultSupervisor() Supervisor {
 			AcceptsOpAMPConnectionSettings: false,
 			ReportsEffectiveConfig:         true,
 			ReportsOwnMetrics:              true,
+			ReportsOwnLogs:                 true,
+			ReportsOwnTraces:               true,
 			ReportsHealth:                  true,
 			ReportsRemoteConfig:            false,
 		},

--- a/cmd/opampsupervisor/supervisor/config/config_test.go
+++ b/cmd/opampsupervisor/supervisor/config/config_test.go
@@ -463,6 +463,8 @@ func TestCapabilities_SupportedCapabilities(t *testing.T) {
 			capabilities: DefaultSupervisor().Capabilities,
 			expectedAgentCapabilities: protobufs.AgentCapabilities_AgentCapabilities_ReportsStatus |
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics |
+				protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnLogs |
+				protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnTraces |
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig |
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsHealth,
 		},
@@ -479,6 +481,8 @@ func TestCapabilities_SupportedCapabilities(t *testing.T) {
 				AcceptsOpAMPConnectionSettings: true,
 				ReportsEffectiveConfig:         true,
 				ReportsOwnMetrics:              true,
+				ReportsOwnLogs:                 true,
+				ReportsOwnTraces:               true,
 				ReportsHealth:                  true,
 				ReportsRemoteConfig:            true,
 			},
@@ -486,6 +490,8 @@ func TestCapabilities_SupportedCapabilities(t *testing.T) {
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsEffectiveConfig |
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsHealth |
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnMetrics |
+				protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnLogs |
+				protobufs.AgentCapabilities_AgentCapabilities_ReportsOwnTraces |
 				protobufs.AgentCapabilities_AgentCapabilities_AcceptsRemoteConfig |
 				protobufs.AgentCapabilities_AgentCapabilities_ReportsRemoteConfig |
 				protobufs.AgentCapabilities_AgentCapabilities_AcceptsRestartCommand |
@@ -600,6 +606,8 @@ telemetry:
 					Capabilities: Capabilities{
 						ReportsEffectiveConfig:         false,
 						ReportsOwnMetrics:              false,
+						ReportsOwnLogs:                 false,
+						ReportsOwnTraces:               false,
 						ReportsHealth:                  false,
 						AcceptsRemoteConfig:            true,
 						ReportsRemoteConfig:            true,

--- a/cmd/opampsupervisor/supervisor/supervisor.go
+++ b/cmd/opampsupervisor/supervisor/supervisor.go
@@ -869,19 +869,16 @@ func (s *Supervisor) setupOwnMetrics(_ context.Context, settings *protobufs.Tele
 	} else {
 		s.logger.Debug("Enabling own metrics pipeline in the config")
 
-		port, err := s.findRandomPort()
-		if err != nil {
-			s.logger.Error("Could not setup own metrics", zap.Error(err))
-			return
+		data := map[string]any{
+			"MetricsEndpoint": settings.DestinationEndpoint,
+			"MetricsHeaders":  []protobufs.Header{},
 		}
 
-		err = s.ownTelemetryTemplate.Execute(
-			&cfg,
-			map[string]any{
-				"PrometheusPort":  port,
-				"MetricsEndpoint": settings.DestinationEndpoint,
-			},
-		)
+		if settings.Headers != nil {
+			data["MetricsHeaders"] = settings.Headers.Headers
+		}
+
+		err := s.ownTelemetryTemplate.Execute(&cfg, data)
 		if err != nil {
 			s.logger.Error("Could not setup own metrics", zap.Error(err))
 			return

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -364,7 +364,6 @@ func Test_onMessage(t *testing.T) {
 		require.Equal(t, newID, s.persistentState.InstanceID)
 		t.Log(s.cfgState.Load())
 		mergedCfg := s.cfgState.Load().(*configState).mergedConfig
-		require.Contains(t, mergedCfg, "prometheus/own_metrics")
 		require.Contains(t, mergedCfg, newID.String())
 		require.Contains(t, mergedCfg, "runtime.type: test")
 	})
@@ -1137,8 +1136,8 @@ service:
         - periodic:
             exporter:
               otlp:
-			    protocol: http/protobuf
-				endpoint: "localhost"
+                protocol: http/protobuf
+                endpoint: localhost
 `
 
 		assert.True(t, configChanged)
@@ -1198,10 +1197,7 @@ func TestSupervisor_loadAndWriteInitialMergedConfig(t *testing.T) {
   debug/remote:
 `
 
-		const expectedMergedConfig = `exporters:
-    otlphttp/own_metrics:
-        metrics_endpoint: localhost
-extensions:
+		const expectedMergedConfig = `extensions:
     health_check:
         endpoint: ""
     opamp:
@@ -1215,30 +1211,20 @@ extensions:
                     insecure: true
 receiver:
     debug/remote: null
-receivers:
-    prometheus/own_metrics:
-        config:
-            scrape_configs:
-                - job_name: otel-collector
-                  scrape_interval: 10s
-                  static_configs:
-                    - targets:
-                        - 0.0.0.0:55555
 service:
     extensions:
         - health_check
         - opamp
-    pipelines:
-        metrics/own_metrics:
-            exporters:
-                - otlphttp/own_metrics
-            receivers:
-                - prometheus/own_metrics
     telemetry:
         logs:
             encoding: json
         metrics:
-            address: :55555
+            readers:
+                - periodic:
+                    exporter:
+                        otlp:
+                            endpoint: localhost
+                            protocol: http/protobuf
         resource:
             service.name: otelcol
 `

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -357,7 +357,13 @@ func Test_onMessage(t *testing.T) {
 				},
 			},
 			OwnMetricsConnSettings: &protobufs.TelemetryConnectionSettings{
-				DestinationEndpoint: "http://localhost:4318",
+				DestinationEndpoint: "http://127.0.0.1:4318",
+				Headers: &protobufs.Headers{
+					Headers: []*protobufs.Header{
+						{Key: "testkey", Value: "testval"},
+						{Key: "testkey2", Value: "testval2"},
+					},
+				},
 			},
 		})
 
@@ -1125,7 +1131,13 @@ func TestSupervisor_setupOwnMetrics(t *testing.T) {
 		require.NoError(t, err)
 
 		configChanged := s.setupOwnMetrics(context.Background(), &protobufs.TelemetryConnectionSettings{
-			DestinationEndpoint: "localhost",
+			DestinationEndpoint: "http://127.0.0.1:4318",
+			Headers: &protobufs.Headers{
+				Headers: []*protobufs.Header{
+					{Key: "testkey", Value: "testval"},
+					{Key: "testkey2", Value: "testval2"},
+				},
+			},
 		})
 
 		expectedOwnMetricsSection := `
@@ -1137,7 +1149,10 @@ service:
             exporter:
               otlp:
                 protocol: http/protobuf
-                endpoint: localhost
+                endpoint: http://127.0.0.1:4318
+                headers:
+                  "testkey": "testval"
+                  "testkey2": "testval2"
 `
 
 		assert.True(t, configChanged)

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -49,6 +49,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true
@@ -1233,15 +1235,28 @@ service:
     telemetry:
         logs:
             encoding: json
+            processors:
+                - batch:
+                    exporter:
+                        otlp:
+                            endpoint: localhost-logs
+                            protocol: http/protobuf
         metrics:
             readers:
                 - periodic:
                     exporter:
                         otlp:
-                            endpoint: localhost
+                            endpoint: localhost-metrics
                             protocol: http/protobuf
         resource:
             service.name: otelcol
+        traces:
+            processors:
+                - batch:
+                    exporter:
+                        otlp:
+                            endpoint: localhost-traces
+                            protocol: http/protobuf
 `
 
 		remoteCfg := &protobufs.AgentRemoteConfig{
@@ -1274,6 +1289,8 @@ service:
 				Capabilities: config.Capabilities{
 					AcceptsRemoteConfig: true,
 					ReportsOwnMetrics:   true,
+					ReportsOwnLogs:      true,
+					ReportsOwnTraces:    true,
 				},
 				Storage: config.Storage{
 					Directory: configDir,

--- a/cmd/opampsupervisor/supervisor/supervisor_test.go
+++ b/cmd/opampsupervisor/supervisor/supervisor_test.go
@@ -1129,27 +1129,16 @@ func TestSupervisor_setupOwnMetrics(t *testing.T) {
 			DestinationEndpoint: "localhost",
 		})
 
-		expectedOwnMetricsSection := `receivers:
-  # Collect own metrics
-  prometheus/own_metrics:
-    config:
-      scrape_configs:
-        - job_name: 'otel-collector'
-          scrape_interval: 10s
-          static_configs:
-            - targets: ['0.0.0.0:55555']  
-exporters:
-  otlphttp/own_metrics:
-    metrics_endpoint: "localhost"
-
+		expectedOwnMetricsSection := `
 service:
   telemetry:
     metrics:
-      address: ":55555"
-  pipelines:
-    metrics/own_metrics:
-      receivers: [prometheus/own_metrics]
-      exporters: [otlphttp/own_metrics]
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+			    protocol: http/protobuf
+				endpoint: "localhost"
 `
 
 		assert.True(t, configChanged)

--- a/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
@@ -1,21 +1,10 @@
-receivers:
-  # Collect own metrics
-  prometheus/own_metrics:
-    config:
-      scrape_configs:
-        - job_name: 'otel-collector'
-          scrape_interval: 10s
-          static_configs:
-            - targets: ['0.0.0.0:{{.PrometheusPort}}']  
-exporters:
-  otlphttp/own_metrics:
-    metrics_endpoint: "{{.MetricsEndpoint}}"
 
 service:
   telemetry:
     metrics:
-      address: ":{{.PrometheusPort}}"
-  pipelines:
-    metrics/own_metrics:
-      receivers: [prometheus/own_metrics]
-      exporters: [otlphttp/own_metrics]
+      readers:
+        - periodic:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: {{.MetricsEndpoint}}

--- a/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
@@ -1,6 +1,17 @@
 
 service:
   telemetry:
+{{if .TracesEndpoint}}
+    traces:
+      processors:
+        - batch:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: {{.TracesEndpoint}}{{if .TracesHeaders}}
+                headers:{{range $k := .TracesHeaders}}
+                  "{{$k.Key}}": "{{$k.Value}}"{{end}}{{end}}
+{{end}}
     metrics:
       readers:
         - periodic:
@@ -10,3 +21,14 @@ service:
                 endpoint: {{.MetricsEndpoint}}{{if .MetricsHeaders}}
                 headers:{{range $k := .MetricsHeaders}}
                   "{{$k.Key}}": "{{$k.Value}}"{{end}}{{end}}
+{{if .LogsEndpoint}}
+    logs:
+      processors:
+        - batch:
+            exporter:
+              otlp:
+                protocol: http/protobuf
+                endpoint: {{.LogsEndpoint}}{{if .LogsHeaders}}
+                headers:{{range $k := .LogsHeaders}}
+                  "{{$k.Key}}": "{{$k.Value}}"{{end}}{{end}}
+{{end}}

--- a/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
+++ b/cmd/opampsupervisor/supervisor/templates/owntelemetry.yaml
@@ -7,4 +7,6 @@ service:
             exporter:
               otlp:
                 protocol: http/protobuf
-                endpoint: {{.MetricsEndpoint}}
+                endpoint: {{.MetricsEndpoint}}{{if .MetricsHeaders}}
+                headers:{{range $k := .MetricsHeaders}}
+                  "{{$k.Key}}": "{{$k.Value}}"{{end}}{{end}}

--- a/cmd/opampsupervisor/supervisor/testdata/supervisor_windows_service_test_config.yaml
+++ b/cmd/opampsupervisor/supervisor/testdata/supervisor_windows_service_test_config.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_accepts_conn.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_accepts_conn.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_agent_description.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_basic.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_basic.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_healthcheck_port.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_logging.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_logging.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_nocap.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_nocap.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: false
   reports_own_metrics: false
+  reports_own_logs: false
+  reports_own_traces: false
   reports_health: false
   accepts_remote_config: false
   reports_remote_config: false

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_persistence.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_persistence.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_report_status.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_report_status.yaml
@@ -6,6 +6,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_server_port.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_server_port.yaml
@@ -4,6 +4,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true

--- a/cmd/opampsupervisor/testdata/supervisor/supervisor_test.yaml
+++ b/cmd/opampsupervisor/testdata/supervisor/supervisor_test.yaml
@@ -6,6 +6,8 @@ server:
 capabilities:
   reports_effective_config: true
   reports_own_metrics: true
+  reports_own_logs: true
+  reports_own_traces: true
   reports_health: true
   accepts_remote_config: true
   reports_remote_config: true


### PR DESCRIPTION
This allows the supervisor to configure capability to configure both
traces and logs for the collector's own telemetry via OTLP, the same
way it is enabled for metrics.