### PR TITLE
[receiver/awscontainerinsight] Fix TLS insecure skip verify parameter in readme

### DIFF
--- a/receiver/kafkareceiver/README.md
+++ b/receiver/kafkareceiver/README.md
@@ -66,8 +66,8 @@ The following settings can be optionally configured:
       only be used if `insecure` is set to false.
     - `key_file`: path to the TLS key to use for TLS required connections. Should
       only be used if `insecure` is set to false.
-    - `insecure` (default = false): Disable verifying the server's certificate
-      chain and host name (`InsecureSkipVerify` in the tls config)
+    - `insecure_skip_verify` (default = false): Disable verifying the server's certificate
+      chain and host name (`InsecureSkipVerify` in the [tls config](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/configtls.go#L100))
     - `server_name_override`: ServerName indicates the name of the server requested by the client
       in order to support virtual hosting.
   - `kerberos`


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

The Kafka receiver's readme is incorrect. TLS `insecure` should be `insecure_skip_verify`.

See the following source code
- https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/internal/kafka/authentication.go#L24
- https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/configtls/configtls.go#L100
