### PR TITLE
[DUPLICATE] Added setting to config to redact data of all types

### DIFF
--- a/processor/redactionprocessor/README.md
+++ b/processor/redactionprocessor/README.md
@@ -73,6 +73,8 @@ processors:
     # Any keys in this list are allowed so they don't need to be in both lists.
     ignored_keys:
       - safe_attribute
+    # redact_all_types will check incoming fields for sensitive data based on their AsString() representation. This allows the processor to redact sensitive data from ints. This is useful for redacting credit card numbers
+    redact_all_types: true
     # blocked_values is a list of regular expressions for blocking values of
     # allowed span attributes. Values that match are masked
     blocked_values:

--- a/processor/redactionprocessor/config.go
+++ b/processor/redactionprocessor/config.go
@@ -19,6 +19,11 @@ type Config struct {
 	// without being changed or removed.
 	IgnoredKeys []string `mapstructure:"ignored_keys"`
 
+	// RedactAllTypes is a flag to allow the processor to redact all span
+	// attribute values including those that are not strings. By default
+	// it is false and only string values are redacted.
+	RedactAllTypes bool `mapstructure:"redact_all_types"`
+
 	// BlockedValues is a list of regular expressions for blocking values of
 	// allowed span attributes. Values that match are masked
 	BlockedValues []string `mapstructure:"blocked_values"`

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -188,6 +188,9 @@ func (s *redaction) processAttrs(_ context.Context, attributes pcommon.Map) {
 
 		// Mask any blocked values for the other attributes
 		strVal := value.Str()
+		if s.config.RedactAllTypes {
+			strVal = value.AsString()
+		}
 		var matched bool
 		for _, compiledRE := range s.blockRegexList {
 			match := compiledRE.MatchString(strVal)


### PR DESCRIPTION
Description
The redaction is done based on its AsString value
rather than SDR. This is based on this issue:
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36684

The bug is that credit card numbers (as in the example on the README) are often provided as int numbers. The current redaction processor ignores all fields that are not of type int.

Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36684

Fixes No way to redact non string values

Documentation
I added the setting and turned it to true in the README as redacting un-delimited credit cards would definitely be under the scope of this setting.