### PR TITLE
[cmd/opampsupervisor] ensure OnConnectClosed is hooked up

### DIFF
--- a/.chloggen/codeboten_ensure-onclose-hookedup.yaml
+++ b/.chloggen/codeboten_ensure-onclose-hookedup.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: opampsupervisor
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The OnConnectionClose was not correctly connected for the supervisor.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37761]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/cmd/opampsupervisor/supervisor/server.go
+++ b/cmd/opampsupervisor/supervisor/server.go
@@ -44,7 +44,8 @@ func (fs flattenedSettings) OnConnecting(request *http.Request) serverTypes.Conn
 	return serverTypes.ConnectionResponse{
 		Accept: true,
 		ConnectionCallbacks: serverTypes.ConnectionCallbacks{
-			OnMessage: fs.OnMessage,
+			OnMessage:         fs.OnMessage,
+			OnConnectionClose: fs.OnConnectionClose,
 		},
 	}
 }


### PR DESCRIPTION
OnConnectionClose was never hooked up to the server's OnConnectionClose, causing the restart of the agent to never be able to reconnect.
