### PR TITLE
[chore] fix codeowners allowlist

### DIFF
--- a/cmd/githubgen/allowlist.txt
+++ b/cmd/githubgen/allowlist.txt
@@ -12,7 +12,6 @@ jcreixell
 jriguera
 KiranmayiB
 m1rp
-michael-burt
 rlankfo
 shazlehu
 swar8080


### PR DESCRIPTION
@michael-burt is now a member of the OpenTelemetry organization and no longer needs to be in the allowslist. Congrats!