### PR TITLE
deltatocumulative: Fix selection of the target scale for exponential histograms

### DIFF
--- a/.chloggen/expo-histogram-fix-downscaling.yaml
+++ b/.chloggen/expo-histogram-fix-downscaling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: deltatocumulativeprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: In order to cap number of histogram buckets take the min of desired scale across negative and positive buckets instead of the max
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37416]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/deltatocumulativeprocessor/internal/data/add.go
+++ b/processor/deltatocumulativeprocessor/internal/data/add.go
@@ -80,7 +80,7 @@ func (dp ExpHistogram) Add(in ExpHistogram) ExpHistogram {
 
 	// Downscale if an expected number of buckets after the merge is too large.
 	from := expo.Scale(dp.Scale())
-	to := max(
+	to := min(
 		expo.Limit(maxBuckets, from, dp.Positive(), in.Positive()),
 		expo.Limit(maxBuckets, from, dp.Negative(), in.Negative()),
 	)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
While addressing comments a bug was added to the logic of calculating of the desired scale and it slipped through tests.
Fix the bug (use `min` instead of `max`) and update tests to avoid regressions in the future.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37416 

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Update tests to separately cover positive and negative buckets.

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->
