### PR TITLE
[chore][exporter/datadog] move a feature gate to pkg/datadog

### DIFF
--- a/pkg/datadog/gates.go
+++ b/pkg/datadog/gates.go
@@ -5,6 +5,7 @@ package datadog // import "github.com/open-telemetry/opentelemetry-collector-con
 
 import "go.opentelemetry.io/collector/featuregate"
 
+// ReceiveResourceSpansV2FeatureGate is a feature gate that enables a refactored implementation of span processing in Datadog exporter and connector
 var ReceiveResourceSpansV2FeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"datadog.EnableReceiveResourceSpansV2",
 	featuregate.StageAlpha,
@@ -13,9 +14,18 @@ var ReceiveResourceSpansV2FeatureGate = featuregate.GlobalRegistry().MustRegiste
 	featuregate.WithRegisterToVersion("v0.124.0"),
 )
 
+// OperationAndResourceNameV2FeatureGate is a feature gate that enables enhanced span operation name and resource names in Datadog exporter and connector
 var OperationAndResourceNameV2FeatureGate = featuregate.GlobalRegistry().MustRegister(
 	"datadog.EnableOperationAndResourceNameV2",
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("When enabled, datadogexporter and datadogconnector use improved logic to compute operation name and resource name."),
 	featuregate.WithRegisterFromVersion("v0.118.0"),
+)
+
+// MetricRemappingDisabledFeatureGate is a feature gate that controls the client-side mapping from OpenTelemetry semantic conventions to Datadog semantic conventions
+var MetricRemappingDisabledFeatureGate = featuregate.GlobalRegistry().MustRegister(
+	"exporter.datadogexporter.metricremappingdisabled",
+	featuregate.StageAlpha,
+	featuregate.WithRegisterDescription("When enabled the Datadog Exporter stops mapping OpenTelemetry semantic conventions to Datadog semantic conventions. This feature gate is only for internal use."),
+	featuregate.WithRegisterReferenceURL("https://docs.datadoghq.com/opentelemetry/schema_semantics/metrics_mapping/"),
 )


### PR DESCRIPTION
#### Description
Move feature gate `exporter.datadogexporter.metricremappingdisabled` to pkg/datadog so that it can be reused in datadog-agent