### PR TITLE
Bump Datadog agent versions and change datadog.EnableReceiveResourceS…

### DIFF
--- a/connector/datadogconnector/connector.go
+++ b/connector/datadogconnector/connector.go
@@ -119,8 +119,8 @@ func getTraceAgentCfg(logger *zap.Logger, cfg TracesConfig, attributesTranslator
 		logger.Info("traces::compute_top_level_by_span_kind needs to be enabled in both the Datadog connector and Datadog exporter configs if both components are being used")
 		acfg.Features["enable_otlp_compute_top_level_by_span_kind"] = struct{}{}
 	}
-	if datadog.ReceiveResourceSpansV2FeatureGate.IsEnabled() {
-		acfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !datadog.ReceiveResourceSpansV2FeatureGate.IsEnabled() {
+		acfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	if datadog.OperationAndResourceNameV2FeatureGate.IsEnabled() {
 		acfg.Features["enable_operation_and_resource_name_logic_v2"] = struct{}{}

--- a/connector/datadogconnector/go.mod
+++ b/connector/datadogconnector/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/DataDog/datadog-agent/comp/otelcol/otlp/components/statsprocessor v0.61.0
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.63.0-devel.0.20250123185937-1feb84b482c8
 	github.com/DataDog/datadog-agent/pkg/proto v0.63.0-devel.0.20250123185937-1feb84b482c8
-	github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8
+	github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61
 	github.com/DataDog/datadog-go/v5 v5.6.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.24.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics v0.24.0
@@ -137,7 +137,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
-	github.com/containerd/cgroups/v3 v3.0.4 // indirect
+	github.com/containerd/cgroups/v3 v3.0.5 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/go-units v0.5.0 // indirect

--- a/connector/datadogconnector/go.sum
+++ b/connector/datadogconnector/go.sum
@@ -149,8 +149,8 @@ github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 h1:qMrc4qvum2GfZW1yRb
 github.com/DataDog/datadog-agent/pkg/status/health v0.61.0/go.mod h1:u7btrms/cuXnU5HAmEauHLXdsiVqUS9TfGGiYCwdpTs=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 h1:5eqDN9YnIm1Y7TNzc+y3rLGIKA08tz2sqS8y3VqjAc0=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0/go.mod h1:6L8df1TdfYzCI0EGo0BPFgf4k2OJ19d2At96VbtTHgk=
-github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8 h1:PCRnIPazrYw3hThLjQDwuKiJMypmCNVNuyG1pnpB824=
-github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8/go.mod h1:5TEeZF01pkIbQskIcBnz6QooMpqC+cX+sYoqwdJfByI=
+github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61 h1:vCSPUaK/NYjayQ7W/8jp7H/wk432GM1BlKNDSSYEnFQ=
+github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61/go.mod h1:pJcvXfnlgmRtJbFRBFfR3ykl0w9Th9mM+ZwKakwGPMg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 h1:VP1r5qulh6MwzcoWeMhOT197/QSY1t94U4MXLqnJM30=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0/go.mod h1:7qKGHdQGovGp3EeuleYs6Fuh8/7J1cp2FEcObvw7ZZo=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.61.0 h1:i2RyhdAma2TNMKoohQC+uXZvHODhBfx6VtMACFlfkgM=
@@ -311,8 +311,8 @@ github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575/go.mod h1:9d6lWj8KzO/
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 h1:QVw89YDxXxEe+l8gU8ETbOasdwEV+avkR75ZzsVV9WI=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
-github.com/containerd/cgroups/v3 v3.0.4 h1:2fs7l3P0Qxb1nKWuJNFiwhp2CqiKzho71DQkDrHJIo4=
-github.com/containerd/cgroups/v3 v3.0.4/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
+github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
+github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=

--- a/exporter/datadogexporter/go.mod
+++ b/exporter/datadogexporter/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/logs/status/statusinterface v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/proto v0.63.0-devel.0.20250123185937-1feb84b482c8
 	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8
+	github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61
 	github.com/DataDog/datadog-agent/pkg/util/hostname/validate v0.61.0
 	github.com/DataDog/datadog-agent/pkg/util/startstop v0.61.0 // indirect
 	github.com/DataDog/datadog-api-client-go/v2 v2.34.0
@@ -180,7 +180,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 // indirect
-	github.com/containerd/cgroups/v3 v3.0.4 // indirect
+	github.com/containerd/cgroups/v3 v3.0.5 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -166,8 +166,6 @@ github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 h1:qMrc4qvum2GfZW1yRb
 github.com/DataDog/datadog-agent/pkg/status/health v0.61.0/go.mod h1:u7btrms/cuXnU5HAmEauHLXdsiVqUS9TfGGiYCwdpTs=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 h1:5eqDN9YnIm1Y7TNzc+y3rLGIKA08tz2sqS8y3VqjAc0=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0/go.mod h1:6L8df1TdfYzCI0EGo0BPFgf4k2OJ19d2At96VbtTHgk=
-github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8 h1:PCRnIPazrYw3hThLjQDwuKiJMypmCNVNuyG1pnpB824=
-github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8/go.mod h1:5TEeZF01pkIbQskIcBnz6QooMpqC+cX+sYoqwdJfByI=
 github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61 h1:vCSPUaK/NYjayQ7W/8jp7H/wk432GM1BlKNDSSYEnFQ=
 github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61/go.mod h1:pJcvXfnlgmRtJbFRBFfR3ykl0w9Th9mM+ZwKakwGPMg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 h1:VP1r5qulh6MwzcoWeMhOT197/QSY1t94U4MXLqnJM30=
@@ -343,8 +341,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 h1:QVw89YDxXxEe+l8gU8ETbOasdwEV+avkR75ZzsVV9WI=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
-github.com/containerd/cgroups/v3 v3.0.4 h1:2fs7l3P0Qxb1nKWuJNFiwhp2CqiKzho71DQkDrHJIo4=
-github.com/containerd/cgroups/v3 v3.0.4/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
+github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=

--- a/exporter/datadogexporter/go.sum
+++ b/exporter/datadogexporter/go.sum
@@ -168,6 +168,8 @@ github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 h1:5eqDN9YnIm1Y7TNzc+y3rL
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0/go.mod h1:6L8df1TdfYzCI0EGo0BPFgf4k2OJ19d2At96VbtTHgk=
 github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8 h1:PCRnIPazrYw3hThLjQDwuKiJMypmCNVNuyG1pnpB824=
 github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8/go.mod h1:5TEeZF01pkIbQskIcBnz6QooMpqC+cX+sYoqwdJfByI=
+github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61 h1:vCSPUaK/NYjayQ7W/8jp7H/wk432GM1BlKNDSSYEnFQ=
+github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61/go.mod h1:pJcvXfnlgmRtJbFRBFfR3ykl0w9Th9mM+ZwKakwGPMg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 h1:VP1r5qulh6MwzcoWeMhOT197/QSY1t94U4MXLqnJM30=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0/go.mod h1:7qKGHdQGovGp3EeuleYs6Fuh8/7J1cp2FEcObvw7ZZo=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.61.0 h1:i2RyhdAma2TNMKoohQC+uXZvHODhBfx6VtMACFlfkgM=
@@ -343,6 +345,7 @@ github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 h1:QVw89YDxXxEe+l8gU8E
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/containerd/cgroups/v3 v3.0.4 h1:2fs7l3P0Qxb1nKWuJNFiwhp2CqiKzho71DQkDrHJIo4=
 github.com/containerd/cgroups/v3 v3.0.4/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
+github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=

--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/remoteconfig/state v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 // indirect
-	github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8 // indirect
+	github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/cgroups v0.61.0 // indirect
 	github.com/DataDog/datadog-agent/pkg/util/executable v0.61.0 // indirect
@@ -151,7 +151,7 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575 // indirect
 	github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 // indirect
-	github.com/containerd/cgroups/v3 v3.0.4 // indirect
+	github.com/containerd/cgroups/v3 v3.0.5 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/dennwc/varint v1.0.0 // indirect

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -166,6 +166,7 @@ github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 h1:5eqDN9YnIm1Y7TNzc+y3rL
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0/go.mod h1:6L8df1TdfYzCI0EGo0BPFgf4k2OJ19d2At96VbtTHgk=
 github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8 h1:PCRnIPazrYw3hThLjQDwuKiJMypmCNVNuyG1pnpB824=
 github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8/go.mod h1:5TEeZF01pkIbQskIcBnz6QooMpqC+cX+sYoqwdJfByI=
+github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61/go.mod h1:pJcvXfnlgmRtJbFRBFfR3ykl0w9Th9mM+ZwKakwGPMg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 h1:VP1r5qulh6MwzcoWeMhOT197/QSY1t94U4MXLqnJM30=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0/go.mod h1:7qKGHdQGovGp3EeuleYs6Fuh8/7J1cp2FEcObvw7ZZo=
 github.com/DataDog/datadog-agent/pkg/util/cgroups v0.61.0 h1:i2RyhdAma2TNMKoohQC+uXZvHODhBfx6VtMACFlfkgM=
@@ -341,6 +342,7 @@ github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 h1:QVw89YDxXxEe+l8gU8E
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
 github.com/containerd/cgroups/v3 v3.0.4 h1:2fs7l3P0Qxb1nKWuJNFiwhp2CqiKzho71DQkDrHJIo4=
 github.com/containerd/cgroups/v3 v3.0.4/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
+github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -164,8 +164,7 @@ github.com/DataDog/datadog-agent/pkg/status/health v0.61.0 h1:qMrc4qvum2GfZW1yRb
 github.com/DataDog/datadog-agent/pkg/status/health v0.61.0/go.mod h1:u7btrms/cuXnU5HAmEauHLXdsiVqUS9TfGGiYCwdpTs=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0 h1:5eqDN9YnIm1Y7TNzc+y3rLGIKA08tz2sqS8y3VqjAc0=
 github.com/DataDog/datadog-agent/pkg/telemetry v0.61.0/go.mod h1:6L8df1TdfYzCI0EGo0BPFgf4k2OJ19d2At96VbtTHgk=
-github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8 h1:PCRnIPazrYw3hThLjQDwuKiJMypmCNVNuyG1pnpB824=
-github.com/DataDog/datadog-agent/pkg/trace v0.63.0-devel.0.20250123185937-1feb84b482c8/go.mod h1:5TEeZF01pkIbQskIcBnz6QooMpqC+cX+sYoqwdJfByI=
+github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61 h1:vCSPUaK/NYjayQ7W/8jp7H/wk432GM1BlKNDSSYEnFQ=
 github.com/DataDog/datadog-agent/pkg/trace v0.64.0-devel.0.20250129182827-bab631c10d61/go.mod h1:pJcvXfnlgmRtJbFRBFfR3ykl0w9Th9mM+ZwKakwGPMg=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0 h1:VP1r5qulh6MwzcoWeMhOT197/QSY1t94U4MXLqnJM30=
 github.com/DataDog/datadog-agent/pkg/util/backoff v0.61.0/go.mod h1:7qKGHdQGovGp3EeuleYs6Fuh8/7J1cp2FEcObvw7ZZo=
@@ -340,8 +339,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78 h1:QVw89YDxXxEe+l8gU8ETbOasdwEV+avkR75ZzsVV9WI=
 github.com/cncf/xds/go v0.0.0-20240905190251-b4127c9b8d78/go.mod h1:W+zGtBO5Y1IgJhy4+A9GOqVhqLpfZi+vwmdNXUehLA8=
-github.com/containerd/cgroups/v3 v3.0.4 h1:2fs7l3P0Qxb1nKWuJNFiwhp2CqiKzho71DQkDrHJIo4=
-github.com/containerd/cgroups/v3 v3.0.4/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
+github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJHo6Bzo=
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=

--- a/exporter/datadogexporter/traces_exporter.go
+++ b/exporter/datadogexporter/traces_exporter.go
@@ -244,8 +244,8 @@ func newTraceAgentConfig(ctx context.Context, params exporter.Settings, cfg *Con
 	if cfg.Traces.ComputeTopLevelBySpanKind {
 		acfg.Features["enable_otlp_compute_top_level_by_span_kind"] = struct{}{}
 	}
-	if datadog.ReceiveResourceSpansV2FeatureGate.IsEnabled() {
-		acfg.Features["enable_receive_resource_spans_v2"] = struct{}{}
+	if !datadog.ReceiveResourceSpansV2FeatureGate.IsEnabled() {
+		acfg.Features["disable_receive_resource_spans_v2"] = struct{}{}
 	}
 	tracelog.SetLogger(&zaplogger{params.Logger}) // TODO: This shouldn't be a singleton
 	return acfg, nil


### PR DESCRIPTION
…pansV2 result

<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

In latest `datadog-agent` version, `enable_receive_resource_spans_v2` is replaced by `disable_receive_resource_spans_v2` (opt-out instead of opt-in). Import the latest `datadog-agent` version, which has these changes, and change which flag is set by `datadog.EnableReceiveResourceSpansV2` (no change for end user)

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests on ReceiveResourceSpansV2 continue to pass, and ran collector locally with `datadog.EnableReceiveResourceSpansV2` on and off.
