### PR TITLE
[chore] [receiver/github] fix flaky test

### DIFF
--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -899,6 +899,12 @@ func TestEvalCommits(t *testing.T) {
 			assert.Equal(t, tc.expectedAge, age)
 			assert.Equal(t, tc.expectedDeletions, dels)
 			assert.Equal(t, tc.expectedAdditions, adds)
+			// assert.WithinRange(t, age, time.tc.expectedAge, time.Now())
+			if tc.expectedAge != 0 {
+				assert.WithinDuration(t, time.UnixMilli(tc.expectedAge), time.UnixMilli(age), 10*time.Second)
+			} else {
+				assert.Equal(t, tc.expectedAge, age)
+			}
 
 			if tc.expectedErr == nil {
 				assert.NoError(t, err)


### PR DESCRIPTION
#### Description

Fixes a flaky test where when with contracted resources, there was be a one ms delay in calculation of age causing a non-equal comparison.

#### Link to tracking issue
Fixes #34983

#### Testing

Replicated tests locally. Ran 100 tests to replicate failure (2% failure rate)  and then repeated after fix (0 failures). 