### PR TITLE
[chore] Upgrade otel-arrow dependencies to v0.33.0

### DIFF
--- a/exporter/otelarrowexporter/go.mod
+++ b/exporter/otelarrowexporter/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/apache/arrow/go/v16 v16.1.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow v0.119.0
-	github.com/open-telemetry/otel-arrow v0.32.0
+	github.com/open-telemetry/otel-arrow v0.33.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.25.0
 	go.opentelemetry.io/collector/component v0.119.0

--- a/exporter/otelarrowexporter/go.sum
+++ b/exporter/otelarrowexporter/go.sum
@@ -84,8 +84,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
 github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
-github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
+github.com/open-telemetry/otel-arrow v0.33.0 h1:WSix8XA2KrUUorQ/5uE89RnhwI7XGwCtJW74tWhK0JI=
+github.com/open-telemetry/otel-arrow v0.33.0/go.mod h1:k9SLR7+8SdWEYFLFGUR0KqfIxK0k+72zi5/zqGlfrbQ=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/otelarrow/go.mod
+++ b/internal/otelarrow/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/klauspost/compress v1.17.11
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/otelarrowexporter v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/otelarrowreceiver v0.119.0
-	github.com/open-telemetry/otel-arrow v0.32.0
+	github.com/open-telemetry/otel-arrow v0.33.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/component v0.119.0
 	go.opentelemetry.io/collector/component/componenttest v0.119.0

--- a/internal/otelarrow/go.sum
+++ b/internal/otelarrow/go.sum
@@ -84,8 +84,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
 github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
-github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
+github.com/open-telemetry/otel-arrow v0.33.0 h1:WSix8XA2KrUUorQ/5uE89RnhwI7XGwCtJW74tWhK0JI=
+github.com/open-telemetry/otel-arrow v0.33.0/go.mod h1:k9SLR7+8SdWEYFLFGUR0KqfIxK0k+72zi5/zqGlfrbQ=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/receiver/otelarrowreceiver/go.mod
+++ b/receiver/otelarrowreceiver/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/grpcutil v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/otelarrow v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/sharedcomponent v0.119.0
-	github.com/open-telemetry/otel-arrow v0.32.0
+	github.com/open-telemetry/otel-arrow v0.33.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/collector/client v1.25.0
 	go.opentelemetry.io/collector/component v0.119.0

--- a/receiver/otelarrowreceiver/go.sum
+++ b/receiver/otelarrowreceiver/go.sum
@@ -78,8 +78,8 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/mostynb/go-grpc-compression v1.2.3 h1:42/BKWMy0KEJGSdWvzqIyOZ95YcR9mLPqKctH7Uo//I=
 github.com/mostynb/go-grpc-compression v1.2.3/go.mod h1:AghIxF3P57umzqM9yz795+y1Vjs47Km/Y2FE6ouQ7Lg=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/open-telemetry/otel-arrow v0.32.0 h1:kC2xK648hWyQFGOFUhKTZ37GP3S7k1aO7TZsknMqVx8=
-github.com/open-telemetry/otel-arrow v0.32.0/go.mod h1:QL1RCKicTfiaujmrlyrwwQPRJXvIRUJ0gEFoMPRkWqU=
+github.com/open-telemetry/otel-arrow v0.33.0 h1:WSix8XA2KrUUorQ/5uE89RnhwI7XGwCtJW74tWhK0JI=
+github.com/open-telemetry/otel-arrow v0.33.0/go.mod h1:k9SLR7+8SdWEYFLFGUR0KqfIxK0k+72zi5/zqGlfrbQ=
 github.com/pierrec/lz4/v4 v4.1.21 h1:yOVMLb6qSIDP67pl/5F7RepeKYu/VmTyEXvuMI5d9mQ=
 github.com/pierrec/lz4/v4 v4.1.21/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/receiver/otelarrowreceiver/otelarrow.go
+++ b/receiver/otelarrowreceiver/otelarrow.go
@@ -142,9 +142,7 @@ func (r *otelArrowReceiver) startProtocolServers(ctx context.Context, host compo
 			opts = append(opts, arrowRecord.WithMemoryLimit(r.cfg.Arrow.MemoryLimitMiB<<20))
 		}
 		if r.settings.TelemetrySettings.MeterProvider != nil {
-			// This alt method call should be replaced once https://github.com/open-telemetry/otel-arrow/issues/280 is resolved.
-			// The WithMeterProvider function will be updated in a future release cycle.
-			opts = append(opts, arrowRecord.WithMeterProviderAlt(r.settings.TelemetrySettings.MeterProvider))
+			opts = append(opts, arrowRecord.WithMeterProvider(r.settings.TelemetrySettings.MeterProvider))
 		}
 		return arrowRecord.NewConsumer(opts...)
 	}, r.boundedQueue, r.netReporter)


### PR DESCRIPTION
#### Description

Upgrade otel-arrow dependencies to v0.33.0 following [opentelemetry/otel-arrow's latest release](https://github.com/open-telemetry/otel-arrow/releases).

This is a follow-up to #37512 targeting an issue opened in otel-arrow https://github.com/open-telemetry/otel-arrow/issues/280 regarding deprecation of `MetricsLevel`. The regular `WithMeterProvider` function now has the desired behavior, so removing the `WithMeterProviderAlt` invocation.
