### PR TITLE
[receiver/splunkhec] Add support for passing access tokens via context

### DIFF
--- a/.chloggen/splunkhec-context-access-token.yaml
+++ b/.chloggen/splunkhec-context-access-token.yaml
@@ -1,0 +1,32 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/splunkhec,exporter/splunkhec
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Added support for passing access tokens via context in Splunk HEC receiver to enhance security and prevent token exposure in exported data.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37307]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This change ensures that access tokens are securely passed via request contexts
+  rather than as resource attributes in the payload.
+  The modification also includes changes to `exporter/splunkhec` to utilize the
+  context-based access token handling, improving security when working with downstream exporters.
+
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/splunkhecexporter/client.go
+++ b/exporter/splunkhecexporter/client.go
@@ -90,11 +90,8 @@ func (c *client) pushMetricsData(
 	defer c.wg.Done()
 
 	localHeaders := map[string]string{}
-	if md.ResourceMetrics().Len() != 0 {
-		accessToken, found := md.ResourceMetrics().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
-		if found {
-			localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
-		}
+	if accessToken, ok := ctx.Value(splunk.HecTokenLabel).(string); ok {
+		localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken
 	}
 
 	if c.config.UseMultiMetricFormat {
@@ -111,11 +108,8 @@ func (c *client) pushTraceData(
 	defer c.wg.Done()
 
 	localHeaders := map[string]string{}
-	if td.ResourceSpans().Len() != 0 {
-		accessToken, found := td.ResourceSpans().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
-		if found {
-			localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
-		}
+	if accessToken, ok := ctx.Value(splunk.HecTokenLabel).(string); ok {
+		localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken
 	}
 
 	return c.pushTracesDataInBatches(ctx, td, localHeaders)
@@ -130,11 +124,8 @@ func (c *client) pushLogData(ctx context.Context, ld plog.Logs) error {
 	}
 
 	localHeaders := map[string]string{}
-
-	// All logs in a batch have the same access token after batchperresourceattr, so we can just check the first one.
-	accessToken, found := ld.ResourceLogs().At(0).Resource().Attributes().Get(splunk.HecTokenLabel)
-	if found {
-		localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken.Str()
+	if accessToken, ok := ctx.Value(splunk.HecTokenLabel).(string); ok {
+		localHeaders["Authorization"] = splunk.HECTokenHeader + " " + accessToken
 	}
 
 	// All logs in a batch have only one type (regular or profiling logs) after perScopeBatcher,

--- a/receiver/splunkhecreceiver/receiver.go
+++ b/receiver/splunkhecreceiver/receiver.go
@@ -32,8 +32,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/splunkhecreceiver/internal/metadata"
 )
 
-type contextKey string
-
 const (
 	defaultServerTimeout = 20 * time.Second
 
@@ -60,8 +58,6 @@ const (
 	httpContentEncodingHeader = "Content-Encoding"
 	httpContentTypeHeader     = "Content-Type"
 	httpJSONTypeHeader        = "application/json"
-
-	accessTokenKey contextKey = contextKey(splunk.HecTokenLabel)
 )
 
 var (
@@ -503,7 +499,7 @@ func (r *splunkReceiver) contextWithAccessToken(parent context.Context, req *htt
 		accessToken := req.Header.Get("Authorization")
 		if strings.HasPrefix(accessToken, splunk.HECTokenHeader+" ") {
 			accessTokenValue := accessToken[len(splunk.HECTokenHeader)+1:]
-			return context.WithValue(parent, accessTokenKey, accessTokenValue)
+			return context.WithValue(parent, splunk.HecTokenLabel, accessTokenValue)
 		}
 	}
 

--- a/receiver/splunkhecreceiver/splunk_to_logdata_test.go
+++ b/receiver/splunkhecreceiver/splunk_to_logdata_test.go
@@ -330,7 +330,7 @@ func Test_SplunkHecToLogData(t *testing.T) {
 	n := len(tests)
 	for _, tt := range tests[n-1:] {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := splunkHecToLogData(zap.NewNop(), tt.events, func(_ pcommon.Resource) {}, tt.hecConfig)
+			result, err := splunkHecToLogData(zap.NewNop(), tt.events, tt.hecConfig)
 			assert.Equal(t, tt.wantErr, err)
 			require.Equal(t, tt.output.Len(), result.ResourceLogs().Len())
 			for i := 0; i < result.ResourceLogs().Len(); i++ {
@@ -476,7 +476,7 @@ func Test_SplunkHecRawToLogData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, slLen, err := splunkHecRawToLogData(tt.sc, tt.query, func(_ pcommon.Resource) {}, tt.config, tt.time)
+			result, slLen, err := splunkHecRawToLogData(tt.sc, tt.query, tt.config, tt.time)
 			require.NoError(t, err)
 			tt.assertResource(t, result, slLen)
 		})

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata.go
@@ -18,7 +18,7 @@ import (
 // splunkHecToMetricsData converts Splunk HEC metric points to
 // pmetric.Metrics. Returning the converted data and the number of
 // dropped time series.
-func splunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resourceCustomizer func(pcommon.Resource), config *Config) (pmetric.Metrics, int) {
+func splunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, config *Config) (pmetric.Metrics, int) {
 	numDroppedTimeSeries := 0
 	md := pmetric.NewMetrics()
 	scopeMetricsMap := make(map[[4]string]pmetric.ScopeMetrics)
@@ -77,9 +77,6 @@ func splunkHecToMetricsData(logger *zap.Logger, events []*splunk.Event, resource
 			}
 			if event.Index != "" {
 				attrs.PutStr(config.HecToOtelAttrs.Index, event.Index)
-			}
-			if resourceCustomizer != nil {
-				resourceCustomizer(resourceMetrics.Resource())
 			}
 		}
 		metrics.MoveAndAppendTo(sm.Metrics())

--- a/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
+++ b/receiver/splunkhecreceiver/splunkhec_to_metricdata_test.go
@@ -307,7 +307,7 @@ func Test_splunkV2ToMetricsData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), []*splunk.Event{tt.splunkDataPoint}, func(_ pcommon.Resource) {}, tt.hecConfig)
+			md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), []*splunk.Event{tt.splunkDataPoint}, tt.hecConfig)
 			assert.Equal(t, tt.wantDroppedTimeseries, numDroppedTimeseries)
 			assert.NoError(t, pmetrictest.CompareMetrics(tt.wantMetricsData, md, pmetrictest.IgnoreMetricsOrder()))
 		})
@@ -454,7 +454,7 @@ func TestGroupMetricsByResource(t *testing.T) {
 		dataPt.SetTimestamp(pcommon.Timestamp(nanoseconds))
 		dataPt.Attributes().PutStr("field", "value2-1")
 	}
-	md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), events, func(_ pcommon.Resource) {}, defaultTestingHecConfig)
+	md, numDroppedTimeseries := splunkHecToMetricsData(zap.NewNop(), events, defaultTestingHecConfig)
 	assert.Equal(t, 0, numDroppedTimeseries)
 	assert.EqualValues(t, metrics, md)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Added support for securely passing access tokens via the request context in the Splunk HEC receiver, replacing the previous method of embedding tokens in resource attributes.


<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue

Fixes #37307 

<!--Describe what testing was performed and which tests were added.-->
#### Testing

passes tests.

<!--Describe the documentation added.-->
#### Documentation

no need to update.

<!--Please delete paragraphs that you did not use before submitting.-->
