### PR TITLE
[receiver/github] add support for tracing github actions

### DIFF
--- a/receiver/githubreceiver/README.md
+++ b/receiver/githubreceiver/README.md
@@ -95,8 +95,7 @@ see the [Scraping README][ghsread].
 
 ## Traces - Getting Started
 
-Workflow tracing support is actively being added to the GitHub receiver.
-This is accomplished through the processing of GitHub Actions webhook
+Workflow tracing support processes the GitHub Actions webhook
 events for workflows and jobs. The [`workflow_job`][wjob] and
 [`workflow_run`][wrun] event payloads are then constructed into `trace`
 telemetry.
@@ -107,14 +106,13 @@ success, and failure rates.
 
 ### Configuration
 
-**IMPORTANT: At this time the tracing portion of this receiver only serves a health check endpoint.**
-
 The WebHook configuration exposes the following settings:
 
 * `endpoint`: (default = `localhost:8080`) - The address and port to bind the WebHook to.
 * `path`: (default = `/events`) - The path for Action events to be sent to.
 * `health_path`: (default = `/health`) - The path for health checks.
 * `secret`: (optional) - The secret used to [validates the payload][valid].
++ `service_name`: (optional) - The `service.name` to set in created spans.
 * `required_header`: (optional) - The required header key and value for incoming requests.
 
 The WebHook configuration block also accepts all the [confighttp][cfghttp]

--- a/receiver/githubreceiver/config.go
+++ b/receiver/githubreceiver/config.go
@@ -36,6 +36,7 @@ type WebHook struct {
 	HealthPath              string                   `mapstructure:"health_path"`     // path for health check api. Default is /health_check
 	RequiredHeader          RequiredHeader           `mapstructure:"required_header"` // optional setting to set a required header for all requests to have
 	Secret                  string                   `mapstructure:"secret"`          // secret for webhook
+	ServiceName             string                   `mapstructure:"service_name"`    // optional name of service to use for spans
 }
 
 type RequiredHeader struct {

--- a/receiver/githubreceiver/config.go
+++ b/receiver/githubreceiver/config.go
@@ -58,12 +58,6 @@ var (
 func (cfg *Config) Validate() error {
 	var errs error
 
-	// For now, scrapers are required to be defined in the config. As tracing
-	// and other signals are added, this requirement will change.
-	if len(cfg.Scrapers) == 0 {
-		errs = multierr.Append(errs, errRequireOneScraper)
-	}
-
 	maxReadWriteTimeout, _ := time.ParseDuration("10s")
 
 	if cfg.WebHook.ServerConfig.Endpoint == "" {

--- a/receiver/githubreceiver/config_test.go
+++ b/receiver/githubreceiver/config_test.go
@@ -50,8 +50,9 @@ func TestLoadConfig(t *testing.T) {
 			ReadTimeout:  500 * time.Millisecond,
 			WriteTimeout: 500 * time.Millisecond,
 		},
-		Path:       "some/path",
-		HealthPath: "health/path",
+		Path:        "some/path",
+		ServiceName: defaultServiceName,
+		HealthPath:  "health/path",
 		RequiredHeader: RequiredHeader{
 			Key:   "key-present",
 			Value: "value-present",
@@ -75,8 +76,9 @@ func TestLoadConfig(t *testing.T) {
 				ReadTimeout:  500 * time.Millisecond,
 				WriteTimeout: 500 * time.Millisecond,
 			},
-			Path:       "some/path",
-			HealthPath: "health/path",
+			Path:        "some/path",
+			HealthPath:  "health/path",
+			ServiceName: defaultServiceName,
 			RequiredHeader: RequiredHeader{
 				Key:   "key-present",
 				Value: "value-present",
@@ -85,19 +87,6 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	assert.Equal(t, expectedConfig, r1)
-}
-
-func TestLoadInvalidConfig_NoScrapers(t *testing.T) {
-	factories, err := otelcoltest.NopFactories()
-	require.NoError(t, err)
-
-	factory := NewFactory()
-	factories.Receivers[metadata.Type] = factory
-	// https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33594
-	// nolint:staticcheck
-	_, err = otelcoltest.LoadConfigAndValidate(filepath.Join("testdata", "config-noscrapers.yaml"), factories)
-
-	require.ErrorContains(t, err, "must specify at least one scraper")
 }
 
 func TestLoadInvalidConfig_InvalidScraperKey(t *testing.T) {

--- a/receiver/githubreceiver/factory.go
+++ b/receiver/githubreceiver/factory.go
@@ -29,6 +29,7 @@ const (
 	defaultPath         = "/events"
 	defaultHealthPath   = "/health"
 	defaultEndpoint     = "localhost:8080"
+	defaultServiceName  = "github-actions"
 )
 
 var (
@@ -68,8 +69,9 @@ func createDefaultConfig() component.Config {
 				ReadTimeout:  defaultReadTimeout,
 				WriteTimeout: defaultWriteTimeout,
 			},
-			Path:       defaultPath,
-			HealthPath: defaultHealthPath,
+			Path:        defaultPath,
+			HealthPath:  defaultHealthPath,
+			ServiceName: defaultServiceName,
 		},
 	}
 }

--- a/receiver/githubreceiver/traces_receiver_test.go
+++ b/receiver/githubreceiver/traces_receiver_test.go
@@ -17,8 +17,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+	semconv "go.opentelemetry.io/collector/semconv/v1.27.0"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -49,18 +51,21 @@ func TestWebhook(t *testing.T) {
 		{
 			"validEvent",
 			github.WorkflowJobEvent{
+				Action: github.Ptr(COMPLETED),
 				WorkflowJob: &github.WorkflowJob{
 					WorkflowName: github.Ptr("test"),
+					StartedAt:    &github.Timestamp{Time: time.Now().Add(time.Second)},
+					CompletedAt:  &github.Timestamp{Time: time.Now().Add(time.Second * 2)},
 					Steps: []*github.TaskStep{
 						{
 							Name:        github.Ptr("test1"),
-							StartedAt:   &github.Timestamp{Time: time.Now()},
-							CompletedAt: &github.Timestamp{Time: time.Now()},
+							StartedAt:   &github.Timestamp{Time: time.Now().Add(time.Second * 3)},
+							CompletedAt: &github.Timestamp{Time: time.Now().Add(time.Second * 4)},
 						},
 						{
 							Name:        github.Ptr("test2"),
-							StartedAt:   &github.Timestamp{Time: time.Now()},
-							CompletedAt: &github.Timestamp{Time: time.Now()},
+							StartedAt:   &github.Timestamp{Time: time.Now().Add(time.Second * 5)},
+							CompletedAt: &github.Timestamp{Time: time.Now().Add(time.Second * 6)},
 						},
 					},
 				},
@@ -97,15 +102,58 @@ func TestWebhook(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, response.StatusCode, string(body))
 
-			traces := consumer.AllTraces()
+			traces := clearTraces(consumer.AllTraces())
 
-			require.Equal(t, len(traces), 1)
+			require.Equal(t, tracesFromEvent(&tc.event), traces)
 		})
 	}
 }
 
-func tracesFromEvent(event *github.WorkflowJobEvent) ptrace.Traces {
+func tracesFromEvent(event *github.WorkflowJobEvent) []ptrace.Traces {
 	trace := ptrace.NewTraces()
 
-	return trace
+	rs := trace.ResourceSpans().AppendEmpty()
+	attributes := rs.Resource().Attributes()
+	attributes.PutStr(semconv.AttributeServiceName, defaultServiceName)
+	attributes.PutStr("github.workflow.name", *event.WorkflowJob.WorkflowName)
+	rs.SetSchemaUrl(semconv.SchemaURL)
+
+	ss := rs.ScopeSpans().AppendEmpty()
+
+	createSpan(event.WorkflowJob).CopyTo(ss.Spans().AppendEmpty())
+	for _, step := range event.WorkflowJob.Steps {
+		span := createSpan(step)
+
+		span.CopyTo(ss.Spans().AppendEmpty())
+	}
+
+	return []ptrace.Traces{trace}
+}
+
+func clearTraces(traces []ptrace.Traces) []ptrace.Traces {
+	newTraces := make([]ptrace.Traces, len(traces))
+
+	for i, trace := range traces {
+		newTrace := ptrace.NewTraces()
+		trace.CopyTo(newTrace)
+
+		for i := 0; i < trace.ResourceSpans().Len(); i++ {
+			rs := newTrace.ResourceSpans().At(i)
+
+			for i := 0; i < rs.ScopeSpans().Len(); i++ {
+				ss := rs.ScopeSpans().At(i)
+
+				for i := 0; i < ss.Spans().Len(); i++ {
+					span := ss.Spans().At(i)
+					span.SetTraceID(pcommon.NewTraceIDEmpty())
+					span.SetSpanID(pcommon.NewSpanIDEmpty())
+					span.SetParentSpanID(pcommon.NewSpanIDEmpty())
+				}
+			}
+		}
+
+		newTraces[i] = newTrace
+	}
+
+	return newTraces
 }

--- a/receiver/githubreceiver/traces_receiver_test.go
+++ b/receiver/githubreceiver/traces_receiver_test.go
@@ -4,14 +4,20 @@
 package githubreceiver // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/githubreceiver"
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/google/go-github/v68/github"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 )
 
@@ -33,4 +39,73 @@ func TestHealthCheck(t *testing.T) {
 
 	response := w.Result()
 	require.Equal(t, http.StatusOK, response.StatusCode)
+}
+
+func TestWebhook(t *testing.T) {
+	testCases := []struct {
+		name  string
+		event github.WorkflowJobEvent
+	}{
+		{
+			"validEvent",
+			github.WorkflowJobEvent{
+				WorkflowJob: &github.WorkflowJob{
+					WorkflowName: github.Ptr("test"),
+					Steps: []*github.TaskStep{
+						{
+							Name:        github.Ptr("test1"),
+							StartedAt:   &github.Timestamp{Time: time.Now()},
+							CompletedAt: &github.Timestamp{Time: time.Now()},
+						},
+						{
+							Name:        github.Ptr("test2"),
+							StartedAt:   &github.Timestamp{Time: time.Now()},
+							CompletedAt: &github.Timestamp{Time: time.Now()},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			defaultConfig := createDefaultConfig().(*Config)
+			defaultConfig.WebHook.Endpoint = "localhost:0"
+			consumer := &consumertest.TracesSink{}
+			receiver, err := newTracesReceiver(receivertest.NewNopSettings(), defaultConfig, consumer)
+			require.NoError(t, err, "failed to create receiver")
+
+			r := receiver
+			require.NoError(t, r.Start(context.Background(), componenttest.NewNopHost()), "failed to start receiver")
+			defer func() {
+				require.NoError(t, r.Shutdown(context.Background()), "failed to shutdown revceiver")
+			}()
+
+			body, err := json.Marshal(tc.event)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			request := httptest.NewRequest(http.MethodPost, "http://localhost/event", bytes.NewReader(body))
+			request.Header.Add("Content-Type", "application/json")
+			// https://docs.github.com/en/webhooks/webhook-events-and-payloads
+			request.Header.Add("X-Github-Event", "workflow_job")
+			r.handleWebhook(w, request)
+
+			response := w.Result()
+			body, err = io.ReadAll(response.Body)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, response.StatusCode, string(body))
+
+			traces := consumer.AllTraces()
+
+			require.Equal(t, len(traces), 1)
+		})
+	}
+}
+
+func tracesFromEvent(event *github.WorkflowJobEvent) ptrace.Traces {
+	trace := ptrace.NewTraces()
+
+	return trace
 }


### PR DESCRIPTION
#### Description
Adds support for tracing github action executions. Github actions only gives up to seconds so things that take < 1 second are reported as 0.

![image](https://github.com/user-attachments/assets/cca6e8b3-3293-4e64-8e61-668274332e7e)

#### Testing

Added basic scaffolding to unit tests the components, but unfamiliar with the best practices here.

#### Documentation

Updated the README to show the new functionality.
