### PR TITLE
[chore][Makefile] Fix usage of deprecated builder flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -344,7 +344,7 @@ chlog-update: $(CHLOGGEN)
 
 .PHONY: genotelcontribcol
 genotelcontribcol: $(BUILDER)
-	$(BUILDER) --skip-compilation --config cmd/otelcontribcol/builder-config.yaml --output-path cmd/otelcontribcol
+	$(BUILDER) --skip-compilation --config cmd/otelcontribcol/builder-config.yaml
 
 # Build the Collector executable.
 .PHONY: otelcontribcol
@@ -360,7 +360,7 @@ otelcontribcollite: genotelcontribcol
 
 .PHONY: genoteltestbedcol
 genoteltestbedcol: $(BUILDER)
-	$(BUILDER) --skip-compilation --config cmd/oteltestbedcol/builder-config.yaml --output-path cmd/oteltestbedcol
+	$(BUILDER) --skip-compilation --config cmd/oteltestbedcol/builder-config.yaml
 
 # Build the Collector executable, with only components used in testbed.
 .PHONY: oteltestbedcol

--- a/cmd/otelcontribcol/builder-config.yaml
+++ b/cmd/otelcontribcol/builder-config.yaml
@@ -11,6 +11,7 @@ dist:
   name: otelcontribcol
   description: Local OpenTelemetry Collector Contrib binary, testing only.
   version: 0.118.0-dev
+  output_path: ./cmd/otelcontribcol
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.118.1-0.20250121185328-fbefb22cc2b3

--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -8,6 +8,7 @@ dist:
   name: oteltestbedcol
   description: OpenTelemetry Collector binary for testbed only tests.
   version: 0.118.0-dev
+  output_path: ./cmd/oteltestbedcol
 
 extensions:
   - gomod: go.opentelemetry.io/collector/extension/zpagesextension v0.118.1-0.20250121185328-fbefb22cc2b3


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Currently, when running `make otelcontribcol` or `make oteltestbedcol`, the following line is logged:
```
Flag --output-path has been deprecated, use config distribution::output_path
```
This change updates the Makefile configuration to use the proper commands instead of the deprecated ones.