### PR TITLE
[connector/routing] Remove match_once parameter

### DIFF
--- a/.chloggen/routing-deprecations-v120.yaml
+++ b/.chloggen/routing-deprecations-v120.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `match_once` configuration parameter.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [36824]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/connector/routingconnector/config.go
+++ b/connector/routingconnector/config.go
@@ -22,9 +22,6 @@ var (
 
 // Config defines configuration for the Routing processor.
 type Config struct {
-	// MatchOnce determines whether the connector matches multiple statements.
-	// Unused. Deprecated in v0.116.0. Will be removed in v0.120.0.
-	MatchOnce *bool `mapstructure:"match_once"`
 	// ErrorMode determines how the processor reacts to errors that occur while processing an OTTL
 	// condition.
 	// Valid values are `ignore` and `propagate`.

--- a/connector/routingconnector/logs.go
+++ b/connector/routingconnector/logs.go
@@ -34,11 +34,6 @@ func newLogsConnector(
 	logs consumer.Logs,
 ) (*logsConnector, error) {
 	cfg := config.(*Config)
-
-	if cfg.MatchOnce != nil {
-		set.Logger.Error("The 'match_once' field has been deprecated and no longer has any effect. It will be removed in v0.120.0.")
-	}
-
 	lr, ok := logs.(connector.LogsRouterAndConsumer)
 	if !ok {
 		return nil, errUnexpectedConsumer

--- a/connector/routingconnector/metrics.go
+++ b/connector/routingconnector/metrics.go
@@ -35,11 +35,6 @@ func newMetricsConnector(
 	metrics consumer.Metrics,
 ) (*metricsConnector, error) {
 	cfg := config.(*Config)
-
-	if cfg.MatchOnce != nil {
-		set.Logger.Error("The 'match_once' field has been deprecated and no longer has any effect. It will be removed in v0.120.0.")
-	}
-
 	mr, ok := metrics.(connector.MetricsRouterAndConsumer)
 	if !ok {
 		return nil, errUnexpectedConsumer

--- a/connector/routingconnector/traces.go
+++ b/connector/routingconnector/traces.go
@@ -34,11 +34,6 @@ func newTracesConnector(
 	traces consumer.Traces,
 ) (*tracesConnector, error) {
 	cfg := config.(*Config)
-
-	if cfg.MatchOnce != nil {
-		set.Logger.Error("The 'match_once' field has been deprecated and no longer has any effect. It will be removed in v0.120.0.")
-	}
-
 	tr, ok := traces.(connector.TracesRouterAndConsumer)
 	if !ok {
 		return nil, errUnexpectedConsumer


### PR DESCRIPTION
This follows the deprecation plan which is itself removed in this PR.