### PR TITLE
Update troubleshooting info for GMP exporter

### DIFF
--- a/exporter/googlemanagedprometheusexporter/README.md
+++ b/exporter/googlemanagedprometheusexporter/README.md
@@ -220,6 +220,12 @@ written as a double going forward. The simplest way to do this is by using the
 "Try this method" tab in the API reference for
 [DeleteMetricDescriptor](https://cloud.google.com/monitoring/api/ref_v3/rest/v3/projects.metricDescriptors/delete).
 
+Alternatively, you can run this
+[Go program](https://github.com/GoogleCloudPlatform/prometheus-engine/blob/v0.13.0/examples/scripts/delete_metric_descriptors/delete_metric_descriptors.go)
+that accepts your project ID and a [RE2](https://github.com/google/re2/wiki/syntax) regular expression to match multiple metric descriptors and delete them
+simulataneously.\
+This is useful if the conflicting value type errors are across multiple descriptors, especially with similar names.
+
 ### Points Written Too Frequently
 
 Error: `One or more points were written more frequently than the maximum sampling period configured for the metric.`


### PR DESCRIPTION
GMP exporter may run into the conflicting value type errors if there already exists same metric descriptors with different value types. In this case, deleting the old metric descriptors might become necessary.

Added information about the Go program that can be used to delete multiple metric descriptors simultaneously.

#### Description

The added information makes users aware of a workaround to delete multiple metric descriptors simultaneously using a Go program.

#### Documentation

Added documentation in the troubleshooting section for bulk deletion of metric descriptors.
