### PR TITLE
[chore] use AvailablePort for grpc/http receivers

### DIFF
--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -94,6 +94,9 @@ func testIntegration(t *testing.T) {
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
 	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
+	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)
@@ -106,7 +109,7 @@ func testIntegration(t *testing.T) {
 	waitForReadiness(app)
 
 	// 3. Generate and send traces
-	sendTraces(t)
+	sendTraces(t, otlpGRPCEndpoint)
 
 	// 4. Validate traces and APM stats from the mock server
 	var spans []*pb.Span
@@ -225,11 +228,11 @@ func waitForReadiness(app *otelcol.Collector) {
 	}
 }
 
-func sendTraces(t *testing.T) {
+func sendTraces(t *testing.T, endpoint string) {
 	ctx := context.Background()
 
 	// Set up OTel-Go SDK and exporter
-	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithInsecure())
+	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithInsecure(), otlptracegrpc.WithEndpoint(endpoint))
 	require.NoError(t, err)
 	bsp := sdktrace.NewBatchSpanProcessor(traceExporter)
 	r1, _ := resource.New(ctx, resource.WithAttributes(attribute.String("k8s.node.name", "aaaa")))
@@ -287,6 +290,9 @@ func TestIntegrationComputeTopLevelBySpanKind(t *testing.T) {
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
 	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
+	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)
@@ -299,7 +305,7 @@ func TestIntegrationComputeTopLevelBySpanKind(t *testing.T) {
 	waitForReadiness(app)
 
 	// 3. Generate and send traces
-	sendTracesComputeTopLevelBySpanKind(t)
+	sendTracesComputeTopLevelBySpanKind(t, otlpGRPCEndpoint)
 
 	// 4. Validate traces and APM stats from the mock server
 	var spans []*pb.Span
@@ -387,11 +393,11 @@ func TestIntegrationComputeTopLevelBySpanKind(t *testing.T) {
 	}
 }
 
-func sendTracesComputeTopLevelBySpanKind(t *testing.T) {
+func sendTracesComputeTopLevelBySpanKind(t *testing.T, endpoint string) {
 	ctx := context.Background()
 
 	// Set up OTel-Go SDK and exporter
-	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithInsecure())
+	traceExporter, err := otlptracegrpc.New(ctx, otlptracegrpc.WithInsecure(), otlptracegrpc.WithEndpoint(endpoint))
 	require.NoError(t, err)
 	bsp := sdktrace.NewBatchSpanProcessor(traceExporter)
 	r1, _ := resource.New(ctx, resource.WithAttributes(attribute.String("k8s.node.name", "aaaa")))
@@ -469,6 +475,9 @@ func TestIntegrationLogs(t *testing.T) {
 	thing := commonTestutil.GetAvailableLocalAddress(t)
 	t.Setenv("SERVER_URL", server.URL)
 	t.Setenv("PROM_SERVER", thing)
+	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
+	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)
@@ -481,7 +490,7 @@ func TestIntegrationLogs(t *testing.T) {
 	waitForReadiness(app)
 
 	// 3. Generate and send logs
-	sendLogs(t, 5)
+	sendLogs(t, 5, otlpGRPCEndpoint)
 
 	// 4. Validate logs and metrics from the mock server
 	// Wait until `doneChannel` is closed and prometheus metrics are received.
@@ -525,9 +534,9 @@ func TestIntegrationLogs(t *testing.T) {
 	assert.Equal(t, 2, numSentLogRecords)
 }
 
-func sendLogs(t *testing.T, numLogs int) {
+func sendLogs(t *testing.T, numLogs int, endpoint string) {
 	ctx := context.Background()
-	logExporter, err := otlploggrpc.New(ctx, otlploggrpc.WithInsecure())
+	logExporter, err := otlploggrpc.New(ctx, otlploggrpc.WithInsecure(), otlploggrpc.WithEndpoint(endpoint))
 	assert.NoError(t, err)
 	lr := make([]log.Record, numLogs)
 	assert.NoError(t, logExporter.Export(ctx, lr))

--- a/exporter/datadogexporter/integrationtest/integration_test_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_config.yaml
@@ -3,9 +3,9 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: "localhost:4318"
+        endpoint: ${env:OTLP_HTTP_SERVER}
       grpc:
-        endpoint: "localhost:4317"
+        endpoint: ${env:OTLP_GRPC_SERVER}
 
 processors:
   tail_sampling:

--- a/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_internal_metrics_config.yaml
@@ -3,9 +3,9 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: "localhost:4318"
+        endpoint: ${env:OTLP_HTTP_SERVER}
       grpc:
-        endpoint: "localhost:4317"
+        endpoint: ${env:OTLP_GRPC_SERVER}
   prometheus:
     config:
       scrape_configs:

--- a/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_logs_config.yaml
@@ -3,9 +3,9 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: "localhost:4318"
+        endpoint: ${env:OTLP_HTTP_SERVER}
       grpc:
-        endpoint: "localhost:4317"
+        endpoint: ${env:OTLP_GRPC_SERVER}
   prometheus:
     config:
       scrape_configs:

--- a/exporter/datadogexporter/integrationtest/integration_test_toplevel_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_toplevel_config.yaml
@@ -3,9 +3,9 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: "localhost:4318"
+        endpoint: ${env:OTLP_HTTP_SERVER}
       grpc:
-        endpoint: "localhost:4317"
+        endpoint: ${env:OTLP_GRPC_SERVER}
 
 connectors:
   datadog/connector:

--- a/exporter/datadogexporter/integrationtest/no_race_integration_test.go
+++ b/exporter/datadogexporter/integrationtest/no_race_integration_test.go
@@ -29,6 +29,9 @@ func TestIntegrationInternalMetrics(t *testing.T) {
 	defer server.Close()
 	t.Setenv("SERVER_URL", server.URL)
 	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
+	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
 
 	// 2. Start in-process collector
 	factories := getIntegrationTestComponents(t)
@@ -41,7 +44,7 @@ func TestIntegrationInternalMetrics(t *testing.T) {
 	waitForReadiness(app)
 
 	// 3. Generate and send traces
-	sendTraces(t)
+	sendTraces(t, otlpGRPCEndpoint)
 
 	// 4. Validate Datadog trace agent & OTel internal metrics are sent to the mock server
 	expectedMetrics := map[string]struct{}{


### PR DESCRIPTION
Prevent tests from using the same port, possibly address flaky test.
