### PR TITLE
[exporter/prometheusremotewrite] Fix WAL deadlock

### DIFF
--- a/.chloggen/prw-WAL-deadlock.yaml
+++ b/.chloggen/prw-WAL-deadlock.yaml
@@ -1,0 +1,19 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewriteexproter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Resolves a deadlock in the WAL by temporarily releasing a lock while waiting for new writes to the WAL.
+# One or more tracking issues related to the change
+issues: [19363, 24399, 15277]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+
+change_logs: [user]

--- a/exporter/prometheusremotewriteexporter/go.mod
+++ b/exporter/prometheusremotewriteexporter/go.mod
@@ -4,7 +4,6 @@ go 1.22.0
 
 require (
 	github.com/cenkalti/backoff/v4 v4.3.0
-	github.com/fsnotify/fsnotify v1.8.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/snappy v0.0.4
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.118.0
@@ -36,6 +35,8 @@ require (
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.27.0
 )
+
+require github.com/fsnotify/fsnotify v1.8.0 // indirect
 
 require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -12,18 +12,15 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/prometheus/prompb"
 	"github.com/tidwall/wal"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
-
-	"github.com/ietxaniz/delock"
 )
 
 type prweWAL struct {
-	mu        delock.Mutex // mu protects the fields below.
+	mu        sync.Mutex // mu protects the fields below.
 	wal       *wal.Log
 	walConfig *WALConfig
 	walPath   string
@@ -32,6 +29,7 @@ type prweWAL struct {
 
 	stopOnce  sync.Once
 	stopChan  chan struct{}
+	rNotify   chan struct{}
 	rWALIndex *atomic.Uint64
 	wWALIndex *atomic.Uint64
 }
@@ -72,6 +70,7 @@ func newWAL(walConfig *WALConfig, exportSink func(context.Context, []*prompb.Wri
 		exportSink: exportSink,
 		walConfig:  walConfig,
 		stopChan:   make(chan struct{}),
+		rNotify:    make(chan struct{}),
 		rWALIndex:  &atomic.Uint64{},
 		wWALIndex:  &atomic.Uint64{},
 	}
@@ -96,11 +95,8 @@ var (
 
 // retrieveWALIndices queries the WriteAheadLog for its current first and last indices.
 func (prwe *prweWAL) retrieveWALIndices() (err error) {
-	lockID, err := prwe.mu.Lock()
-	if err != nil {
-		panic(err)
-	}
-	defer prwe.mu.Unlock(lockID)
+	prwe.mu.Lock()
+	defer prwe.mu.Unlock()
 
 	err = prwe.closeWAL()
 	if err != nil {
@@ -132,11 +128,8 @@ func (prwe *prweWAL) retrieveWALIndices() (err error) {
 func (prwe *prweWAL) stop() error {
 	err := errAlreadyClosed
 	prwe.stopOnce.Do(func() {
-		lockID, err := prwe.mu.Lock()
-	if err != nil {
-		panic(err)
-	}
-	defer prwe.mu.Unlock(lockID)
+		prwe.mu.Lock()
+		defer prwe.mu.Unlock()
 
 		close(prwe.stopChan)
 		err = prwe.closeWAL()
@@ -268,11 +261,8 @@ func (prwe *prweWAL) closeWAL() error {
 }
 
 func (prwe *prweWAL) syncAndTruncateFront() error {
-	lockID, err := prwe.mu.Lock()
-	if err != nil {
-		panic(err)
-	}
-	defer prwe.mu.Unlock(lockID)
+	prwe.mu.Lock()
+	defer prwe.mu.Unlock()
 
 	if prwe.wal == nil {
 		return errNilWAL
@@ -312,11 +302,8 @@ func (prwe *prweWAL) exportThenFrontTruncateWAL(ctx context.Context, reqL []*pro
 // write them to the Write-Ahead-Log so that shutdowns won't lose data, and that the routine that
 // reads from the WAL can then process the previously serialized requests.
 func (prwe *prweWAL) persistToWAL(requests []*prompb.WriteRequest) error {
-	lockID, err := prwe.mu.Lock()
-	if err != nil {
-		panic(err)
-	}
-	defer prwe.mu.Unlock(lockID)
+	prwe.mu.Lock()
+	defer prwe.mu.Unlock()
 
 	// Write all the requests to the WAL in a batch.
 	batch := new(wal.Batch)
@@ -329,16 +316,15 @@ func (prwe *prweWAL) persistToWAL(requests []*prompb.WriteRequest) error {
 		batch.Write(wIndex, protoBlob)
 	}
 
+	// Notify reader go routine that is possibly waiting for writes.
+	select {
+	case prwe.rNotify <- struct{}{}:
+	default:
+	}
 	return prwe.wal.WriteBatch(batch)
 }
 
 func (prwe *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wreq *prompb.WriteRequest, err error) {
-	lockID, err := prwe.mu.Lock()
-	if err != nil {
-		panic(err)
-	}
-	defer prwe.mu.Unlock(lockID)
-
 	var protoBlob []byte
 	for i := 0; i < 12; i++ {
 		// Firstly check if we've been terminated, then exit if so.
@@ -354,10 +340,10 @@ func (prwe *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wreq 
 			index = 1
 		}
 
+		prwe.mu.Lock()
 		if prwe.wal == nil {
 			return nil, fmt.Errorf("attempt to read from closed WAL")
 		}
-
 		protoBlob, err = prwe.wal.Read(index)
 		if err == nil { // The read succeeded.
 			req := new(prompb.WriteRequest)
@@ -368,74 +354,24 @@ func (prwe *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wreq 
 			// Now increment the WAL's read index.
 			prwe.rWALIndex.Add(1)
 
+			prwe.mu.Unlock()
 			return req, nil
+		}
+		prwe.mu.Unlock()
+
+		// If WAL was empty, let's wait for a notification from
+		// the writer go routine.
+		if errors.Is(err, wal.ErrNotFound) {
+			select {
+			case <-prwe.rNotify:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
 		}
 
 		if !errors.Is(err, wal.ErrNotFound) {
 			return nil, err
 		}
-
-		if index <= 1 {
-			// This could be the very first attempted read, so try again, after a small sleep.
-			time.Sleep(time.Duration(1<<i) * time.Millisecond)
-			continue
-		}
-
-		// Otherwise, we couldn't find the record, let's try watching
-		// the WAL file until perhaps there is a write to it.
-		walWatcher, werr := fsnotify.NewWatcher()
-		if werr != nil {
-			return nil, werr
-		}
-		if werr = walWatcher.Add(prwe.walPath); werr != nil {
-			return nil, werr
-		}
-
-		// Watch until perhaps there is a write to the WAL file.
-		watchCh := make(chan error)
-		wErr := err
-		go func() {
-			defer func() {
-				watchCh <- wErr
-				close(watchCh)
-				// Close the file watcher.
-				walWatcher.Close()
-			}()
-
-			select {
-			case <-ctx.Done(): // If the context was cancelled, bail out ASAP.
-				wErr = ctx.Err()
-				return
-
-			case event, ok := <-walWatcher.Events:
-				if !ok {
-					return
-				}
-				switch event.Op {
-				case fsnotify.Remove:
-					// The file got deleted.
-					// TODO: Add capabilities to search for the updated file.
-				case fsnotify.Rename:
-					// Renamed, we don't have information about the renamed file's new name.
-				case fsnotify.Write:
-					// Finally a write, let's try reading again, but after some watch.
-					wErr = nil
-				}
-
-			case eerr, ok := <-walWatcher.Errors:
-				if ok {
-					wErr = eerr
-				}
-			}
-		}()
-
-		if gerr := <-watchCh; gerr != nil {
-			return nil, gerr
-		}
-
-		// Otherwise a write occurred might have occurred,
-		// and we can sleep for a little bit then try again.
-		time.Sleep(time.Duration(1<<i) * time.Millisecond)
 	}
 	return nil, err
 }

--- a/exporter/prometheusremotewriteexporter/wal.go
+++ b/exporter/prometheusremotewriteexporter/wal.go
@@ -366,6 +366,8 @@ func (prwe *prweWAL) readPrompbFromWAL(ctx context.Context, index uint64) (wreq 
 			case <-prwe.rNotify:
 			case <-ctx.Done():
 				return nil, ctx.Err()
+			case <-prwe.stopChan:
+				return nil, fmt.Errorf("attempt to read from WAL after stopped")
 			}
 		}
 

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -209,4 +209,9 @@ func TestExportWithWALEnabled(t *testing.T) {
 	}
 	err = prwe.handleExport(context.Background(), metrics, nil)
 	assert.NoError(t, err)
+
+	// While on Unix systems, t.TempDir() would easily close the WAL files,
+	// on Windows, it doesn't. So we need to close it manually to avoid flaky tests.
+	err = prwe.Shutdown(context.Background())
+	assert.NoError(t, err)
 }

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -164,7 +164,7 @@ func TestExportWithWALEnabled(t *testing.T) {
 		WAL: &WALConfig{
 			Directory: t.TempDir(),
 		},
-		TargetInfo: &TargetInfo{}, // Declared just to avoid nil pointer dereference.
+		TargetInfo:    &TargetInfo{},    // Declared just to avoid nil pointer dereference.
 		CreatedMetric: &CreatedMetric{}, // Declared just to avoid nil pointer dereference.
 	}
 	buildInfo := component.BuildInfo{
@@ -174,20 +174,19 @@ func TestExportWithWALEnabled(t *testing.T) {
 	set := exportertest.NewNopSettings()
 	set.BuildInfo = buildInfo
 
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
-		require.NoError(t, err)
-		require.NotNil(t, body)
+		assert.NoError(t, err)
+		assert.NotNil(t, body)
 		// Receives the http requests and unzip, unmarshalls, and extracts TimeSeries
 		writeReq := &prompb.WriteRequest{}
 		var unzipped []byte
 
 		dest, err := snappy.Decode(unzipped, body)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		ok := proto.Unmarshal(dest, writeReq)
-		require.NoError(t, ok)
+		assert.NoError(t, ok)
 
 		assert.Len(t, writeReq.Timeseries, 1)
 	}))


### PR DESCRIPTION
I was taking a look over #20875 and hoping to finish it.
Fixes #19363
Fixes #24399
Fixes #15277 

---

As mentioned in https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/24399#issuecomment-2628546126, I used a library to help me understand how the deadlock was happening. (1st commit). It showed that `persistToWal` was trying to acquire the lock, while `readPrompbFromWal` held it forever.

I changed the strategy here and instead of using fs.Notify, and all that complicated logic around it, we're just using a pub/sub strategy between the writer and reader Go routines. 

The reader go routine, once finding an empty WAL, will now release the lock immediately and wait for a notification from the writer. While previously it would hold the lock while waiting for a write that would never happen.