### PR TITLE
[elasticsearchexporter] Remove dedot config

### DIFF
--- a/.chloggen/elasticsearchexporter-rm-dedot-config.yaml
+++ b/.chloggen/elasticsearchexporter-rm-dedot-config.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove dedot config. ECS mode now always dedots, no others dedot at all.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33772]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -168,9 +168,6 @@ behaviours, which may be configured through the following settings:
             It works only for logs where the log record body is a map. Each LogRecord
             body is serialized to JSON as-is and becomes a separate document for ingestion.
             If the log record body is not a map, the exporter will log a warning and drop the log record.
-  - `dedot` (default=true; DEPRECATED, in future dedotting will always be enabled
-    for ECS mode, and never for other modes): When enabled attributes with `.`
-    will be split into proper json objects.
 
 #### ECS mapping mode
 

--- a/exporter/elasticsearchexporter/config.go
+++ b/exporter/elasticsearchexporter/config.go
@@ -189,11 +189,6 @@ type RetrySettings struct {
 type MappingsSettings struct {
 	// Mode configures the field mappings.
 	Mode string `mapstructure:"mode"`
-
-	// Deprecated: [v0.104.0] dedotting will always be applied for ECS mode
-	// in future, and never for other modes. Elasticsearch's "dot_expander"
-	// Ingest processor may be used as an alternative for non-ECS modes.
-	Dedot bool `mapstructure:"dedot"`
 }
 
 type MappingMode int
@@ -363,9 +358,6 @@ func (cfg *Config) MappingMode() MappingMode {
 }
 
 func handleDeprecatedConfig(cfg *Config, logger *zap.Logger) {
-	if cfg.Mapping.Dedot && cfg.MappingMode() != MappingECS || !cfg.Mapping.Dedot && cfg.MappingMode() == MappingECS {
-		logger.Warn("dedot has been deprecated: in the future, dedotting will always be performed in ECS mode only")
-	}
 	if cfg.Retry.MaxRequests != 0 {
 		cfg.Retry.MaxRetries = cfg.Retry.MaxRequests - 1
 		// Do not set cfg.Retry.Enabled = false if cfg.Retry.MaxRequest = 1 to avoid breaking change on behavior

--- a/exporter/elasticsearchexporter/config_test.go
+++ b/exporter/elasticsearchexporter/config_test.go
@@ -106,8 +106,7 @@ func TestConfig(t *testing.T) {
 					RetryOnStatus:   []int{http.StatusTooManyRequests, http.StatusInternalServerError},
 				},
 				Mapping: MappingsSettings{
-					Mode:  "none",
-					Dedot: true,
+					Mode: "none",
 				},
 				LogstashFormat: LogstashFormatSettings{
 					Enabled:         false,
@@ -180,8 +179,7 @@ func TestConfig(t *testing.T) {
 					RetryOnStatus:   []int{http.StatusTooManyRequests, http.StatusInternalServerError},
 				},
 				Mapping: MappingsSettings{
-					Mode:  "none",
-					Dedot: true,
+					Mode: "none",
 				},
 				LogstashFormat: LogstashFormatSettings{
 					Enabled:         false,
@@ -254,8 +252,7 @@ func TestConfig(t *testing.T) {
 					RetryOnStatus:   []int{http.StatusTooManyRequests, http.StatusInternalServerError},
 				},
 				Mapping: MappingsSettings{
-					Mode:  "none",
-					Dedot: true,
+					Mode: "none",
 				},
 				LogstashFormat: LogstashFormatSettings{
 					Enabled:         false,

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -53,8 +53,7 @@ func newExporter(
 	dynamicIndex bool,
 ) *elasticsearchExporter {
 	model := &encodeModel{
-		dedot: cfg.Mapping.Dedot,
-		mode:  cfg.MappingMode(),
+		mode: cfg.MappingMode(),
 	}
 
 	otel := model.mode == MappingOTel

--- a/exporter/elasticsearchexporter/factory.go
+++ b/exporter/elasticsearchexporter/factory.go
@@ -75,8 +75,7 @@ func createDefaultConfig() component.Config {
 			},
 		},
 		Mapping: MappingsSettings{
-			Mode:  "none",
-			Dedot: true,
+			Mode: "none",
 		},
 		LogstashFormat: LogstashFormatSettings{
 			Enabled:         false,

--- a/exporter/elasticsearchexporter/factory_test.go
+++ b/exporter/elasticsearchexporter/factory_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/component/componenttest"
 	"go.opentelemetry.io/collector/exporter/exportertest"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestCreateDefaultConfig(t *testing.T) {
@@ -59,43 +57,4 @@ func TestFactory_CreateTraces(t *testing.T) {
 	require.NotNil(t, exporter)
 
 	require.NoError(t, exporter.Shutdown(context.Background()))
-}
-
-func TestFactory_DedotDeprecated(t *testing.T) {
-	loggerCore, logObserver := observer.New(zap.WarnLevel)
-	set := exportertest.NewNopSettings()
-	set.Logger = zap.New(loggerCore)
-
-	cfgNoDedotECS := withDefaultConfig(func(cfg *Config) {
-		cfg.Endpoint = "http://testing.invalid:9200"
-		cfg.Mapping.Dedot = false
-		cfg.Mapping.Mode = "ecs"
-	})
-
-	cfgDedotRaw := withDefaultConfig(func(cfg *Config) {
-		cfg.Endpoint = "http://testing.invalid:9200"
-		cfg.Mapping.Dedot = true
-		cfg.Mapping.Mode = "raw"
-	})
-
-	for _, cfg := range []*Config{cfgNoDedotECS, cfgDedotRaw} {
-		factory := NewFactory()
-		logsExporter, err := factory.CreateLogs(context.Background(), set, cfg)
-		require.NoError(t, err)
-		require.NoError(t, logsExporter.Shutdown(context.Background()))
-
-		tracesExporter, err := factory.CreateTraces(context.Background(), set, cfg)
-		require.NoError(t, err)
-		require.NoError(t, tracesExporter.Shutdown(context.Background()))
-
-		metricsExporter, err := factory.CreateMetrics(context.Background(), set, cfg)
-		require.NoError(t, err)
-		require.NoError(t, metricsExporter.Shutdown(context.Background()))
-	}
-
-	records := logObserver.AllUntimed()
-	assert.Len(t, records, 6)
-	for _, record := range records {
-		assert.Equal(t, "dedot has been deprecated: in the future, dedotting will always be performed in ECS mode only", record.Message)
-	}
 }

--- a/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
+++ b/exporter/elasticsearchexporter/internal/objmodel/objmodel.go
@@ -272,10 +272,11 @@ func newJSONVisitor(w io.Writer) *json.Visitor {
 	return v
 }
 
-// Serialize writes the document to the given writer. The serializer will create nested objects if dedot is true.
-//
-// NOTE: The documented MUST be sorted if dedot is true.
+// Serialize writes the document to the given writer. The document fields will be
+// deduplicated and, if dedot is true, turned into nested objects prior to
+// serialization.
 func (doc *Document) Serialize(w io.Writer, dedot bool) error {
+	doc.Dedup()
 	v := newJSONVisitor(w)
 	return doc.iterJSON(v, dedot)
 }

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -79,19 +79,15 @@ type mappingModel interface {
 	encodeSpan(pcommon.Resource, string, ptrace.Span, pcommon.InstrumentationScope, string, elasticsearch.Index, *bytes.Buffer) error
 	encodeSpanEvent(resource pcommon.Resource, resourceSchemaURL string, span ptrace.Span, spanEvent ptrace.SpanEvent, scope pcommon.InstrumentationScope, scopeSchemaURL string, idx elasticsearch.Index, buf *bytes.Buffer)
 	hashDataPoint(datapoints.DataPoint) uint32
-	encodeDocument(objmodel.Document, *bytes.Buffer) error
 	encodeMetrics(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, dataPoints []datapoints.DataPoint, validationErrors *[]error, idx elasticsearch.Index, buf *bytes.Buffer) (map[string]string, error)
 }
 
 // encodeModel tries to keep the event as close to the original open telemetry semantics as is.
 // No fields will be mapped by default.
 //
-// Field deduplication and dedotting of attributes is supported by the encodeModel.
-//
 // See: https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md
 type encodeModel struct {
-	dedot bool
-	mode  MappingMode
+	mode MappingMode
 }
 
 const (
@@ -112,9 +108,7 @@ func (m *encodeModel) encodeLog(resource pcommon.Resource, resourceSchemaURL str
 	default:
 		document = m.encodeLogDefaultMode(resource, record, scope, idx)
 	}
-	document.Dedup()
-
-	return document.Serialize(buf, m.dedot)
+	return document.Serialize(buf, m.mode == MappingECS)
 }
 
 func (m *encodeModel) encodeLogDefaultMode(resource pcommon.Resource, record plog.LogRecord, scope pcommon.InstrumentationScope, idx elasticsearch.Index) objmodel.Document {
@@ -191,16 +185,6 @@ func (m *encodeModel) encodeLogECSMode(resource pcommon.Resource, record plog.Lo
 	return document
 }
 
-func (m *encodeModel) encodeDocument(document objmodel.Document, buf *bytes.Buffer) error {
-	document.Dedup()
-
-	err := document.Serialize(buf, m.dedot)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
 // upsertMetricDataPointValue upserts a datapoint value to documents which is already hashed by resource and index
 func (m *encodeModel) hashDataPoint(dp datapoints.DataPoint) uint32 {
 	switch m.mode {
@@ -228,7 +212,7 @@ func (m *encodeModel) encodeDataPointsECSMode(resource pcommon.Resource, dataPoi
 		}
 		document.AddAttribute(dp.Metric().Name(), value)
 	}
-	err := m.encodeDocument(document, buf)
+	err := document.Serialize(buf, true)
 
 	return document.DynamicTemplates(), err
 }
@@ -258,9 +242,7 @@ func (m *encodeModel) encodeSpan(resource pcommon.Resource, resourceSchemaURL st
 	default:
 		document = m.encodeSpanDefaultMode(resource, span, scope, idx)
 	}
-	document.Dedup()
-	err := document.Serialize(buf, m.dedot)
-	return err
+	return document.Serialize(buf, m.mode == MappingECS)
 }
 
 func (m *encodeModel) encodeSpanDefaultMode(resource pcommon.Resource, span ptrace.Span, scope pcommon.InstrumentationScope, idx elasticsearch.Index) objmodel.Document {

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -31,7 +30,10 @@ import (
 
 var expectedSpanBody = `{"@timestamp":"2023-04-19T03:04:05.000000006Z","Attributes.service.instance.id":"23","Duration":1000000,"EndTimestamp":"2023-04-19T03:04:06.000000006Z","Events.fooEvent.eventMockBar":"bar","Events.fooEvent.eventMockFoo":"foo","Events.fooEvent.time":"2023-04-19T03:04:05.000000006Z","Kind":"SPAN_KIND_CLIENT","Link":"[{\"attribute\":{},\"spanID\":\"\",\"traceID\":\"01020304050607080807060504030200\"}]","Name":"client span","Resource.cloud.platform":"aws_elastic_beanstalk","Resource.cloud.provider":"aws","Resource.deployment.environment":"BETA","Resource.service.instance.id":"23","Resource.service.name":"some-service","Resource.service.version":"env-version-1234","Scope.lib-foo":"lib-bar","Scope.name":"io.opentelemetry.rabbitmq-2.7","Scope.version":"1.30.0-alpha","SpanId":"1920212223242526","TraceId":"01020304050607080807060504030201","TraceStatus":2,"TraceStatusDescription":"Test"}`
 
-var expectedLogBody = `{"@timestamp":"2023-04-19T03:04:05.000000006Z","Attributes.log-attr1":"value1","Body":"log-body","Resource.key1":"value1","Scope.name":"","Scope.version":"","SeverityNumber":0,"TraceFlags":0}`
+var (
+	expectedLogBody                   = `{"@timestamp":"2023-04-19T03:04:05.000000006Z","Attributes.log-attr1":"value1","Body":"log-body","Resource.key1":"value1","Scope.name":"","Scope.version":"","SeverityNumber":0,"TraceFlags":0}`
+	expectedLogBodyWithEmptyTimestamp = `{"@timestamp":"1970-01-01T00:00:00.000000000Z","Attributes.log-attr1":"value1","Body":"log-body","Resource.key1":"value1","Scope.name":"","Scope.version":"","SeverityNumber":0,"TraceFlags":0}`
+)
 
 var expectedMetricsEncoded = `{"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"idle","system":{"cpu":{"time":440.23}}}
 {"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu0","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"interrupt","system":{"cpu":{"time":0.0}}}
@@ -50,13 +52,8 @@ var expectedMetricsEncoded = `{"@timestamp":"2024-06-12T10:20:16.419290690Z","cp
 {"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"user","system":{"cpu":{"time":50.09}}}
 {"@timestamp":"2024-06-12T10:20:16.419290690Z","cpu":"cpu1","host":{"hostname":"my-host","name":"my-host","os":{"platform":"linux"}},"state":"wait","system":{"cpu":{"time":0.95}}}`
 
-var (
-	expectedLogBodyWithEmptyTimestamp         = `{"@timestamp":"1970-01-01T00:00:00.000000000Z","Attributes.log-attr1":"value1","Body":"log-body","Resource.key1":"value1","Scope.name":"","Scope.version":"","SeverityNumber":0,"TraceFlags":0}`
-	expectedLogBodyDeDottedWithEmptyTimestamp = `{"@timestamp":"1970-01-01T00:00:00.000000000Z","Attributes":{"log-attr1":"value1"},"Body":"log-body","Resource":{"foo":{"bar":"baz"},"key1":"value1"},"Scope":{"name":"","version":""},"SeverityNumber":0,"TraceFlags":0}`
-)
-
 func TestEncodeSpan(t *testing.T) {
-	model := &encodeModel{dedot: false}
+	model := &encodeModel{}
 	td := mockResourceSpans()
 	var buf bytes.Buffer
 	err := model.encodeSpan(td.ResourceSpans().At(0).Resource(), "", td.ResourceSpans().At(0).ScopeSpans().At(0).Spans().At(0), td.ResourceSpans().At(0).ScopeSpans().At(0).Scope(), "", elasticsearch.Index{}, &buf)
@@ -66,7 +63,7 @@ func TestEncodeSpan(t *testing.T) {
 
 func TestEncodeLog(t *testing.T) {
 	t.Run("empty timestamp with observedTimestamp override", func(t *testing.T) {
-		model := &encodeModel{dedot: false}
+		model := &encodeModel{}
 		td := mockResourceLogs()
 		td.ScopeLogs().At(0).LogRecords().At(0).SetObservedTimestamp(pcommon.NewTimestampFromTime(time.Date(2023, 4, 19, 3, 4, 5, 6, time.UTC)))
 		var buf bytes.Buffer
@@ -76,22 +73,12 @@ func TestEncodeLog(t *testing.T) {
 	})
 
 	t.Run("both timestamp and observedTimestamp empty", func(t *testing.T) {
-		model := &encodeModel{dedot: false}
+		model := &encodeModel{}
 		td := mockResourceLogs()
 		var buf bytes.Buffer
 		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), elasticsearch.Index{}, &buf)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedLogBodyWithEmptyTimestamp, buf.String())
-	})
-
-	t.Run("dedot true", func(t *testing.T) {
-		model := &encodeModel{dedot: true}
-		td := mockResourceLogs()
-		td.Resource().Attributes().PutStr("foo.bar", "baz")
-		var buf bytes.Buffer
-		err := model.encodeLog(td.Resource(), td.SchemaUrl(), td.ScopeLogs().At(0).LogRecords().At(0), td.ScopeLogs().At(0).Scope(), td.ScopeLogs().At(0).SchemaUrl(), elasticsearch.Index{}, &buf)
-		require.NoError(t, err)
-		require.Equal(t, expectedLogBodyDeDottedWithEmptyTimestamp, buf.String())
 	})
 }
 
@@ -101,8 +88,7 @@ func TestEncodeMetric(t *testing.T) {
 
 	// Encode the metrics.
 	model := &encodeModel{
-		dedot: true,
-		mode:  MappingECS,
+		mode: MappingECS,
 	}
 
 	groupedDataPoints := make(map[uint32][]datapoints.DataPoint)
@@ -348,8 +334,7 @@ func TestEncodeLogECSModeDuplication(t *testing.T) {
 	logs.MarkReadOnly()
 
 	m := encodeModel{
-		mode:  MappingECS,
-		dedot: true,
+		mode: MappingECS,
 	}
 	var buf bytes.Buffer
 	err = m.encodeLog(resource, "", record, scope, "", elasticsearch.Index{}, &buf)
@@ -427,57 +412,83 @@ func TestEncodeLogECSMode(t *testing.T) {
 	var buf bytes.Buffer
 	m := encodeModel{}
 	doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
-	require.NoError(t, doc.Serialize(&buf, false))
+	require.NoError(t, doc.Serialize(&buf, true))
 
 	require.JSONEq(t, `{
-		"@timestamp":                 "2024-03-12T20:00:41.123456789Z",
-		"service.name":               "foo.bar",
-		"service.version":            "1.1.0",
-		"service.node.name":          "i-103de39e0a",
-		"agent.name":                 "opentelemetry/perl",
-		"agent.version":              "7.9.12",
-		"cloud.provider":             "gcp",
-		"cloud.account.id":           "19347013",
-		"cloud.region":               "us-west-1",
-		"cloud.availability_zone":    "us-west-1b",
-		"cloud.service.name":         "gke",
-		"container.name":             "happy-seger",
-		"container.id":               "e69cc5d3dda",
-		"container.image.name":       "my-app",
-		"container.image.tag":        ["v3.4.0"],
-		"container.runtime":          "docker",
-		"host.hostname":              "i-103de39e0a.gke.us-west-1b.cloud.google.com",
-		"host.name":                  "i-103de39e0a.gke.us-west-1b.cloud.google.com",
-		"host.id":                    "i-103de39e0a",
-		"host.type":                  "t2.medium",
-		"host.architecture":          "x86_64",
-		"process.pid":                9833,
-		"process.command_line":       "/usr/bin/ssh -l user 10.0.0.16",
-		"process.executable":         "/usr/bin/ssh",
-		"service.runtime.name":       "OpenJDK Runtime Environment",
-		"service.runtime.version":    "14.0.2",
-		"host.os.platform":           "darwin",
-		"host.os.full":               "Mac OS Mojave",
-		"host.os.name":               "Mac OS X",
-		"host.os.version":            "10.14.1",
-		"host.os.type":               "macos",
-		"device.id":                  "00000000-54b3-e7c7-0000-000046bffd97",
-		"device.model.identifier":    "SM-G920F",
-		"device.model.name":          "Samsung Galaxy S6",
-		"device.manufacturer":        "Samsung",
-		"event.action":               "user-password-change",
-		"kubernetes.namespace":       "default",
-		"kubernetes.node.name":       "node-1",
-		"kubernetes.pod.name":        "opentelemetry-pod-autoconf",
-		"kubernetes.pod.uid":         "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff",
-		"kubernetes.deployment.name": "coredns",
-		"kubernetes.job.name":         "job.name",
-		"kubernetes.cronjob.name":     "cronjob.name",
-		"kubernetes.statefulset.name": "statefulset.name",
-		"kubernetes.replicaset.name":  "replicaset.name",
-		"kubernetes.daemonset.name":   "daemonset.name",
-		"kubernetes.container.name":   "container.name",
-		"orchestrator.cluster.name":   "cluster.name"
+		"@timestamp": "2024-03-12T20:00:41.123456789Z",
+		"agent": {
+		  "name": "opentelemetry/perl",
+		  "version": "7.9.12"
+		},
+		"cloud": {
+		  "provider": "gcp",
+		  "account": {"id": "19347013"},
+		  "region": "us-west-1",
+		  "availability_zone": "us-west-1b",
+		  "service": {"name": "gke"}
+		},
+		"container": {
+		  "name": "happy-seger",
+		  "id": "e69cc5d3dda",
+		  "image": {
+		    "name": "my-app",
+		    "tag": ["v3.4.0"]
+		  },
+		  "runtime": "docker"
+		},
+		"host": {
+		  "hostname": "i-103de39e0a.gke.us-west-1b.cloud.google.com",
+		  "name": "i-103de39e0a.gke.us-west-1b.cloud.google.com",
+		  "id": "i-103de39e0a",
+		  "type": "t2.medium",
+		  "architecture": "x86_64",
+		  "os": {
+		    "platform": "darwin",
+		    "full": "Mac OS Mojave",
+		    "name": "Mac OS X",
+		    "version": "10.14.1",
+		    "type": "macos"
+		  }
+		},
+		"process": {
+		  "pid": 9833,
+		  "command_line": "/usr/bin/ssh -l user 10.0.0.16",
+		  "executable": "/usr/bin/ssh"
+		},
+		"service": {
+		  "name": "foo.bar",
+		  "version": "1.1.0",
+		  "node": {"name": "i-103de39e0a"},
+		  "runtime": {
+		    "name": "OpenJDK Runtime Environment",
+		    "version": "14.0.2"
+		  }
+		},
+		"device": {
+		  "id": "00000000-54b3-e7c7-0000-000046bffd97",
+		  "model": {
+		    "identifier": "SM-G920F",
+		    "name": "Samsung Galaxy S6"
+		  },
+		  "manufacturer": "Samsung"
+		},
+		"event": {"action": "user-password-change"},
+		"kubernetes": {
+		  "namespace": "default",
+		  "node": {"name": "node-1"},
+		  "pod": {
+		    "name": "opentelemetry-pod-autoconf",
+		    "uid": "275ecb36-5aa8-4c2a-9c47-d8bb681b9aff"
+		  },
+		  "deployment": {"name": "coredns"},
+		  "job": {"name": "job.name"},
+		  "cronjob": {"name": "cronjob.name"},
+		  "statefulset": {"name": "statefulset.name"},
+		  "replicaset": {"name": "replicaset.name"},
+		  "daemonset": {"name": "daemonset.name"},
+		  "container": {"name": "container.name"}
+		},
+		"orchestrator": {"cluster": {"name": "cluster.name"}}
 	}`, buf.String())
 }
 
@@ -560,10 +571,10 @@ func TestEncodeLogECSModeAgentName(t *testing.T) {
 			var buf bytes.Buffer
 			m := encodeModel{}
 			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
-			require.NoError(t, doc.Serialize(&buf, false))
+			require.NoError(t, doc.Serialize(&buf, true))
 			require.JSONEq(t, fmt.Sprintf(`{
 				"@timestamp": "2024-03-13T23:50:59.123456789Z",
-				"agent.name": %q
+				"agent": {"name": %q}
 			}`, test.expectedAgentName), buf.String())
 		})
 	}
@@ -614,18 +625,17 @@ func TestEncodeLogECSModeAgentVersion(t *testing.T) {
 			var buf bytes.Buffer
 			m := encodeModel{}
 			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
-			require.NoError(t, doc.Serialize(&buf, false))
+			require.NoError(t, doc.Serialize(&buf, true))
 
 			if test.expectedAgentVersion == "" {
 				require.JSONEq(t, `{
 					"@timestamp": "2024-03-13T23:50:59.123456789Z",
-					"agent.name": "otlp"
+					"agent": {"name": "otlp"}
 				}`, buf.String())
 			} else {
 				require.JSONEq(t, fmt.Sprintf(`{
 					"@timestamp": "2024-03-13T23:50:59.123456789Z",
-					"agent.name": "otlp",
-					"agent.version": %q
+					"agent": {"name": "otlp", "version": %q}
 				}`, test.expectedAgentVersion), buf.String())
 			}
 		})
@@ -723,17 +733,29 @@ func TestEncodeLogECSModeHostOSType(t *testing.T) {
 			m := encodeModel{}
 			logs.MarkReadOnly()
 			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
-			require.NoError(t, doc.Serialize(&buf, false))
+			require.NoError(t, doc.Serialize(&buf, true))
 
-			expectedJSON := `{"@timestamp":"2024-03-13T23:50:59.123456789Z", "agent.name":"otlp"`
-			if test.expectedHostOsName != "" {
-				expectedJSON += `, "host.os.name":` + strconv.Quote(test.expectedHostOsName)
-			}
-			if test.expectedHostOsType != "" {
-				expectedJSON += `, "host.os.type":` + strconv.Quote(test.expectedHostOsType)
-			}
-			if test.expectedHostOsPlatform != "" {
-				expectedJSON += `, "host.os.platform":` + strconv.Quote(test.expectedHostOsPlatform)
+			expectedJSON := `{"@timestamp":"2024-03-13T23:50:59.123456789Z", "agent":{"name":"otlp"}`
+			if test.expectedHostOsName != "" ||
+				test.expectedHostOsPlatform != "" ||
+				test.expectedHostOsType != "" {
+				expectedJSON += `, "host":{"os":{`
+
+				first := true
+				maybeAdd := func(k, v string) {
+					if v != "" {
+						if first {
+							first = false
+						} else {
+							expectedJSON += ","
+						}
+						expectedJSON += fmt.Sprintf("%q:%q", k, v)
+					}
+				}
+				maybeAdd("name", test.expectedHostOsName)
+				maybeAdd("type", test.expectedHostOsType)
+				maybeAdd("platform", test.expectedHostOsPlatform)
+				expectedJSON += "}}"
 			}
 			expectedJSON += "}"
 			require.JSONEq(t, expectedJSON, buf.String())
@@ -774,10 +796,10 @@ func TestEncodeLogECSModeTimestamps(t *testing.T) {
 			var buf bytes.Buffer
 			m := encodeModel{}
 			doc := m.encodeLogECSMode(resource, record, scope, elasticsearch.Index{})
-			require.NoError(t, doc.Serialize(&buf, false))
+			require.NoError(t, doc.Serialize(&buf, true))
 
 			require.JSONEq(t, fmt.Sprintf(
-				`{"@timestamp":%q,"agent.name":"otlp"}`, test.expectedTimestamp,
+				`{"@timestamp":%q,"agent":{"name":"otlp"}}`, test.expectedTimestamp,
 			), buf.String())
 		})
 	}
@@ -1126,8 +1148,7 @@ func TestEncodeLogOtelMode(t *testing.T) {
 	}
 
 	m := encodeModel{
-		dedot: true, // default
-		mode:  MappingOTel,
+		mode: MappingOTel,
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
#### Description

Remove the "dedot" config from the Elasticsearch exporter. This config has been deprecated for over 6 months, so it's time to remove it. ECS mode now dedots by default, and none of the others dedot at all.

#### Link to tracking issue

Closes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/33772

#### Testing

I only updated unit tests. No other testing performed, since this is a purely subtractive change that is covered by unit tests.

#### Documentation

Updated README