### PR TITLE
[chore] Make additional config validation tests more resilient

### DIFF
--- a/receiver/dockerstatsreceiver/config_test.go
+++ b/receiver/dockerstatsreceiver/config_test.go
@@ -101,7 +101,7 @@ func TestValidateErrors(t *testing.T) {
 	cfg := &Config{ControllerConfig: scraperhelper.NewDefaultControllerConfig(), Config: docker.Config{
 		DockerAPIVersion: "1.25",
 	}}
-	assert.Equal(t, "endpoint must be specified", component.ValidateConfig(cfg).Error())
+	assert.ErrorContains(t, component.ValidateConfig(cfg), "endpoint must be specified")
 
 	cfg = &Config{
 		Config: docker.Config{
@@ -110,7 +110,7 @@ func TestValidateErrors(t *testing.T) {
 		},
 		ControllerConfig: scraperhelper.ControllerConfig{CollectionInterval: 1 * time.Second},
 	}
-	assert.Equal(t, `"api_version" 1.21 must be at least 1.25`, component.ValidateConfig(cfg).Error())
+	assert.ErrorContains(t, component.ValidateConfig(cfg), `"api_version" 1.21 must be at least 1.25`)
 
 	cfg = &Config{
 		Config: docker.Config{
@@ -119,7 +119,7 @@ func TestValidateErrors(t *testing.T) {
 		},
 		ControllerConfig: scraperhelper.ControllerConfig{},
 	}
-	assert.Equal(t, `"collection_interval": requires positive value`, component.ValidateConfig(cfg).Error())
+	assert.ErrorContains(t, component.ValidateConfig(cfg), `"collection_interval": requires positive value`)
 }
 
 func TestApiVersionCustomError(t *testing.T) {

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestScrape(t *testing.T) {
+	t.Skip("")
 	type testCase struct {
 		name                     string
 		config                   Config

--- a/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
+++ b/receiver/hostmetricsreceiver/internal/scraper/filesystemscraper/filesystem_scraper_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestScrape(t *testing.T) {
-	t.Skip("")
 	type testCase struct {
 		name                     string
 		config                   Config

--- a/receiver/k8sclusterreceiver/config_test.go
+++ b/receiver/k8sclusterreceiver/config_test.go
@@ -85,7 +85,7 @@ func TestInvalidConfig(t *testing.T) {
 	}
 	err := component.ValidateConfig(cfg)
 	assert.Error(t, err)
-	assert.Equal(t, "invalid authType for kubernetes: ", err.Error())
+	assert.ErrorContains(t, err, "invalid authType for kubernetes: ")
 
 	// Wrong distro
 	cfg = &Config{

--- a/receiver/podmanreceiver/config_test.go
+++ b/receiver/podmanreceiver/config_test.go
@@ -24,9 +24,9 @@ func TestLoadConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	tests := []struct {
-		id             component.ID
-		expected       component.Config
-		expectedErrMsg string
+		id              component.ID
+		expected        component.Config
+		expectedErrMsgs []string
 	}{
 		{
 			id: component.NewIDWithName(metadata.Type, ""),
@@ -55,12 +55,12 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
-			id:             component.NewIDWithName(metadata.Type, "empty_endpoint"),
-			expectedErrMsg: "config.Endpoint must be specified",
+			id:              component.NewIDWithName(metadata.Type, "empty_endpoint"),
+			expectedErrMsgs: []string{"config.Endpoint must be specified"},
 		},
 		{
-			id:             component.NewIDWithName(metadata.Type, "invalid_collection_interval"),
-			expectedErrMsg: `config.CollectionInterval must be specified; "collection_interval": requires positive value`,
+			id:              component.NewIDWithName(metadata.Type, "invalid_collection_interval"),
+			expectedErrMsgs: []string{`config.CollectionInterval must be specified`, `"collection_interval": requires positive value`},
 		},
 	}
 
@@ -73,8 +73,10 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, sub.Unmarshal(cfg))
 
-			if tt.expectedErrMsg != "" {
-				assert.ErrorContains(t, component.ValidateConfig(cfg), tt.expectedErrMsg)
+			if len(tt.expectedErrMsgs) > 0 {
+				for _, msg := range tt.expectedErrMsgs {
+					assert.ErrorContains(t, component.ValidateConfig(cfg), msg)
+				}
 				return
 			}
 

--- a/receiver/postgresqlreceiver/config_test.go
+++ b/receiver/postgresqlreceiver/config_test.go
@@ -15,7 +15,6 @@ import (
 	"go.opentelemetry.io/collector/config/confignet"
 	"go.opentelemetry.io/collector/config/configtls"
 	"go.opentelemetry.io/collector/confmap/confmaptest"
-	"go.uber.org/multierr"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/postgresqlreceiver/internal/metadata"
 )
@@ -24,33 +23,33 @@ func TestValidate(t *testing.T) {
 	testCases := []struct {
 		desc                  string
 		defaultConfigModifier func(cfg *Config)
-		expected              error
+		expected              []error
 	}{
 		{
 			desc:                  "missing username and password",
 			defaultConfigModifier: func(*Config) {},
-			expected: multierr.Combine(
+			expected: []error{
 				errors.New(ErrNoUsername),
 				errors.New(ErrNoPassword),
-			),
+			},
 		},
 		{
 			desc: "missing password",
 			defaultConfigModifier: func(cfg *Config) {
 				cfg.Username = "otel"
 			},
-			expected: multierr.Combine(
+			expected: []error{
 				errors.New(ErrNoPassword),
-			),
+			},
 		},
 		{
 			desc: "missing username",
 			defaultConfigModifier: func(cfg *Config) {
 				cfg.Password = "otel"
 			},
-			expected: multierr.Combine(
+			expected: []error{
 				errors.New(ErrNoUsername),
-			),
+			},
 		},
 		{
 			desc: "bad endpoint",
@@ -59,9 +58,9 @@ func TestValidate(t *testing.T) {
 				cfg.Password = "otel"
 				cfg.Endpoint = "open-telemetry"
 			},
-			expected: multierr.Combine(
+			expected: []error{
 				errors.New(ErrHostPort),
-			),
+			},
 		},
 		{
 			desc: "bad transport",
@@ -70,9 +69,9 @@ func TestValidate(t *testing.T) {
 				cfg.Password = "otel"
 				cfg.Transport = "udp"
 			},
-			expected: multierr.Combine(
+			expected: []error{
 				errors.New(ErrTransportsSupported),
-			),
+			},
 		},
 		{
 			desc: "unsupported SSL params",
@@ -83,11 +82,11 @@ func TestValidate(t *testing.T) {
 				cfg.MinVersion = "1.0"
 				cfg.MaxVersion = "1.0"
 			},
-			expected: multierr.Combine(
+			expected: []error{
 				fmt.Errorf(ErrNotSupported, "ServerName"),
 				fmt.Errorf(ErrNotSupported, "MaxVersion"),
 				fmt.Errorf(ErrNotSupported, "MinVersion"),
-			),
+			},
 		},
 		{
 			desc: "no error",
@@ -104,7 +103,11 @@ func TestValidate(t *testing.T) {
 			cfg := factory.CreateDefaultConfig().(*Config)
 			tC.defaultConfigModifier(cfg)
 			actual := component.ValidateConfig(cfg)
-			require.Equal(t, tC.expected, actual)
+			if len(tC.expected) > 0 {
+				for _, err := range tC.expected {
+					require.ErrorContains(t, actual, err.Error())
+				}
+			}
 		})
 	}
 }

--- a/receiver/prometheusreceiver/config_test.go
+++ b/receiver/prometheusreceiver/config_test.go
@@ -216,7 +216,7 @@ func TestRejectUnsupportedPrometheusFeatures(t *testing.T) {
         rule_files`
 
 	gotErrMsg := strings.ReplaceAll(err.Error(), "\t", strings.Repeat(" ", 8))
-	require.Equal(t, wantErrMsg, gotErrMsg)
+	require.Contains(t, gotErrMsg, wantErrMsg)
 }
 
 func TestNonExistentAuthCredentialsFile(t *testing.T) {

--- a/receiver/solacereceiver/config_test.go
+++ b/receiver/solacereceiver/config_test.go
@@ -71,7 +71,7 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, sub.Unmarshal(cfg))
 
 			if tt.expectedErr != nil {
-				assert.ErrorIs(t, component.ValidateConfig(cfg), tt.expectedErr)
+				assert.ErrorContains(t, component.ValidateConfig(cfg), tt.expectedErr.Error())
 				return
 			}
 			assert.NoError(t, component.ValidateConfig(cfg))
@@ -84,7 +84,7 @@ func TestConfigValidateMissingAuth(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Queue = "someQueue"
 	err := component.ValidateConfig(cfg)
-	assert.Equal(t, errMissingAuthDetails, err)
+	assert.ErrorContains(t, err, errMissingAuthDetails.Error())
 }
 
 func TestConfigValidateMultipleAuth(t *testing.T) {
@@ -93,14 +93,14 @@ func TestConfigValidateMultipleAuth(t *testing.T) {
 	cfg.Auth.PlainText = &SaslPlainTextConfig{"Username", "Password"}
 	cfg.Auth.XAuth2 = &SaslXAuth2Config{"Username", "Bearer"}
 	err := component.ValidateConfig(cfg)
-	assert.Equal(t, errTooManyAuthDetails, err)
+	assert.ErrorContains(t, err, errTooManyAuthDetails.Error())
 }
 
 func TestConfigValidateMissingQueue(t *testing.T) {
 	cfg := createDefaultConfig().(*Config)
 	cfg.Auth.PlainText = &SaslPlainTextConfig{"Username", "Password"}
 	err := component.ValidateConfig(cfg)
-	assert.Equal(t, errMissingQueueName, err)
+	assert.ErrorContains(t, err, errMissingQueueName.Error())
 }
 
 func TestConfigValidateMissingFlowControl(t *testing.T) {
@@ -110,7 +110,7 @@ func TestConfigValidateMissingFlowControl(t *testing.T) {
 	// this should never happen in reality, test validation anyway
 	cfg.Flow.DelayedRetry = nil
 	err := cfg.Validate()
-	assert.Equal(t, errMissingFlowControl, err)
+	assert.ErrorContains(t, err, errMissingFlowControl.Error())
 }
 
 func TestConfigValidateInvalidFlowControlDelayedRetryDelay(t *testing.T) {
@@ -121,7 +121,7 @@ func TestConfigValidateInvalidFlowControlDelayedRetryDelay(t *testing.T) {
 		Delay: -30 * time.Second,
 	}
 	err := cfg.Validate()
-	assert.Equal(t, errInvalidDelayedRetryDelay, err)
+	assert.ErrorContains(t, err, errInvalidDelayedRetryDelay.Error())
 }
 
 func TestConfigValidateSuccess(t *testing.T) {

--- a/receiver/windowsperfcountersreceiver/config_test.go
+++ b/receiver/windowsperfcountersreceiver/config_test.go
@@ -48,9 +48,9 @@ func TestLoadConfig(t *testing.T) {
 	}
 
 	tests := []struct {
-		id          component.ID
-		expected    component.Config
-		expectedErr string
+		id           component.ID
+		expected     component.Config
+		expectedErrs []string
 	}{
 		{
 			id:       component.NewIDWithName(metadata.Type, ""),
@@ -180,34 +180,34 @@ func TestLoadConfig(t *testing.T) {
 			},
 		},
 		{
-			id:          component.NewIDWithName(metadata.Type, "negative-collection-interval"),
-			expectedErr: "collection_interval must be a positive duration; " + negativeCollectionIntervalErr,
+			id:           component.NewIDWithName(metadata.Type, "negative-collection-interval"),
+			expectedErrs: []string{"collection_interval must be a positive duration", negativeCollectionIntervalErr},
 		},
 		{
-			id:          component.NewIDWithName(metadata.Type, "noperfcounters"),
-			expectedErr: noPerfCountersErr,
+			id:           component.NewIDWithName(metadata.Type, "noperfcounters"),
+			expectedErrs: []string{noPerfCountersErr},
 		},
 		{
-			id:          component.NewIDWithName(metadata.Type, "noobjectname"),
-			expectedErr: noObjectNameErr,
+			id:           component.NewIDWithName(metadata.Type, "noobjectname"),
+			expectedErrs: []string{noObjectNameErr},
 		},
 		{
-			id:          component.NewIDWithName(metadata.Type, "nocounters"),
-			expectedErr: fmt.Sprintf(noCountersErr, "object"),
+			id:           component.NewIDWithName(metadata.Type, "nocounters"),
+			expectedErrs: []string{fmt.Sprintf(noCountersErr, "object")},
 		},
 		{
 			id: component.NewIDWithName(metadata.Type, "allerrors"),
-			expectedErr: fmt.Sprintf(
-				"collection_interval must be a positive duration; %s; %s; %s; %s",
+			expectedErrs: []string{
+				"collection_interval must be a positive duration",
 				fmt.Sprintf(noCountersErr, "object"),
 				fmt.Sprintf(emptyInstanceErr, "object"),
 				noObjectNameErr,
 				negativeCollectionIntervalErr,
-			),
+			},
 		},
 		{
-			id:          component.NewIDWithName(metadata.Type, "emptyinstance"),
-			expectedErr: fmt.Sprintf(emptyInstanceErr, "object"),
+			id:           component.NewIDWithName(metadata.Type, "emptyinstance"),
+			expectedErrs: []string{fmt.Sprintf(emptyInstanceErr, "object")},
 		},
 	}
 
@@ -220,8 +220,10 @@ func TestLoadConfig(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, sub.Unmarshal(cfg))
 
-			if tt.expectedErr != "" {
-				assert.Equal(t, tt.expectedErr, component.ValidateConfig(cfg).Error())
+			if len(tt.expectedErrs) > 0 {
+				for _, err := range tt.expectedErrs {
+					assert.ErrorContains(t, component.ValidateConfig(cfg), err)
+				}
 				return
 			}
 			assert.NoError(t, component.ValidateConfig(cfg))


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Follow up to https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37579. This should address issues with the remaining tests.
