### PR TITLE
Update module github.com/ReneKroon/ttlcache/v2 to v3

### DIFF
--- a/receiver/googlecloudspannerreceiver/go.mod
+++ b/receiver/googlecloudspannerreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	cloud.google.com/go/spanner v1.73.0
-	github.com/ReneKroon/ttlcache/v2 v2.11.0
+	github.com/ReneKroon/ttlcache/v3 v3.3.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.118.1-0.20250123125445-24f88da7b583

--- a/receiver/googlecloudspannerreceiver/go.mod
+++ b/receiver/googlecloudspannerreceiver/go.mod
@@ -4,7 +4,7 @@ go 1.22.0
 
 require (
 	cloud.google.com/go/spanner v1.73.0
-	github.com/ReneKroon/ttlcache/v3 v3.3.0
+	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.118.1-0.20250123125445-24f88da7b583

--- a/receiver/googlecloudspannerreceiver/go.sum
+++ b/receiver/googlecloudspannerreceiver/go.sum
@@ -621,8 +621,6 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0/go.mod h1:obipzmGjfSjam60XLwGfqUkJsfiheAl+TUjG+4yzyPM=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c/go.mod h1:X0CRv0ky0k6m906ixxpzmDRLvX58TFUKS2eePweuyxk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/ReneKroon/ttlcache/v2 v2.11.0 h1:OvlcYFYi941SBN3v9dsDcC2N8vRxyHcCmJb3Vl4QMoM=
-github.com/ReneKroon/ttlcache/v2 v2.11.0/go.mod h1:mBxvsNY+BT8qLLd6CuAJubbKo6r0jh3nb5et22bbfGY=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
@@ -833,6 +831,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jellydator/ttlcache/v3 v3.3.0 h1:BdoC9cE81qXfrxeb9eoJi9dWrdhSuwXMAnHTbnBm4Wc=
+github.com/jellydator/ttlcache/v3 v3.3.0/go.mod h1:bj2/e0l4jRnQdrnSTaGTsh4GSXvMjQcy41i7th0GVGw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
@@ -999,7 +999,6 @@ go.opentelemetry.io/otel/trace v1.34.0/go.mod h1:Svm7lSjQD7kG7KJ/MUHPVXSDGz2OX4h
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
@@ -1313,7 +1312,6 @@ golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191012152004-8de300cfc20a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20191108193012-7d206e10da11/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191113191852-77e3bb0ad9e7/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191115202509-3a792d9c32b2/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
@@ -1348,7 +1346,6 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20210112230658-8b4aab62c064/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality.go
@@ -4,12 +4,12 @@
 package filter // import "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/googlecloudspannerreceiver/internal/filter"
 
 import (
-	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"time"
 
-	"github.com/ReneKroon/ttlcache/v2"
+	"github.com/jellydator/ttlcache/v3"
 	"go.uber.org/zap"
 )
 
@@ -36,7 +36,8 @@ type itemCardinalityFilter struct {
 	limitByTimestamp   int
 	itemActivityPeriod time.Duration
 	logger             *zap.Logger
-	cache              *ttlcache.Cache
+	cache              *ttlcache.Cache[string, struct{}]
+	stopOnce           sync.Once
 }
 
 type currentLimitByTimestamp struct {
@@ -58,10 +59,11 @@ func NewItemCardinalityFilter(metricName string, totalLimit int, limitByTimestam
 		return nil, fmt.Errorf("total limit %q is lower or equal to limit by timestamp %q", totalLimit, limitByTimestamp)
 	}
 
-	cache := ttlcache.NewCache()
-
-	cache.SetCacheSizeLimit(totalLimit)
-	cache.SkipTTLExtensionOnHit(true)
+	cache := ttlcache.New[string, struct{}](
+		ttlcache.WithCapacity[string, struct{}](uint64(totalLimit)),
+		ttlcache.WithDisableTouchOnHit[string, struct{}](),
+	)
+	go cache.Start()
 
 	return &itemCardinalityFilter{
 		metricName:         metricName,
@@ -116,23 +118,15 @@ func (f *itemCardinalityFilter) filterItems(items []*Item) ([]*Item, error) {
 }
 
 func (f *itemCardinalityFilter) includeItem(item *Item, limit *currentLimitByTimestamp) (bool, error) {
-	if _, err := f.cache.Get(item.SeriesKey); err == nil {
+	if f.cache.Get(item.SeriesKey) != nil {
 		return true, nil
-	} else if !errors.Is(err, ttlcache.ErrNotFound) {
-		return false, err
 	}
-
 	if !f.canIncludeNewItem(limit.get()) {
 		f.logger.Debug("Skip item", zap.String("seriesKey", item.SeriesKey), zap.Time("timestamp", item.Timestamp))
 		return false, nil
 	}
 
-	if err := f.cache.SetWithTTL(item.SeriesKey, struct{}{}, f.itemActivityPeriod); err != nil {
-		if errors.Is(err, ttlcache.ErrClosed) {
-			err = fmt.Errorf("set item from cache failed for metric %q because cache has been already closed: %w", f.metricName, err)
-		}
-		return false, err
-	}
+	_ = f.cache.Set(item.SeriesKey, struct{}{}, f.itemActivityPeriod)
 
 	f.logger.Debug("Added item to cache", zap.String("seriesKey", item.SeriesKey), zap.Time("timestamp", item.Timestamp))
 
@@ -142,11 +136,12 @@ func (f *itemCardinalityFilter) includeItem(item *Item, limit *currentLimitByTim
 }
 
 func (f *itemCardinalityFilter) canIncludeNewItem(currentLimitByTimestamp int) bool {
-	return f.cache.Count() < f.totalLimit && currentLimitByTimestamp > 0
+	return f.cache.Len() < f.totalLimit && currentLimitByTimestamp > 0
 }
 
 func (f *itemCardinalityFilter) Shutdown() error {
-	return f.cache.Close()
+	f.stopOnce.Do(func() { f.cache.Stop() })
+	return nil
 }
 
 func groupByTimestamp(items []*Item) map[time.Time][]*Item {

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -4,10 +4,12 @@
 package filter
 
 import (
+	"context"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -82,8 +84,8 @@ func TestItemCardinalityFilter_CanIncludeNewItem(t *testing.T) {
 			defer executeShutdown(t, filterCasted)
 
 			for _, key := range testCase.keysAlreadyInCache {
-				err = filterCasted.cache.Set(key, byte(1))
-				require.NoError(t, err)
+				item := filterCasted.cache.Set(key, struct{}{}, time.Duration(0))
+				assert.NotNil(t, item)
 			}
 
 			assert.Equal(t, testCase.expectedResult, filterCasted.canIncludeNewItem(testCase.limitByTimestamp))
@@ -93,33 +95,12 @@ func TestItemCardinalityFilter_CanIncludeNewItem(t *testing.T) {
 
 func TestItemCardinalityFilter_Shutdown(t *testing.T) {
 	logger := zaptest.NewLogger(t)
-	testCases := map[string]struct {
-		closeCache  bool
-		expectError bool
-	}{
-		"Happy path":            {false, false},
-		"Cache has been closed": {true, true},
-	}
+	filter, err := NewItemCardinalityFilter(metricName, totalLimit, limitByTimestamp, itemActivityPeriod, logger)
+	require.NoError(t, err)
 
-	for name, testCase := range testCases {
-		t.Run(name, func(t *testing.T) {
-			filter, err := NewItemCardinalityFilter(metricName, totalLimit, limitByTimestamp, itemActivityPeriod, logger)
-			require.NoError(t, err)
-			filterCasted := filter.(*itemCardinalityFilter)
-
-			if testCase.closeCache {
-				// Covering case when by some reasons cache is closed
-				err = filterCasted.cache.Close()
-				require.NoError(t, err)
-			}
-
-			if testCase.expectError {
-				require.Error(t, filter.Shutdown())
-			} else {
-				require.NoError(t, filter.Shutdown())
-			}
-		})
-	}
+	// Ensure shutdown is safe to be called multiple times.
+	require.NoError(t, filter.Shutdown())
+	require.NoError(t, filter.Shutdown())
 }
 
 func TestItemCardinalityFilter_Filter(t *testing.T) {
@@ -149,8 +130,8 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 	// Doing this to avoid of relying on timeouts and sleeps(avoid potential flaky tests)
 	syncChannel := make(chan bool, 10)
 
-	filterCasted.cache.SetExpirationCallback(func(string, any) {
-		if filterCasted.cache.Count() > 0 {
+	filterCasted.cache.OnEviction(func(context.Context, ttlcache.EvictionReason, *ttlcache.Item[string, struct{}]) {
+		if filterCasted.cache.Len() > 0 {
 			// Waiting until cache is really empty - all items are expired
 			return
 		}
@@ -159,23 +140,13 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 
 	<-syncChannel
 
-	filterCasted.cache.SetExpirationCallback(nil)
+	filterCasted.cache.OnEviction(nil)
 
 	filteredItems, err = filter.Filter(items)
 	require.NoError(t, err)
 
 	// All entries expired, nothing should be filtered out from items
 	assertInitialFiltering(t, items, filteredItems)
-
-	// Test filtering when cache was closed
-	filter, err = NewItemCardinalityFilter(metricName, totalLimit, limitByTimestamp, itemActivityPeriod, logger)
-	require.NoError(t, err)
-	require.NoError(t, filter.Shutdown())
-
-	filteredItems, err = filter.Filter(items)
-
-	require.Error(t, err)
-	require.Nil(t, filteredItems)
 }
 
 func TestItemCardinalityFilter_FilterItems(t *testing.T) {
@@ -210,8 +181,8 @@ func TestItemCardinalityFilter_FilterItems(t *testing.T) {
 	// Doing this to avoid of relying on timeouts and sleeps(avoid potential flaky tests)
 	syncChannel := make(chan bool, 10)
 
-	filterCasted.cache.SetExpirationCallback(func(string, any) {
-		if filterCasted.cache.Count() > 0 {
+	filterCasted.cache.OnEviction(func(context.Context, ttlcache.EvictionReason, *ttlcache.Item[string, struct{}]) {
+		if filterCasted.cache.Len() > 0 {
 			// Waiting until cache is really empty - all items are expired
 			return
 		}
@@ -220,23 +191,13 @@ func TestItemCardinalityFilter_FilterItems(t *testing.T) {
 
 	<-syncChannel
 
-	filterCasted.cache.SetExpirationCallback(nil)
+	filterCasted.cache.OnEviction(nil)
 
 	filteredItems, err = filter.Filter(items)
 	require.NoError(t, err)
 
 	// All entries expired, same picture as on first case
 	assertInitialFiltering(t, expectedFilteredInitialItemsWithSameTimestamp(t), filteredItems)
-
-	// Test filtering when cache was closed
-	filter, err = NewItemCardinalityFilter(metricName, totalLimit, limitByTimestamp, itemActivityPeriod, logger)
-	require.NoError(t, err)
-	require.NoError(t, filter.Shutdown())
-
-	filteredItems, err = filter.Filter(items)
-
-	require.Error(t, err)
-	require.Nil(t, filteredItems)
 }
 
 func TestItemCardinalityFilter_IncludeItem(t *testing.T) {
@@ -267,15 +228,6 @@ func TestItemCardinalityFilter_IncludeItem(t *testing.T) {
 	// Limit by timestamp reached
 	result, err = filterCasted.includeItem(item2, timestampLimiter)
 	require.NoError(t, err)
-	assert.False(t, result)
-
-	// Test with closed cache - do not need to execute shutdown in this case
-	filter, err = NewItemCardinalityFilter(metricName, totalLimit, limitByTimestamp, itemActivityPeriod, logger)
-	require.NoError(t, err)
-	filterCasted = filter.(*itemCardinalityFilter)
-	require.NoError(t, filterCasted.cache.Close())
-	result, err = filterCasted.includeItem(item1, timestampLimiter)
-	require.Error(t, err)
 	assert.False(t, result)
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -138,8 +138,6 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 
 	<-syncChannel
 
-	filterCasted.cache.OnEviction(nil)
-
 	filteredItems = filter.Filter(items)
 
 	// All entries expired, nothing should be filtered out from items
@@ -184,8 +182,6 @@ func TestItemCardinalityFilter_FilterItems(t *testing.T) {
 	})
 
 	<-syncChannel
-
-	filterCasted.cache.OnEviction(nil)
 
 	filteredItems = filter.Filter(items)
 

--- a/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/itemcardinality_test.go
@@ -114,15 +114,13 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 	filterCasted := filter.(*itemCardinalityFilter)
 	defer executeShutdown(t, filterCasted)
 
-	filteredItems, err := filter.Filter(items)
-	require.NoError(t, err)
+	filteredItems := filter.Filter(items)
 
 	// Items with key3 and key6 must be not present in filtered items
 	assertInitialFiltering(t, expectedFilteredInitialItems(t), filteredItems)
 
 	items = additionalTestData(t)
-	filteredItems, err = filter.Filter(items)
-	require.NoError(t, err)
+	filteredItems = filter.Filter(items)
 
 	// Cache timeout hasn't been reached, so filtered out all items
 	assert.Empty(t, filteredItems)
@@ -142,8 +140,7 @@ func TestItemCardinalityFilter_Filter(t *testing.T) {
 
 	filterCasted.cache.OnEviction(nil)
 
-	filteredItems, err = filter.Filter(items)
-	require.NoError(t, err)
+	filteredItems = filter.Filter(items)
 
 	// All entries expired, nothing should be filtered out from items
 	assertInitialFiltering(t, items, filteredItems)
@@ -160,20 +157,17 @@ func TestItemCardinalityFilter_FilterItems(t *testing.T) {
 	filterCasted := filter.(*itemCardinalityFilter)
 	defer executeShutdown(t, filterCasted)
 
-	filteredItems, err := filterCasted.filterItems(items)
-	require.NoError(t, err)
+	filteredItems := filterCasted.filterItems(items)
 
 	// Items with key1 and key2 must be not present in filtered items
 	assertInitialFiltering(t, expectedFilteredInitialItemsWithSameTimestamp(t), filteredItems)
 
 	// 2 new and 2 existing items must be present in filtered items
-	filteredItems, err = filterCasted.filterItems(items)
-	require.NoError(t, err)
+	filteredItems = filterCasted.filterItems(items)
 
 	assert.Len(t, filteredItems, totalLimit)
 
-	filteredItems, err = filter.Filter(items)
-	require.NoError(t, err)
+	filteredItems = filter.Filter(items)
 
 	// Cache timeout hasn't been reached, so no more new items expected
 	assert.Len(t, filteredItems, totalLimit)
@@ -193,8 +187,7 @@ func TestItemCardinalityFilter_FilterItems(t *testing.T) {
 
 	filterCasted.cache.OnEviction(nil)
 
-	filteredItems, err = filter.Filter(items)
-	require.NoError(t, err)
+	filteredItems = filter.Filter(items)
 
 	// All entries expired, same picture as on first case
 	assertInitialFiltering(t, expectedFilteredInitialItemsWithSameTimestamp(t), filteredItems)
@@ -216,18 +209,15 @@ func TestItemCardinalityFilter_IncludeItem(t *testing.T) {
 		limitByTimestamp: 1,
 	}
 
-	result, err := filterCasted.includeItem(item1, timestampLimiter)
-	require.NoError(t, err)
+	result := filterCasted.includeItem(item1, timestampLimiter)
 	assert.True(t, result)
 
 	// Item already exists in cache
-	result, err = filterCasted.includeItem(item1, timestampLimiter)
-	require.NoError(t, err)
+	result = filterCasted.includeItem(item1, timestampLimiter)
 	assert.True(t, result)
 
 	// Limit by timestamp reached
-	result, err = filterCasted.includeItem(item2, timestampLimiter)
-	require.NoError(t, err)
+	result = filterCasted.includeItem(item2, timestampLimiter)
 	assert.False(t, result)
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality.go
@@ -21,8 +21,8 @@ func NewNopItemFilterResolver() ItemFilterResolver {
 	}
 }
 
-func (f *nopItemCardinalityFilter) Filter(sourceItems []*Item) ([]*Item, error) {
-	return sourceItems, nil
+func (f *nopItemCardinalityFilter) Filter(sourceItems []*Item) []*Item {
+	return sourceItems
 }
 
 func (f *nopItemCardinalityFilter) Shutdown() error {

--- a/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/nopitemcardinality_test.go
@@ -14,9 +14,8 @@ func TestNopItemCardinalityFilter_Filter(t *testing.T) {
 	filter := NewNopItemCardinalityFilter()
 	sourceItems := []*Item{{}}
 
-	filteredItems, err := filter.Filter(sourceItems)
+	filteredItems := filter.Filter(sourceItems)
 
-	require.NoError(t, err)
 	assert.Equal(t, sourceItems, filteredItems)
 }
 

--- a/receiver/googlecloudspannerreceiver/internal/filter/package_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filter/package_test.go
@@ -10,5 +10,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/ReneKroon/ttlcache/v2.(*Cache).checkExpirationCallback"))
+	goleak.VerifyTestMain(m, goleak.IgnoreTopFunction("github.com/jellydator/ttlcache/v3.(*Cache).checkExpirationCallback"))
 }

--- a/receiver/googlecloudspannerreceiver/internal/filterfactory/testhelpers_test.go
+++ b/receiver/googlecloudspannerreceiver/internal/filterfactory/testhelpers_test.go
@@ -21,8 +21,8 @@ type mockFilter struct {
 	mock.Mock
 }
 
-func (f *mockFilter) Filter(source []*filter.Item) ([]*filter.Item, error) {
-	return source, nil
+func (f *mockFilter) Filter(source []*filter.Item) []*filter.Item {
+	return source
 }
 
 func (f *mockFilter) Shutdown() error {

--- a/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
+++ b/receiver/googlecloudspannerreceiver/internal/metadata/metricsbuilder.go
@@ -108,10 +108,7 @@ func (b *metricsFromDataPointBuilder) filter(metricName string, dataPoints []*Me
 		}
 	}
 
-	filteredItems, err := itemFilter.Filter(itemsForFiltering)
-	if err != nil {
-		return nil, err
-	}
+	filteredItems := itemFilter.Filter(itemsForFiltering)
 
 	// Creating new slice instead of removing elements from source slice because removing by value is not efficient operation.
 	// Need to use such approach for preserving data points order.


### PR DESCRIPTION
#### Description

Supersedes #36209

Most of the changes are obvious renames or refactors.  The non-obvious changes are:

* `Start()` must now be called on the cache to enable cleanup in the background.
* `Stop()` can only be called once (or it will block indefinitely).  I've added a sync.Once to ensure it is only ever called once.
* `Set()` and `Get()` no longer return errors--even if Stop has already been called.  This makes some of our tests obsolete, and I removed those tests.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36112
