### PR TITLE
[processor/resourcedetection] Add fail_on_missing_metadata to EC2 detector

### DIFF
--- a/.chloggen/ec2_fail_on_missing_metadata.yaml
+++ b/.chloggen/ec2_fail_on_missing_metadata.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: resourcedetectionprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add `fail_on_missing_metadata` option on EC2 detector
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35936]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  If the EC2 metadata endpoint is unavailable, the EC2 detector by default ignores the error.
+  By setting `fail_on_missing_metadata` to true on the detector, the user will now trigger an error explicitly,
+  which will stop the collector from starting.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -253,6 +253,7 @@ In some cases, you might need to change the behavior of the AWS metadata client 
 By default, the client retries 3 times with a max backoff delay of 20s.
 
 We offer a limited set of options to override those defaults specifically, such that you can set the client to retry 10 times, for up to 5 minutes, for example:
+
 ```yaml
 processors:
   resourcedetection/ec2:
@@ -260,6 +261,16 @@ processors:
     ec2:
       max_attempts: 10
       max_backoff: 5m
+```
+
+The EC2 detector will report an error in logs if the EC2 metadata endpoint is unavailable. You can configure the detector to instead fail with this flag:
+
+```yaml
+processors:
+  resourcedetection/ec2:
+    detectors: ["ec2"]
+    ec2:
+      fail_on_missing_metadata: true
 ```
 
 ### Amazon ECS

--- a/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
+++ b/processor/resourcedetectionprocessor/internal/aws/ec2/config.go
@@ -15,10 +15,11 @@ import (
 type Config struct {
 	// Tags is a list of regex's to match ec2 instance tag keys that users want
 	// to add as resource attributes to processed data
-	Tags               []string                          `mapstructure:"tags"`
-	ResourceAttributes metadata.ResourceAttributesConfig `mapstructure:"resource_attributes"`
-	MaxAttempts        int                               `mapstructure:"max_attempts"`
-	MaxBackoff         time.Duration                     `mapstructure:"max_backoff"`
+	Tags                  []string                          `mapstructure:"tags"`
+	ResourceAttributes    metadata.ResourceAttributesConfig `mapstructure:"resource_attributes"`
+	MaxAttempts           int                               `mapstructure:"max_attempts"`
+	MaxBackoff            time.Duration                     `mapstructure:"max_backoff"`
+	FailOnMissingMetadata bool                              `mapstructure:"fail_on_missing_metadata"`
 }
 
 func CreateDefaultConfig() Config {


### PR DESCRIPTION


<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Add `fail_on_missing_metadata` option on EC2 detector

If the EC2 metadata endpoint is unavailable, the EC2 detector by default ignores the error.
By setting `fail_on_missing_metadata` to true on the detector, the user will now trigger an error explicitly,
which will stop the collector from starting.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Relates to #35936

