### PR TITLE
fix config key collision: un-squash client config (issue 37332)

### DIFF
--- a/exporter/prometheusremotewriteexporter/README.md
+++ b/exporter/prometheusremotewriteexporter/README.md
@@ -29,14 +29,16 @@ how this exporter works.
 
 The following settings are required:
 
-- `endpoint` (no default): The remote write URL to send remote write samples.
+- `prw_client`
+  - `endpoint` (no default): The remote write URL to send remote write samples.
+- `endpoint`: DEPRECATED
 
-By default, TLS is enabled and must be configured under `tls:`:
+By default, TLS is enabled and must be configured under `prw_client.tls:`:
 
 - `insecure` (default = `false`): whether to enable client transport security for
   the exporter's connection.
 
-As a result, the following parameters are also required under `tls:`:
+As a result, the following parameters are also required under `prw_client.tls:`:
 
 - `cert_file` (no default): path to the TLS cert to use for TLS required connections. Should
   only be used if `insecure` is set to false.
@@ -46,8 +48,11 @@ As a result, the following parameters are also required under `tls:`:
 The following settings can be optionally configured:
 
 - `external_labels`: map of labels names and values to be attached to each metric data point
-- `headers`: additional headers attached to each HTTP request.
-  - *Note the following headers cannot be changed: `Content-Encoding`, `Content-Type`, `X-Prometheus-Remote-Write-Version`, and `User-Agent`.*
+- `prw_client`
+  - `headers`: additional headers attached to each HTTP request.
+    - *Note the following headers cannot be changed: `Content-Encoding`, `Content-Type`, `X-Prometheus-Remote-Write-Version`, and `User-Agent`.*
+  - `timeout`: sets timeout for HTTP requests to Prometheus remote write endpoint (default 5s).
+- `headers`: DEPRECATED
 - `namespace`: prefix attached to each exported metric name.
 - `add_metric_suffixes`: If set to false, type and unit suffixes will not be added to metrics. Default: true.
 - `send_metadata`: If set to true, prometheus metadata will be generated and sent. Default: false.
@@ -73,7 +78,8 @@ Example:
 ```yaml
 exporters:
   prometheusremotewrite:
-    endpoint: "https://my-cortex:7900/api/v1/push"
+    prw_client:
+      endpoint: "https://my-cortex:7900/api/v1/push"
     wal: # Enabling the Write-Ahead-Log for the exporter.
       directory: ./prom_rw # The directory to store the WAL in
       buffer_size: 100 # Optional count of elements to be read from the WAL before truncating; default of 300
@@ -87,7 +93,8 @@ Example:
 ```yaml
 exporters:
   prometheusremotewrite:
-    endpoint: "https://my-cortex:7900/api/v1/push"
+    prw_client:
+      endpoint: "https://my-cortex:7900/api/v1/push"
     external_labels:
       label_name1: label_value1
       label_name2: label_value2

--- a/exporter/prometheusremotewriteexporter/config_test.go
+++ b/exporter/prometheusremotewriteexporter/config_test.go
@@ -45,6 +45,9 @@ func TestLoadConfig(t *testing.T) {
 		"Prometheus-Remote-Write-Version": "0.1.0",
 		"X-Scope-OrgID":                   "234",
 	}
+	prwClientConfig := newDefaultPRWClientConfig()
+	prwClientConfig.Endpoint = "localhost:8888"
+	prwClientConfig.Timeout = 11 * time.Second
 	tests := []struct {
 		id           component.ID
 		expected     component.Config
@@ -77,11 +80,42 @@ func TestLoadConfig(t *testing.T) {
 				Namespace:                   "test-space",
 				ExternalLabels:              map[string]string{"key1": "value1", "key2": "value2"},
 				ClientConfig:                clientConfig,
+				PRWClient:                   nil,
 				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: true},
 				TargetInfo: &TargetInfo{
 					Enabled: true,
 				},
 				CreatedMetric: &CreatedMetric{Enabled: true},
+			},
+		},
+		{
+			id: component.NewIDWithName(metadata.Type, "prw_client"),
+			expected: &Config{
+				MaxBatchSizeBytes: 3000000,
+				TimeoutSettings:   exporterhelper.NewDefaultTimeoutConfig(),
+				BackOffConfig: configretry.BackOffConfig{
+					Enabled:             true,
+					InitialInterval:     50 * time.Millisecond,
+					MaxInterval:         30 * time.Second,
+					MaxElapsedTime:      5 * time.Minute,
+					RandomizationFactor: backoff.DefaultRandomizationFactor,
+					Multiplier:          backoff.DefaultMultiplier,
+				},
+				RemoteWriteQueue: RemoteWriteQueue{
+					Enabled:      true,
+					QueueSize:    10000,
+					NumConsumers: 5,
+				},
+				AddMetricSuffixes:           true,
+				Namespace:                   "",
+				ExternalLabels:              make(map[string]string),
+				ClientConfig:                newDefaultPRWClientConfig(),
+				PRWClient:                   &prwClientConfig,
+				ResourceToTelemetrySettings: resourcetotelemetry.Settings{Enabled: false},
+				TargetInfo: &TargetInfo{
+					Enabled: true,
+				},
+				CreatedMetric: &CreatedMetric{Enabled: false},
 			},
 		},
 		{

--- a/exporter/prometheusremotewriteexporter/exporter.go
+++ b/exporter/prometheusremotewriteexporter/exporter.go
@@ -122,7 +122,12 @@ func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
 		return nil, err
 	}
 
-	endpointURL, err := url.ParseRequestURI(cfg.ClientConfig.Endpoint)
+	clientSettings := &cfg.ClientConfig
+	if cfg.PRWClient != nil {
+		clientSettings = cfg.PRWClient
+	}
+
+	endpointURL, err := url.ParseRequestURI(clientSettings.Endpoint)
 	if err != nil {
 		return nil, errors.New("invalid endpoint")
 	}
@@ -152,7 +157,7 @@ func newPRWExporter(cfg *Config, set exporter.Settings) (*prwExporter, error) {
 		userAgentHeader:   userAgentHeader,
 		maxBatchSizeBytes: cfg.MaxBatchSizeBytes,
 		concurrency:       concurrency,
-		clientSettings:    &cfg.ClientConfig,
+		clientSettings:    clientSettings,
 		settings:          set.TelemetrySettings,
 		retrySettings:     cfg.BackOffConfig,
 		retryOnHTTP429:    retryOn429FeatureGate.IsEnabled(),

--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -141,6 +141,36 @@ func Test_NewPRWExporter(t *testing.T) {
 	}
 }
 
+func Test_NewPRWExporter_ClientConfig(t *testing.T) {
+	prwClientConfig := confighttp.NewDefaultClientConfig()
+	prwClientConfig.Endpoint = "overridden.endpoint:8080"
+	cfg := &Config{
+		TimeoutSettings: exporterhelper.TimeoutConfig{},
+		BackOffConfig:   configretry.BackOffConfig{},
+		Namespace:       "",
+		ExternalLabels:  map[string]string{},
+		ClientConfig:    confighttp.NewDefaultClientConfig(),
+		PRWClient:       &prwClientConfig,
+		TargetInfo: &TargetInfo{
+			Enabled: true,
+		},
+		CreatedMetric: &CreatedMetric{
+			Enabled: false,
+		},
+	}
+	buildInfo := component.BuildInfo{
+		Description: "OpenTelemetry Collector",
+		Version:     "1.0",
+	}
+	set := exportertest.NewNopSettings()
+	set.BuildInfo = buildInfo
+
+	prwe, err := newPRWExporter(cfg, set)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "overridden.endpoint:8080", prwe.endpointURL.String())
+}
+
 // Test_Start checks if the client is properly created as expected.
 func Test_Start(t *testing.T) {
 	cfg := &Config{

--- a/exporter/prometheusremotewriteexporter/testdata/config.yaml
+++ b/exporter/prometheusremotewriteexporter/testdata/config.yaml
@@ -27,6 +27,11 @@ prometheusremotewrite/2:
     queue_size: 2000
     num_consumers: 10
 
+prometheusremotewrite/prw_client:
+  prw_client:
+    endpoint: "localhost:8888"
+    timeout: "11s"
+
 prometheusremotewrite/negative_queue_size:
   endpoint: "localhost:8888"
   remote_write_queue:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Prometheus remote write HTTP client config [is squashed](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.117.0/exporter/prometheusremotewriteexporter/config.go#L33) into the exporter config hence causing a collision for [`timeout`](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.117.0/exporter/prometheusremotewriteexporter/config.go#L19) key.
This PR fixes the issue ([#37332](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37332)) by putting the HTTP config under its own key `prw_client` (unsquashed) in a backward-compatible manner.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37332
<!--Describe what testing was performed and which tests were added.-->
#### Testing
New test:
* `Test_NewPRWExporter_ClientConfig`

Additional case for test:
* `TestLoadConfig`
<!--Describe the documentation added.-->
#### Documentation
My intention is to put the HTTP client config under its own key `prw_client` such that:
* it's backward-compatible: prior configs will continue working
* if new `prw_client` config section is specified, it takes precedence over the squashed version
* default options for the `prw_client` are preserved in a single place: see `setDefaultsPRWClientConfig` function
* the squashed version ([Config.ClientConfig](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.117.0/exporter/prometheusremotewriteexporter/config.go#L33)) is deprecated in favor of the new format
<!--Please delete paragraphs that you did not use before submitting.-->
