### PR TITLE
[exporter/elasticsearch] [chore] move esIndex into elasticsearch.Index

### DIFF
--- a/exporter/elasticsearchexporter/data_stream_router.go
+++ b/exporter/elasticsearchexporter/data_stream_router.go
@@ -10,6 +10,8 @@ import (
 	"unicode"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/elasticsearch"
 )
 
 var receiverRegex = regexp.MustCompile(`/receiver/(\w*receiver)`)
@@ -46,7 +48,7 @@ func routeWithDefaults(defaultDSType string) func(
 	string,
 	bool,
 	string,
-) esIndex {
+) elasticsearch.Index {
 	return func(
 		recordAttr pcommon.Map,
 		scopeAttr pcommon.Map,
@@ -54,7 +56,7 @@ func routeWithDefaults(defaultDSType string) func(
 		fIndex string,
 		otel bool,
 		scopeName string,
-	) esIndex {
+	) elasticsearch.Index {
 		// Order:
 		// 1. read data_stream.* from attributes
 		// 2. read elasticsearch.index.* from attributes
@@ -67,7 +69,7 @@ func routeWithDefaults(defaultDSType string) func(
 			prefix, prefixExists := getFromAttributes(indexPrefix, "", resourceAttr, scopeAttr, recordAttr)
 			suffix, suffixExists := getFromAttributes(indexSuffix, "", resourceAttr, scopeAttr, recordAttr)
 			if prefixExists || suffixExists {
-				return esIndex{Index: fmt.Sprintf("%s%s%s", prefix, fIndex, suffix)}
+				return elasticsearch.Index{Index: fmt.Sprintf("%s%s%s", prefix, fIndex, suffix)}
 			}
 		}
 
@@ -89,28 +91,8 @@ func routeWithDefaults(defaultDSType string) func(
 
 		dataset = sanitizeDataStreamField(dataset, disallowedDatasetRunes, datasetSuffix)
 		namespace = sanitizeDataStreamField(namespace, disallowedNamespaceRunes, "")
-		return newDataStream(defaultDSType, dataset, namespace)
+		return elasticsearch.NewDataStreamIndex(defaultDSType, dataset, namespace)
 	}
-}
-
-type esIndex struct {
-	Index     string
-	Type      string
-	Dataset   string
-	Namespace string
-}
-
-func newDataStream(typ, dataset, namespace string) esIndex {
-	return esIndex{
-		Index:     fmt.Sprintf("%s-%s-%s", typ, dataset, namespace),
-		Type:      typ,
-		Dataset:   dataset,
-		Namespace: namespace,
-	}
-}
-
-func (i esIndex) isDataStream() bool {
-	return i.Type != "" && i.Dataset != "" && i.Namespace != ""
 }
 
 var (

--- a/exporter/elasticsearchexporter/data_stream_router_test.go
+++ b/exporter/elasticsearchexporter/data_stream_router_test.go
@@ -8,21 +8,23 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pcommon"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/elasticsearch"
 )
 
 type routeTestCase struct {
 	name      string
 	otel      bool
 	scopeName string
-	want      esIndex
+	want      elasticsearch.Index
 }
 
 func createRouteTests(dsType string) []routeTestCase {
-	renderWantRoute := func(dsType, dsDataset string, otel bool) esIndex {
+	renderWantRoute := func(dsType, dsDataset string, otel bool) elasticsearch.Index {
 		if otel {
 			dsDataset += ".otel"
 		}
-		return newDataStream(dsType, dsDataset, defaultDataStreamNamespace)
+		return elasticsearch.NewDataStreamIndex(dsType, dsDataset, defaultDataStreamNamespace)
 	}
 
 	return []routeTestCase{

--- a/exporter/elasticsearchexporter/internal/elasticsearch/index.go
+++ b/exporter/elasticsearchexporter/internal/elasticsearch/index.go
@@ -1,0 +1,26 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package elasticsearch // import "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/elasticsearch"
+
+import "fmt"
+
+type Index struct {
+	Index     string
+	Type      string
+	Dataset   string
+	Namespace string
+}
+
+func NewDataStreamIndex(typ, dataset, namespace string) Index {
+	return Index{
+		Index:     fmt.Sprintf("%s-%s-%s", typ, dataset, namespace),
+		Type:      typ,
+		Dataset:   dataset,
+		Namespace: namespace,
+	}
+}
+
+func (i Index) IsDataStream() bool {
+	return i.Type != "" && i.Dataset != "" && i.Namespace != ""
+}

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -24,6 +24,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	semconv "go.opentelemetry.io/collector/semconv/v1.22.0"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/elasticsearch"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/objmodel"
 )
 
@@ -57,7 +58,7 @@ func TestEncodeSpan(t *testing.T) {
 	model := &encodeModel{dedot: false}
 	td := mockResourceSpans()
 	var buf bytes.Buffer
-	err := model.encodeSpan(td.ResourceSpans().At(0).Resource(), "", td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0), td.ResourceSpans().At(0).ScopeSpans().At(0).Scope(), "", esIndex{}, &buf)
+	err := model.encodeSpan(td.ResourceSpans().At(0).Resource(), "", td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0), td.ResourceSpans().At(0).ScopeSpans().At(0).Scope(), "", elasticsearch.Index{}, &buf)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedSpanBody, buf.String())
 }
@@ -68,7 +69,7 @@ func TestEncodeLog(t *testing.T) {
 		td := mockResourceLogs()
 		td.ScopeLogs().At(0).LogRecords().At(0).SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 4, 19, 3, 4, 5, 6, time.UTC)))
 		var buf bytes.Buffer
-		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), esIndex{}, &buf)
+		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), elasticsearch.Index{}, &buf)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedLogBody, buf.String())
 	})
@@ -77,7 +78,7 @@ func TestEncodeLog(t *testing.T) {
 		model := &encodeModel{dedot: false}
 		td := mockResourceLogs()
 		var buf bytes.Buffer
-		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), esIndex{}, &buf)
+		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), elasticsearch.Index{}, &buf)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedLogBodyWithEmptyTimestamp, buf.String())
 	})
@@ -87,7 +88,7 @@ func TestEncodeLog(t *testing.T) {
 		td := mockResourceLogs()
 		td.Resource().Attributes().PutStr("foo.bar", "baz")
 		var buf bytes.Buffer
-		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), esIndex{}, &buf)
+		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), elasticsearch.Index{}, &buf)
 		require.NoError(t, err)
 		require.Equal(t, expectedLogBodyDeDottedWithEmptyTimestamp, buf.String())
 	})
@@ -124,7 +125,7 @@ func TestEncodeMetric(t *testing.T) {
 	for _, dataPoints := range groupedDataPoints {
 		var buf bytes.Buffer
 		errors := make([]error, 0)
-		_, err := model.encodeMetrics(rm.Resource(), rm.SchemaUrl(), sm.Scope(), sm.SchemaUrl(), dataPoints, &errors, esIndex{}, &buf)
+		_, err := model.encodeMetrics(rm.Resource(), rm.SchemaUrl(), sm.Scope(), sm.SchemaUrl(), dataPoints, &errors, elasticsearch.Index{}, &buf)
 		require.Empty(t, errors, err)
 		require.NoError(t, err)
 		docsBytes = append(docsBytes, buf.Bytes())
@@ -253,7 +254,7 @@ func TestEncodeAttributes(t *testing.T) {
 			}
 
 			doc := objmodel.Document{}
-			m.encodeAttributes(&doc, attributes, esIndex{})
+			m.encodeAttributes(&doc, attributes, elasticsearch.Index{})
 			require.Equal(t, test.want(), doc)
 		})
 	}
@@ -350,7 +351,7 @@ func TestEncodeLogECSModeDuplication(t *testing.T) {
 		dedot: true,
 	}
 	var buf bytes.Buffer
-	err = m.encodeLog(resource, "", record, scope, "", esIndex{}, &buf)
+	err = m.encodeLog(resource, "", record, scope, "", elasticsearch.Index{}, &buf)
 	require.NoError(t, err)
 
 	assert.Equal(t, want, buf.String())
@@ -424,7 +425,7 @@ func TestEncodeLogECSMode(t *testing.T) {
 
 	var buf bytes.Buffer
 	m := encodeModel{}
-	doc := m.encodeLogECSMode(resource, record, scope, esIndex{})
+	doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
 	require.NoError(t, doc.Serialize(&buf, false))
 
 	require.JSONEq(t, `{
@@ -557,7 +558,7 @@ func TestEncodeLogECSModeAgentName(t *testing.T) {
 
 			var buf bytes.Buffer
 			m := encodeModel{}
-			doc := m.encodeLogECSMode(resource, record, scope, esIndex{})
+			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
 			require.NoError(t, doc.Serialize(&buf, false))
 			require.JSONEq(t, fmt.Sprintf(`{
 				"@timestamp": "2024-03-13T23:50:59.123456789Z",
@@ -611,7 +612,7 @@ func TestEncodeLogECSModeAgentVersion(t *testing.T) {
 
 			var buf bytes.Buffer
 			m := encodeModel{}
-			doc := m.encodeLogECSMode(resource, record, scope, esIndex{})
+			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
 			require.NoError(t, doc.Serialize(&buf, false))
 
 			if test.expectedAgentVersion == "" {
@@ -720,7 +721,7 @@ func TestEncodeLogECSModeHostOSType(t *testing.T) {
 			var buf bytes.Buffer
 			m := encodeModel{}
 			logs.MarkReadOnly()
-			doc := m.encodeLogECSMode(resource, record, scope, esIndex{})
+			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
 			require.NoError(t, doc.Serialize(&buf, false))
 
 			expectedJSON := `{"@timestamp":"2024-03-13T23:50:59.123456789Z", "agent.name":"otlp"`
@@ -771,7 +772,7 @@ func TestEncodeLogECSModeTimestamps(t *testing.T) {
 
 			var buf bytes.Buffer
 			m := encodeModel{}
-			doc := m.encodeLogECSMode(resource, record, scope, esIndex{})
+			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
 			require.NoError(t, doc.Serialize(&buf, false))
 
 			require.JSONEq(t, fmt.Sprintf(
@@ -1265,7 +1266,7 @@ func TestEncodeLogScalarObjectConflict(t *testing.T) {
 	td.ScopeLogs().At(0).LogRecords().At(0).Attributes().PutStr("foo", "scalar")
 	td.ScopeLogs().At(0).LogRecords().At(0).Attributes().PutStr("foo.bar", "baz")
 	var buf bytes.Buffer
-	err := model.encodeLog(td.Resource(), "", td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), "", esIndex{}, &buf)
+	err := model.encodeLog(td.Resource(), "", td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), "", elasticsearch.Index{}, &buf)
 	assert.NoError(t, err)
 
 	encoded := buf.Bytes()
@@ -1279,7 +1280,7 @@ func TestEncodeLogScalarObjectConflict(t *testing.T) {
 	// If there is an attribute named "foo.value", then "foo" would be omitted rather than renamed.
 	td.ScopeLogs().At(0).LogRecords().At(0).Attributes().PutStr("foo.value", "foovalue")
 	buf = bytes.Buffer{}
-	err = model.encodeLog(td.Resource(), "", td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), "", esIndex{}, &buf)
+	err = model.encodeLog(td.Resource(), "", td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), "", elasticsearch.Index{}, &buf)
 	assert.NoError(t, err)
 
 	encoded = buf.Bytes()

--- a/exporter/elasticsearchexporter/pdata_serializer.go
+++ b/exporter/elasticsearchexporter/pdata_serializer.go
@@ -21,7 +21,7 @@ import (
 
 const tsLayout = "2006-01-02T15:04:05.000000000Z"
 
-func serializeMetrics(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, dataPoints []dataPoint, validationErrors *[]error, idx esIndex, buf *bytes.Buffer) (map[string]string, error) {
+func serializeMetrics(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, dataPoints []dataPoint, validationErrors *[]error, idx elasticsearch.Index, buf *bytes.Buffer) (map[string]string, error) {
 	if len(dataPoints) == 0 {
 		return nil, nil
 	}
@@ -94,7 +94,7 @@ func serializeDataPoints(v *json.Visitor, dataPoints []dataPoint, validationErro
 	return dynamicTemplates
 }
 
-func serializeSpanEvent(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, span ptrace.Span, spanEvent ptrace.SpanEvent, idx esIndex, buf *bytes.Buffer) {
+func serializeSpanEvent(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, span ptrace.Span, spanEvent ptrace.SpanEvent, idx elasticsearch.Index, buf *bytes.Buffer) {
 	v := json.NewVisitor(buf)
 	// Enable ExplicitRadixPoint such that 1.0 is encoded as 1.0 instead of 1.
 	// This is required to generate the correct dynamic mapping in ES.
@@ -121,7 +121,7 @@ func serializeSpanEvent(resource pcommon.Resource, resourceSchemaURL string, sco
 	_ = v.OnObjectFinished()
 }
 
-func serializeSpan(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, span ptrace.Span, idx esIndex, buf *bytes.Buffer) error {
+func serializeSpan(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, span ptrace.Span, idx elasticsearch.Index, buf *bytes.Buffer) error {
 	v := json.NewVisitor(buf)
 	// Enable ExplicitRadixPoint such that 1.0 is encoded as 1.0 instead of 1.
 	// This is required to generate the correct dynamic mapping in ES.
@@ -181,7 +181,7 @@ func serializeMap(m pcommon.Map, buf *bytes.Buffer) {
 	writeMap(v, m, false)
 }
 
-func serializeLog(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, record plog.LogRecord, idx esIndex, buf *bytes.Buffer) error {
+func serializeLog(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, record plog.LogRecord, idx elasticsearch.Index, buf *bytes.Buffer) error {
 	v := json.NewVisitor(buf)
 	// Enable ExplicitRadixPoint such that 1.0 is encoded as 1.0 instead of 1.
 	// This is required to generate the correct dynamic mapping in ES.
@@ -215,8 +215,8 @@ func serializeLog(resource pcommon.Resource, resourceSchemaURL string, scope pco
 	return nil
 }
 
-func writeDataStream(v *json.Visitor, idx esIndex) {
-	if !idx.isDataStream() {
+func writeDataStream(v *json.Visitor, idx elasticsearch.Index) {
+	if !idx.IsDataStream() {
 		return
 	}
 	_ = v.OnKey("data_stream")

--- a/exporter/elasticsearchexporter/pdata_serializer_test.go
+++ b/exporter/elasticsearchexporter/pdata_serializer_test.go
@@ -13,6 +13,8 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter/internal/elasticsearch"
 )
 
 func TestSerializeLog(t *testing.T) {
@@ -185,7 +187,7 @@ func TestSerializeLog(t *testing.T) {
 			logs.MarkReadOnly()
 
 			var buf bytes.Buffer
-			err := serializeLog(resourceLogs.Resource(), "", scopeLogs.Scope(), "", record, esIndex{}, &buf)
+			err := serializeLog(resourceLogs.Resource(), "", scopeLogs.Scope(), "", record, elasticsearch.Index{}, &buf)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("serializeLog() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -220,7 +222,7 @@ func TestSerializeMetricsConflict(t *testing.T) {
 
 	var validationErrors []error
 	var buf bytes.Buffer
-	_, err := serializeMetrics(resourceMetrics.Resource(), "", scopeMetrics.Scope(), "", dataPoints, &validationErrors, esIndex{}, &buf)
+	_, err := serializeMetrics(resourceMetrics.Resource(), "", scopeMetrics.Scope(), "", dataPoints, &validationErrors, elasticsearch.Index{}, &buf)
 	if err != nil {
 		t.Errorf("serializeMetrics() error = %v", err)
 	}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This moves the internal `esIndex` struct into `elasticsearch.Index`, so other internal packages can use it.