### PR TITLE
[chore] Fix genoteltestbedcol

### DIFF
--- a/cmd/oteltestbedcol/builder-config.yaml
+++ b/cmd/oteltestbedcol/builder-config.yaml
@@ -112,3 +112,4 @@ replaces:
   - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil => ../../pkg/pdatautil
   - github.com/openshift/api v3.9.0+incompatible => github.com/openshift/api v0.0.0-20180801171038-322a19404e37
   - github.com/open-telemetry/opentelemetry-collector-contrib/extension/ackextension => ../../extension/ackextension
+  - github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils => ../../pkg/core/xidutils


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
```
Error: failed to update go.mod: go subcommand failed with args '[mod tidy -compat=1.22]': exit status 1, error message: go: downloading go.opentelemetry.io/collector/confmap/provider/httpsprovider v1.24.1-0.20250123125445-24f88da7b583
go: downloading github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils v0.118.0
go: github.com/open-telemetry/opentelemetry-collector-contrib/cmd/oteltestbedcol imports
        github.com/open-telemetry/opentelemetry-collector-contrib/exporter/sapmexporter imports
        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/translator/jaeger imports
        github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils: reading github.com/open-telemetry/opentelemetry-collector-contrib/pkg/core/xidutils/go.mod at revision pkg/core/xidutils/v0.118.0: unknown revision pkg/core/xidutils/v0.118.0
```
<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
n/a

<!--Describe what testing was performed and which tests were added.-->
#### Testing
n/a

<!--Describe the documentation added.-->
#### Documentation
n/a

<!--Please delete paragraphs that you did not use before submitting.-->
