### PR TITLE
[chore] Use math/rand/v2 everywhere

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -153,6 +153,8 @@ linters-settings:
             desc: "Use 'errors' or 'fmt' instead of github.com/pkg/errors"
           - pkg: github.com/hashicorp/go-multierror
             desc: "Use go.uber.org/multierr instead of github.com/hashicorp/go-multierror"
+          - pkg: "math/rand$"
+            desc: "Use math/rand/v2 instead of math/rand"
         # Add a different guard rule so that we can ignore tests.
       ignore-in-test:
           deny:

--- a/connector/servicegraphconnector/internal/store/store_test.go
+++ b/connector/servicegraphconnector/internal/store/store_test.go
@@ -5,7 +5,7 @@ package store
 
 import (
 	"encoding/hex"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -146,7 +146,7 @@ func TestStoreConcurrency(t *testing.T) {
 	}
 
 	go accessor(func() {
-		key := NewKey(pcommon.TraceID([16]byte{byte(rand.Intn(32))}), pcommon.SpanID([8]byte{1, 2, 3}))
+		key := NewKey(pcommon.TraceID([16]byte{byte(rand.IntN(32))}), pcommon.SpanID([8]byte{1, 2, 3}))
 
 		_, err := s.UpsertEdge(key, func(e *Edge) {
 			e.ClientService = hex.EncodeToString(key.tid[:])

--- a/examples/demo/client/main.go
+++ b/examples/demo/client/main.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"time"
@@ -150,16 +150,15 @@ func main() {
 	)
 
 	defaultCtx := baggage.ContextWithBaggage(context.Background(), bag)
-	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for {
 		startTime := time.Now()
 		ctx, span := tracer.Start(defaultCtx, "ExecuteRequest")
 		makeRequest(ctx)
 		span.End()
 		latencyMs := float64(time.Since(startTime)) / 1e6
-		nr := int(rng.Int31n(7))
+		nr := rand.IntN(7)
 		for i := 0; i < nr; i++ {
-			randLineLength := rng.Int63n(999)
+			randLineLength := rand.Int64N(999)
 			lineCounts.Add(ctx, 1, metric.WithAttributes(commonLabels...))
 			lineLengths.Record(ctx, randLineLength, metric.WithAttributes(commonLabels...))
 			fmt.Printf("#%d: LineLength: %dBy\n", i, randLineLength)

--- a/examples/demo/server/main.go
+++ b/examples/demo/server/main.go
@@ -8,7 +8,7 @@ package main
 import (
 	"context"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"os"
 	"time"
@@ -28,8 +28,6 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.opentelemetry.io/otel/trace"
 )
-
-var rng = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 // Initializes an OTLP exporter, and configures the corresponding trace and
 // metric providers.
@@ -125,15 +123,15 @@ func main() {
 
 		switch modulus := time.Now().Unix() % 5; modulus {
 		case 0:
-			sleep = rng.Int63n(2000)
+			sleep = rand.Int64N(2000)
 		case 1:
-			sleep = rng.Int63n(15)
+			sleep = rand.Int64N(15)
 		case 2:
-			sleep = rng.Int63n(917)
+			sleep = rand.Int64N(917)
 		case 3:
-			sleep = rng.Int63n(87)
+			sleep = rand.Int64N(87)
 		case 4:
-			sleep = rng.Int63n(1173)
+			sleep = rand.Int64N(1173)
 		}
 		time.Sleep(time.Duration(sleep) * time.Millisecond)
 		ctx := req.Context()

--- a/exporter/awskinesisexporter/internal/compress/compresser_test.go
+++ b/exporter/awskinesisexporter/internal/compress/compresser_test.go
@@ -10,7 +10,7 @@ import (
 	"compress/zlib"
 	"fmt"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -77,7 +77,7 @@ func createRandomString(length int) string {
 
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+		b[i] = letterBytes[rand.IntN(len(letterBytes))]
 	}
 
 	return string(b)
@@ -118,16 +118,13 @@ func BenchmarkGzipCompressor_1Mb(b *testing.B) {
 func benchmarkCompressor(b *testing.B, format string, length int) {
 	b.Helper()
 
-	source := rand.NewSource(time.Now().UnixMilli())
-	genRand := rand.New(source)
-
 	compressor, err := compress.NewCompressor(format)
 	require.NoError(b, err, "Must not error when given a valid format")
 	require.NotNil(b, compressor, "Must have a valid compressor")
 
 	data := make([]byte, length)
 	for i := 0; i < length; i++ {
-		data[i] = byte(genRand.Int31())
+		data[i] = byte(rand.Int32())
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -185,12 +182,9 @@ func concurrentCompressFunc(t *testing.T) {
 		go func() {
 			defer wg.Done()
 
-			source := rand.NewSource(time.Now().UnixMilli())
-			genRand := rand.New(source)
-
 			data := make([]byte, dataLength)
 			for i := 0; i < dataLength; i++ {
-				data[i] = byte(genRand.Int31())
+				data[i] = byte(rand.Int32())
 			}
 
 			result, localErr := compressFunc(data)

--- a/exporter/azuredataexplorerexporter/adx_exporter_test.go
+++ b/exporter/azuredataexplorerexporter/adx_exporter_test.go
@@ -6,7 +6,7 @@ package azuredataexplorerexporter // import "github.com/open-telemetry/opentelem
 import (
 	"context"
 	"io"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"testing"
 	"time"
@@ -164,9 +164,7 @@ func TestIngestedDataRecordCount(t *testing.T) {
 		ingestOptions: ingestOptions,
 		logger:        logger,
 	}
-	source := rand.NewSource(time.Now().UTC().UnixNano())
-	genRand := rand.New(source)
-	recordstoingest := genRand.Intn(20)
+	recordstoingest := rand.IntN(20)
 	err := adxDataProducer.metricsDataPusher(context.Background(), createMetricsData(recordstoingest))
 	ingestedrecordsactual := ingestor.Records()
 	assert.Len(t, ingestedrecordsactual, recordstoingest, "Number of metrics created should match number of records ingested")

--- a/exporter/clickhouseexporter/integration_test.go
+++ b/exporter/clickhouseexporter/integration_test.go
@@ -9,7 +9,7 @@ package clickhouseexporter
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 	"time"
@@ -606,7 +606,5 @@ func verifySummaryMetric(t *testing.T, db *sqlx.DB) {
 }
 
 func randPort() string {
-	rs := rand.NewSource(time.Now().Unix())
-	r := rand.New(rs)
-	return strconv.Itoa(r.Intn(999) + 9000)
+	return strconv.Itoa(rand.IntN(999) + 9000)
 }

--- a/exporter/datasetexporter/logs_exporter_stress_test.go
+++ b/exporter/datasetexporter/logs_exporter_stress_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -111,7 +111,7 @@ func TestConsumeLogsManyLogsShouldSucceed(t *testing.T) {
 				log.SetTimestamp(pcommon.NewTimestampFromTime(time.Now()))
 				log.Body().SetStr(key)
 				log.Attributes().PutStr("key", key)
-				log.Attributes().PutStr("p1", strings.Repeat("A", rand.Intn(2000)))
+				log.Attributes().PutStr("p1", strings.Repeat("A", rand.IntN(2000)))
 				expectedKeys[key] = 1
 			}
 			err = logs.ConsumeLogs(context.Background(), batch)

--- a/exporter/loadbalancingexporter/log_exporter.go
+++ b/exporter/loadbalancingexporter/log_exporter.go
@@ -5,7 +5,7 @@ package loadbalancingexporter // import "github.com/open-telemetry/opentelemetry
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"time"
 
@@ -141,9 +141,9 @@ func traceIDFromLogs(ld plog.Logs) pcommon.TraceID {
 }
 
 func random() pcommon.TraceID {
-	v1 := uint8(rand.Intn(256))
-	v2 := uint8(rand.Intn(256))
-	v3 := uint8(rand.Intn(256))
-	v4 := uint8(rand.Intn(256))
+	v1 := uint8(rand.IntN(256))
+	v2 := uint8(rand.IntN(256))
+	v3 := uint8(rand.IntN(256))
+	v4 := uint8(rand.IntN(256))
 	return [16]byte{v1, v2, v3, v4}
 }

--- a/exporter/loadbalancingexporter/metrics_exporter_test.go
+++ b/exporter/loadbalancingexporter/metrics_exporter_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"
@@ -835,13 +835,13 @@ func TestRollingUpdatesWhenConsumeMetrics(t *testing.T) {
 func randomMetrics(t require.TestingT, rmCount int, smCount int, mCount int, dpCount int) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 
-	timeStamp := pcommon.Timestamp(rand.Intn(256))
-	value := int64(rand.Intn(256))
+	timeStamp := pcommon.Timestamp(rand.IntN(256))
+	value := rand.Int64N(256)
 
 	for i := 0; i < rmCount; i++ {
 		rm := md.ResourceMetrics().AppendEmpty()
 		err := rm.Resource().Attributes().FromRaw(map[string]any{
-			conventions.AttributeServiceName: fmt.Sprintf("service-%d", rand.Intn(512)),
+			conventions.AttributeServiceName: fmt.Sprintf("service-%d", rand.IntN(512)),
 		})
 		require.NoError(t, err)
 
@@ -851,13 +851,13 @@ func randomMetrics(t require.TestingT, rmCount int, smCount int, mCount int, dpC
 			scope.SetName("MyTestInstrument")
 			scope.SetVersion("1.2.3")
 			err = scope.Attributes().FromRaw(map[string]any{
-				"scope.key": fmt.Sprintf("scope-%d", rand.Intn(512)),
+				"scope.key": fmt.Sprintf("scope-%d", rand.IntN(512)),
 			})
 			require.NoError(t, err)
 
 			for k := 0; k < mCount; k++ {
 				m := sm.Metrics().AppendEmpty()
-				m.SetName(fmt.Sprintf("metric.%d.test", rand.Intn(512)))
+				m.SetName(fmt.Sprintf("metric.%d.test", rand.IntN(512)))
 
 				sum := m.SetEmptySum()
 				sum.SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
@@ -873,7 +873,7 @@ func randomMetrics(t require.TestingT, rmCount int, smCount int, mCount int, dpC
 					value += 15
 
 					err = dp.Attributes().FromRaw(map[string]any{
-						"datapoint.key": fmt.Sprintf("dp-%d", rand.Intn(512)),
+						"datapoint.key": fmt.Sprintf("dp-%d", rand.IntN(512)),
 					})
 					require.NoError(t, err)
 				}

--- a/exporter/loadbalancingexporter/trace_exporter_test.go
+++ b/exporter/loadbalancingexporter/trace_exporter_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -646,10 +646,10 @@ func BenchmarkConsumeTraces_10E1000T(b *testing.B) {
 }
 
 func randomTraces() ptrace.Traces {
-	v1 := uint8(rand.Intn(256))
-	v2 := uint8(rand.Intn(256))
-	v3 := uint8(rand.Intn(256))
-	v4 := uint8(rand.Intn(256))
+	v1 := uint8(rand.IntN(256))
+	v2 := uint8(rand.IntN(256))
+	v3 := uint8(rand.IntN(256))
+	v4 := uint8(rand.IntN(256))
 	traces := ptrace.NewTraces()
 	appendSimpleTraceWithID(traces.ResourceSpans().AppendEmpty(), [16]byte{v1, v2, v3, v4})
 	return traces

--- a/exporter/mezmoexporter/utils_test.go
+++ b/exporter/mezmoexporter/utils_test.go
@@ -4,7 +4,7 @@
 package mezmoexporter
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,7 +51,7 @@ const letters = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 func randString(n int) string {
 	b := make([]byte, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[rand.IntN(len(letters))]
 	}
 	return string(b)
 }

--- a/exporter/otelarrowexporter/internal/arrow/bestofn.go
+++ b/exporter/otelarrowexporter/internal/arrow/bestofn.go
@@ -5,7 +5,7 @@ package arrow // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"context"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"sort"
 	"time"
@@ -100,7 +100,7 @@ func (lp *bestOfNPrioritizer) sendOne(item writeItem, rnd *rand.Rand, tmp []stre
 
 func (lp *bestOfNPrioritizer) run() {
 	tmp := make([]streamSorter, len(lp.state))
-	rnd := rand.New(rand.NewSource(rand.Int63()))
+	rnd := rand.New(rand.NewPCG(rand.Uint64(), rand.Uint64()))
 	for {
 		select {
 		case <-lp.done:
@@ -143,7 +143,7 @@ func (lp *bestOfNPrioritizer) streamFor(_ writeItem, rnd *rand.Rand, tmp []strea
 	// Select numChoices at random by shifting the selection into the start
 	// of the temporary slice.
 	for i := 0; i < lp.numChoices; i++ {
-		pick := rnd.Intn(lp.numChoices - i)
+		pick := rnd.IntN(lp.numChoices - i)
 		tmp[i], tmp[i+pick] = tmp[i+pick], tmp[i]
 	}
 	for i := 0; i < lp.numChoices; i++ {

--- a/exporter/otelarrowexporter/internal/arrow/exporter.go
+++ b/exporter/otelarrowexporter/internal/arrow/exporter.go
@@ -6,7 +6,7 @@ package arrow // import "github.com/open-telemetry/opentelemetry-collector-contr
 import (
 	"context"
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"runtime"
 	"strconv"
 	"sync"
@@ -255,7 +255,7 @@ func addJitter(v time.Duration) time.Duration {
 	if v == 0 {
 		return 0
 	}
-	return v - time.Duration(rand.Int63n(int64(v/20)))
+	return v - time.Duration(rand.Int64N(int64(v/20)))
 }
 
 // runArrowStream begins one gRPC stream using a child of the background context.

--- a/exporter/rabbitmqexporter/integration_test.go
+++ b/exporter/rabbitmqexporter/integration_test.go
@@ -8,7 +8,7 @@ package rabbitmqexporter
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 	"time"
@@ -166,7 +166,5 @@ func setupQueueConsumer(t *testing.T, queueName string, endpoint string) (*amqp.
 }
 
 func randPort() string {
-	rs := rand.NewSource(time.Now().Unix())
-	r := rand.New(rs)
-	return strconv.Itoa(r.Intn(999) + 9000)
+	return strconv.Itoa(rand.IntN(999) + 9000)
 }

--- a/internal/aws/cwlogs/pusher_test.go
+++ b/internal/aws/cwlogs/pusher_test.go
@@ -5,7 +5,7 @@ package cwlogs
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strings"
 	"testing"
 	"time"

--- a/internal/aws/metrics/metric_calculator_test.go
+++ b/internal/aws/metrics/metric_calculator_test.go
@@ -4,7 +4,7 @@
 package metrics
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"sync/atomic"
 	"testing"

--- a/internal/exp/metrics/metrics_test.go
+++ b/internal/exp/metrics/metrics_test.go
@@ -4,7 +4,7 @@
 package metrics_test
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"path/filepath"
 	"testing"
 
@@ -133,8 +133,8 @@ func BenchmarkMergeManyIntoMany(b *testing.B) {
 func generateMetrics(t require.TestingT, rmCount int) pmetric.Metrics {
 	md := pmetric.NewMetrics()
 
-	timeStamp := pcommon.Timestamp(rand.Intn(256))
-	value := int64(rand.Intn(256))
+	timeStamp := pcommon.Timestamp(rand.IntN(256))
+	value := rand.Int64N(256)
 
 	for i := 0; i < rmCount; i++ {
 		rm := md.ResourceMetrics().AppendEmpty()

--- a/internal/otelarrow/test/e2e_test.go
+++ b/internal/otelarrow/test/e2e_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"regexp"
 	"strings"
 	"sync"

--- a/pkg/batchperresourceattr/batchperresourceattr_test.go
+++ b/pkg/batchperresourceattr/batchperresourceattr_test.go
@@ -6,7 +6,7 @@ package batchperresourceattr
 import (
 	"context"
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"strconv"
 	"testing"
@@ -450,9 +450,9 @@ func fillResourceLogs(rs plog.ResourceLogs, kv ...string) {
 	rs.Resource().Attributes().PutInt("__other_key__", 123)
 	ils := rs.ScopeLogs().AppendEmpty()
 	firstLogRecord := ils.LogRecords().AppendEmpty()
-	firstLogRecord.SetFlags(plog.LogRecordFlags(rand.Int31()))
+	firstLogRecord.SetFlags(plog.LogRecordFlags(rand.Int32()))
 	secondLogRecord := ils.LogRecords().AppendEmpty()
-	secondLogRecord.SetFlags(plog.LogRecordFlags(rand.Int31()))
+	secondLogRecord.SetFlags(plog.LogRecordFlags(rand.Int32()))
 }
 
 func BenchmarkBatchPerResourceTraces(b *testing.B) {

--- a/pkg/sampling/encoding_test.go
+++ b/pkg/sampling/encoding_test.go
@@ -6,7 +6,7 @@ package sampling
 import (
 	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"strconv"
 	"testing"
 
@@ -200,15 +200,15 @@ func TestRValueSyntax(t *testing.T) {
 					// This explicitly constructs a TraceID from 9 random
 					// bytes plus the 7 lowest bytes of the input value.
 					pcommon.TraceID{
-						byte(rand.Intn(256)),   // 0
-						byte(rand.Intn(256)),   // 1
-						byte(rand.Intn(256)),   // 2
-						byte(rand.Intn(256)),   // 3
-						byte(rand.Intn(256)),   // 4
-						byte(rand.Intn(256)),   // 5
-						byte(rand.Intn(256)),   // 6
-						byte(rand.Intn(256)),   // 7
-						byte(rand.Intn(256)),   // 8
+						byte(rand.IntN(256)),   // 0
+						byte(rand.IntN(256)),   // 1
+						byte(rand.IntN(256)),   // 2
+						byte(rand.IntN(256)),   // 3
+						byte(rand.IntN(256)),   // 4
+						byte(rand.IntN(256)),   // 5
+						byte(rand.IntN(256)),   // 6
+						byte(rand.IntN(256)),   // 7
+						byte(rand.IntN(256)),   // 8
 						byte(val >> 48 & 0xff), // 9
 						byte(val >> 40 & 0xff), // 10
 						byte(val >> 32 & 0xff), // 11

--- a/pkg/stanza/fileconsumer/internal/filetest/filetest.go
+++ b/pkg/stanza/fileconsumer/internal/filetest/filetest.go
@@ -4,7 +4,7 @@
 package filetest // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/stanza/fileconsumer/internal/filetest"
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"path/filepath"
 	"testing"
@@ -43,7 +43,7 @@ func TokenWithLength(length int) []byte {
 	charset := "abcdefghijklmnopqrstuvwxyz"
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
+		b[i] = charset[rand.IntN(len(charset))]
 	}
 	return b
 }

--- a/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
+++ b/pkg/stanza/fileconsumer/internal/fingerprint/fingerprint_test.go
@@ -4,8 +4,9 @@
 package fingerprint
 
 import (
+	"encoding/binary"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"testing"
 
@@ -222,20 +223,34 @@ func TestStartsWith(t *testing.T) {
 // the file, while each iteration of the growing file represents
 // a possible state of the same file at a previous time.
 func TestStartsWith_FromFile(t *testing.T) {
-	r := rand.New(rand.NewSource(112358))
+	r := rand.New(rand.NewPCG(112, 358))
 	fingerprintSize := 10
 	fileLength := 12 * fingerprintSize
+	fillRandomBytes := func(buf []byte) {
+		// TODO: when we upgrade to go1.23,
+		// use rand.ChaCha8.Read.
+		//
+		// NOTE: we can cheat here since know the
+		// buffer length is a multiple of 4, due to
+		// fileLength being a multiple of 12.
+		for i := range len(buf) / 4 {
+			binary.BigEndian.PutUint32(
+				buf[i*4:(i+1)*4],
+				r.Uint32(),
+			)
+		}
+	}
 
 	tempDir := t.TempDir()
 
 	// Make a []byte we can write one at a time
 	content := make([]byte, fileLength)
-	r.Read(content) // Fill slice with random bytes
+	fillRandomBytes(content)
 
 	// Overwrite some bytes with \n to ensure
 	// we are testing a file with multiple lines
 	newlineMask := make([]byte, fileLength)
-	r.Read(newlineMask) // Fill slice with random bytes
+	fillRandomBytes(newlineMask)
 	for i, b := range newlineMask {
 		if b == 0 && i != 0 { // 1/256 chance, but never first byte
 			content[i] = byte('\n')
@@ -278,7 +293,7 @@ func tokenWithLength(length int) []byte {
 	charset := "abcdefghijklmnopqrstuvwxyz"
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = charset[rand.Intn(len(charset))]
+		b[i] = charset[rand.IntN(len(charset))]
 	}
 	return b
 }

--- a/pkg/stanza/operator/input/tcp/input_test.go
+++ b/pkg/stanza/operator/input/tcp/input_test.go
@@ -5,7 +5,7 @@ package tcp
 
 import (
 	"crypto/tls"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"strconv"
@@ -380,7 +380,7 @@ func TestFailToBind(t *testing.T) {
 	minPort := 30000
 	maxPort := 40000
 	for i := 1; i < 10; i++ {
-		port = minPort + rand.Intn(maxPort-minPort+1)
+		port = minPort + rand.IntN(maxPort-minPort+1)
 		_, err := net.DialTimeout("tcp", net.JoinHostPort(ip, strconv.Itoa(port)), time.Second*2)
 		if err != nil {
 			// a failed connection indicates that the port is available for use

--- a/pkg/stanza/operator/input/udp/input_test.go
+++ b/pkg/stanza/operator/input/udp/input_test.go
@@ -4,7 +4,7 @@
 package udp
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strconv"
 	"testing"
@@ -168,7 +168,7 @@ func TestFailToBind(t *testing.T) {
 	minPort := 30000
 	maxPort := 40000
 	for i := 1; 1 < 10; i++ {
-		port = minPort + rand.Intn(maxPort-minPort+1)
+		port = minPort + rand.IntN(maxPort-minPort+1)
 		_, err := net.DialTimeout("tcp", net.JoinHostPort(ip, strconv.Itoa(port)), time.Second*2)
 		if err != nil {
 			// a failed connection indicates that the port is available for use

--- a/pkg/stanza/operator/parser/regex/parser_test.go
+++ b/pkg/stanza/operator/parser/regex/parser_test.go
@@ -6,7 +6,7 @@ package regex
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -213,7 +213,7 @@ func benchParseInput() (patterns []string) {
 	for i := 1; i <= 100; i++ {
 		b := make([]byte, 15)
 		for i := range b {
-			b[i] = letterBytes[rand.Intn(len(letterBytes))]
+			b[i] = letterBytes[rand.IntN(len(letterBytes))]
 		}
 		randomStr := string(b)
 		p := fmt.Sprintf("%s-5644d7b6d9-mzngq_kube-system_coredns-901f7510281180a402936c92f5bc0f3557f5a21ccb5a4591c5bf98f3ddbffdd6.log", randomStr)

--- a/processor/groupbyattrsprocessor/attribute_groups_test.go
+++ b/processor/groupbyattrsprocessor/attribute_groups_test.go
@@ -5,7 +5,7 @@ package groupbyattrsprocessor
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,7 +21,7 @@ func simpleResource() pcommon.Resource {
 	rs.Attributes().PutInt("somekey2", 123)
 	for i := 0; i < 10; i++ {
 		k := fmt.Sprint("random-", i)
-		v := fmt.Sprint("value-", rand.Intn(100))
+		v := fmt.Sprint("value-", rand.IntN(100))
 		rs.Attributes().PutStr(k, v)
 	}
 	return rs
@@ -31,7 +31,7 @@ func randomAttributeMap() pcommon.Map {
 	attrs := pcommon.NewMap()
 	for i := 0; i < 10; i++ {
 		k := fmt.Sprint("key-", i)
-		v := fmt.Sprint("value-", rand.Intn(500000))
+		v := fmt.Sprint("value-", rand.IntN(500000))
 		attrs.PutStr(k, v)
 	}
 	return attrs
@@ -150,6 +150,6 @@ func BenchmarkAttrGrouping(b *testing.B) {
 	lg := newLogsGroup()
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		lg.findOrCreateResourceLogs(res, groups[rand.Intn(count)])
+		lg.findOrCreateResourceLogs(res, groups[rand.IntN(count)])
 	}
 }

--- a/processor/groupbyattrsprocessor/processor_test.go
+++ b/processor/groupbyattrsprocessor/processor_test.go
@@ -6,7 +6,7 @@ package groupbyattrsprocessor
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"sort"
 	"testing"
 	"time"

--- a/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
+++ b/processor/probabilisticsamplerprocessor/tracesprocessor_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"math"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1129,9 +1129,9 @@ func initSpanWithAttribute(key string, value pcommon.Value, dest ptrace.Span) {
 
 // genRandomTestData generates a slice of ptrace.Traces with the numBatches elements which one with
 // numTracesPerBatch spans (ie.: each span has a different trace ID). All spans belong to the specified
-// serviceName.
+// serviceName. A fixed-seed random generator is used to ensure tests are repeatable.
 func genRandomTestData(numBatches, numTracesPerBatch int, serviceName string, resourceSpanCount int) (tdd []ptrace.Traces) {
-	r := rand.New(rand.NewSource(1))
+	r := rand.New(rand.NewPCG(123, 456))
 	var traceBatches []ptrace.Traces
 	for i := 0; i < numBatches; i++ {
 		traces := ptrace.NewTraces()

--- a/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
+++ b/processor/tailsamplingprocessor/internal/sampling/probabilistic_test.go
@@ -6,7 +6,7 @@ package sampling
 import (
 	"context"
 	"encoding/binary"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -91,7 +91,10 @@ func TestProbabilisticSampling(t *testing.T) {
 }
 
 func genRandomTraceIDs(num int) (ids []pcommon.TraceID) {
-	r := rand.New(rand.NewSource(1))
+	// NOTE: using a fixed seed is intentional here,
+	// as otherwise the delta in the tests above will
+	// be unpredictable.
+	r := rand.New(rand.NewPCG(123, 456))
 	ids = make([]pcommon.TraceID, 0, num)
 	for i := 0; i < num; i++ {
 		traceID := [16]byte{}

--- a/testbed/testbed/mock_backend.go
+++ b/testbed/testbed/mock_backend.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"errors"
 	"log"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"sync"
 	"sync/atomic"

--- a/testbed/tests/scenarios.go
+++ b/testbed/tests/scenarios.go
@@ -8,7 +8,7 @@ package tests // import "github.com/open-telemetry/opentelemetry-collector-contr
 
 import (
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"path"
 	"path/filepath"
 	"regexp"
@@ -265,7 +265,7 @@ type TestCase struct {
 func genRandByteString(length int) string {
 	b := make([]byte, length)
 	for i := range b {
-		b[i] = byte(rand.Intn(128))
+		b[i] = byte(rand.IntN(128))
 	}
 	return string(b)
 }
@@ -649,8 +649,8 @@ func constructLoadOptions(test TestCase) testbed.LoadOptions {
 
 	// Generate attributes.
 	for i := 0; i < test.attrCount; i++ {
-		attrName := genRandByteString(rand.Intn(199) + 1)
-		options.Attributes[attrName] = genRandByteString(rand.Intn(test.attrSizeByte*2-1) + 1)
+		attrName := genRandByteString(rand.IntN(199) + 1)
+		options.Attributes[attrName] = genRandByteString(rand.IntN(test.attrSizeByte*2-1) + 1)
 	}
 	return options
 }


### PR DESCRIPTION
#### Description

Update all modules to use `math/rand/v2` and forbid `math/rand` with a new depguard rule.

#### Link to tracking issue

Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34676

#### Testing

N/A, non-functional change

#### Documentation

N/A