### PR TITLE
[chore] deprecate githubgen further

### DIFF
--- a/cmd/githubgen/README.md
+++ b/cmd/githubgen/README.md
@@ -1,4 +1,4 @@
-:warn: This executable has moved to [opentelemetry-go-build-tools](Deprecated: use https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/githubgen).
+⚠️ This executable has moved to [opentelemetry-go-build-tools](https://github.com/open-telemetry/opentelemetry-go-build-tools/tree/main/githubgen).
 
 This code is deprecated and will be removed soon. See https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37294.
 

--- a/cmd/githubgen/main.go
+++ b/cmd/githubgen/main.go
@@ -31,6 +31,7 @@ type generator interface {
 // .github/ISSUE_TEMPLATES/*.yaml (list of components)
 // reports/distributions/*
 func main() {
+	fmt.Println("[DEPRECATED] this tool is now deprecated. Please make sure to install go.opentelemetry.io/build-tools/githubgen instead")
 	folder := flag.String("folder", ".", "folder investigated for codeowners")
 	allowlistFilePath := flag.String("allowlist", "cmd/githubgen/allowlist.txt", "path to a file containing an allowlist of members outside the OpenTelemetry organization")
 	skipGithubCheck := flag.Bool("skipgithub", false, "skip checking GitHub membership check for CODEOWNERS generator")


### PR DESCRIPTION
Going a bit further than #37295:

* Fix the link in README
* Add a message when starting githubgen asking users to move over to the new tool.