### PR TITLE
[processor/metricsgeneration] Add config validation for generated metric names

### DIFF
--- a/.chloggen/metricsgeneration_loop.yaml
+++ b/.chloggen/metricsgeneration_loop.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: metricsgenerationprocessor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Generated metric name may not match metric being scaled
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37474]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/metricsgenerationprocessor/config.go
+++ b/processor/metricsgenerationprocessor/config.go
@@ -162,8 +162,10 @@ func (config *Config) Validate() error {
 			return fmt.Errorf("%q must be in %q", operationFieldName, operationTypeKeys())
 		}
 
-		if rule.Name == rule.Metric1 || rule.Name == rule.Metric2 {
-			return fmt.Errorf("The generated metric name may not match a given metric name.")
+		if rule.Name == rule.Metric1 {
+			return fmt.Errorf("value of field %q may not match value of field %q", nameFieldName, metric1FieldName)
+		} else if rule.Name == rule.Metric2 {
+			return fmt.Errorf("value of field %q may not match value of field %q", nameFieldName, metric2FieldName)
 		}
 	}
 	return nil

--- a/processor/metricsgenerationprocessor/config.go
+++ b/processor/metricsgenerationprocessor/config.go
@@ -161,6 +161,10 @@ func (config *Config) Validate() error {
 		if rule.Operation != "" && !rule.Operation.isValid() {
 			return fmt.Errorf("%q must be in %q", operationFieldName, operationTypeKeys())
 		}
+
+		if rule.Name == rule.Metric1 || rule.Name == rule.Metric2 {
+			return fmt.Errorf("The generated metric name may not match a given metric name.")
+		}
 	}
 	return nil
 }

--- a/processor/metricsgenerationprocessor/config_test.go
+++ b/processor/metricsgenerationprocessor/config_test.go
@@ -75,6 +75,10 @@ func TestLoadConfig(t *testing.T) {
 			id:           component.NewIDWithName(metadata.Type, "invalid_operation"),
 			errorMessage: fmt.Sprintf("%q must be in %q", operationFieldName, operationTypeKeys()),
 		},
+		{
+			id:           component.NewIDWithName(metadata.Type, "scale_by_matching_metric_names"),
+			errorMessage: fmt.Sprintf("The generated metric name may not match a given metric name."),
+		},
 	}
 
 	for _, tt := range tests {

--- a/processor/metricsgenerationprocessor/config_test.go
+++ b/processor/metricsgenerationprocessor/config_test.go
@@ -76,8 +76,12 @@ func TestLoadConfig(t *testing.T) {
 			errorMessage: fmt.Sprintf("%q must be in %q", operationFieldName, operationTypeKeys()),
 		},
 		{
-			id:           component.NewIDWithName(metadata.Type, "scale_by_matching_metric_names"),
-			errorMessage: fmt.Sprintf("The generated metric name may not match a given metric name."),
+			id:           component.NewIDWithName(metadata.Type, "matching_metric1"),
+			errorMessage: fmt.Sprintf("value of field %q may not match value of field %q", nameFieldName, metric1FieldName),
+		},
+		{
+			id:           component.NewIDWithName(metadata.Type, "matching_metric2"),
+			errorMessage: fmt.Sprintf("value of field %q may not match value of field %q", nameFieldName, metric2FieldName),
 		},
 	}
 

--- a/processor/metricsgenerationprocessor/testdata/config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/config.yaml
@@ -69,10 +69,18 @@ metricsgeneration/missing_type:
       metric2: metric2
       operation: percent
 
-metricsgeneration/scale_by_matching_metric_names:
+metricsgeneration/matching_metric1:
   rules:
     - name: new_metric
       type: scale
       metric1: new_metric
       operation: multiply
       scale_by: 100
+
+metricsgeneration/matching_metric2:
+  rules:
+    - name: new_metric
+      type: calculate
+      metric1: original
+      metric2: new_metric
+      operation: multiply

--- a/processor/metricsgenerationprocessor/testdata/config.yaml
+++ b/processor/metricsgenerationprocessor/testdata/config.yaml
@@ -68,3 +68,11 @@ metricsgeneration/missing_type:
       metric1: metric1
       metric2: metric2
       operation: percent
+
+metricsgeneration/scale_by_matching_metric_names:
+  rules:
+    - name: new_metric
+      type: scale
+      metric1: new_metric
+      operation: multiply
+      scale_by: 100


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
If a generated metric name matched the metric being scaled an infinite loop is hit. Since this action is not supported by this processor, and is supported by the metrics transform processor, the fix here is to add config validation to enforce metric names are different.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37474

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Added a test to ensure enforcement is done properly.