### PR TITLE
[exporter/googlecloudpubsub] add support for pubsub ordering

### DIFF
--- a/.chloggen/add-pubsub-ordering.yaml
+++ b/.chloggen/add-pubsub-ordering.yaml
@@ -1,0 +1,4 @@
+change_type: enhancement
+component: googlecloudpubsubexporter
+note: Add support for exporting ordered messages to GCP Pub/Sub
+issues: [32850]

--- a/exporter/googlecloudpubsubexporter/config_test.go
+++ b/exporter/googlecloudpubsubexporter/config_test.go
@@ -34,18 +34,21 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, sub.Unmarshal(cfg))
 
-	customConfig := factory.CreateDefaultConfig().(*Config)
+	expectedConfig := factory.CreateDefaultConfig().(*Config)
 
-	customConfig.ProjectID = "my-project"
-	customConfig.UserAgent = "opentelemetry-collector-contrib {{version}}"
-	customConfig.TimeoutSettings = exporterhelper.TimeoutConfig{
+	expectedConfig.ProjectID = "my-project"
+	expectedConfig.UserAgent = "opentelemetry-collector-contrib {{version}}"
+	expectedConfig.TimeoutSettings = exporterhelper.TimeoutConfig{
 		Timeout: 20 * time.Second,
 	}
-	customConfig.Topic = "projects/my-project/topics/otlp-topic"
-	customConfig.Compression = "gzip"
-	customConfig.Watermark.Behavior = "earliest"
-	customConfig.Watermark.AllowedDrift = time.Hour
-	assert.Equal(t, cfg, customConfig)
+	expectedConfig.Topic = "projects/my-project/topics/otlp-topic"
+	expectedConfig.Compression = "gzip"
+	expectedConfig.Watermark.Behavior = "earliest"
+	expectedConfig.Watermark.AllowedDrift = time.Hour
+	expectedConfig.Ordering.Enabled = true
+	expectedConfig.Ordering.FromResourceAttribute = "ordering_key"
+	expectedConfig.Ordering.RemoveResourceAttribute = true
+	assert.Equal(t, expectedConfig, cfg)
 }
 
 func TestTopicConfigValidation(t *testing.T) {
@@ -99,4 +102,15 @@ func TestWatermarkDefaultMaxDriftValidation(t *testing.T) {
 	assert.Equal(t, time.Duration(0), c.Watermark.AllowedDrift)
 	assert.NoError(t, c.Validate())
 	assert.Equal(t, time.Duration(9223372036854775807), c.Watermark.AllowedDrift)
+}
+
+func TestOrderConfigValidation(t *testing.T) {
+	factory := NewFactory()
+	c := factory.CreateDefaultConfig().(*Config)
+	c.Topic = "projects/project/topics/my-topic"
+	assert.NoError(t, c.Validate())
+	c.Ordering.Enabled = true
+	assert.Error(t, c.Validate())
+	c.Ordering.FromResourceAttribute = "key"
+	assert.NoError(t, c.Validate())
 }

--- a/exporter/googlecloudpubsubexporter/exporter_test.go
+++ b/exporter/googlecloudpubsubexporter/exporter_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	pb "cloud.google.com/go/pubsub/apiv1/pubsubpb"
 	"github.com/google/uuid"
@@ -27,6 +28,81 @@ const (
 	defaultProjectID = "my-project"
 	defaultTopic     = "projects/my-project/topics/otlp"
 )
+
+func TestGetMessageAttributes(t *testing.T) {
+	date := time.Date(2021, time.January, 1, 2, 3, 4, 5, time.UTC)
+
+	t.Run("logs", func(t *testing.T) {
+		exporter, _ := newTestExporter(t)
+
+		gotAttributes, err := exporter.getMessageAttributes(otlpProtoLog, date)
+		require.NoError(t, err)
+
+		expectedAttributes := map[string]string{
+			"ce-id":          "00000000-0000-0000-0000-000000000000",
+			"ce-source":      "/opentelemetry/collector/googlecloudpubsub/latest",
+			"ce-specversion": "1.0",
+			"ce-time":        "2021-01-01T02:03:04.000000005Z",
+			"ce-type":        "org.opentelemetry.otlp.logs.v1",
+			"content-type":   "application/protobuf",
+		}
+		assert.Equal(t, expectedAttributes, gotAttributes)
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		exporter, _ := newTestExporter(t)
+
+		gotAttributes, err := exporter.getMessageAttributes(otlpProtoMetric, date)
+		require.NoError(t, err)
+
+		expectedAttributes := map[string]string{
+			"ce-id":          "00000000-0000-0000-0000-000000000000",
+			"ce-source":      "/opentelemetry/collector/googlecloudpubsub/latest",
+			"ce-specversion": "1.0",
+			"ce-time":        "2021-01-01T02:03:04.000000005Z",
+			"ce-type":        "org.opentelemetry.otlp.metrics.v1",
+			"content-type":   "application/protobuf",
+		}
+		assert.Equal(t, expectedAttributes, gotAttributes)
+	})
+
+	t.Run("traces", func(t *testing.T) {
+		exporter, _ := newTestExporter(t)
+
+		gotAttributes, err := exporter.getMessageAttributes(otlpProtoTrace, date)
+		require.NoError(t, err)
+
+		expectedAttributes := map[string]string{
+			"ce-id":          "00000000-0000-0000-0000-000000000000",
+			"ce-source":      "/opentelemetry/collector/googlecloudpubsub/latest",
+			"ce-specversion": "1.0",
+			"ce-time":        "2021-01-01T02:03:04.000000005Z",
+			"ce-type":        "org.opentelemetry.otlp.traces.v1",
+			"content-type":   "application/protobuf",
+		}
+		assert.Equal(t, expectedAttributes, gotAttributes)
+	})
+
+	t.Run("logs with compression", func(t *testing.T) {
+		exporter, _ := newTestExporter(t, func(cfg *Config) {
+			cfg.Compression = "gzip"
+		})
+
+		gotAttributes, err := exporter.getMessageAttributes(otlpProtoLog, date)
+		require.NoError(t, err)
+
+		expectedAttributes := map[string]string{
+			"ce-id":            "00000000-0000-0000-0000-000000000000",
+			"ce-source":        "/opentelemetry/collector/googlecloudpubsub/latest",
+			"ce-specversion":   "1.0",
+			"ce-time":          "2021-01-01T02:03:04.000000005Z",
+			"ce-type":          "org.opentelemetry.otlp.logs.v1",
+			"content-type":     "application/protobuf",
+			"content-encoding": "gzip",
+		}
+		assert.Equal(t, expectedAttributes, gotAttributes)
+	})
+}
 
 func TestExporterNoData(t *testing.T) {
 	exporter, publisher := newTestExporter(t, func(config *Config) {
@@ -198,6 +274,163 @@ func TestExporterSimpleDataWithCompression(t *testing.T) {
 			"content-type":     "application/protobuf",
 			"content-encoding": "gzip",
 		})
+	})
+}
+
+func TestExporterWithOrdering(t *testing.T) {
+	const orderingKey = "ordering.key"
+	withOrdering := func(cfg *Config) {
+		cfg.Ordering.Enabled = true
+		cfg.Ordering.FromResourceAttribute = orderingKey
+		cfg.Ordering.RemoveResourceAttribute = true
+	}
+
+	ctx := context.Background()
+
+	t.Run("logs", func(t *testing.T) {
+		exporter, publisher := newTestExporter(t, withOrdering)
+
+		logs := plog.NewLogs()
+		{
+			resourceLogs := logs.ResourceLogs().AppendEmpty()
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message without ordering key 1")
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message without ordering key 2")
+		}
+		{
+			resourceLogs := logs.ResourceLogs().AppendEmpty()
+			resourceLogs.Resource().Attributes().PutStr(orderingKey, "")
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message without ordering key 1")
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message without ordering key 2")
+		}
+		{
+			resourceLogs := logs.ResourceLogs().AppendEmpty()
+			resourceLogs.Resource().Attributes().PutStr(orderingKey, "value 1")
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message 1 with ordering key 1")
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message 2 with ordering key 1")
+		}
+		{
+			resourceLogs := logs.ResourceLogs().AppendEmpty()
+			resourceLogs.Resource().Attributes().PutStr(orderingKey, "value 2")
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message 1 with ordering key 2")
+			resourceLogs.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty().Body().SetStr("some log message 2 with ordering key 2")
+		}
+
+		require.NoError(t, exporter.consumeLogs(ctx, logs))
+		require.Len(t, publisher.requests, 3, "one publish call per ordering key should've been made")
+
+		var orderingKeyValues []string
+		for _, request := range publisher.requests {
+			assert.Equal(t, defaultTopic, request.Topic)
+			assert.Len(t, request.Messages, 1)
+
+			for _, msg := range request.Messages {
+				orderingKeyValues = append(orderingKeyValues, msg.OrderingKey)
+
+				assert.NotEmpty(t, msg.Data)
+				assert.NotEmpty(t, msg.Attributes)
+			}
+		}
+		assert.ElementsMatch(t, orderingKeyValues, []string{"", "value 1", "value 2"})
+	})
+
+	t.Run("metrics", func(t *testing.T) {
+		exporter, publisher := newTestExporter(t, withOrdering)
+
+		metrics := pmetric.NewMetrics()
+		{
+			resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+			metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			metric.SetName("some.metric")
+			metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(42)
+			metric.Gauge().DataPoints().AppendEmpty().SetIntValue(24)
+		}
+		{
+			resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+			resourceMetrics.Resource().Attributes().PutStr(orderingKey, "")
+			metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			metric.SetName("some.metric")
+			metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(42)
+			metric.Gauge().DataPoints().AppendEmpty().SetIntValue(24)
+		}
+		{
+			resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+			resourceMetrics.Resource().Attributes().PutStr(orderingKey, "value 1")
+			metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			metric.SetName("some.metric")
+			metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(42)
+			metric.Gauge().DataPoints().AppendEmpty().SetIntValue(24)
+		}
+		{
+			resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
+			resourceMetrics.Resource().Attributes().PutStr(orderingKey, "value 2")
+			metric := resourceMetrics.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+			metric.SetName("some.metric")
+			metric.SetEmptyGauge().DataPoints().AppendEmpty().SetIntValue(42)
+			metric.Gauge().DataPoints().AppendEmpty().SetIntValue(24)
+		}
+
+		require.NoError(t, exporter.consumeMetrics(ctx, metrics))
+		require.Len(t, publisher.requests, 3, "one publish call per ordering key should've been made")
+
+		var orderingKeyValues []string
+		for _, request := range publisher.requests {
+			assert.Equal(t, defaultTopic, request.Topic)
+			assert.Len(t, request.Messages, 1)
+
+			for _, msg := range request.Messages {
+				orderingKeyValues = append(orderingKeyValues, msg.OrderingKey)
+
+				assert.NotEmpty(t, msg.Data)
+				assert.NotEmpty(t, msg.Attributes)
+			}
+		}
+		assert.ElementsMatch(t, orderingKeyValues, []string{"", "value 1", "value 2"})
+	})
+
+	t.Run("traces", func(t *testing.T) {
+		exporter, publisher := newTestExporter(t, withOrdering)
+
+		traces := ptrace.NewTraces()
+		{
+			resourceSpans := traces.ResourceSpans().AppendEmpty()
+			span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetName("some span 1")
+		}
+		{
+			resourceSpans := traces.ResourceSpans().AppendEmpty()
+			resourceSpans.Resource().Attributes().PutStr(orderingKey, "")
+			span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetName("some span 1")
+		}
+		{
+			resourceSpans := traces.ResourceSpans().AppendEmpty()
+			resourceSpans.Resource().Attributes().PutStr(orderingKey, "value 1")
+			span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetName("some span 2")
+		}
+		{
+			resourceSpans := traces.ResourceSpans().AppendEmpty()
+			resourceSpans.Resource().Attributes().PutStr(orderingKey, "value 2")
+			span := resourceSpans.ScopeSpans().AppendEmpty().Spans().AppendEmpty()
+			span.SetName("some span 3")
+		}
+
+		require.NoError(t, exporter.consumeTraces(ctx, traces))
+		require.Len(t, publisher.requests, 3, "one publish call per ordering key should've been made")
+
+		var orderingKeyValues []string
+		for _, request := range publisher.requests {
+			assert.Equal(t, defaultTopic, request.Topic)
+			assert.Len(t, request.Messages, 1)
+
+			for _, msg := range request.Messages {
+				orderingKeyValues = append(orderingKeyValues, msg.OrderingKey)
+
+				assert.NotEmpty(t, msg.Data)
+				assert.NotEmpty(t, msg.Attributes)
+			}
+		}
+		assert.ElementsMatch(t, orderingKeyValues, []string{"", "value 1", "value 2"})
 	})
 }
 

--- a/exporter/googlecloudpubsubexporter/factory.go
+++ b/exporter/googlecloudpubsubexporter/factory.go
@@ -81,6 +81,11 @@ func createDefaultConfig() component.Config {
 			Behavior:     "current",
 			AllowedDrift: 0,
 		},
+		Ordering: OrderingConfig{
+			Enabled:                 false,
+			FromResourceAttribute:   "",
+			RemoveResourceAttribute: false,
+		},
 	}
 }
 

--- a/exporter/googlecloudpubsubexporter/factory.go
+++ b/exporter/googlecloudpubsubexporter/factory.go
@@ -40,11 +40,11 @@ func NewFactory() exporter.Factory {
 var exporters = map[*Config]*pubsubExporter{}
 
 func ensureExporter(params exporter.Settings, pCfg *Config) *pubsubExporter {
-	receiver := exporters[pCfg]
-	if receiver != nil {
-		return receiver
+	exp := exporters[pCfg]
+	if exp != nil {
+		return exp
 	}
-	receiver = &pubsubExporter{
+	exp = &pubsubExporter{
 		logger:           params.Logger,
 		userAgent:        strings.ReplaceAll(pCfg.UserAgent, "{{version}}", params.BuildInfo.Version),
 		ceSource:         fmt.Sprintf("/opentelemetry/collector/%s/%s", metadata.Type.String(), params.BuildInfo.Version),
@@ -56,20 +56,20 @@ func ensureExporter(params exporter.Settings, pCfg *Config) *pubsubExporter {
 		makeClient:       newPublisherClient,
 	}
 	// we ignore the error here as the config is already validated with the same method
-	receiver.ceCompression, _ = pCfg.parseCompression()
+	exp.ceCompression, _ = pCfg.parseCompression()
 	watermarkBehavior, _ := pCfg.Watermark.parseWatermarkBehavior()
 	switch watermarkBehavior {
 	case earliest:
-		receiver.tracesWatermarkFunc = earliestTracesWatermark
-		receiver.metricsWatermarkFunc = earliestMetricsWatermark
-		receiver.logsWatermarkFunc = earliestLogsWatermark
+		exp.tracesWatermarkFunc = earliestTracesWatermark
+		exp.metricsWatermarkFunc = earliestMetricsWatermark
+		exp.logsWatermarkFunc = earliestLogsWatermark
 	case current:
-		receiver.tracesWatermarkFunc = currentTracesWatermark
-		receiver.metricsWatermarkFunc = currentMetricsWatermark
-		receiver.logsWatermarkFunc = currentLogsWatermark
+		exp.tracesWatermarkFunc = currentTracesWatermark
+		exp.metricsWatermarkFunc = currentMetricsWatermark
+		exp.logsWatermarkFunc = currentLogsWatermark
 	}
-	exporters[pCfg] = receiver
-	return receiver
+	exporters[pCfg] = exp
+	return exp
 }
 
 // createDefaultConfig creates the default configuration for exporter.
@@ -89,67 +89,55 @@ func createDefaultConfig() component.Config {
 	}
 }
 
-func createTracesExporter(
-	ctx context.Context,
-	set exporter.Settings,
-	cfg component.Config,
-) (exporter.Traces, error) {
+func createTracesExporter(ctx context.Context, set exporter.Settings, cfg component.Config) (exporter.Traces, error) {
 	pCfg := cfg.(*Config)
-	pubsubExporter := ensureExporter(set, pCfg)
+	exp := ensureExporter(set, pCfg)
 
 	return exporterhelper.NewTraces(
 		ctx,
 		set,
 		cfg,
-		pubsubExporter.consumeTraces,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exp.consumeTraces,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithTimeout(pCfg.TimeoutSettings),
 		exporterhelper.WithRetry(pCfg.BackOffConfig),
 		exporterhelper.WithQueue(pCfg.QueueSettings),
-		exporterhelper.WithStart(pubsubExporter.start),
-		exporterhelper.WithShutdown(pubsubExporter.shutdown),
+		exporterhelper.WithStart(exp.start),
+		exporterhelper.WithShutdown(exp.shutdown),
 	)
 }
 
-func createMetricsExporter(
-	ctx context.Context,
-	set exporter.Settings,
-	cfg component.Config,
-) (exporter.Metrics, error) {
+func createMetricsExporter(ctx context.Context, set exporter.Settings, cfg component.Config) (exporter.Metrics, error) {
 	pCfg := cfg.(*Config)
-	pubsubExporter := ensureExporter(set, pCfg)
+	exp := ensureExporter(set, pCfg)
 	return exporterhelper.NewMetrics(
 		ctx,
 		set,
 		cfg,
-		pubsubExporter.consumeMetrics,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exp.consumeMetrics,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithTimeout(pCfg.TimeoutSettings),
 		exporterhelper.WithRetry(pCfg.BackOffConfig),
 		exporterhelper.WithQueue(pCfg.QueueSettings),
-		exporterhelper.WithStart(pubsubExporter.start),
-		exporterhelper.WithShutdown(pubsubExporter.shutdown),
+		exporterhelper.WithStart(exp.start),
+		exporterhelper.WithShutdown(exp.shutdown),
 	)
 }
 
-func createLogsExporter(
-	ctx context.Context,
-	set exporter.Settings,
-	cfg component.Config,
-) (exporter.Logs, error) {
+func createLogsExporter(ctx context.Context, set exporter.Settings, cfg component.Config) (exporter.Logs, error) {
 	pCfg := cfg.(*Config)
-	pubsubExporter := ensureExporter(set, pCfg)
+	exp := ensureExporter(set, pCfg)
 
 	return exporterhelper.NewLogs(
 		ctx,
 		set,
 		cfg,
-		pubsubExporter.consumeLogs,
-		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: false}),
+		exp.consumeLogs,
+		exporterhelper.WithCapabilities(consumer.Capabilities{MutatesData: true}),
 		exporterhelper.WithTimeout(pCfg.TimeoutSettings),
 		exporterhelper.WithRetry(pCfg.BackOffConfig),
 		exporterhelper.WithQueue(pCfg.QueueSettings),
-		exporterhelper.WithStart(pubsubExporter.start),
-		exporterhelper.WithShutdown(pubsubExporter.shutdown),
+		exporterhelper.WithStart(exp.start),
+		exporterhelper.WithShutdown(exp.shutdown),
 	)
 }

--- a/exporter/googlecloudpubsubexporter/go.mod
+++ b/exporter/googlecloudpubsubexporter/go.mod
@@ -16,6 +16,7 @@ require (
 	go.opentelemetry.io/collector/exporter/exportertest v0.120.1-0.20250226024140-8099e51f9a77
 	go.opentelemetry.io/collector/pdata v1.26.1-0.20250226024140-8099e51f9a77
 	go.uber.org/goleak v1.3.0
+	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 	google.golang.org/api v0.223.0
 	google.golang.org/grpc v1.70.0
@@ -65,7 +66,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
-	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.33.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/oauth2 v0.26.0 // indirect

--- a/exporter/googlecloudpubsubexporter/testdata/config.yaml
+++ b/exporter/googlecloudpubsubexporter/testdata/config.yaml
@@ -8,3 +8,7 @@ googlecloudpubsub/customname:
   watermark:
     behavior: earliest
     allowed_drift: 1h
+  ordering:
+    enabled: true
+    from_resource_attribute: ordering_key
+    remove_resource_attribute: true


### PR DESCRIPTION
#### Description
Add support for publishing ordered OTLP data to GCP PubSub. 

#### Link to tracking issue
Fixes #32850

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Unit tests updated.

Local testing for validating the ordering is properly enabled:
<details><summary>Details</summary>
<p>

GCP resources created:
```bash
gcloud pubsub topics create topic-for-testing-c9dbe8e5
gcloud pubsub subscriptions create subscription-test-ordered-c9dbe8e5 --topic topic-for-testing-c9dbe8e5 --topic-project xxx --expiration-period 1d --message-retention-duration 10m --enable-message-ordering
```

OTel collector config used:
```yaml
receivers:
  filelog/1:
    include:
      - /xxx/logs-1.jsonl
    start_at: beginning
    resource:
      file: logs-1
  filelog/2:
    include:
      - /xxx/logs-2.jsonl
    start_at: beginning
    resource:
      file: logs-2

  googlecloudpubsub/1:
    project: xxx
    subscription: projects/xxx/subscriptions/subsription-test-ordered-c9dbe8e5
    client_id: "local-test-1"

  googlecloudpubsub/2:
    project: xxx
    subscription: projects/xxx/subscriptions/subsription-test-ordered-c9dbe8e5
    client_id: "local-test-2"

processors:
  batch:

exporters:
  debug/exported:
    verbosity: basic

  debug/received:
    verbosity: basic

  googlecloudpubsub:
    project: xxx
    topic: projects/xxx/topics/topic-for-testing-c9dbe8e5
    ordering:
      enabled: true
      from_resource_attribute: file
      remove_resource_attribute: false

  file/output_1:
    path: /xxx/output/logs-1.jsonl

  file/output_2:
    path: /xxx/output/logs-2.jsonl

service:
  telemetry:
    logs:
      level: info
    metrics:
      address: "localhost:8888"

  pipelines:
    logs/exporter:
      receivers:
        - filelog/1
        - filelog/2
      processors:
        - batch
      exporters:
        - debug/exported
        - googlecloudpubsub

    logs/receiver_1:
      receivers:
        - googlecloudpubsub/1
      processors:
      exporters:
        - debug/received
        - file/output_1

    logs/receiver_2:
      receivers:
        - googlecloudpubsub/2
      processors:
      exporters:
        - debug/received
        - file/output_2
```

With input test data:
```console
➜ wc -l *.jsonl
 10000 logs-1.jsonl
 10000 logs-2.jsonl
 20000 total
```

Run OTel logs:
```console
➜ make RUN_CONFIG=.mylocal/config-pubsub-ordered.yaml run
cd ./cmd/otelcontribcol && GO111MODULE=on go run --race . --config ../../config-pubsub-ordered.yaml 
2025-01-30T11:22:27.610+0100    info    service@v0.118.1-0.20250130000211-c119b2a55eb4/service.go:186   Setting up own telemetry...
2025-01-30T11:22:27.610+0100    warn    service@v0.118.1-0.20250130000211-c119b2a55eb4/service.go:235   service::telemetry::metrics::address is being deprecated in favor of service::telemetry::metrics::readers
2025-01-30T11:22:27.611+0100    info    builders/builders.go:26 Development component. May change in the future.        {"kind": "exporter", "data_type": "logs", "name": "debug/received"}
2025-01-30T11:22:27.621+0100    info    builders/builders.go:26 Development component. May change in the future.        {"kind": "exporter", "data_type": "logs", "name": "debug/exported"}
2025-01-30T11:22:27.624+0100    info    service@v0.118.1-0.20250130000211-c119b2a55eb4/service.go:252   Starting otelcontribcol...      {"Version": "0.118.0-dev", "NumCPU": 7}
2025-01-30T11:22:27.625+0100    info    extensions/extensions.go:39     Starting extensions...
2025-01-30T11:22:28.117+0100    info    adapter/receiver.go:41  Starting stanza receiver        {"kind": "receiver", "name": "filelog/2", "data_type": "logs"}
2025-01-30T11:22:28.117+0100    info    internal/handler.go:105 Starting Streaming Pull {"kind": "receiver", "name": "googlecloudpubsub/1", "data_type": "logs"}
2025-01-30T11:22:28.317+0100    info    fileconsumer/file.go:265        Started watching file   {"kind": "receiver", "name": "filelog/2", "data_type": "logs", "component": "fileconsumer", "path": "/xxx/logs-2.jsonl"}
2025-01-30T11:22:28.343+0100    info    adapter/receiver.go:41  Starting stanza receiver        {"kind": "receiver", "name": "filelog/1", "data_type": "logs"}
2025-01-30T11:22:28.343+0100    info    internal/handler.go:105 Starting Streaming Pull {"kind": "receiver", "name": "googlecloudpubsub/2", "data_type": "logs"}
2025-01-30T11:22:28.344+0100    info    service@v0.118.1-0.20250130000211-c119b2a55eb4/service.go:275   Everything is ready. Begin running and processing data.
2025-01-30T11:22:28.546+0100    info    fileconsumer/file.go:265        Started watching file   {"kind": "receiver", "name": "filelog/1", "data_type": "logs", "component": "fileconsumer", "path": "/xxx/logs-1.jsonl"}
2025-01-30T11:22:29.470+0100    info    Logs    {"kind": "exporter", "data_type": "logs", "name": "debug/exported", "resource logs": 82, "log records": 8200}
2025-01-30T11:22:30.390+0100    info    Logs    {"kind": "exporter", "data_type": "logs", "name": "debug/exported", "resource logs": 82, "log records": 8200}
2025-01-30T11:22:30.799+0100    info    Logs    {"kind": "exporter", "data_type": "logs", "name": "debug/exported", "resource logs": 36, "log records": 3600}
2025-01-30T11:22:31.240+0100    info    Logs    {"kind": "exporter", "data_type": "logs", "name": "debug/received", "resource logs": 82, "log records": 8200}
2025-01-30T11:22:31.559+0100    info    Logs    {"kind": "exporter", "data_type": "logs", "name": "debug/received", "resource logs": 64, "log records": 6400}
2025-01-30T11:22:38.277+0100    info    Logs    {"kind": "exporter", "data_type": "logs", "name": "debug/received", "resource logs": 36, "log records": 3600}
2025-01-30T11:22:38.564+0100    info    Logs    {"kind": "exporter", "data_type": "logs", "name": "debug/received", "resource logs": 18, "log records": 1800}
^C2025-01-30T11:23:10.705+0100  info    otelcol@v0.118.1-0.20250130000211-c119b2a55eb4/collector.go:331 Received signal from OS {"signal": "interrupt"}
2025-01-30T11:23:10.705+0100    info    service@v0.118.1-0.20250130000211-c119b2a55eb4/service.go:317   Starting shutdown...
```

The numbers adds up and are ordered:
```console
➜ jq '.resourceLogs[].scopeLogs[].logRecords[].body | select(has("stringValue")) | .stringValue' output/*.jsonl | wc -l    
20000

➜ jq '.resourceLogs[].scopeLogs[].logRecords[].body | select(has("stringValue")) | .stringValue' output/*.jsonl | grep logs-1 | (head -n5; tail -n5)
"message 50000 for logs-1.jsonl"
"message 50001 for logs-1.jsonl"
"message 50002 for logs-1.jsonl"
"message 50003 for logs-1.jsonl"
"message 50004 for logs-1.jsonl"
"message 59995 for logs-1.jsonl"
"message 59996 for logs-1.jsonl"
"message 59997 for logs-1.jsonl"
"message 59998 for logs-1.jsonl"
"message 59999 for logs-1.jsonl"

➜ jq '.resourceLogs[].scopeLogs[].logRecords[].body | select(has("stringValue")) | .stringValue' output/*.jsonl | grep logs-2 | (head -n5; tail -n5)
"message 50000 for logs-2.jsonl"
"message 50001 for logs-2.jsonl"
"message 50002 for logs-2.jsonl"
"message 50003 for logs-2.jsonl"
"message 50004 for logs-2.jsonl"
"message 59995 for logs-2.jsonl"
"message 59996 for logs-2.jsonl"
"message 59997 for logs-2.jsonl"
"message 59998 for logs-2.jsonl"
"message 59999 for logs-2.jsonl"
```

</p>
</details> 

#### Documentation
Updated the README with new configurations + some fixes
