### PR TITLE
[receiver/cloudfoundry] Promote `cloudfoundry.resourceAttributes.allow` feature gate to beta

### DIFF
--- a/.chloggen/cf_feature_flag_update.yaml
+++ b/.chloggen/cf_feature_flag_update.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/cloudfoundry
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Promote `cloudfoundry.resourceAttributes.allow` feature gate to beta
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34824]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  The `cloudfoundry.resourceAttributes.allow` feature gate is now enabled by default.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/cloudfoundryreceiver/converter.go
+++ b/receiver/cloudfoundryreceiver/converter.go
@@ -39,7 +39,7 @@ var ResourceAttributesKeys = []string{
 
 var allowResourceAttributes = featuregate.GlobalRegistry().MustRegister(
 	"cloudfoundry.resourceAttributes.allow",
-	featuregate.StageAlpha,
+	featuregate.StageBeta,
 	featuregate.WithRegisterDescription("When enabled, envelope tags are copied to the metrics as resource attributes instead of datapoint attributes"),
 	featuregate.WithRegisterFromVersion("v0.117.0"),
 )


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This feature gate, when enabled, allows some metric attributes received from Cloud Foundry to be properly moved to be resource attributes. This feature gate was introduced in `v0.117.0`, so it can now be moved to `beta` for `v0.119.0`.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Related to #34824