### PR TITLE
[chore] remove equal assertion after fixing flaky test

### DIFF
--- a/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
+++ b/receiver/githubreceiver/internal/scraper/githubscraper/helpers_test.go
@@ -896,10 +896,8 @@ func TestEvalCommits(t *testing.T) {
 			client := graphql.NewClient(server.URL, ghs.client)
 			adds, dels, age, err := ghs.evalCommits(context.Background(), client, "repo1", tc.branch)
 
-			assert.Equal(t, tc.expectedAge, age)
 			assert.Equal(t, tc.expectedDeletions, dels)
 			assert.Equal(t, tc.expectedAdditions, adds)
-			// assert.WithinRange(t, age, time.tc.expectedAge, time.Now())
 			if tc.expectedAge != 0 {
 				assert.WithinDuration(t, time.UnixMilli(tc.expectedAge), time.UnixMilli(age), 10*time.Second)
 			} else {


### PR DESCRIPTION
#### Description
Removes the previous assert.Equal statement that was causing the test to intermittently fail. The equal assertion was intended to be removed previously with the new logic but I missed it.

Will keep an eye on this because I'm surprised I couldn't get it to happen locally (whereas before adding the new logic I could consistently get it to fail 2% of the time.)

#### Link to tracking issue
Fixes #34983


