### PR TITLE
[chore][CI] disable failIfEmpty in check-links

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -45,3 +45,4 @@ jobs:
         uses: lycheeverse/lychee-action@f796c8b7d468feb9b8c0a46da3fac0af6874d374
         with:
           args: "--verbose --no-progress ${{needs.changedfiles.outputs.md_files}} ${{needs.changedfiles.outputs.yaml_files}} --config .github/lychee.toml"
+          failIfEmpty: false


### PR DESCRIPTION
#### Description
When there are no links in docs, do not fail the check-links CI. E.g. https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/12942375890/job/36100042406?pr=36142