### PR TITLE
[processor/redaction] introduce `allowed_values` parameter in processor config

### DIFF
--- a/.chloggen/redaction-allowed-values.yaml
+++ b/.chloggen/redaction-allowed-values.yaml
@@ -7,7 +7,7 @@ change_type: enhancement
 component: processor/redaction
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: `Introduce 'allowed_values' parameter for allowed values of attributes`
+note: "Introduce 'allowed_values' parameter for allowed values of attributes"
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [35840]

--- a/.chloggen/redaction-allowed-values.yaml
+++ b/.chloggen/redaction-allowed-values.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/redaction
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: `Introduce 'allowed_values' parameter for allowed values of attributes`
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [35840]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/redactionprocessor/README.md
+++ b/processor/redactionprocessor/README.md
@@ -109,7 +109,7 @@ explicitly set `allow_all_keys` to true.
 If the value of an allowed key matches the regular expression for an allowed value, the matching
 part of the value is not masked even if it matches the regular expression for a blocked value.
 If the value matches the regular expression for a blocked value only, the matching
-part of the value is masked with a fixed lenght of asterisks.
+part of the value is masked with a fixed length of asterisks.
 
 For example, if `notes` is on the list of allowed keys, then the `notes`
 attribute is retained. However, if there is a value such as a credit card

--- a/processor/redactionprocessor/README.md
+++ b/processor/redactionprocessor/README.md
@@ -78,6 +78,10 @@ processors:
     blocked_values:
       - "4[0-9]{12}(?:[0-9]{3})?" ## Visa credit card number
       - "(5[1-5][0-9]{14})"       ## MasterCard number
+    # AllowedValues is a list of regular expressions for allowing values of
+    # blocked span attributes. Values that match are not masked.
+    allowed_values:
+      - ".+@mycompany.com"
     # summary controls the verbosity level of the diagnostic attributes that
     # the processor adds to the spans/logs/datapoints when it redacts or masks other
     # attributes. In some contexts a list of redacted attributes leaks
@@ -101,9 +105,11 @@ If `allowed_keys` is empty, then no attributes are allowed. All
 attributes are removed in that case. To keep all span attributes, you should
 explicitly set `allow_all_keys` to true.
 
-`blocked_values` applies to the values of the allowed keys. If the value of an
-allowed key matches the regular expression for a blocked value, the matching
-part of the value is then masked with a fixed length of asterisks.
+`blocked_values` and `allowed_values` applies to the values of the allowed keys.
+If the value of an allowed key matches the regular expression for an allowed value, the matching
+part of the value is not masked even if it matches the regular expression for a blocked value.
+If the value matches the regular expression for a blocked value only, the matching
+part of the value is masked with a fixed lenght of asterisks.
 
 For example, if `notes` is on the list of allowed keys, then the `notes`
 attribute is retained. However, if there is a value such as a credit card

--- a/processor/redactionprocessor/config.go
+++ b/processor/redactionprocessor/config.go
@@ -20,8 +20,12 @@ type Config struct {
 	IgnoredKeys []string `mapstructure:"ignored_keys"`
 
 	// BlockedValues is a list of regular expressions for blocking values of
-	// allowed span attributes. Values that match are masked
+	// allowed span attributes. Values that match are masked.
 	BlockedValues []string `mapstructure:"blocked_values"`
+
+	// AllowedValues is a list of regular expressions for allowing values of
+	// blocked span attributes. Values that match are not masked.
+	AllowedValues []string `mapstructure:"allowed_values"`
 
 	// Summary controls the verbosity level of the diagnostic attributes that
 	// the processor adds to the spans when it redacts or masks other

--- a/processor/redactionprocessor/config_test.go
+++ b/processor/redactionprocessor/config_test.go
@@ -29,6 +29,7 @@ func TestLoadConfig(t *testing.T) {
 				AllowedKeys:   []string{"description", "group", "id", "name"},
 				IgnoredKeys:   []string{"safe_attribute"},
 				BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?", "(5[1-5][0-9]{14})"},
+				AllowedValues: []string{".+@mycompany.com"},
 				Summary:       debug,
 			},
 		},

--- a/processor/redactionprocessor/factory_test.go
+++ b/processor/redactionprocessor/factory_test.go
@@ -16,6 +16,7 @@ func TestDefaultConfiguration(t *testing.T) {
 	c := createDefaultConfig().(*Config)
 	assert.Empty(t, c.AllowedKeys)
 	assert.Empty(t, c.BlockedValues)
+	assert.Empty(t, c.AllowedValues)
 }
 
 func TestCreateTestProcessor(t *testing.T) {

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -198,7 +198,7 @@ func (s *redaction) processAttrs(_ context.Context, attributes pcommon.Map) {
 
 		strVal := value.Str()
 
-		// Allow any blocked values maching the allowed list regex
+		// Allow any values matching the allowed list regex
 		for _, compiledRE := range s.allowRegexList {
 			if match := compiledRE.MatchString(strVal); match {
 				allowed = append(allowed, k)

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -26,6 +26,8 @@ type redaction struct {
 	ignoreList map[string]string
 	// Attribute values blocked in a span
 	blockRegexList map[string]*regexp.Regexp
+	// Attribute values allowed in a span
+	allowRegexList map[string]*regexp.Regexp
 	// Redaction processor configuration
 	config *Config
 	// Logger
@@ -36,7 +38,13 @@ type redaction struct {
 func newRedaction(ctx context.Context, config *Config, logger *zap.Logger) (*redaction, error) {
 	allowList := makeAllowList(config)
 	ignoreList := makeIgnoreList(config)
-	blockRegexList, err := makeBlockRegexList(ctx, config)
+	blockRegexList, err := makeRegexList(ctx, config.BlockedValues)
+	if err != nil {
+		// TODO: Placeholder for an error metric in the next PR
+		return nil, fmt.Errorf("failed to process block list: %w", err)
+	}
+
+	allowRegexList, err := makeRegexList(ctx, config.AllowedValues)
 	if err != nil {
 		// TODO: Placeholder for an error metric in the next PR
 		return nil, fmt.Errorf("failed to process block list: %w", err)
@@ -46,6 +54,7 @@ func newRedaction(ctx context.Context, config *Config, logger *zap.Logger) (*red
 		allowList:      allowList,
 		ignoreList:     ignoreList,
 		blockRegexList: blockRegexList,
+		allowRegexList: allowRegexList,
 		config:         config,
 		logger:         logger,
 	}, nil
@@ -159,6 +168,7 @@ func (s *redaction) processAttrs(_ context.Context, attributes pcommon.Map) {
 	// TODO: Use the context for recording metrics
 	var toDelete []string
 	var toBlock []string
+	var allowed []string
 	var ignoring []string
 
 	// Identify attributes to redact and mask in the following sequence
@@ -186,8 +196,17 @@ func (s *redaction) processAttrs(_ context.Context, attributes pcommon.Map) {
 			}
 		}
 
-		// Mask any blocked values for the other attributes
 		strVal := value.Str()
+
+		// Allow any blocked values maching the allowed list regex
+		for _, compiledRE := range s.allowRegexList {
+			if match := compiledRE.MatchString(strVal); match {
+				allowed = append(allowed, k)
+				return true
+			}
+		}
+
+		// Mask any blocked values for the other attributes
 		var matched bool
 		for _, compiledRE := range s.blockRegexList {
 			match := compiledRE.MatchString(strVal)
@@ -212,6 +231,7 @@ func (s *redaction) processAttrs(_ context.Context, attributes pcommon.Map) {
 	// Add diagnostic information to the span
 	s.addMetaAttrs(toDelete, attributes, redactedKeys, redactedKeyCount)
 	s.addMetaAttrs(toBlock, attributes, maskedValues, maskedValueCount)
+	s.addMetaAttrs(allowed, attributes, allowedValues, allowedValueCount)
 	s.addMetaAttrs(ignoring, attributes, "", ignoredKeyCount)
 }
 
@@ -239,13 +259,15 @@ func (s *redaction) addMetaAttrs(redactedAttrs []string, attributes pcommon.Map,
 }
 
 const (
-	debug            = "debug"
-	info             = "info"
-	redactedKeys     = "redaction.redacted.keys"
-	redactedKeyCount = "redaction.redacted.count"
-	maskedValues     = "redaction.masked.keys"
-	maskedValueCount = "redaction.masked.count"
-	ignoredKeyCount  = "redaction.ignored.count"
+	debug             = "debug"
+	info              = "info"
+	redactedKeys      = "redaction.redacted.keys"
+	redactedKeyCount  = "redaction.redacted.count"
+	maskedValues      = "redaction.masked.keys"
+	maskedValueCount  = "redaction.masked.count"
+	allowedValues     = "redaction.allowed.keys"
+	allowedValueCount = "redaction.allowed.count"
+	ignoredKeyCount   = "redaction.ignored.count"
 )
 
 // makeAllowList sets up a lookup table of allowed span attribute keys
@@ -282,16 +304,16 @@ func makeIgnoreList(c *Config) map[string]string {
 	return ignoreList
 }
 
-// makeBlockRegexList precompiles all the blocked regex patterns
-func makeBlockRegexList(_ context.Context, config *Config) (map[string]*regexp.Regexp, error) {
-	blockRegexList := make(map[string]*regexp.Regexp, len(config.BlockedValues))
-	for _, pattern := range config.BlockedValues {
+// makeRegexList precompiles all the regex patterns in the defined list
+func makeRegexList(_ context.Context, valuesList []string) (map[string]*regexp.Regexp, error) {
+	regexList := make(map[string]*regexp.Regexp, len(valuesList))
+	for _, pattern := range valuesList {
 		re, err := regexp.Compile(pattern)
 		if err != nil {
 			// TODO: Placeholder for an error metric in the next PR
-			return nil, fmt.Errorf("error compiling regex in block list: %w", err)
+			return nil, fmt.Errorf("error compiling regex in list: %w", err)
 		}
-		blockRegexList[pattern] = re
+		regexList[pattern] = re
 	}
-	return blockRegexList, nil
+	return regexList, nil
 }

--- a/processor/redactionprocessor/processor.go
+++ b/processor/redactionprocessor/processor.go
@@ -47,7 +47,7 @@ func newRedaction(ctx context.Context, config *Config, logger *zap.Logger) (*red
 	allowRegexList, err := makeRegexList(ctx, config.AllowedValues)
 	if err != nil {
 		// TODO: Placeholder for an error metric in the next PR
-		return nil, fmt.Errorf("failed to process block list: %w", err)
+		return nil, fmt.Errorf("failed to process allow list: %w", err)
 	}
 
 	return &redaction{

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -257,7 +257,7 @@ func TestRedactSummaryDebug(t *testing.T) {
 // of any attributes it deleted to the new redaction.redacted.count span
 // attribute (but not to redaction.redacted.keys) when set to the info level
 // of output
-func TestRedactSummaryInfo(t *testing.T) { //tu
+func TestRedactSummaryInfo(t *testing.T) {
 	config := &Config{
 		AllowedKeys:   []string{"id", "name", "group", "email"},
 		BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?"},

--- a/processor/redactionprocessor/processor_test.go
+++ b/processor/redactionprocessor/processor_test.go
@@ -36,13 +36,13 @@ func TestRedactUnknownAttributes(t *testing.T) {
 		"credit_card": pcommon.NewValueStr("4111111111111111"),
 	}
 
-	outTraces := runTest(t, allowed, redacted, nil, ignored, config)
-	outLogs := runLogsTest(t, allowed, redacted, nil, ignored, config)
-	outMetricsGauge := runMetricsTest(t, allowed, redacted, nil, ignored, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, redacted, nil, ignored, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, redacted, nil, ignored, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, nil, ignored, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, redacted, nil, ignored, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, redacted, nil, nil, ignored, config)
+	outLogs := runLogsTest(t, allowed, redacted, nil, nil, ignored, config)
+	outMetricsGauge := runMetricsTest(t, allowed, redacted, nil, nil, ignored, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, redacted, nil, nil, ignored, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, redacted, nil, nil, ignored, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, nil, nil, ignored, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, redacted, nil, nil, ignored, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -81,13 +81,13 @@ func TestAllowAllKeys(t *testing.T) {
 		"name":  pcommon.NewValueStr("placeholder"),
 	}
 
-	outTraces := runTest(t, allowed, nil, nil, nil, config)
-	outLogs := runLogsTest(t, allowed, nil, nil, nil, config)
-	outMetricsGauge := runMetricsTest(t, allowed, nil, nil, nil, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, nil, nil, nil, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, nil, nil, nil, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, nil, nil, nil, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, nil, nil, nil, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, nil, nil, nil, nil, config)
+	outLogs := runLogsTest(t, allowed, nil, nil, nil, nil, config)
+	outMetricsGauge := runMetricsTest(t, allowed, nil, nil, nil, nil, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, nil, nil, nil, nil, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, nil, nil, nil, nil, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, nil, nil, nil, nil, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, nil, nil, nil, nil, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -112,11 +112,12 @@ func TestAllowAllKeys(t *testing.T) {
 
 // TestAllowAllKeysMaskValues validates that the processor still redacts
 // span attribute values if Config.AllowAllKeys is set to true
-func TestAllowAllKeysMaskValues(t *testing.T) {
+func TestAllowAllKeysMaskValuesAllowValues(t *testing.T) {
 	config := &Config{
 		AllowedKeys:   []string{"group", "id", "name"},
 		BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?"},
 		AllowAllKeys:  true,
+		AllowedValues: []string{"4111111111111112", ".+@mycompany.com"},
 	}
 	allowed := map[string]pcommon.Value{
 		"group": pcommon.NewValueStr("temporary"),
@@ -126,14 +127,18 @@ func TestAllowAllKeysMaskValues(t *testing.T) {
 	masked := map[string]pcommon.Value{
 		"credit_card": pcommon.NewValueStr("placeholder 4111111111111111"),
 	}
+	allowedValues := map[string]pcommon.Value{
+		"credit_card2": pcommon.NewValueStr("placeholder 4111111111111112"),
+		"email":        pcommon.NewValueStr("user@mycompany.com"),
+	}
 
-	outTraces := runTest(t, allowed, nil, masked, nil, config)
-	outLogs := runLogsTest(t, allowed, nil, masked, nil, config)
-	outMetricsGauge := runMetricsTest(t, allowed, nil, masked, nil, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, nil, masked, nil, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, nil, masked, nil, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, nil, masked, nil, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, nil, masked, nil, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, nil, masked, allowedValues, nil, config)
+	outLogs := runLogsTest(t, allowed, nil, masked, allowedValues, nil, config)
+	outMetricsGauge := runMetricsTest(t, allowed, nil, nil, masked, allowedValues, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, nil, masked, allowedValues, nil, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, nil, masked, allowedValues, nil, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, nil, masked, allowedValues, nil, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, nil, masked, allowedValues, nil, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -153,6 +158,12 @@ func TestAllowAllKeysMaskValues(t *testing.T) {
 		}
 		value, _ := attr.Get("credit_card")
 		assert.Equal(t, "placeholder ****", value.Str())
+
+		value, _ = attr.Get("credit_card2")
+		assert.Equal(t, "placeholder 4111111111111112", value.Str())
+
+		value, _ = attr.Get("email")
+		assert.Equal(t, "user@mycompany.com", value.Str())
 	}
 }
 
@@ -163,9 +174,10 @@ func TestAllowAllKeysMaskValues(t *testing.T) {
 // redaction.redacted.count span attributes while set to full debug output
 func TestRedactSummaryDebug(t *testing.T) {
 	config := &Config{
-		AllowedKeys:   []string{"id", "group", "name", "group.id", "member (id)"},
+		AllowedKeys:   []string{"id", "group", "name", "group.id", "member (id)", "email"},
 		BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?"},
 		IgnoredKeys:   []string{"safe_attribute"},
+		AllowedValues: []string{".+@mycompany.com"},
 		Summary:       "debug",
 	}
 	allowed := map[string]pcommon.Value{
@@ -182,14 +194,17 @@ func TestRedactSummaryDebug(t *testing.T) {
 	redacted := map[string]pcommon.Value{
 		"credit_card": pcommon.NewValueStr("4111111111111111"),
 	}
+	allowedValues := map[string]pcommon.Value{
+		"email": pcommon.NewValueStr("user@mycompany.com"),
+	}
 
-	outTraces := runTest(t, allowed, redacted, masked, ignored, config)
-	outLogs := runLogsTest(t, allowed, redacted, masked, ignored, config)
-	outMetricsGauge := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, redacted, masked, allowedValues, ignored, config)
+	outLogs := runLogsTest(t, allowed, redacted, masked, allowedValues, ignored, config)
+	outMetricsGauge := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -229,6 +244,12 @@ func TestRedactSummaryDebug(t *testing.T) {
 		assert.Equal(t, int64(1), maskedValueCount.Int())
 		value, _ := attr.Get("name")
 		assert.Equal(t, "placeholder ****", value.Str())
+
+		allowedValueCount, ok := attr.Get(allowedValueCount)
+		assert.True(t, ok)
+		assert.Equal(t, int64(1), allowedValueCount.Int())
+		value, _ = attr.Get("email")
+		assert.Equal(t, "user@mycompany.com", value.Str())
 	}
 }
 
@@ -236,11 +257,12 @@ func TestRedactSummaryDebug(t *testing.T) {
 // of any attributes it deleted to the new redaction.redacted.count span
 // attribute (but not to redaction.redacted.keys) when set to the info level
 // of output
-func TestRedactSummaryInfo(t *testing.T) {
+func TestRedactSummaryInfo(t *testing.T) { //tu
 	config := &Config{
-		AllowedKeys:   []string{"id", "name", "group"},
+		AllowedKeys:   []string{"id", "name", "group", "email"},
 		BlockedValues: []string{"4[0-9]{12}(?:[0-9]{3})?"},
 		IgnoredKeys:   []string{"safe_attribute"},
+		AllowedValues: []string{".+@mycompany.com"},
 		Summary:       "info",
 	}
 	allowed := map[string]pcommon.Value{
@@ -255,14 +277,17 @@ func TestRedactSummaryInfo(t *testing.T) {
 	redacted := map[string]pcommon.Value{
 		"credit_card": pcommon.NewValueStr("4111111111111111"),
 	}
+	allowedValues := map[string]pcommon.Value{
+		"email": pcommon.NewValueStr("user@mycompany.com"),
+	}
 
-	outTraces := runTest(t, allowed, redacted, masked, ignored, config)
-	outLogs := runLogsTest(t, allowed, redacted, masked, ignored, config)
-	outMetricsGauge := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, ignored, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, redacted, masked, allowedValues, ignored, config)
+	outLogs := runLogsTest(t, allowed, redacted, masked, allowedValues, ignored, config)
+	outMetricsGauge := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, allowedValues, ignored, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -295,6 +320,12 @@ func TestRedactSummaryInfo(t *testing.T) {
 		value, _ := attr.Get("name")
 		assert.Equal(t, "placeholder ****", value.Str())
 
+		allowedValueCount, ok := attr.Get(allowedValueCount)
+		assert.True(t, ok)
+		assert.Equal(t, int64(1), allowedValueCount.Int())
+		value, _ = attr.Get("email")
+		assert.Equal(t, "user@mycompany.com", value.Str())
+
 		ignoredKeyCount, ok := attr.Get(ignoredKeyCount)
 		assert.True(t, ok)
 		assert.Equal(t, int64(1), ignoredKeyCount.Int())
@@ -321,13 +352,13 @@ func TestRedactSummarySilent(t *testing.T) {
 		"credit_card": pcommon.NewValueStr("4111111111111111"),
 	}
 
-	outTraces := runTest(t, allowed, redacted, masked, nil, config)
-	outLogs := runLogsTest(t, allowed, redacted, masked, nil, config)
-	outMetricsGauge := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, redacted, masked, nil, nil, config)
+	outLogs := runLogsTest(t, allowed, redacted, masked, nil, nil, config)
+	outMetricsGauge := runMetricsTest(t, allowed, redacted, nil, masked, nil, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -371,13 +402,13 @@ func TestRedactSummaryDefault(t *testing.T) {
 		"name": pcommon.NewValueStr("placeholder 4111111111111111"),
 	}
 
-	outTraces := runTest(t, allowed, nil, masked, ignored, config)
-	outLogs := runLogsTest(t, allowed, nil, masked, ignored, config)
-	outMetricsGauge := runMetricsTest(t, allowed, nil, masked, ignored, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, nil, masked, ignored, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, nil, masked, ignored, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, nil, masked, ignored, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, nil, masked, ignored, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, nil, masked, nil, ignored, config)
+	outLogs := runLogsTest(t, allowed, nil, masked, nil, ignored, config)
+	outMetricsGauge := runMetricsTest(t, allowed, nil, masked, nil, ignored, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, nil, masked, nil, ignored, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, nil, masked, nil, ignored, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, nil, masked, nil, ignored, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, nil, masked, nil, ignored, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -422,13 +453,13 @@ func TestMultipleBlockValues(t *testing.T) {
 		"credit_card": pcommon.NewValueStr("4111111111111111"),
 	}
 
-	outTraces := runTest(t, allowed, redacted, masked, nil, config)
-	outLogs := runLogsTest(t, allowed, redacted, masked, nil, config)
-	outMetricsGauge := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeGauge)
-	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeSum)
-	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeHistogram)
-	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeExponentialHistogram)
-	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, nil, config, pmetric.MetricTypeSummary)
+	outTraces := runTest(t, allowed, redacted, masked, nil, nil, config)
+	outLogs := runLogsTest(t, allowed, redacted, masked, nil, nil, config)
+	outMetricsGauge := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeGauge)
+	outMetricsSum := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeSum)
+	outMetricsHistogram := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeHistogram)
+	outMetricsExponentialHistogram := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeExponentialHistogram)
+	outMetricsSummary := runMetricsTest(t, allowed, redacted, masked, nil, nil, config, pmetric.MetricTypeSummary)
 
 	attrs := []pcommon.Map{
 		outTraces.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0).Attributes(),
@@ -516,6 +547,7 @@ func runTest(
 	allowed map[string]pcommon.Value,
 	redacted map[string]pcommon.Value,
 	masked map[string]pcommon.Value,
+	allowedValues map[string]pcommon.Value,
 	ignored map[string]pcommon.Value,
 	config *Config,
 ) ptrace.Traces {
@@ -529,11 +561,14 @@ func runTest(
 	span.SetName("first-batch-first-span")
 	span.SetTraceID([16]byte{1, 2, 3, 4})
 
-	length := len(allowed) + len(masked) + len(redacted) + len(ignored)
+	length := len(allowed) + len(masked) + len(redacted) + len(ignored) + len(allowedValues)
 	for k, v := range allowed {
 		v.CopyTo(span.Attributes().PutEmpty(k))
 	}
 	for k, v := range masked {
+		v.CopyTo(span.Attributes().PutEmpty(k))
+	}
+	for k, v := range allowedValues {
 		v.CopyTo(span.Attributes().PutEmpty(k))
 	}
 	for k, v := range redacted {
@@ -564,6 +599,7 @@ func runLogsTest(
 	allowed map[string]pcommon.Value,
 	redacted map[string]pcommon.Value,
 	masked map[string]pcommon.Value,
+	allowedValues map[string]pcommon.Value,
 	ignored map[string]pcommon.Value,
 	config *Config,
 ) plog.Logs {
@@ -578,11 +614,14 @@ func runLogsTest(
 	logEntry.Body().SetStr("first-batch-first-logEntry")
 	logEntry.SetTraceID([16]byte{1, 2, 3, 4})
 
-	length := len(allowed) + len(masked) + len(redacted) + len(ignored)
+	length := len(allowed) + len(masked) + len(redacted) + len(ignored) + len(allowedValues)
 	for k, v := range allowed {
 		v.CopyTo(logEntry.Attributes().PutEmpty(k))
 	}
 	for k, v := range masked {
+		v.CopyTo(logEntry.Attributes().PutEmpty(k))
+	}
+	for k, v := range allowedValues {
 		v.CopyTo(logEntry.Attributes().PutEmpty(k))
 	}
 	for k, v := range redacted {
@@ -613,6 +652,7 @@ func runMetricsTest(
 	allowed map[string]pcommon.Value,
 	redacted map[string]pcommon.Value,
 	masked map[string]pcommon.Value,
+	allowedValues map[string]pcommon.Value,
 	ignored map[string]pcommon.Value,
 	config *Config,
 	metricType pmetric.MetricType,
@@ -626,7 +666,7 @@ func runMetricsTest(
 	metric := ils.Metrics().AppendEmpty()
 	metric.SetDescription("first-batch-first-metric")
 
-	length := len(allowed) + len(masked) + len(redacted) + len(ignored)
+	length := len(allowed) + len(masked) + len(redacted) + len(ignored) + len(allowedValues)
 
 	var dataPointAttrs pcommon.Map
 	switch metricType {
@@ -647,6 +687,10 @@ func runMetricsTest(
 		v.CopyTo(rl.Resource().Attributes().PutEmpty(k))
 	}
 	for k, v := range masked {
+		v.CopyTo(dataPointAttrs.PutEmpty(k))
+		v.CopyTo(rl.Resource().Attributes().PutEmpty(k))
+	}
+	for k, v := range allowedValues {
 		v.CopyTo(dataPointAttrs.PutEmpty(k))
 		v.CopyTo(rl.Resource().Attributes().PutEmpty(k))
 	}

--- a/processor/redactionprocessor/testdata/config.yaml
+++ b/processor/redactionprocessor/testdata/config.yaml
@@ -17,10 +17,14 @@ redaction:
   ignored_keys:
     - safe_attribute
   # BlockedValues is a list of regular expressions for blocking values of
-  # allowed span attributes. Values that match are masked
+  # allowed span attributes. Values that match are masked.
   blocked_values:
     - "4[0-9]{12}(?:[0-9]{3})?" ## Visa credit card number
     - "(5[1-5][0-9]{14})"       ## MasterCard number
+  # AllowedValues is a list of regular expressions for allowing values of
+	# blocked span attributes. Values that match are not masked.
+  allowed_values:
+    - ".+@mycompany.com"
   # Summary controls the verbosity level of the diagnostic attributes that
   # the processor adds to the spans when it redacts or masks other
   # attributes. In some contexts a list of redacted attributes leaks

--- a/processor/redactionprocessor/testdata/config.yaml
+++ b/processor/redactionprocessor/testdata/config.yaml
@@ -21,7 +21,7 @@ redaction:
   blocked_values:
     - "4[0-9]{12}(?:[0-9]{3})?" ## Visa credit card number
     - "(5[1-5][0-9]{14})"       ## MasterCard number
-  # AllowedValues is a list of regular expressions for allowing values of
+  # allowed_values is a list of regular expressions for allowing values of
   # blocked span attributes. Values that match are not masked.
   allowed_values:
     - ".+@mycompany.com"

--- a/processor/redactionprocessor/testdata/config.yaml
+++ b/processor/redactionprocessor/testdata/config.yaml
@@ -22,7 +22,7 @@ redaction:
     - "4[0-9]{12}(?:[0-9]{3})?" ## Visa credit card number
     - "(5[1-5][0-9]{14})"       ## MasterCard number
   # AllowedValues is a list of regular expressions for allowing values of
-	# blocked span attributes. Values that match are not masked.
+  # blocked span attributes. Values that match are not masked.
   allowed_values:
     - ".+@mycompany.com"
   # Summary controls the verbosity level of the diagnostic attributes that


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Introduce `allowed_values` parameter to the processor config.

If the value of an allowed key matches the regular expression for an allowed value, the matching
part of the value is not masked even if it matches the regular expression for a blocked value.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #35840
