### PR TITLE
Fix race in shutdown of AWS Container Insight receiver

### DIFF
--- a/.chloggen/shutdown-race-on-awscontainerinsightreceiver.yaml
+++ b/.chloggen/shutdown-race-on-awscontainerinsightreceiver.yaml
@@ -1,0 +1,9 @@
+change_type: bug_fix
+
+component: awscontainerinsightreceiver
+
+note: Fix race condition in shutdown of AWS Container Insight receiver
+
+issues: []
+
+change_logs: [user]

--- a/.chloggen/shutdown-race-on-awscontainerinsightreceiver.yaml
+++ b/.chloggen/shutdown-race-on-awscontainerinsightreceiver.yaml
@@ -4,6 +4,6 @@ component: awscontainerinsightreceiver
 
 note: Fix race condition in shutdown of AWS Container Insight receiver
 
-issues: []
+issues: [37695]
 
 change_logs: [user]


### PR DESCRIPTION
#### Description
Fix race condition during the shutdown of the AWS Container Insight receiver. Found by code inspection.

#### Documentation
Changelog.