### PR TITLE
[processor/tailsampling] Minor rework to improve performance

### DIFF
--- a/.chloggen/tailsamplingprocessor-performance-rework.yaml
+++ b/.chloggen/tailsamplingprocessor-performance-rework.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: tailsamplingprocessor
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: "Reworked the consume traces and sampling decision paths to improve performance"
+note: "Reworked the consume traces, sampling decision, and policy loading paths to improve performance and readability"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [37560]

--- a/.chloggen/tailsamplingprocessor-performance-rework.yaml
+++ b/.chloggen/tailsamplingprocessor-performance-rework.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: tailsamplingprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Reworked the consume traces and sampling decision paths to improve performance"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37560]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -316,7 +316,7 @@ func (tsp *tailSamplingSpanProcessor) loadPendingSamplingPolicy() {
 
 	if err != nil {
 		tsp.logger.Error("Failed to load pending sampling policy", zap.Error(err))
-		tsp.logger.Debug("Continue to use the previous sampling policy")
+		tsp.logger.Debug("Continuing to use the previously loaded sampling policy")
 	}
 }
 

--- a/processor/tailsamplingprocessor/processor.go
+++ b/processor/tailsamplingprocessor/processor.go
@@ -254,6 +254,10 @@ func (tsp *tailSamplingSpanProcessor) loadSamplingPolicy(cfgs []PolicyCfg) error
 	policyNames := make(map[string]struct{}, cLen)
 
 	for _, cfg := range cfgs {
+		if cfg.Name == "" {
+			return fmt.Errorf("policy name cannot be empty")
+		}
+
 		if _, exists := policyNames[cfg.Name]; exists {
 			return fmt.Errorf("duplicate policy name %q", cfg.Name)
 		}


### PR DESCRIPTION
This pull-request reworks the consume traces, sampling decision, and policy loading paths to improve performance and readability. Pressing the current architecture for the best results, by reducing allocations and calls when sensible.

The `makeDecision()` changes alone resulted in a noticeable improvement, using the existing benchmark:

`Sampling-8   16.37µ ± 2%   10.96µ ± 3%  -33.02% (p=0.000 n=10)`
