### PR TITLE
[connector/routing] Mark MutatesData: true

### DIFF
--- a/.chloggen/routing-fix-mutates-data.yaml
+++ b/.chloggen/routing-fix-mutates-data.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The connector splits the original payload so that it may be emitted in parts to each route.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37390]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -61,7 +61,7 @@ func newLogsConnector(
 }
 
 func (c *logsConnector) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
+	return consumer.Capabilities{MutatesData: true}
 }
 
 func (c *logsConnector) ConsumeLogs(ctx context.Context, ld plog.Logs) error {

--- a/connector/routingconnector/logs_test.go
+++ b/connector/routingconnector/logs_test.go
@@ -54,7 +54,7 @@ func TestLogsRegisterConsumersForValidRoute(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	assert.False(t, conn.Capabilities().MutatesData)
+	assert.True(t, conn.Capabilities().MutatesData)
 
 	rtConn := conn.(*logsConnector)
 	require.NoError(t, err)
@@ -413,7 +413,7 @@ func TestLogsConnectorCapabilities(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.False(t, conn.Capabilities().MutatesData)
+	assert.True(t, conn.Capabilities().MutatesData)
 }
 
 func TestLogsConnectorDetailed(t *testing.T) {

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -62,7 +62,7 @@ func newMetricsConnector(
 }
 
 func (c *metricsConnector) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
+	return consumer.Capabilities{MutatesData: true}
 }
 
 func (c *metricsConnector) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) error {

--- a/connector/routingconnector/metrics_test.go
+++ b/connector/routingconnector/metrics_test.go
@@ -54,7 +54,7 @@ func TestMetricsRegisterConsumersForValidRoute(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	assert.False(t, conn.Capabilities().MutatesData)
+	assert.True(t, conn.Capabilities().MutatesData)
 
 	rtConn := conn.(*metricsConnector)
 	require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestMetricsConnectorCapabilities(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.False(t, conn.Capabilities().MutatesData)
+	assert.True(t, conn.Capabilities().MutatesData)
 }
 
 func TestMetricsConnectorDetailed(t *testing.T) {

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -61,7 +61,7 @@ func newTracesConnector(
 }
 
 func (*tracesConnector) Capabilities() consumer.Capabilities {
-	return consumer.Capabilities{MutatesData: false}
+	return consumer.Capabilities{MutatesData: true}
 }
 
 func (c *tracesConnector) ConsumeTraces(ctx context.Context, td ptrace.Traces) error {

--- a/connector/routingconnector/traces_test.go
+++ b/connector/routingconnector/traces_test.go
@@ -54,7 +54,7 @@ func TestTracesRegisterConsumersForValidRoute(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, conn)
-	assert.False(t, conn.Capabilities().MutatesData)
+	assert.True(t, conn.Capabilities().MutatesData)
 
 	rtConn := conn.(*tracesConnector)
 	require.NoError(t, err)
@@ -393,7 +393,7 @@ func TestTraceConnectorCapabilities(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	assert.False(t, conn.Capabilities().MutatesData)
+	assert.True(t, conn.Capabilities().MutatesData)
 }
 
 func TestTracesConnectorDetailed(t *testing.T) {


### PR DESCRIPTION
```
panic: invalid access to shared data

goroutine 5496 [running]:
go.opentelemetry.io/collector/pdata/internal.(*State).AssertMutable(...)
	/home/runner/go/pkg/mod/go.opentelemetry.io/collector/pdata@v1.22.0/internal/state.go:20
go.opentelemetry.io/collector/pdata/plog.LogRecordSlice.RemoveIf({0x14000726040?, 0x1400249c000?}, 0x136e82da8?)
	/home/runner/go/pkg/mod/go.opentelemetry.io/collector/pdata@v1.22.0/plog/generated_logrecordslice.go:108 +0x144
github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector/internal/plogutil.MoveRecordsWithContextIf({0x14001a8c000?, 0x1400249c000?}, {0x14001a8d080?, 0x1400249c014?}, 0x14001b2cd30)
	/home/runner/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector@v0.116.0/internal/plogutil/logs.go:36 +0x14c
github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector.(*logsConnector).switchLogs(0x14002aa56e0, {0x10a491cf8, 0x10f2917c0}, {0x14001a8c000?, 0x1400249c000?})
	/home/runner/go/pkg/mod/github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector@v0.116.0/logs.go:99 +0x1e0
github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector.(*logsConnector).ConsumeLogs(0x14001f78f20?, {0x10a491cf8?, 0x10f2917c0?}, {0x14001a8c000?, 0x1400249c000?})
```