### PR TITLE
[confmap/provider/secretsmanagerprovider] Add support for default values

### DIFF
--- a/.chloggen/secretsmanager-default-values.yaml
+++ b/.chloggen/secretsmanager-default-values.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: secretsmanagerprovider
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Allow for default values when the selector is empty or the JSON key is not found
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37535]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Uses the same syntax as the `envprovider`
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/confmap/provider/secretsmanagerprovider/README.md
+++ b/confmap/provider/secretsmanagerprovider/README.md
@@ -23,6 +23,8 @@ stored in AWS Secrets Manager.
 - Just use the placeholders with the following pattern `${secretsmanager:<arn or name>}`
 - Make sure you have the `secretsmanager:GetSecretValue` in the OTEL Collector Role
 - If your secret is a json string, you can get the value for a json key using the following pattern `${secretsmanager:<arn or name>#json-key}`
+- You can also specify a default value by using the following pattern `${secretsmanager:<arn or name>:-<default>}`
+  - The default value is used when the ARN or name is empty or the json key is not found
 
 Prerequisites:
 

--- a/confmap/provider/secretsmanagerprovider/go.mod
+++ b/confmap/provider/secretsmanagerprovider/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/confmap v1.27.1-0.20250307194215-7d3e03e500b0
 	go.uber.org/goleak v1.3.0
+	go.uber.org/zap v1.27.0
 )
 
 require (
@@ -33,6 +34,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	go.opentelemetry.io/collector/featuregate v1.27.1-0.20250307194215-7d3e03e500b0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
This PR adds support for default values when using the `secretsmanager` provider.
It uses the same syntax as the `envprovider` and falls back to the default value when:
* the selector is empty
* the json key is not found in the secret map

In both cases, a warning is logged to call out unintentional fallback.

By nesting substitutions, this allows users to specify either a secret manager reference or plain value through environment variables like this:
```
password: "${secretsmanager:${env:PASSWORD_ARN}:-${env:PASSWORD}}"
```
When `PASSWORD_ARN` is set, the collector retrieves the value from AWS Secrets Manager, falling back to the value specified in `PASSWORD` if the secret is not found or the json key in `PASSWORD_ARN` is undefined.

<!--Describe what testing was performed and which tests were added.-->
#### Testing
* Manual testing performed using a custom build of the [opentelemetry-lambda](https://github.com/open-telemetry/opentelemetry-lambda/blob/main/collector/README.md) extension layer.
* Added unit tests

<!--Describe the documentation added.-->
#### Documentation
* Provider documentation & go API docs
