### PR TITLE
feat(receiver/azuremonitor): Adds filtering by metric and/or aggregation

### DIFF
--- a/.chloggen/feat_azuremonitorreceiver_filter_metrics.yaml
+++ b/.chloggen/feat_azuremonitorreceiver_filter_metrics.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azuremonitorreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds filtering by metric and/or aggregation
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37420]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]
+

--- a/receiver/azuremonitorreceiver/README.md
+++ b/receiver/azuremonitorreceiver/README.md
@@ -137,7 +137,7 @@ receivers:
     auth: "default_credentials"
     metrics:
       - metric1 # This will scrape all known aggregations for "metric1"
-      - metric2/total # This will restrict scraping to "metric2" with the "Total" aggregation
+      - metric2/total # This will include "metric2" with the "Total" aggregation in the scraping
       - metric3/average # This will include "metric3" with the "Average" aggregation in the scraping
 ```
 

--- a/receiver/azuremonitorreceiver/README.md
+++ b/receiver/azuremonitorreceiver/README.md
@@ -25,6 +25,7 @@ The following settings are optional:
 - `auth` (default = service_principal): Specifies the used authentication method. Supported values are `service_principal`, `workload_identity`, `managed_identity`, `default_credentials`.
 - `resource_groups` (default = none): Filter metrics for specific resource groups, not setting a value will scrape metrics for all resources in the subscription.
 - `services` (default = none): Filter metrics for specific services, not setting a value will scrape metrics for all services integrated with Azure Monitor.
+- `metrics` (default = none): Filter specific metrics (e.g., `metrics: ["MetricName"]`) and aggregations (e.g., `metrics: ["MetricName/Total"]`).
 - `cache_resources` (default = 86400): List of resources will be cached for the provided amount of time in seconds.
 - `cache_resources_definitions` (default = 86400): List of metrics definitions will be cached for the provided amount of time in seconds.
 - `maximum_number_of_metrics_in_a_call` (default = 20): Maximum number of metrics to fetch in per API call, current limit in Azure is 20 (as of 03/27/2023).
@@ -50,6 +51,10 @@ Authenticating using managed identities has the following optional settings:
 
 - `client_id`
 
+### Filtering metrics
+
+The `metrics` configuration setting is designed to constrain scraping to particular metrics and their specific aggregations. It accepts an array of metrics, where each metric can optionally include an aggregation method following a `/` (slash): `MetricName/Aggregation`. The metric name should correspond to a supported Azure Monitor metric for the designated resource groups and services. The aggregation method can be any aggregation compatible with Azure Monitor (e.g., Average, Minimum, Maximum, Total, Count). The case of the metric name and aggregation does not affect the functionality.
+
 ### Example Configurations
 
 Using [Service Principal](https://learn.microsoft.com/en-us/azure/developer/go/azure-sdk-authentication?tabs=bash#service-principal-with-a-secret) for authentication:
@@ -68,6 +73,10 @@ receivers:
     services:
       - "${service1}"
       - "${service2}"
+    metrics:
+      - "${metric1}"
+      - "${metric2}/${aggregator1}"
+      - "${metric2}/${aggregator2}"
     collection_interval: 60s
     initial_delay: 1s
 ```
@@ -119,6 +128,18 @@ receivers:
           "NetworkRuleHit": [Reason, Status]
 ```
 
+Scrapping limited metrics and aggregations:
+
+```yaml
+receivers:
+  azuremonitor:
+    subscription_id: "${subscription_id}"
+    auth: "default_credentials"
+    metrics:
+      - metric1 # This will scrape all known aggregations for "metric1"
+      - metric2/total # This will restrict scraping to "metric2" with the "Total" aggregation
+      - metric3/average # This will include "metric3" with the "Average" aggregation in the scraping
+```
 
 ## Metrics
 

--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -246,6 +246,7 @@ type Config struct {
 	FederatedTokenFile                string                        `mapstructure:"federated_token_file"`
 	ResourceGroups                    []string                      `mapstructure:"resource_groups"`
 	Services                          []string                      `mapstructure:"services"`
+	Metrics                           []string                      `mapstructure:"metrics"`
 	CacheResources                    float64                       `mapstructure:"cache_resources"`
 	CacheResourcesDefinitions         float64                       `mapstructure:"cache_resources_definitions"`
 	MaximumNumberOfMetricsInACall     int                           `mapstructure:"maximum_number_of_metrics_in_a_call"`

--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -228,31 +228,33 @@ var (
 	}
 )
 
+type NestedListAlias = map[string]map[string][]string
+
 type DimensionsConfig struct {
-	Enabled   *bool                          `mapstructure:"enabled"`
-	Overrides map[string]map[string][]string `mapstructure:"overrides"`
+	Enabled   *bool           `mapstructure:"enabled"`
+	Overrides NestedListAlias `mapstructure:"overrides"`
 }
 
 // Config defines the configuration for the various elements of the receiver agent.
 type Config struct {
 	scraperhelper.ControllerConfig    `mapstructure:",squash"`
-	MetricsBuilderConfig              metadata.MetricsBuilderConfig  `mapstructure:",squash"`
-	Cloud                             string                         `mapstructure:"cloud"`
-	SubscriptionID                    string                         `mapstructure:"subscription_id"`
-	Authentication                    string                         `mapstructure:"auth"`
-	TenantID                          string                         `mapstructure:"tenant_id"`
-	ClientID                          string                         `mapstructure:"client_id"`
-	ClientSecret                      string                         `mapstructure:"client_secret"`
-	FederatedTokenFile                string                         `mapstructure:"federated_token_file"`
-	ResourceGroups                    []string                       `mapstructure:"resource_groups"`
-	Services                          []string                       `mapstructure:"services"`
-	Metrics                           map[string]map[string][]string `mapstructure:"metrics"`
-	CacheResources                    float64                        `mapstructure:"cache_resources"`
-	CacheResourcesDefinitions         float64                        `mapstructure:"cache_resources_definitions"`
-	MaximumNumberOfMetricsInACall     int                            `mapstructure:"maximum_number_of_metrics_in_a_call"`
-	MaximumNumberOfRecordsPerResource int32                          `mapstructure:"maximum_number_of_records_per_resource"`
-	AppendTagsAsAttributes            bool                           `mapstructure:"append_tags_as_attributes"`
-	Dimensions                        DimensionsConfig               `mapstructure:"dimensions"`
+	MetricsBuilderConfig              metadata.MetricsBuilderConfig `mapstructure:",squash"`
+	Cloud                             string                        `mapstructure:"cloud"`
+	SubscriptionID                    string                        `mapstructure:"subscription_id"`
+	Authentication                    string                        `mapstructure:"auth"`
+	TenantID                          string                        `mapstructure:"tenant_id"`
+	ClientID                          string                        `mapstructure:"client_id"`
+	ClientSecret                      string                        `mapstructure:"client_secret"`
+	FederatedTokenFile                string                        `mapstructure:"federated_token_file"`
+	ResourceGroups                    []string                      `mapstructure:"resource_groups"`
+	Services                          []string                      `mapstructure:"services"`
+	Metrics                           NestedListAlias               `mapstructure:"metrics"`
+	CacheResources                    float64                       `mapstructure:"cache_resources"`
+	CacheResourcesDefinitions         float64                       `mapstructure:"cache_resources_definitions"`
+	MaximumNumberOfMetricsInACall     int                           `mapstructure:"maximum_number_of_metrics_in_a_call"`
+	MaximumNumberOfRecordsPerResource int32                         `mapstructure:"maximum_number_of_records_per_resource"`
+	AppendTagsAsAttributes            bool                          `mapstructure:"append_tags_as_attributes"`
+	Dimensions                        DimensionsConfig              `mapstructure:"dimensions"`
 }
 
 const (

--- a/receiver/azuremonitorreceiver/config.go
+++ b/receiver/azuremonitorreceiver/config.go
@@ -236,23 +236,23 @@ type DimensionsConfig struct {
 // Config defines the configuration for the various elements of the receiver agent.
 type Config struct {
 	scraperhelper.ControllerConfig    `mapstructure:",squash"`
-	MetricsBuilderConfig              metadata.MetricsBuilderConfig `mapstructure:",squash"`
-	Cloud                             string                        `mapstructure:"cloud"`
-	SubscriptionID                    string                        `mapstructure:"subscription_id"`
-	Authentication                    string                        `mapstructure:"auth"`
-	TenantID                          string                        `mapstructure:"tenant_id"`
-	ClientID                          string                        `mapstructure:"client_id"`
-	ClientSecret                      string                        `mapstructure:"client_secret"`
-	FederatedTokenFile                string                        `mapstructure:"federated_token_file"`
-	ResourceGroups                    []string                      `mapstructure:"resource_groups"`
-	Services                          []string                      `mapstructure:"services"`
-	Metrics                           []string                      `mapstructure:"metrics"`
-	CacheResources                    float64                       `mapstructure:"cache_resources"`
-	CacheResourcesDefinitions         float64                       `mapstructure:"cache_resources_definitions"`
-	MaximumNumberOfMetricsInACall     int                           `mapstructure:"maximum_number_of_metrics_in_a_call"`
-	MaximumNumberOfRecordsPerResource int32                         `mapstructure:"maximum_number_of_records_per_resource"`
-	AppendTagsAsAttributes            bool                          `mapstructure:"append_tags_as_attributes"`
-	Dimensions                        DimensionsConfig              `mapstructure:"dimensions"`
+	MetricsBuilderConfig              metadata.MetricsBuilderConfig  `mapstructure:",squash"`
+	Cloud                             string                         `mapstructure:"cloud"`
+	SubscriptionID                    string                         `mapstructure:"subscription_id"`
+	Authentication                    string                         `mapstructure:"auth"`
+	TenantID                          string                         `mapstructure:"tenant_id"`
+	ClientID                          string                         `mapstructure:"client_id"`
+	ClientSecret                      string                         `mapstructure:"client_secret"`
+	FederatedTokenFile                string                         `mapstructure:"federated_token_file"`
+	ResourceGroups                    []string                       `mapstructure:"resource_groups"`
+	Services                          []string                       `mapstructure:"services"`
+	Metrics                           map[string]map[string][]string `mapstructure:"metrics"`
+	CacheResources                    float64                        `mapstructure:"cache_resources"`
+	CacheResourcesDefinitions         float64                        `mapstructure:"cache_resources_definitions"`
+	MaximumNumberOfMetricsInACall     int                            `mapstructure:"maximum_number_of_metrics_in_a_call"`
+	MaximumNumberOfRecordsPerResource int32                          `mapstructure:"maximum_number_of_records_per_resource"`
+	AppendTagsAsAttributes            bool                           `mapstructure:"append_tags_as_attributes"`
+	Dimensions                        DimensionsConfig               `mapstructure:"dimensions"`
 }
 
 const (

--- a/receiver/azuremonitorreceiver/dimension_test.go
+++ b/receiver/azuremonitorreceiver/dimension_test.go
@@ -65,7 +65,7 @@ func TestFilterDimensions(t *testing.T) {
 				},
 				cfg: DimensionsConfig{
 					Enabled: to.Ptr(true),
-					Overrides: map[string]map[string][]string{
+					Overrides: NestedListAlias{
 						"rt1": {
 							"m1": {
 								"foo",

--- a/receiver/azuremonitorreceiver/scraper.go
+++ b/receiver/azuremonitorreceiver/scraper.go
@@ -452,7 +452,7 @@ func getResourceMetricsValuesRequestOptions(
 	metrics []string,
 	dimensionsStr string,
 	timeGrain string,
-	aggregations string,
+	aggregationsStr string,
 	start int,
 	end int,
 	top int32,
@@ -461,7 +461,7 @@ func getResourceMetricsValuesRequestOptions(
 		Metricnames: to.Ptr(strings.Join(metrics[start:end], ",")),
 		Interval:    to.Ptr(timeGrain),
 		Timespan:    to.Ptr(timeGrain),
-		Aggregation: to.Ptr(aggregations),
+		Aggregation: to.Ptr(aggregationsStr),
 		Top:         to.Ptr(top),
 		Filter:      buildDimensionsFilter(dimensionsStr),
 	}
@@ -503,7 +503,7 @@ func (s *azureScraper) processTimeseriesData(
 	}
 }
 
-func getMetricAggregations(metricNamespace, metricName string, filters map[string]map[string][]string) []string {
+func getMetricAggregations(metricNamespace, metricName string, filters NestedListAlias) []string {
 	// default behavior when no metric filters specified: pass all metrics with all aggregations
 	if len(filters) == 0 {
 		return aggregations

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -772,79 +772,79 @@ func TestGetMetricAggregations(t *testing.T) {
 		want    []string
 	}{
 		{
-			"should return all aggregations when metrics filter empty",
-			NestedListAlias{},
-			aggregations,
+			name:    "should return all aggregations when metrics filter empty",
+			filters: NestedListAlias{},
+			want:    aggregations,
 		},
 		{
-			"should return all aggregations when namespace not in filters",
-			NestedListAlias{
+			name: "should return all aggregations when namespace not in filters",
+			filters: NestedListAlias{
 				"another.namespace": nil,
 			},
-			aggregations,
+			want: aggregations,
 		},
 		{
-			"should return all aggregations when metric in filters",
-			NestedListAlias{
+			name: "should return all aggregations when metric in filters",
+			filters: NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {},
 				},
 			},
-			aggregations,
+			want: aggregations,
 		},
 		{
-			"should return all aggregations ignoring metric name case",
-			NestedListAlias{
+			name: "should return all aggregations ignoring metric name case",
+			filters: NestedListAlias{
 				testNamespaceName: {
 					strings.ToLower(testMetricName): {},
 				},
 			},
-			aggregations,
+			want: aggregations,
 		},
 		{
-			"should return all aggregations when asterisk in filters",
-			NestedListAlias{
+			name: "should return all aggregations when asterisk in filters",
+			filters: NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {filterAllAggregations},
 				},
 			},
-			aggregations,
+			want: aggregations,
 		},
 		{
-			"should be empty when metric not in filters",
-			NestedListAlias{
+			name: "should be empty when metric not in filters",
+			filters: NestedListAlias{
 				testNamespaceName: {
 					"not_this_metric": {},
 				},
 			},
-			[]string{},
+			want: []string{},
 		},
 		{
-			"should return one aggregations",
-			NestedListAlias{
+			name: "should return one aggregations",
+			filters: NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {aggregations[0]},
 				},
 			},
-			[]string{aggregations[0]},
+			want: []string{aggregations[0]},
 		},
 		{
-			"should return one aggregations ignoring aggregation case",
-			NestedListAlias{
+			name: "should return one aggregations ignoring aggregation case",
+			filters: NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {strings.ToLower(aggregations[0])},
 				},
 			},
-			[]string{aggregations[0]},
+			want: []string{aggregations[0]},
 		},
 		{
-			"should return many aggregations",
-			NestedListAlias{
+			name: "should return many aggregations",
+			filters: NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {aggregations[0], aggregations[2]},
 				},
 			},
-			[]string{aggregations[0], aggregations[2]},
+			want: []string{aggregations[0], aggregations[2]},
 		},
 	}
 
@@ -869,19 +869,19 @@ func TestMapFindInsensitive(t *testing.T) {
 		want bool
 	}{
 		{
-			"should find when same case",
-			testNamespace,
-			true,
+			name: "should find when same case",
+			key:  testNamespace,
+			want: true,
 		},
 		{
-			"should find when different case",
-			strings.ToLower(testNamespace),
-			true,
+			name: "should find when different case",
+			key:  strings.ToLower(testNamespace),
+			want: true,
 		},
 		{
-			"should not find when not exists",
-			"microsoft.eventhub/namespaces",
-			false,
+			name: "should not find when not exists",
+			key:  "microsoft.eventhub/namespaces",
+			want: false,
 		},
 	}
 	for _, tt := range tests {

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -5,6 +5,7 @@ package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -251,12 +252,83 @@ func (mdcm *metricsDefinitionsClientMock) NewListPager(resourceURI string, _ *ar
 	})
 }
 
-type metricsValuesClientMock struct {
-	lists map[string]map[string]armmonitor.MetricsClientListResponse
+type metricsValuesClientMock struct{}
+
+func (mvcm metricsValuesClientMock) List(_ context.Context, _ string, options *armmonitor.MetricsClientListOptions) (armmonitor.MetricsClientListResponse, error) {
+	var unit1 armmonitor.Unit = "unit1"
+
+	amMetrics := []*armmonitor.Metric{}
+	for _, name := range strings.Split(*options.Metricnames, ",") {
+		amMetric := &armmonitor.Metric{
+			Name: &armmonitor.LocalizableString{
+				Value: &name,
+			},
+			Unit: &unit1,
+			Timeseries: []*armmonitor.TimeSeriesElement{
+				{
+					Data: []*armmonitor.MetricValue{
+						mvcm.getAMDataPoints(*options.Aggregation),
+					},
+				},
+			},
+		}
+		amMetrics = append(amMetrics, amMetric)
+
+		switch name {
+		case "metric5":
+			amMetric.Timeseries[0].Metadatavalues = mvcm.getAMMetadataValues(2)
+
+		case "metric6":
+			amMetric.Timeseries[0].Metadatavalues = mvcm.getAMMetadataValues(1)
+
+		case "metric7":
+			amMetric.Timeseries[0].Data[0] = mvcm.getAMDataPoints("Count")
+			amMetric.Timeseries[0].Metadatavalues = mvcm.getAMMetadataValues(1)
+		}
+	}
+
+	return armmonitor.MetricsClientListResponse{
+		Response: armmonitor.Response{Value: amMetrics},
+	}, nil
 }
 
-func (mvcm metricsValuesClientMock) List(_ context.Context, resourceURI string, options *armmonitor.MetricsClientListOptions) (armmonitor.MetricsClientListResponse, error) {
-	return mvcm.lists[resourceURI][*options.Metricnames], nil
+func (mvcm metricsValuesClientMock) getAMDataPoints(aggregations string) *armmonitor.MetricValue {
+	var value1 float64 = 1
+
+	amPoints := &armmonitor.MetricValue{}
+	for _, aggregation := range strings.Split(aggregations, ",") {
+		switch aggregation {
+		case "Average":
+			amPoints.Average = &value1
+		case "Count":
+			amPoints.Count = &value1
+		case "Maximum":
+			amPoints.Maximum = &value1
+		case "Minimum":
+			amPoints.Minimum = &value1
+		case "Total":
+			amPoints.Total = &value1
+		}
+	}
+
+	return amPoints
+}
+
+func (mvcm metricsValuesClientMock) getAMMetadataValues(n int) []*armmonitor.MetadataValue {
+	dimensionValue := "dimension value"
+
+	out := make([]*armmonitor.MetadataValue, n)
+	for idx := range out {
+		dimension := fmt.Sprintf("dimension%d", idx+1)
+		out[idx] = &armmonitor.MetadataValue{
+			Name: &armmonitor.LocalizableString{
+				Value: &dimension,
+			},
+			Value: &dimensionValue,
+		}
+	}
+
+	return out
 }
 
 func TestAzureScraperScrape(t *testing.T) {
@@ -272,6 +344,10 @@ func TestAzureScraperScrape(t *testing.T) {
 	cfgTagsEnabled := createDefaultConfig().(*Config)
 	cfgTagsEnabled.AppendTagsAsAttributes = true
 	cfgTagsEnabled.MaximumNumberOfMetricsInACall = 2
+
+	cfgLimitedMertics := createDefaultConfig().(*Config)
+	cfgLimitedMertics.MaximumNumberOfMetricsInACall = 2
+	cfgLimitedMertics.Metrics = []string{"metric1", "metric3/total", "metric4/average", "metric4/minimum", "metric4/maximum"}
 
 	tests := []struct {
 		name    string
@@ -297,6 +373,15 @@ func TestAzureScraperScrape(t *testing.T) {
 				ctx: context.Background(),
 			},
 		},
+		{
+			name: "metrics_filtered",
+			fields: fields{
+				cfg: cfgLimitedMertics,
+			},
+			args: args{
+				ctx: context.Background(),
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -315,9 +400,7 @@ func TestAzureScraperScrape(t *testing.T) {
 				pages:   pages,
 			}
 
-			metricsValuesClientMock := &metricsValuesClientMock{
-				lists: getMetricsValuesMockData(),
-			}
+			metricsValuesClientMock := &metricsValuesClientMock{}
 
 			s := &azureScraper{
 				cfg:                      tt.fields.cfg,
@@ -609,217 +692,6 @@ func getMetricsDefinitionsMockData() (map[string]int, map[string][]armmonitor.Me
 	return counters, pages
 }
 
-func getMetricsValuesMockData() map[string]map[string]armmonitor.MetricsClientListResponse {
-	name1, name2, name3, name4, name5, name6, name7, dimension1, dimension2, dimensionValue := "metric1", "metric2",
-		"metric3", "metric4", "metric5", "metric6", "metric7", "dimension1", "dimension2", "dimension value"
-	var unit1 armmonitor.Unit = "unit1"
-	var value1 float64 = 1
-
-	return map[string]map[string]armmonitor.MetricsClientListResponse{
-		"/resourceGroups/group1/resourceId1": {
-			strings.Join([]string{name1, name2}, ","): {
-				Response: armmonitor.Response{
-					Value: []*armmonitor.Metric{
-						{
-							Name: &armmonitor.LocalizableString{
-								Value: &name1,
-							},
-							Unit: &unit1,
-							Timeseries: []*armmonitor.TimeSeriesElement{
-								{
-									Data: []*armmonitor.MetricValue{
-										{
-											Average: &value1,
-											Count:   &value1,
-											Maximum: &value1,
-											Minimum: &value1,
-											Total:   &value1,
-										},
-									},
-								},
-							},
-						},
-						{
-							Name: &armmonitor.LocalizableString{
-								Value: &name2,
-							},
-							Unit: &unit1,
-							Timeseries: []*armmonitor.TimeSeriesElement{
-								{
-									Data: []*armmonitor.MetricValue{
-										{
-											Average: &value1,
-											Count:   &value1,
-											Maximum: &value1,
-											Minimum: &value1,
-											Total:   &value1,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			name3: {
-				Response: armmonitor.Response{
-					Value: []*armmonitor.Metric{
-						{
-							Name: &armmonitor.LocalizableString{
-								Value: &name3,
-							},
-							Unit: &unit1,
-							Timeseries: []*armmonitor.TimeSeriesElement{
-								{
-									Data: []*armmonitor.MetricValue{
-										{
-											Average: &value1,
-											Count:   &value1,
-											Maximum: &value1,
-											Minimum: &value1,
-											Total:   &value1,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"/resourceGroups/group1/resourceId2": {
-			name4: {
-				Response: armmonitor.Response{
-					Value: []*armmonitor.Metric{
-						{
-							Name: &armmonitor.LocalizableString{
-								Value: &name4,
-							},
-							Unit: &unit1,
-							Timeseries: []*armmonitor.TimeSeriesElement{
-								{
-									Data: []*armmonitor.MetricValue{
-										{
-											Average: &value1,
-											Count:   &value1,
-											Maximum: &value1,
-											Minimum: &value1,
-											Total:   &value1,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			name5: {
-				Response: armmonitor.Response{
-					Value: []*armmonitor.Metric{
-						{
-							Name: &armmonitor.LocalizableString{
-								Value: &name5,
-							},
-							Unit: &unit1,
-							Timeseries: []*armmonitor.TimeSeriesElement{
-								{
-									Data: []*armmonitor.MetricValue{
-										{
-											Average: &value1,
-											Count:   &value1,
-											Maximum: &value1,
-											Minimum: &value1,
-											Total:   &value1,
-										},
-									},
-									Metadatavalues: []*armmonitor.MetadataValue{
-										{
-											Name: &armmonitor.LocalizableString{
-												Value: &dimension1,
-											},
-											Value: &dimensionValue,
-										},
-										{
-											Name: &armmonitor.LocalizableString{
-												Value: &dimension2,
-											},
-											Value: &dimensionValue,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-			name6: {
-				Response: armmonitor.Response{
-					Value: []*armmonitor.Metric{
-						{
-							Name: &armmonitor.LocalizableString{
-								Value: &name6,
-							},
-							Unit: &unit1,
-							Timeseries: []*armmonitor.TimeSeriesElement{
-								{
-									Data: []*armmonitor.MetricValue{
-										{
-											Average: &value1,
-											Count:   &value1,
-											Maximum: &value1,
-											Minimum: &value1,
-											Total:   &value1,
-										},
-									},
-									Metadatavalues: []*armmonitor.MetadataValue{
-										{
-											Name: &armmonitor.LocalizableString{
-												Value: &dimension1,
-											},
-											Value: &dimensionValue,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-		"/resourceGroups/group1/resourceId3": {
-			name7: {
-				Response: armmonitor.Response{
-					Value: []*armmonitor.Metric{
-						{
-							Name: &armmonitor.LocalizableString{
-								Value: &name7,
-							},
-							Unit: &unit1,
-							Timeseries: []*armmonitor.TimeSeriesElement{
-								{
-									Data: []*armmonitor.MetricValue{
-										{
-											Count: &value1,
-										},
-									},
-									Metadatavalues: []*armmonitor.MetadataValue{
-										{
-											Name: &armmonitor.LocalizableString{
-												Value: &dimension1,
-											},
-											Value: &dimensionValue,
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
 func TestAzureScraperClientOptions(t *testing.T) {
 	type fields struct {
 		cfg *Config
@@ -877,6 +749,95 @@ func TestAzureScraperClientOptions(t *testing.T) {
 			if got := s.getArmClientOptions(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getArmClientOptions() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIsMetricMatchFilters(t *testing.T) {
+	testMetricName := "MetricName1"
+	tests := []struct {
+		name    string
+		filters []string
+		want    bool
+	}{
+		{
+			"filters_empty",
+			[]string{},
+			true,
+		},
+		{
+			"filters_include_metric",
+			[]string{"foo", testMetricName, "bar"},
+			true,
+		},
+		{
+			"filters_include_metric_ignore_case",
+			[]string{"foo", strings.ToLower(testMetricName), "bar"},
+			true,
+		},
+		{
+			"filters_include_metric_aggregation",
+			[]string{"foo/count", testMetricName + "/total", "bar/total"},
+			true,
+		},
+		{
+			"filters_exclude_metric",
+			[]string{"foo", "bar"},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMetricMatchFilters(testMetricName, tt.filters)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetMetricAggregations(t *testing.T) {
+	testMetricName := "MetricName"
+	tests := []struct {
+		name    string
+		filters []string
+		want    string
+	}{
+		{
+			"filters_empty",
+			[]string{},
+			strings.Join(aggregations, ","),
+		},
+		{
+			"filters_include_metric",
+			[]string{"foo", testMetricName, "bar"},
+			strings.Join(aggregations, ","),
+		},
+		{
+			"filters_include_metric_ignore_case",
+			[]string{"foo", strings.ToLower(testMetricName), "bar"},
+			strings.Join(aggregations, ","),
+		},
+		{
+			"filters_include_metric_aggregation",
+			[]string{"foo/count", testMetricName + "/" + aggregations[0], "bar/total"},
+			aggregations[0],
+		},
+		{
+			"filters_include_metric_aggregation_ignore_case",
+			[]string{"foo/count", testMetricName + "/" + strings.ToLower(aggregations[0]), "bar/total"},
+			aggregations[0],
+		},
+		{
+			"filters_include_metric_multiple_aggregations",
+			[]string{"foo/count", testMetricName + "/" + aggregations[0], testMetricName + "/" + aggregations[2]},
+			aggregations[0] + "," + aggregations[2],
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getMetricAggregations(testMetricName, tt.filters)
+			require.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -753,84 +753,42 @@ func TestAzureScraperClientOptions(t *testing.T) {
 	}
 }
 
-func TestIsMetricMatchFilters(t *testing.T) {
-	testMetricName := "MetricName1"
-	tests := []struct {
-		name    string
-		filters []string
-		want    bool
-	}{
-		{
-			"filters_empty",
-			[]string{},
-			true,
-		},
-		{
-			"filters_include_metric",
-			[]string{"foo", testMetricName, "bar"},
-			true,
-		},
-		{
-			"filters_include_metric_ignore_case",
-			[]string{"foo", strings.ToLower(testMetricName), "bar"},
-			true,
-		},
-		{
-			"filters_include_metric_aggregation",
-			[]string{"foo/count", testMetricName + "/total", "bar/total"},
-			true,
-		},
-		{
-			"filters_exclude_metric",
-			[]string{"foo", "bar"},
-			false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := isMetricMatchFilters(testMetricName, tt.filters)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
 func TestGetMetricAggregations(t *testing.T) {
 	testMetricName := "MetricName"
 	tests := []struct {
 		name    string
 		filters []string
-		want    string
+		want    []string
 	}{
 		{
 			"filters_empty",
 			[]string{},
-			strings.Join(aggregations, ","),
+			aggregations,
 		},
 		{
 			"filters_include_metric",
 			[]string{"foo", testMetricName, "bar"},
-			strings.Join(aggregations, ","),
+			aggregations,
 		},
 		{
 			"filters_include_metric_ignore_case",
 			[]string{"foo", strings.ToLower(testMetricName), "bar"},
-			strings.Join(aggregations, ","),
+			aggregations,
 		},
 		{
 			"filters_include_metric_aggregation",
 			[]string{"foo/count", testMetricName + "/" + aggregations[0], "bar/total"},
-			aggregations[0],
+			[]string{aggregations[0]},
 		},
 		{
 			"filters_include_metric_aggregation_ignore_case",
 			[]string{"foo/count", testMetricName + "/" + strings.ToLower(aggregations[0]), "bar/total"},
-			aggregations[0],
+			[]string{aggregations[0]},
 		},
 		{
 			"filters_include_metric_multiple_aggregations",
 			[]string{"foo/count", testMetricName + "/" + aggregations[0], testMetricName + "/" + aggregations[2]},
-			aggregations[0] + "," + aggregations[2],
+			[]string{aggregations[0], aggregations[2]},
 		},
 	}
 

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -5,7 +5,6 @@ package azuremonitorreceiver // import "github.com/open-telemetry/opentelemetry-
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -259,6 +258,11 @@ func (mvcm metricsValuesClientMock) List(_ context.Context, _ string, options *a
 
 	amMetrics := []*armmonitor.Metric{}
 	for _, name := range strings.Split(*options.Metricnames, ",") {
+		var metaValues []*armmonitor.MetadataValue
+		if options.Filter != nil {
+			metaValues = mvcm.getAMMetadataValues(*options.Filter)
+		}
+
 		amMetric := &armmonitor.Metric{
 			Name: &armmonitor.LocalizableString{
 				Value: &name,
@@ -269,21 +273,14 @@ func (mvcm metricsValuesClientMock) List(_ context.Context, _ string, options *a
 					Data: []*armmonitor.MetricValue{
 						mvcm.getAMDataPoints(*options.Aggregation),
 					},
+					Metadatavalues: metaValues,
 				},
 			},
 		}
 		amMetrics = append(amMetrics, amMetric)
 
-		switch name {
-		case "metric5":
-			amMetric.Timeseries[0].Metadatavalues = mvcm.getAMMetadataValues(2)
-
-		case "metric6":
-			amMetric.Timeseries[0].Metadatavalues = mvcm.getAMMetadataValues(1)
-
-		case "metric7":
+		if name == "metric7" {
 			amMetric.Timeseries[0].Data[0] = mvcm.getAMDataPoints("Count")
-			amMetric.Timeseries[0].Metadatavalues = mvcm.getAMMetadataValues(1)
 		}
 	}
 
@@ -314,17 +311,19 @@ func (mvcm metricsValuesClientMock) getAMDataPoints(aggregations string) *armmon
 	return amPoints
 }
 
-func (mvcm metricsValuesClientMock) getAMMetadataValues(n int) []*armmonitor.MetadataValue {
+func (mvcm metricsValuesClientMock) getAMMetadataValues(filter string) []*armmonitor.MetadataValue {
+	var out []*armmonitor.MetadataValue
+	knownDimensions := []string{"dimension1", "dimension2"}
 	dimensionValue := "dimension value"
 
-	out := make([]*armmonitor.MetadataValue, n)
-	for idx := range out {
-		dimension := fmt.Sprintf("dimension%d", idx+1)
-		out[idx] = &armmonitor.MetadataValue{
-			Name: &armmonitor.LocalizableString{
-				Value: &dimension,
-			},
-			Value: &dimensionValue,
+	for _, dimension := range knownDimensions {
+		if strings.Contains(filter, dimension) {
+			out = append(out, &armmonitor.MetadataValue{
+				Name: &armmonitor.LocalizableString{
+					Value: &dimension,
+				},
+				Value: &dimensionValue,
+			})
 		}
 	}
 

--- a/receiver/azuremonitorreceiver/scraper_test.go
+++ b/receiver/azuremonitorreceiver/scraper_test.go
@@ -346,7 +346,7 @@ func TestAzureScraperScrape(t *testing.T) {
 
 	cfgLimitedMertics := createDefaultConfig().(*Config)
 	cfgLimitedMertics.MaximumNumberOfMetricsInACall = 2
-	cfgLimitedMertics.Metrics = map[string]map[string][]string{
+	cfgLimitedMertics.Metrics = NestedListAlias{
 		"namespace1": {
 			"metric1": {"*"},
 			"metric3": {"total"},
@@ -768,24 +768,24 @@ func TestGetMetricAggregations(t *testing.T) {
 	testMetricName := "MetricName"
 	tests := []struct {
 		name    string
-		filters map[string]map[string][]string
+		filters NestedListAlias
 		want    []string
 	}{
 		{
 			"should return all aggregations when metrics filter empty",
-			map[string]map[string][]string{},
+			NestedListAlias{},
 			aggregations,
 		},
 		{
 			"should return all aggregations when namespace not in filters",
-			map[string]map[string][]string{
+			NestedListAlias{
 				"another.namespace": nil,
 			},
 			aggregations,
 		},
 		{
 			"should return all aggregations when metric in filters",
-			map[string]map[string][]string{
+			NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {},
 				},
@@ -794,7 +794,7 @@ func TestGetMetricAggregations(t *testing.T) {
 		},
 		{
 			"should return all aggregations ignoring metric name case",
-			map[string]map[string][]string{
+			NestedListAlias{
 				testNamespaceName: {
 					strings.ToLower(testMetricName): {},
 				},
@@ -803,7 +803,7 @@ func TestGetMetricAggregations(t *testing.T) {
 		},
 		{
 			"should return all aggregations when asterisk in filters",
-			map[string]map[string][]string{
+			NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {filterAllAggregations},
 				},
@@ -812,7 +812,7 @@ func TestGetMetricAggregations(t *testing.T) {
 		},
 		{
 			"should be empty when metric not in filters",
-			map[string]map[string][]string{
+			NestedListAlias{
 				testNamespaceName: {
 					"not_this_metric": {},
 				},
@@ -821,7 +821,7 @@ func TestGetMetricAggregations(t *testing.T) {
 		},
 		{
 			"should return one aggregations",
-			map[string]map[string][]string{
+			NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {aggregations[0]},
 				},
@@ -830,7 +830,7 @@ func TestGetMetricAggregations(t *testing.T) {
 		},
 		{
 			"should return one aggregations ignoring aggregation case",
-			map[string]map[string][]string{
+			NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {strings.ToLower(aggregations[0])},
 				},
@@ -839,7 +839,7 @@ func TestGetMetricAggregations(t *testing.T) {
 		},
 		{
 			"should return many aggregations",
-			map[string]map[string][]string{
+			NestedListAlias{
 				testNamespaceName: {
 					testMetricName: {aggregations[0], aggregations[2]},
 				},

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
@@ -1,0 +1,221 @@
+resourceMetrics:
+  - resource:
+      attributes:
+        - key: azuremonitor.subscription_id
+          value:
+            stringValue: ""
+        - key: azuremonitor.tenant_id
+          value:
+            stringValue: ""
+    scopeMetrics:
+      - metrics:
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric3_total
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_average
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId2
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric4_maximum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_count
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_minimum
+            unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId1
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric1_average
+            unit: unit1
+        scope:
+          name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
+          version: latest

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
@@ -216,6 +216,32 @@ resourceMetrics:
                   timeUnixNano: "2000000"
             name: azure_metric1_average
             unit: unit1
+          - gauge:
+              dataPoints:
+                - asDouble: 1
+                  attributes:
+                    - key: azuremonitor.resource_id
+                      value:
+                        stringValue: /resourceGroups/group1/resourceId3
+                    - key: location
+                      value:
+                        stringValue: location1
+                    - key: metadata_dimension1
+                      value:
+                        stringValue: dimension value
+                    - key: name
+                      value:
+                        stringValue: name1
+                    - key: resource_group
+                      value:
+                        stringValue: group1
+                    - key: type
+                      value:
+                        stringValue: type1
+                  startTimeUnixNano: "1000000"
+                  timeUnixNano: "2000000"
+            name: azure_metric7_count
+            unit: unit1
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
           version: latest

--- a/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
+++ b/receiver/azuremonitorreceiver/testdata/expected_metrics/metrics_filtered.yaml
@@ -11,237 +11,188 @@ resourceMetrics:
       - metrics:
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 11
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceA/namespace1/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceA/namespace1
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric1_maximum
-            unit: unit1
+            name: azure_connectionstotal_count
+            unit: u
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 0.1
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceB/namespace2/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric4_minimum
-            unit: unit1
+            name: azure_incommingmessages_minimum
+            unit: u
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 11
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceB/namespace2/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric1_total
-            unit: unit1
+            name: azure_incommingmessages_count
+            unit: u
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 11
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceB/namespace2/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric3_total
-            unit: unit1
+            name: azure_incommingmessages_total
+            unit: u
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 123.45
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceB/namespace2/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric4_average
-            unit: unit1
+            name: azure_incommingmessages_average
+            unit: u
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 123.45
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId2
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceB/namespace2/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric4_maximum
-            unit: unit1
+            name: azure_incommingmessages_maximum
+            unit: u
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 123.45
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceB/namespace2/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric1_count
-            unit: unit1
+            name: azure_transferedbytes_maximum
+            unit: u
           - gauge:
               dataPoints:
-                - asDouble: 1
+                - asDouble: 0.1
                   attributes:
                     - key: azuremonitor.resource_id
                       value:
-                        stringValue: /resourceGroups/group1/resourceId1
+                        stringValue: /subscription/azuremonitor-receiver/resourceGroups/resource-group/providers/Microsoft.ServiceB/namespace2/resource-name
                     - key: location
                       value:
-                        stringValue: location1
+                        stringValue: location-name
                     - key: name
                       value:
-                        stringValue: name1
+                        stringValue: resource-name
                     - key: resource_group
                       value:
-                        stringValue: group1
+                        stringValue: resource-group
                     - key: type
                       value:
-                        stringValue: type1
+                        stringValue: Microsoft.ServiceB/namespace2
                   startTimeUnixNano: "1000000"
                   timeUnixNano: "2000000"
-            name: azure_metric1_minimum
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId1
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric1_average
-            unit: unit1
-          - gauge:
-              dataPoints:
-                - asDouble: 1
-                  attributes:
-                    - key: azuremonitor.resource_id
-                      value:
-                        stringValue: /resourceGroups/group1/resourceId3
-                    - key: location
-                      value:
-                        stringValue: location1
-                    - key: metadata_dimension1
-                      value:
-                        stringValue: dimension value
-                    - key: name
-                      value:
-                        stringValue: name1
-                    - key: resource_group
-                      value:
-                        stringValue: group1
-                    - key: type
-                      value:
-                        stringValue: type1
-                  startTimeUnixNano: "1000000"
-                  timeUnixNano: "2000000"
-            name: azure_metric7_count
-            unit: unit1
+            name: azure_transferedbytes_minimum
+            unit: u
         scope:
           name: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/azuremonitorreceiver
           version: latest


### PR DESCRIPTION
#### Description
Adds optional setting `metrics` that allows to limit scrapping to the specific metrics and aggregations.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37420

#### Testing
Unit test coverage extended to verify default behaviour and to cover a new functionality

#### Documentation
Documentation updated respectfully to reflect changes

