### PR TITLE
[processor/resourcedetection] offer to configure the AWS SDK

### DIFF
--- a/.chloggen/configure_aws_sdk_retryer.yaml
+++ b/.chloggen/configure_aws_sdk_retryer.yaml
@@ -1,0 +1,40 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Expose additional configuration parameters for the AWS metadata client used by the EC2 detector
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35936]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  In some cases, you might need to change the behavior of the AWS metadata client from the [standard retryer](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-retries-timeouts.html)
+  
+  By default, the client retries 3 times with a max backoff delay of 20s.
+
+  We offer a limited set of options to override those defaults specifically, such that you can set the client to retry 10 times, for up to 5 minutes, for example:
+  ```yaml
+  processors:
+    resourcedetection/ec2:
+      detectors: ["ec2"]
+      ec2:
+        max_attempts: 10
+        max_backoff: 5m
+  ```
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -248,6 +248,20 @@ If you are using a proxy server on your EC2 instance, it's important that you ex
 
 If the instance is part of AWS ParallelCluster and the detector is failing to connect to the metadata server, check the iptable and make sure the chain `PARALLELCLUSTER_IMDS` contains a rule that allows OTEL user to access `169.254.169.254/32`
 
+In some cases, you might need to change the behavior of the AWS metadata client from the [standard retryer](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-retries-timeouts.html)
+
+By default, the client retries 3 times with a max backoff delay of 20s.
+
+We offer a limited set of options to override those defaults specifically, such that you can set the client to retry 10 times, for up to 5 minutes, for example:
+```yaml
+processors:
+  resourcedetection/ec2:
+    detectors: ["ec2"]
+    ec2:
+      max_attempts: 10
+      max_backoff: 5m
+```
+
 ### Amazon ECS
 
 Queries the [Task Metadata Endpoint](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint.html) (TMDE) to record information about the current ECS Task. Only TMDE V4 and V3 are supported.

--- a/processor/resourcedetectionprocessor/config_test.go
+++ b/processor/resourcedetectionprocessor/config_test.go
@@ -43,6 +43,8 @@ func TestLoadConfig(t *testing.T) {
 	ec2Config.EC2Config = ec2.Config{
 		Tags:               []string{"^tag1$", "^tag2$"},
 		ResourceAttributes: ec2.CreateDefaultConfig().ResourceAttributes,
+		MaxAttempts:        3,
+		MaxBackoff:         20 * time.Second,
 	}
 
 	systemConfig := detectorCreateDefaultConfig()

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
@@ -4,6 +4,10 @@
 package ec2 // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2"
 
 import (
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/resourcedetectionprocessor/internal/aws/ec2/internal/metadata"
 )
 
@@ -13,11 +17,15 @@ type Config struct {
 	// to add as resource attributes to processed data
 	Tags               []string                          `mapstructure:"tags"`
 	ResourceAttributes metadata.ResourceAttributesConfig `mapstructure:"resource_attributes"`
+	MaxAttempts        int                               `mapstructure:"max_attempts"`
+	MaxBackoff         time.Duration                     `mapstructure:"max_backoff"`
 }
 
 func CreateDefaultConfig() Config {
 	return Config{
 		Tags:               []string{},
 		ResourceAttributes: metadata.DefaultResourceAttributesConfig(),
+		MaxAttempts:        retry.DefaultMaxAttempts,
+		MaxBackoff:         retry.DefaultMaxBackoff,
 	}
 }

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/ec2.go
@@ -10,6 +10,7 @@ import (
 	"regexp"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
@@ -60,6 +61,12 @@ type Detector struct {
 func NewDetector(set processor.Settings, dcfg internal.DetectorConfig) (internal.Detector, error) {
 	cfg := dcfg.(Config)
 	awsConfig, err := config.LoadDefaultConfig(context.Background())
+	awsConfig.Retryer = func() aws.Retryer {
+		return retry.NewStandard(func(options *retry.StandardOptions) {
+			options.MaxAttempts = cfg.MaxAttempts
+			options.MaxBackoff = cfg.MaxBackoff
+		})
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
In some cases, you might need to change the behavior of the AWS metadata client from the [standard retryer](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-retries-timeouts.html)

By default, the client retries 3 times with a max backoff delay of 20s.

We offer a limited set of options to override those defaults specifically, such that you can set the client to retry 10 times, for up to 5 minutes, for example:
```yaml
processors:
  resourcedetection/ec2:
    detectors: ["ec2"]
    ec2:
      max_attempts: 10
      max_backoff: 5m
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates to #35936

<!--Describe what testing was performed and which tests were added.-->
#### Testing
No testing was performed.