### PR TITLE
[chore][internal/otelarrow] Remove last MetricsLevel reference

### DIFF
--- a/internal/otelarrow/netstats/netstats_test.go
+++ b/internal/otelarrow/netstats/netstats_test.go
@@ -307,7 +307,6 @@ func testNetStatsReceiver(t *testing.T, level configtelemetry.Level, expect map[
 				ID: component.NewID(component.MustNewType("test")),
 				TelemetrySettings: component.TelemetrySettings{
 					MeterProvider: mp,
-					MetricsLevel:  level,
 				},
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Updates open-telemetry/opentelemetry-collector/issues/11061