### PR TITLE
[exporter/prometheusremotewrite] Make WAL shutdown wait until goroutine exits

### DIFF
--- a/exporter/prometheusremotewriteexporter/exporter_test.go
+++ b/exporter/prometheusremotewriteexporter/exporter_test.go
@@ -686,9 +686,6 @@ func Test_PushMetrics(t *testing.T) {
 			name = "WAL"
 		}
 		t.Run(name, func(t *testing.T) {
-			if useWAL {
-				t.Skip("Flaky test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/9124")
-			}
 			for _, tt := range tests {
 				if useWAL && tt.skipForWAL {
 					t.Skip("test not supported when using WAL")

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -190,6 +190,8 @@ func TestExportWithWALEnabled(t *testing.T) {
 
 		assert.Len(t, writeReq.Timeseries, 1)
 	}))
+	defer server.Close()
+
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.Endpoint = server.URL
 	cfg.ClientConfig = clientConfig

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -191,6 +191,8 @@ func TestExportWithWALEnabled(t *testing.T) {
 
 		assert.Len(t, writeReq.Timeseries, 1)
 	}))
+	defer server.Close()
+
 	clientConfig := confighttp.NewDefaultClientConfig()
 	clientConfig.Endpoint = server.URL
 	cfg.ClientConfig = clientConfig

--- a/exporter/prometheusremotewriteexporter/wal_test.go
+++ b/exporter/prometheusremotewriteexporter/wal_test.go
@@ -160,7 +160,6 @@ func TestWAL_persist(t *testing.T) {
 }
 
 func TestExportWithWALEnabled(t *testing.T) {
-	t.Skip("skipping test, see https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37715")
 	cfg := &Config{
 		WAL: &WALConfig{
 			Directory: t.TempDir(),


### PR DESCRIPTION
#### Description

When WAL is used the shutdown doesn't wait until the go routine launched to handle WAL terminates. This makes the shutdown non-deterministic and cause the test failure issues linked below.

Although a bug on the component it doesn't seem to deserve a changelog since it was detected via tests and there is no open issue around the shutdown of the component.

#### Link to tracking issue

Fixes #9124, #37715

#### Testing

Ran the component tests locally multiple times on Windows (more likely to surface concurrency issues).

#### Documentation

N/A