### PR TITLE
[chore] Change Makefile updatehelper to not require generated files

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -25,7 +25,6 @@ jobs:
           git config user.email 107717825+opentelemetrybot@users.noreply.github.com
           branch="opentelemetrybot/update-otel-$(date +%s)"
           git checkout -b $branch
-          make genotelcontribcol
           make update-otel
           git push --set-upstream origin $branch  
           gh pr create --base main --title "[chore] Update core dependencies" --body "This PR updates the opentelemetry-collector dependency to the latest release"


### PR DESCRIPTION
To avoid calling `make genotelcontribcol genoteltestbedcol` unnecessarily