### PR TITLE
[chore] Fix OTel Arrow Exporter test with new queue batcher enabled

### DIFF
--- a/exporter/otelarrowexporter/metadata_test.go
+++ b/exporter/otelarrowexporter/metadata_test.go
@@ -44,6 +44,7 @@ func TestSendTracesWithMetadata(t *testing.T) {
 		},
 	}
 	cfg.Arrow.MaxStreamLifetime = 100 * time.Second
+	cfg.QueueSettings.Enabled = false
 
 	cfg.MetadataCardinalityLimit = 10
 	cfg.MetadataKeys = []string{"key1", "key2"}

--- a/exporter/otelarrowexporter/otelarrow_test.go
+++ b/exporter/otelarrowexporter/otelarrow_test.go
@@ -932,10 +932,9 @@ func testSendArrowTraces(t *testing.T, clientWaitForReady, streamServiceAvailabl
 		},
 	}
 	// Arrow client is enabled, but the server doesn't support it.
-	cfg.Arrow = ArrowConfig{
-		NumStreams:        1,
-		MaxStreamLifetime: 100 * time.Second,
-	}
+	cfg.Arrow.NumStreams = 1
+	cfg.Arrow.MaxStreamLifetime = 100 * time.Second
+	cfg.QueueSettings.Enabled = false
 
 	set := exportertest.NewNopSettings()
 	set.TelemetrySettings.Logger = zaptest.NewLogger(t)


### PR DESCRIPTION
Fixes issues that arise from the recent promotion of `exporter.UsePullingBasedExporterQueueBatcher` from alpha to beta.

Needed for https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37447.