### PR TITLE
[chore][README] Alphabetize triagers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 Triagers ([@open-telemetry/collector-contrib-triagers](https://github.com/orgs/open-telemetry/teams/collector-contrib-triagers))
 
 - [Benedikt Bongartz](https://github.com/frzifus), Red Hat
+- [Braydon Kains](https://github.com/braydonk), Google
 - [Florian Bacher](https://github.com/bacherfl), Dynatrace
+- [James Moessis](https://github.com/jamesmoessis), Atlassian
 - [Jared Tan](https://github.com/JaredTan95), DaoCloud
 - [Murphy Chen](https://github.com/Frapschen), DaoCloud
 - [Paulo Janotti](https://github.com/pjanotti), Splunk
 - [Vihas Makwana](https://github.com/VihasMakwana), Elastic
-- [Braydon Kains](https://github.com/braydonk), Google
-- [James Moessis](https://github.com/jamesmoessis), Atlassian
 - Actively seeking contributors to triage issues
 
 Emeritus Triagers:


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
The names in the list of triagers/approvers/maintainers is in alphabetical order by first name. This fixes a couple out of order names.