### PR TITLE
[chore][fileconsumer] Fix flush test

### DIFF
--- a/pkg/stanza/flush/flush.go
+++ b/pkg/stanza/flush/flush.go
@@ -61,7 +61,7 @@ func (s *State) Func(splitFunc bufio.SplitFunc, period time.Duration) bufio.Spli
 		}
 
 		// Flush timed out
-		if time.Since(s.LastDataChange) > period {
+		if internaltime.Since(s.LastDataChange) > period {
 			s.LastDataChange = internaltime.Now()
 			s.LastDataLength = 0
 			return len(data), data, nil

--- a/pkg/stanza/flush/flush.go
+++ b/pkg/stanza/flush/flush.go
@@ -15,16 +15,6 @@ type State struct {
 	LastDataLength int
 }
 
-func (s *State) Copy() *State {
-	if s == nil {
-		return nil
-	}
-	return &State{
-		LastDataChange: s.LastDataChange,
-		LastDataLength: s.LastDataLength,
-	}
-}
-
 // Func wraps a bufio.SplitFunc with a timer.
 // When the timer expires, an incomplete token may be returned.
 // The timer will reset any time the data parameter changes.


### PR DESCRIPTION
This PR adds precision to a test that previously may have succeeding for unreliable reasons.
- Manage `internaltime.Since` in addition to `internaltime.Now`
- Advance clock intentionally, rather than relying on implied time passage
- Removes unused Copy function