### PR TITLE
[chore] Fix filelog receiver test with new `component.ValidateConfig` behavior

### DIFF
--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -259,7 +259,8 @@ func testdataConfigYaml() *FileLogConfig {
 						timeCfg.ParseFrom = &timeField
 						// The Validate method modifies private fields on the helper.TimeParser
 						// object that need to be set for later comparison.
-						timeCfg.Validate()
+						// If validation fails, the test will fail, so discard the error.
+						_ := timeCfg.Validate()
 						cfg.TimeParser = &timeCfg
 						return cfg
 					}(),

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -260,7 +260,7 @@ func testdataConfigYaml() *FileLogConfig {
 						// The Validate method modifies private fields on the helper.TimeParser
 						// object that need to be set for later comparison.
 						// If validation fails, the test will fail, so discard the error.
-						_ := timeCfg.Validate()
+						_ = timeCfg.Validate()
 						cfg.TimeParser = &timeCfg
 						return cfg
 					}(),

--- a/receiver/filelogreceiver/filelog_test.go
+++ b/receiver/filelogreceiver/filelog_test.go
@@ -257,6 +257,9 @@ func testdataConfigYaml() *FileLogConfig {
 						timeCfg := helper.NewTimeParser()
 						timeCfg.Layout = "%Y-%m-%d"
 						timeCfg.ParseFrom = &timeField
+						// The Validate method modifies private fields on the helper.TimeParser
+						// object that need to be set for later comparison.
+						timeCfg.Validate()
 						cfg.TimeParser = &timeCfg
 						return cfg
 					}(),


### PR DESCRIPTION
#### Description

`component.ValidateConfig` now validates interfaces. The `(*helper.TimeParser).Validate` method is now called while validating `FileLogConfig` and as a result, the struct is modified during validation. The simplest fix seemed to be to apply these same changes to the expected config struct by calling `Validate` on it, even though the assertion logic in the test now feels a little circular.

I can try to refactor the struct a bit to make it more directly testable if desired.

This is needed for https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37447.