### PR TITLE
Fix flaky prom remote write exporter concurrency test

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_concurrency_test.go
@@ -92,7 +92,7 @@ func Test_PushMetricsConcurrent(t *testing.T) {
 
 	// Adjusted retry settings for faster testing
 	retrySettings := configretry.BackOffConfig{
-		Enabled:         false,
+		Enabled:         true,
 		InitialInterval: 100 * time.Millisecond, // Shorter initial interval
 		MaxInterval:     1 * time.Second,        // Shorter max interval
 		MaxElapsedTime:  2 * time.Second,        // Shorter max elapsed time


### PR DESCRIPTION
Fix #37104

This is more an artifact of the test firing an unbounded number of go routines each one making its own HTTP request. Although keepalive is enabled by default the code ends up not re-using many of the connections causing the many connections to end up in a TIME_WAIT state. In order to avoid this the test now limits the number of concurrent requests and has a small change to the actual code to facilitate re-use of existing TCP connections used by the HTTP client.

Although there is a change to non-test code I don't consider this a bug worth changelog because no user of the component should reach such high burst of "push metrics" in any reasonable production scenario.
