### PR TITLE
Upgrade otel-arrow dependencies to v0.32.0

### DIFF
--- a/exporter/otelarrowexporter/go.mod
+++ b/exporter/otelarrowexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow/go/v16 v16.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow v0.118.0
-	github.com/open-telemetry/otel-arrow v0.31.0
+	github.com/open-telemetry/otel-arrow v0.32.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.24.1-0.20250123125445-24f88da7b583
 	go.opentelemetry.io/collector/component v0.118.1-0.20250123125445-24f88da7b583

--- a/exporter/otelarrowexporter/go.sum
+++ b/exporter/otelarrowexporter/go.sum
@@ -84,8 +84,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
 github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-telemetry/otel-arrow v0.31.0 h1:KEWHM5XrUbuGktf17gp3Tgls0OHPyT0VtT5WEohiCC4=
-github.com/open-telemetry/otel-arrow v0.31.0/go.mod h1:rEiUiCmxRT3RrtB0ZsT5LeTWJBynPCs0iBkVlMGk+E8=
 github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
 github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/exporter/otelarrowexporter/go.sum
+++ b/exporter/otelarrowexporter/go.sum
@@ -86,6 +86,8 @@ github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/open-telemetry/otel-arrow v0.31.0 h1:KEWHM5XrUbuGktf17gp3Tgls0OHPyT0VtT5WEohiCC4=
 github.com/open-telemetry/otel-arrow v0.31.0/go.mod h1:rEiUiCmxRT3RrtB0ZsT5LeTWJBynPCs0iBkVlMGk+E8=
+github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
+github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/otelarrow/go.mod
+++ b/internal/otelarrow/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.118.0
-	github.com/open-telemetry/otel-arrow v0.31.0
+	github.com/open-telemetry/otel-arrow v0.32.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.118.1-0.20250123125445-24f88da7b583
 	go.opentelemetry.io/collector/component/componenttest v0.118.1-0.20250123125445-24f88da7b583

--- a/internal/otelarrow/go.sum
+++ b/internal/otelarrow/go.sum
@@ -84,8 +84,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
 github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-telemetry/otel-arrow v0.31.0 h1:KEWHM5XrUbuGktf17gp3Tgls0OHPyT0VtT5WEohiCC4=
-github.com/open-telemetry/otel-arrow v0.31.0/go.mod h1:rEiUiCmxRT3RrtB0ZsT5LeTWJBynPCs0iBkVlMGk+E8=
 github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
 github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/internal/otelarrow/go.sum
+++ b/internal/otelarrow/go.sum
@@ -86,6 +86,8 @@ github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/open-telemetry/otel-arrow v0.31.0 h1:KEWHM5XrUbuGktf17gp3Tgls0OHPyT0VtT5WEohiCC4=
 github.com/open-telemetry/otel-arrow v0.31.0/go.mod h1:rEiUiCmxRT3RrtB0ZsT5LeTWJBynPCs0iBkVlMGk+E8=
+github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
+github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/receiver/otelarrowreceiver/go.mod
+++ b/receiver/otelarrowreceiver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow v0.118.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.118.0
-	github.com/open-telemetry/otel-arrow v0.31.0
+	github.com/open-telemetry/otel-arrow v0.32.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.24.1-0.20250123125445-24f88da7b583
 	go.opentelemetry.io/collector/component v0.118.1-0.20250123125445-24f88da7b583

--- a/receiver/otelarrowreceiver/go.sum
+++ b/receiver/otelarrowreceiver/go.sum
@@ -78,8 +78,6 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
 github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-telemetry/otel-arrow v0.31.0 h1:KEWHM5XrUbuGktf17gp3Tgls0OHPyT0VtT5WEohiCC4=
-github.com/open-telemetry/otel-arrow v0.31.0/go.mod h1:rEiUiCmxRT3RrtB0ZsT5LeTWJBynPCs0iBkVlMGk+E8=
 github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
 github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=

--- a/receiver/otelarrowreceiver/go.sum
+++ b/receiver/otelarrowreceiver/go.sum
@@ -80,6 +80,8 @@ github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/open-telemetry/otel-arrow v0.31.0 h1:KEWHM5XrUbuGktf17gp3Tgls0OHPyT0VtT5WEohiCC4=
 github.com/open-telemetry/otel-arrow v0.31.0/go.mod h1:rEiUiCmxRT3RrtB0ZsT5LeTWJBynPCs0iBkVlMGk+E8=
+github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
+github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/receiver/otelarrowreceiver/otelarrow.go
+++ b/receiver/otelarrowreceiver/otelarrow.go
@@ -142,7 +142,9 @@ func (r *otelArrowReceiver) startProtocolServers(ctx context.Context, host compo
 			opts = append(opts, arrowRecord.WithMemoryLimit(r.cfg.Arrow.MemoryLimitMiB<<20))
 		}
 		if r.settings.TelemetrySettings.MeterProvider != nil {
-			opts = append(opts, arrowRecord.WithMeterProvider(r.settings.TelemetrySettings.MeterProvider, r.settings.TelemetrySettings.MetricsLevel))
+			// This alt method call should be replaced once https://github.com/open-telemetry/otel-arrow/issues/280 is resolved.
+			// The WithMeterProvider function will be updated in a future release cycle.
+			opts = append(opts, arrowRecord.WithMeterProviderAlt(r.settings.TelemetrySettings.MeterProvider))
 		}
 		return arrowRecord.NewConsumer(opts...)
 	}, r.boundedQueue, r.netReporter)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Upgrade otel-arrow dependencies to v0.32.0 following [opentelemetry/otel-arrow's latest release](https://github.com/open-telemetry/otel-arrow/releases).

This is mostly a chore upgrade, but also includes one code change in `otelarrowreceiver` to aid in resolution of [https://github.com/open-telemetry/otel-arrow/issues/280](https://github.com/open-telemetry/otel-arrow/issues/280).