### PR TITLE
[chore] Relax field tag checks in Cloud Foundry Receiver tests

### DIFF
--- a/receiver/cloudfoundryreceiver/config_test.go
+++ b/receiver/cloudfoundryreceiver/config_test.go
@@ -6,6 +6,7 @@ package cloudfoundryreceiver
 import (
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -167,5 +168,10 @@ func checkTypeFieldMatch(t *testing.T, fieldName string, localType reflect.Type,
 
 	require.True(t, localFieldPresent, "field %s present in local type", fieldName)
 	require.True(t, standardFieldPresent, "field %s present in standard type", fieldName)
-	require.Equal(t, localField.Tag, standardField.Tag, "field %s tag match", fieldName)
+
+	// Check that the mapstructure tag is not empty
+	require.GreaterOrEqual(t, len(strings.Split(localField.Tag.Get("mapstructure"), ",")), 1)
+
+	// Check that the configuration key names are the same, ignoring other tags like omitempty.
+	require.Equal(t, localField.Tag.Get("mapstructure")[0], standardField.Tag.Get("mapstructure")[0], "field %s tag match", fieldName)
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

One option to help with https://github.com/open-telemetry/opentelemetry-collector/pull/12311.

We could also fix this after making that change, but I think the checks now better reflect the intent of the test. 
