### PR TITLE
[chore] Upgrade golang from 1.22.11 to 1.22.12

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.22.11"
+          go-version: "~1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/build-and-test-darwin.yaml
+++ b/.github/workflows/build-and-test-darwin.yaml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.22.11"
+          go-version: "~1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -70,7 +70,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.22.11"
+          go-version: "~1.22.12"
           cache: false
       - name: Install Tools
         if: steps.go-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/build-and-test-windows.yml
+++ b/.github/workflows/build-and-test-windows.yml
@@ -59,7 +59,7 @@ jobs:
         run: Install-WindowsFeature -name Web-Server -IncludeManagementTools
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-mod-cache

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -94,7 +94,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -164,7 +164,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -188,7 +188,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -246,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.23.0", "1.22.11"] # 1.20 is interpreted as 1.2 without quotes
+        go-version: ["1.23.0", "1.22.12"] # 1.20 is interpreted as 1.2 without quotes
         runner: [ubuntu-24.04]
         group:
           - receiver-0
@@ -363,7 +363,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -429,7 +429,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -501,7 +501,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -551,7 +551,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Mkdir bin and dist
         run: |

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/check-codeowners.yaml
+++ b/.github/workflows/check-codeowners.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
 
       - name: Cache Go Tools

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
 
       # Initializes the CodeQL tools for scanning.

--- a/.github/workflows/e2e-tests-windows.yml
+++ b/.github/workflows/e2e-tests-windows.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ~1.22.11
+          go-version: ~1.22.12
           cache: false
       - name: Cache Go
         uses: actions/cache@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -89,7 +89,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -137,7 +137,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -26,7 +26,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Prepare release for contrib
         working-directory: opentelemetry-collector-contrib

--- a/.github/workflows/prometheus-compliance-tests.yml
+++ b/.github/workflows/prometheus-compliance-tests.yml
@@ -31,7 +31,7 @@ jobs:
           path: opentelemetry-collector-contrib
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/scoped-test.yaml
+++ b/.github/workflows/scoped-test.yaml
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
 
       - name: Try to restore go-cache

--- a/.github/workflows/telemetrygen.yml
+++ b/.github/workflows/telemetrygen.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache
@@ -112,7 +112,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/tidy-dependencies.yml
+++ b/.github/workflows/tidy-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
           ref: ${{ github.head_ref }}
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.11"
+          go-version: "1.22.12"
           cache: false
       - name: Cache Go
         id: go-cache


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
[Vulnerability scans](https://github.com/open-telemetry/opentelemetry-collector-contrib/actions/runs/13184143287/job/36802088446?pr=37749) are detecting [GO-2025-3447](https://pkg.go.dev/vuln/GO-2025-3447) in our runs. This upgrades the test environment to run 1.22.12, the fixed version.