### PR TITLE
[chore] update test to use a different prometheus endpoint

### DIFF
--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/proto v0.63.0-devel
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.118.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.118.0
 	github.com/stretchr/testify v1.10.0
@@ -254,7 +255,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/aws/ecsutil v0.118.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.118.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.118.0 // indirect

--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
+	commonTestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 )
@@ -92,6 +93,7 @@ func testIntegration(t *testing.T) {
 	server := testutil.DatadogServerMock(apmstatsRec.HandlerFunc, tracesRec.HandlerFunc)
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
+	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)
@@ -284,6 +286,7 @@ func TestIntegrationComputeTopLevelBySpanKind(t *testing.T) {
 	server := testutil.DatadogServerMock(apmstatsRec.HandlerFunc, tracesRec.HandlerFunc)
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
+	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)
@@ -463,7 +466,9 @@ func TestIntegrationLogs(t *testing.T) {
 		}
 	})
 	defer server.Close()
+	thing := commonTestutil.GetAvailableLocalAddress(t)
 	t.Setenv("SERVER_URL", server.URL)
+	t.Setenv("PROM_SERVER", thing)
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)

--- a/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
@@ -12,7 +12,7 @@ receivers:
         - job_name: 'otelcol'
           scrape_interval: 1s
           static_configs:
-            - targets: [ 'localhost:8888' ]
+            - targets: [ '${env:PROM_SERVER}' ]
 
 exporters:
   datadog:
@@ -33,7 +33,7 @@ service:
   telemetry:
     metrics:
       level: basic
-      address: "localhost:8888"
+      address: ${env:PROM_SERVER}
   pipelines:
     traces:
       receivers: [otlp]

--- a/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
@@ -12,7 +12,7 @@ receivers:
         - job_name: 'otelcol'
           scrape_interval: 1s
           static_configs:
-            - targets: [ 'localhost:8888' ]
+            - targets: [ '${env:PROM_SERVER}' ]
           metric_relabel_configs:
             - source_labels: [ __name__ ]
               regex: "(otelcol_receiver_accepted_log_records|otelcol_exporter_sent_log_records)"
@@ -37,7 +37,7 @@ service:
   telemetry:
     metrics:
       level: basic
-      address: "localhost:8888"
+      address: ${env:PROM_SERVER}
   pipelines:
     logs:
       receivers: [otlp]

--- a/exporter/datadogexporter/integrationtest/no_race_integration_test.go
+++ b/exporter/datadogexporter/integrationtest/no_race_integration_test.go
@@ -14,19 +14,21 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 	"github.com/stretchr/testify/assert"
+
+	commonTestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 )
 
 func TestIntegrationInternalMetrics(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("flaky test on windows https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34836")
 	}
-
 	// 1. Set up mock Datadog server
 	seriesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.MetricV2Endpoint, ReqChan: make(chan []byte, 100)}
 	tracesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.TraceEndpoint, ReqChan: make(chan []byte, 100)}
 	server := testutil.DatadogServerMock(seriesRec.HandlerFunc, tracesRec.HandlerFunc)
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
+	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)


### PR DESCRIPTION
Instead of relying on the same port for each test, use `GetAvailableLocalAddress` to get a new port for each test.
