### PR TITLE
[reciever/prometheusremotewritereciever] handle otel_scope_name and otel_scope_version in prw reciever

### DIFF
--- a/.chloggen/handle-prw-otel_scope_name-and-version.yaml
+++ b/.chloggen/handle-prw-otel_scope_name-and-version.yaml
@@ -1,0 +1,29 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusremotewritereciever
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Handle `otel_scope_name` and `otel_scope_version` labels in Prometheus Remote Write receiver properly if not present"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37791]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  - if otel_scope_name or otel_scope_name is missing, use collector’s version and description according to the otel spec.
+  - makes sure every metric has a complete instrumentation scope as required.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -193,13 +193,13 @@ func (prw *prometheusRemoteWriteReceiver) translateV2(_ context.Context, req *wr
 
 		switch ts.Metadata.Type {
 		case writev2.Metadata_METRIC_TYPE_COUNTER:
-			addCounterDatapoints(rm, ls, ts)
+			prw.addCounterDatapoints(rm, ls, ts)
 		case writev2.Metadata_METRIC_TYPE_GAUGE:
 			prw.addGaugeDatapoints(rm, ls, ts)
 		case writev2.Metadata_METRIC_TYPE_SUMMARY:
-			addSummaryDatapoints(rm, ls, ts)
+			prw.addSummaryDatapoints(rm, ls, ts)
 		case writev2.Metadata_METRIC_TYPE_HISTOGRAM:
-			addHistogramDatapoints(rm, ls, ts)
+			prw.addHistogramDatapoints(rm, ls, ts)
 		default:
 			badRequestErrors = errors.Join(badRequestErrors, fmt.Errorf("unsupported metric type %q for metric %q", ts.Metadata.Type, ls.Get(labels.MetricName)))
 		}
@@ -225,7 +225,7 @@ func parseJobAndInstance(dest pcommon.Map, job, instance string) {
 	}
 }
 
-func addCounterDatapoints(_ pmetric.ResourceMetrics, _ labels.Labels, _ writev2.TimeSeries) {
+func (prw *prometheusRemoteWriteReceiver) addCounterDatapoints(_ pmetric.ResourceMetrics, _ labels.Labels, _ writev2.TimeSeries) {
 	// TODO: Implement this function
 }
 
@@ -264,11 +264,11 @@ func (prw *prometheusRemoteWriteReceiver) addGaugeDatapoints(rm pmetric.Resource
 	addDatapoints(m.DataPoints(), ls, ts)
 }
 
-func addSummaryDatapoints(_ pmetric.ResourceMetrics, _ labels.Labels, _ writev2.TimeSeries) {
+func (prw *prometheusRemoteWriteReceiver) addSummaryDatapoints(_ pmetric.ResourceMetrics, _ labels.Labels, _ writev2.TimeSeries) {
 	// TODO: Implement this function
 }
 
-func addHistogramDatapoints(_ pmetric.ResourceMetrics, _ labels.Labels, _ writev2.TimeSeries) {
+func (prw *prometheusRemoteWriteReceiver) addHistogramDatapoints(_ pmetric.ResourceMetrics, _ labels.Labels, _ writev2.TimeSeries) {
 	// TODO: Implement this function
 }
 

--- a/receiver/prometheusremotewritereceiver/receiver.go
+++ b/receiver/prometheusremotewritereceiver/receiver.go
@@ -28,7 +28,11 @@ import (
 
 func newRemoteWriteReceiver(settings receiver.Settings, cfg *Config, nextConsumer consumer.Metrics) (receiver.Metrics, error) {
 	if settings.BuildInfo.Version != "" {
-		defaultBuildVersion = settings.BuildInfo.Version
+		buildVersion = settings.BuildInfo.Version
+	}
+
+	if settings.BuildInfo.Description != "" {
+		buildName = settings.BuildInfo.Description
 	}
 
 	return &prometheusRemoteWriteReceiver{
@@ -233,7 +237,10 @@ func addCounterDatapoints(_ pmetric.ResourceMetrics, _ labels.Labels, _ writev2.
 	// TODO: Implement this function
 }
 
-var defaultBuildVersion string = "unknown"
+var (
+	buildVersion string = ""
+	buildName    string = ""
+)
 
 func addGaugeDatapoints(rm pmetric.ResourceMetrics, ls labels.Labels, ts writev2.TimeSeries) {
 	// TODO: Cache metric name+type+unit and look up cache before creating new empty metric.
@@ -246,10 +253,11 @@ func addGaugeDatapoints(rm pmetric.ResourceMetrics, ls labels.Labels, ts writev2
 	// If the scope version or scope name is empty, get the information from the collector build tags.
 	// More: https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#:~:text=Metrics%20which%20do%20not%20have%20an%20otel_scope_name%20or%20otel_scope_version%20label%20MUST%20be%20assigned%20an%20instrumentation%20scope%20identifying%20the%20entity%20performing%20the%20translation%20from%20Prometheus%20to%20OpenTelemetry%20(e.g.%20the%20collector%E2%80%99s%20prometheus%20receiver)
 	if scopeName == "" {
-		scopeName = "opentelemetry-collector"
+		scopeName = buildName
 	}
+
 	if scopeVersion == "" {
-		scopeVersion = defaultBuildVersion
+		scopeVersion = buildVersion
 	}
 
 	// Check if the name and version present in the labels are already present in the ResourceMetrics.

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -139,73 +139,6 @@ func TestTranslateV2(t *testing.T) {
 		expectedStats   remote.WriteResponseStats
 	}{
 		{
-			name: "duplicated scope name and version",
-			request: &writev2.Request{
-				Symbols: []string{
-					"",
-					"__name__", "test_metric",
-					"job", "service-x/test",
-					"instance", "107cn001",
-					"otel_scope_name", "scope1",
-					"otel_scope_version", "v1",
-					"otel_scope_name", "scope2",
-					"otel_scope_version", "v2",
-					"d", "e",
-					"foo", "bar",
-				},
-				Timeseries: []writev2.TimeSeries{
-					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
-						Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
-					},
-					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
-						Samples:    []writev2.Sample{{Value: 2, Timestamp: 2}},
-					},
-					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 17, 18},
-						Samples:    []writev2.Sample{{Value: 3, Timestamp: 3}},
-					},
-				},
-			},
-			expectedMetrics: func() pmetric.Metrics {
-				expected := pmetric.NewMetrics()
-				rm1 := expected.ResourceMetrics().AppendEmpty()
-				rm1.Resource().Attributes().PutStr("service.namespace", "service-x")
-				rm1.Resource().Attributes().PutStr("service.name", "test")
-				rm1.Resource().Attributes().PutStr("service.instance.id", "107cn001")
-
-				sm1 := rm1.ScopeMetrics().AppendEmpty()
-				sm1.Scope().SetName("scope1")
-				sm1.Scope().SetVersion("v1")
-
-				dp1 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
-				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				dp1.SetDoubleValue(1.0)
-				dp1.Attributes().PutStr("d", "e")
-
-				dp2 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
-				dp2.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
-				dp2.SetDoubleValue(2.0)
-				dp2.Attributes().PutStr("d", "e")
-
-				sm2 := rm1.ScopeMetrics().AppendEmpty()
-				sm2.Scope().SetName("scope2")
-				sm2.Scope().SetVersion("v2")
-
-				dp3 := sm2.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
-				dp3.SetTimestamp(pcommon.Timestamp(3 * int64(time.Millisecond)))
-				dp3.SetDoubleValue(3.0)
-				dp3.Attributes().PutStr("foo", "bar")
-
-				return expected
-			}(),
-			expectedStats: remote.WriteResponseStats{},
-		},
-		{
 			name: "missing metric name",
 			request: &writev2.Request{
 				Symbols: []string{"", "foo", "bar"},
@@ -352,6 +285,73 @@ func TestTranslateV2(t *testing.T) {
 				dp := m.DataPoints().AppendEmpty()
 				dp.SetTimestamp(pcommon.Timestamp(100 * int64(time.Millisecond)))
 				dp.SetDoubleValue(10.0)
+
+				return expected
+			}(),
+			expectedStats: remote.WriteResponseStats{},
+		},
+		{
+			name: "duplicated scope name and version",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "test_metric",
+					"job", "service-x/test",
+					"instance", "107cn001",
+					"otel_scope_name", "scope1",
+					"otel_scope_version", "v1",
+					"otel_scope_name", "scope2",
+					"otel_scope_version", "v2",
+					"d", "e",
+					"foo", "bar",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
+						Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
+					},
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
+						Samples:    []writev2.Sample{{Value: 2, Timestamp: 2}},
+					},
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 17, 18},
+						Samples:    []writev2.Sample{{Value: 3, Timestamp: 3}},
+					},
+				},
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				expected := pmetric.NewMetrics()
+				rm1 := expected.ResourceMetrics().AppendEmpty()
+				rm1.Resource().Attributes().PutStr("service.namespace", "service-x")
+				rm1.Resource().Attributes().PutStr("service.name", "test")
+				rm1.Resource().Attributes().PutStr("service.instance.id", "107cn001")
+
+				sm1 := rm1.ScopeMetrics().AppendEmpty()
+				sm1.Scope().SetName("scope1")
+				sm1.Scope().SetVersion("v1")
+
+				dp1 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp1.SetDoubleValue(1.0)
+				dp1.Attributes().PutStr("d", "e")
+
+				dp2 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp2.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
+				dp2.SetDoubleValue(2.0)
+				dp2.Attributes().PutStr("d", "e")
+
+				sm2 := rm1.ScopeMetrics().AppendEmpty()
+				sm2.Scope().SetName("scope2")
+				sm2.Scope().SetVersion("v2")
+
+				dp3 := sm2.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp3.SetTimestamp(pcommon.Timestamp(3 * int64(time.Millisecond)))
+				dp3.SetDoubleValue(3.0)
+				dp3.Attributes().PutStr("foo", "bar")
 
 				return expected
 			}(),

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -27,6 +27,11 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/internal/metadata"
 )
 
+const (
+	defaultBuildName    = "defaultBuildName"
+	defaultBuildVersion = "defaultBuildVersion"
+)
+
 var writeV2RequestFixture = &writev2.Request{
 	Symbols: []string{"", "__name__", "test_metric1", "job", "service-x/test", "instance", "107cn001", "d", "e", "foo", "bar", "f", "g", "h", "i", "Test gauge for test purposes", "Maybe op/sec who knows (:", "Test counter for test purposes"},
 	Timeseries: []writev2.TimeSeries{
@@ -124,15 +129,21 @@ func TestHandlePRWContentTypeNegotiation(t *testing.T) {
 
 func TestTranslateV2(t *testing.T) {
 	prwReceiver := setupMetricsReceiver(t)
+	// Save the default BuildInfo values.
+	defaultBuildName := prwReceiver.settings.BuildInfo.Description
+	defaultBuildVersion := prwReceiver.settings.BuildInfo.Version
+
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
 	for _, tc := range []struct {
-		name            string
-		request         *writev2.Request
-		expectError     string
-		expectedMetrics pmetric.Metrics
-		expectedStats   remote.WriteResponseStats
+		name                 string
+		request              *writev2.Request
+		expectError          string
+		expectedMetrics      pmetric.Metrics
+		expectedStats        remote.WriteResponseStats
+		buildNameOverride    string
+		buildVersionOverride string
 	}{
 		{
 			name: "duplicated scope name and version",
@@ -167,6 +178,9 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
+			// Expected:
+			// - The first two timeseries have explicit otel_scope values "scope1"/"v1" and yield gauge datapoints with {"d":"e"}.
+			// - The third timeseries uses "scope2"/"v2" and yields a gauge datapoint with {"foo":"bar"}.
 			expectedMetrics: func() pmetric.Metrics {
 				expected := pmetric.NewMetrics()
 				rm1 := expected.ResourceMetrics().AppendEmpty()
@@ -310,24 +324,18 @@ func TestTranslateV2(t *testing.T) {
 			expectedMetrics: func() pmetric.Metrics {
 				expected := pmetric.NewMetrics()
 				rm := expected.ResourceMetrics().AppendEmpty()
-				// For job "service-y/custom", resource attributes are set as follows:
-				rm.Resource().Attributes().PutStr("service.namespace", "service-y")
-				rm.Resource().Attributes().PutStr("service.name", "custom")
-				rm.Resource().Attributes().PutStr("service.instance.id", "instance-1")
+				parseJobAndInstance(rm.Resource().Attributes(), "service-y/custom", "instance-1")
 				sm := rm.ScopeMetrics().AppendEmpty()
-				// Expect the provided scope values.
 				sm.Scope().SetName("custom_scope")
 				sm.Scope().SetVersion("v1.0")
-				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
-				// The datapoint will have no extra attributes because __name__, otel_scope_name/version,
-				// job and instance are filtered out.
-				_ = m.DataPoints().AppendEmpty()
+				_ = sm.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
 				return expected
 			}(),
 			expectedStats: remote.WriteResponseStats{},
 		},
 		{
-			name: "missing otel_scope_name/version falls back to buildName/buildVersion",
+			name: "missing otel_scope_name/version falls back to BuildInfo",
+			// When missing, ls.Get returns "" so the defaults from BuildInfo are preserved.
 			request: &writev2.Request{
 				Symbols: []string{
 					"",                // index 0
@@ -353,25 +361,60 @@ func TestTranslateV2(t *testing.T) {
 			expectedMetrics: func() pmetric.Metrics {
 				expected := pmetric.NewMetrics()
 				rm := expected.ResourceMetrics().AppendEmpty()
-				// parseJobAndInstance splits "service-z/xyz" into namespace "service-z" and name "xyz"
-				rm.Resource().Attributes().PutStr("service.namespace", "service-z")
-				rm.Resource().Attributes().PutStr("service.name", "xyz")
-				rm.Resource().Attributes().PutStr("service.instance.id", "inst-42")
+				parseJobAndInstance(rm.Resource().Attributes(), "service-z/xyz", "inst-42")
 				sm := rm.ScopeMetrics().AppendEmpty()
-				// Since otel_scope_name/version are missing, the code falls back to buildName/buildVersion.
-				sm.Scope().SetName(buildName)
-				sm.Scope().SetVersion(buildVersion)
+				// Expect fallback to default BuildInfo.
+				sm.Scope().SetName(defaultBuildName)
+				sm.Scope().SetVersion(defaultBuildVersion)
 				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
 				dp := m.DataPoints().AppendEmpty()
-				// Expect the attributes from the labels that are added by addDatapoints.
 				dp.Attributes().PutStr("d", "e")
 				dp.Attributes().PutStr("foo", "bar")
 				return expected
 			}(),
 			expectedStats: remote.WriteResponseStats{},
 		},
+		{
+			name: "custom BuildInfo used when no scope provided",
+			// Even if BuildInfo is overridden, if no otel_scope is provided, the overridden defaults are used.
+			buildNameOverride:    "customBuildName",
+			buildVersionOverride: "customBuildVersion",
+			request: &writev2.Request{
+				Symbols: []string{
+					"", "__name__", "metric_custom",
+					"job", "service-custom/svc",
+					"instance", "inst-custom",
+					"a", "b",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
+						Samples:    []writev2.Sample{{Value: 42, Timestamp: 100}},
+					},
+				},
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				expected := pmetric.NewMetrics()
+				rm := expected.ResourceMetrics().AppendEmpty()
+				parseJobAndInstance(rm.Resource().Attributes(), "service-custom/svc", "inst-custom")
+				sm := rm.ScopeMetrics().AppendEmpty()
+				// Expect the overridden BuildInfo values.
+				sm.Scope().SetName("customBuildName")
+				sm.Scope().SetVersion("customBuildVersion")
+				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
+				dp := m.DataPoints().AppendEmpty()
+				dp.Attributes().PutStr("a", "b")
+				return expected
+			}(),
+			expectedStats: remote.WriteResponseStats{},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.buildNameOverride != "" || tc.buildVersionOverride != "" {
+				prwReceiver.settings.BuildInfo.Description = tc.buildNameOverride
+				prwReceiver.settings.BuildInfo.Version = tc.buildVersionOverride
+			}
 			metrics, stats, err := prwReceiver.translateV2(ctx, tc.request)
 			if tc.expectError != "" {
 				assert.ErrorContains(t, err, tc.expectError)

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -363,8 +363,8 @@ func TestTranslateV2(t *testing.T) {
 				parseJobAndInstance(rm.Resource().Attributes(), "service-z/xyz", "inst-42")
 				sm := rm.ScopeMetrics().AppendEmpty()
 				// Expect fallback to default BuildInfo.
-				sm.Scope().SetName("")
-				sm.Scope().SetVersion("")
+				sm.Scope().SetName(defaultBuildName)
+				sm.Scope().SetVersion(defaultBuildVersion)
 				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
 				dp := m.DataPoints().AppendEmpty()
 				dp.Attributes().PutStr("d", "e")

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -129,7 +129,6 @@ func TestHandlePRWContentTypeNegotiation(t *testing.T) {
 
 func TestTranslateV2(t *testing.T) {
 	prwReceiver := setupMetricsReceiver(t)
-	// Save the default BuildInfo values.
 	defaultBuildName := prwReceiver.settings.BuildInfo.Description
 	defaultBuildVersion := prwReceiver.settings.BuildInfo.Version
 
@@ -338,17 +337,17 @@ func TestTranslateV2(t *testing.T) {
 			// When missing, ls.Get returns "" so the defaults from BuildInfo are preserved.
 			request: &writev2.Request{
 				Symbols: []string{
-					"",                // index 0
-					"__name__",        // index 1
-					"metric_no_scope", // index 2
-					"job",             // index 3
-					"service-z/xyz",   // index 4
-					"instance",        // index 5
-					"inst-42",         // index 6
-					"d",               // index 7
-					"e",               // index 8
-					"foo",             // index 9
-					"bar",             // index 10
+					"",
+					"__name__",
+					"metric_no_scope",
+					"job",
+					"service-z/xyz",
+					"instance",
+					"inst-42",
+					"d",
+					"e",
+					"foo",
+					"bar",
 				},
 				Timeseries: []writev2.TimeSeries{
 					{
@@ -364,8 +363,8 @@ func TestTranslateV2(t *testing.T) {
 				parseJobAndInstance(rm.Resource().Attributes(), "service-z/xyz", "inst-42")
 				sm := rm.ScopeMetrics().AppendEmpty()
 				// Expect fallback to default BuildInfo.
-				sm.Scope().SetName(defaultBuildName)
-				sm.Scope().SetVersion(defaultBuildVersion)
+				sm.Scope().SetName("")
+				sm.Scope().SetVersion("")
 				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
 				dp := m.DataPoints().AppendEmpty()
 				dp.Attributes().PutStr("d", "e")

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -27,11 +27,6 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusremotewritereceiver/internal/metadata"
 )
 
-const (
-	defaultBuildName    = "defaultBuildName"
-	defaultBuildVersion = "defaultBuildVersion"
-)
-
 var writeV2RequestFixture = &writev2.Request{
 	Symbols: []string{"", "__name__", "test_metric1", "job", "service-x/test", "instance", "107cn001", "d", "e", "foo", "bar", "f", "g", "h", "i", "Test gauge for test purposes", "Maybe op/sec who knows (:", "Test counter for test purposes"},
 	Timeseries: []writev2.TimeSeries{
@@ -129,20 +124,19 @@ func TestHandlePRWContentTypeNegotiation(t *testing.T) {
 
 func TestTranslateV2(t *testing.T) {
 	prwReceiver := setupMetricsReceiver(t)
-	defaultBuildName := prwReceiver.settings.BuildInfo.Description
-	defaultBuildVersion := prwReceiver.settings.BuildInfo.Version
-
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 
+	// We'll grab the receiver's current build info for checking fallback.
+	otelCollectorBuildName := prwReceiver.settings.BuildInfo.Description
+	otelCollectorBuildVersion := prwReceiver.settings.BuildInfo.Version
+
 	for _, tc := range []struct {
-		name                 string
-		request              *writev2.Request
-		expectError          string
-		expectedMetrics      pmetric.Metrics
-		expectedStats        remote.WriteResponseStats
-		buildNameOverride    string
-		buildVersionOverride string
+		name            string
+		request         *writev2.Request
+		expectError     string
+		expectedMetrics pmetric.Metrics
+		expectedStats   remote.WriteResponseStats
 	}{
 		{
 			name: "duplicated scope name and version",
@@ -177,16 +171,12 @@ func TestTranslateV2(t *testing.T) {
 					},
 				},
 			},
-			// Expected:
-			// - The first two timeseries have explicit otel_scope values "scope1"/"v1" and yield gauge datapoints with {"d":"e"}.
-			// - The third timeseries uses "scope2"/"v2" and yields a gauge datapoint with {"foo":"bar"}.
 			expectedMetrics: func() pmetric.Metrics {
 				expected := pmetric.NewMetrics()
 				rm1 := expected.ResourceMetrics().AppendEmpty()
-				rmAttributes1 := rm1.Resource().Attributes()
-				rmAttributes1.PutStr("service.namespace", "service-x")
-				rmAttributes1.PutStr("service.name", "test")
-				rmAttributes1.PutStr("service.instance.id", "107cn001")
+				rm1.Resource().Attributes().PutStr("service.namespace", "service-x")
+				rm1.Resource().Attributes().PutStr("service.name", "test")
+				rm1.Resource().Attributes().PutStr("service.instance.id", "107cn001")
 
 				sm1 := rm1.ScopeMetrics().AppendEmpty()
 				sm1.Scope().SetName("scope1")
@@ -244,59 +234,85 @@ func TestTranslateV2(t *testing.T) {
 		{
 			name:    "valid request",
 			request: writeV2RequestFixture,
-			//	This fixture has 3 timeseries:
-			//  #0 job="service-x/test", instance="107cn001", value=1, ts=1 ms
-			//  #1 same job/instance, value=2, ts=2 ms
-			//  #2 job="foo", instance="bar", value=2, ts=2 ms
 			expectedMetrics: func() pmetric.Metrics {
 				expected := pmetric.NewMetrics()
-
-				// =========================
-				// Resource 1: job="service-x/test", instance="107cn001"
-				// =========================
 				rm1 := expected.ResourceMetrics().AppendEmpty()
 				rm1.Resource().Attributes().PutStr("service.namespace", "service-x")
 				rm1.Resource().Attributes().PutStr("service.name", "test")
 				rm1.Resource().Attributes().PutStr("service.instance.id", "107cn001")
 
 				sm1 := rm1.ScopeMetrics().AppendEmpty()
-				sm1.Scope().SetName(buildName)
-				sm1.Scope().SetVersion(buildVersion)
+				sm1.Scope().SetName(otelCollectorBuildName) // fallback is the receiver's build info if no explicit scope
+				sm1.Scope().SetVersion(otelCollectorBuildVersion)
 
-				// Timeseries 0: value=1, ts=1ms
-				gauge0 := sm1.Metrics().AppendEmpty().SetEmptyGauge()
-				dp0 := gauge0.DataPoints().AppendEmpty()
-				dp0.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
-				dp0.SetDoubleValue(1.0)
-				dp0.Attributes().PutStr("d", "e")
-				dp0.Attributes().PutStr("foo", "bar")
-
-				// Timeseries 1: value=2, ts=2ms
-				gauge1 := sm1.Metrics().AppendEmpty().SetEmptyGauge()
-				dp1 := gauge1.DataPoints().AppendEmpty()
-				dp1.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
-				dp1.SetDoubleValue(2.0)
+				dp1 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp1.SetDoubleValue(1.0)
 				dp1.Attributes().PutStr("d", "e")
 				dp1.Attributes().PutStr("foo", "bar")
 
-				// =========================
-				// Resource 2: job="foo", instance="bar"
-				// =========================
+				dp2 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp2.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
+				dp2.SetDoubleValue(2.0)
+				dp2.Attributes().PutStr("d", "e")
+				dp2.Attributes().PutStr("foo", "bar")
+
 				rm2 := expected.ResourceMetrics().AppendEmpty()
 				rm2.Resource().Attributes().PutStr("service.name", "foo")
 				rm2.Resource().Attributes().PutStr("service.instance.id", "bar")
 
 				sm2 := rm2.ScopeMetrics().AppendEmpty()
-				sm2.Scope().SetName(buildName)
-				sm2.Scope().SetVersion(buildVersion)
+				sm2.Scope().SetName(otelCollectorBuildName)
+				sm2.Scope().SetVersion(otelCollectorBuildVersion)
 
-				// Timeseries 2: value=2, ts=2ms
-				gauge2 := sm2.Metrics().AppendEmpty().SetEmptyGauge()
-				dp2 := gauge2.DataPoints().AppendEmpty()
-				dp2.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
-				dp2.SetDoubleValue(2.0)
-				dp2.Attributes().PutStr("d", "e")
-				dp2.Attributes().PutStr("foo", "bar")
+				dp3 := sm2.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp3.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
+				dp3.SetDoubleValue(2.0)
+				dp3.Attributes().PutStr("d", "e")
+				dp3.Attributes().PutStr("foo", "bar")
+
+				return expected
+			}(),
+			expectedStats: remote.WriteResponseStats{},
+		},
+		// If otel_scope_name/version are missing, we fall back to prwReceiver.settings.BuildInfo
+		{
+			name: "missing otel_scope_name/version falls back to BuildInfo",
+			request: &writev2.Request{
+				Symbols: []string{
+					"",
+					"__name__", "metric_no_scope",
+					"job", "service-z/xyz",
+					"instance", "inst-42",
+					"d", "e",
+					"foo", "bar",
+				},
+				Timeseries: []writev2.TimeSeries{
+					{
+						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+						Samples:    []writev2.Sample{{Value: 5, Timestamp: 50}},
+					},
+				},
+			},
+			expectedMetrics: func() pmetric.Metrics {
+				expected := pmetric.NewMetrics()
+
+				rm := expected.ResourceMetrics().AppendEmpty()
+				rm.Resource().Attributes().PutStr("service.namespace", "service-z")
+				rm.Resource().Attributes().PutStr("service.name", "xyz")
+				rm.Resource().Attributes().PutStr("service.instance.id", "inst-42")
+
+				sm := rm.ScopeMetrics().AppendEmpty()
+				sm.Scope().SetName(otelCollectorBuildName) // Fallback to build info
+				sm.Scope().SetVersion(otelCollectorBuildVersion)
+
+				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
+				dp := m.DataPoints().AppendEmpty()
+				dp.Attributes().PutStr("d", "e")
+				dp.Attributes().PutStr("foo", "bar")
+				dp.SetTimestamp(pcommon.Timestamp(50 * int64(time.Millisecond)))
+				dp.SetDoubleValue(5.0)
 
 				return expected
 			}(),
@@ -322,98 +338,27 @@ func TestTranslateV2(t *testing.T) {
 			},
 			expectedMetrics: func() pmetric.Metrics {
 				expected := pmetric.NewMetrics()
+
 				rm := expected.ResourceMetrics().AppendEmpty()
-				parseJobAndInstance(rm.Resource().Attributes(), "service-y/custom", "instance-1")
+				rm.Resource().Attributes().PutStr("service.namespace", "service-y")
+				rm.Resource().Attributes().PutStr("service.name", "custom")
+				rm.Resource().Attributes().PutStr("service.instance.id", "instance-1")
+
 				sm := rm.ScopeMetrics().AppendEmpty()
 				sm.Scope().SetName("custom_scope")
 				sm.Scope().SetVersion("v1.0")
-				_ = sm.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
-				return expected
-			}(),
-			expectedStats: remote.WriteResponseStats{},
-		},
-		{
-			name: "missing otel_scope_name/version falls back to BuildInfo",
-			// When missing, ls.Get returns "" so the defaults from BuildInfo are preserved.
-			request: &writev2.Request{
-				Symbols: []string{
-					"",
-					"__name__",
-					"metric_no_scope",
-					"job",
-					"service-z/xyz",
-					"instance",
-					"inst-42",
-					"d",
-					"e",
-					"foo",
-					"bar",
-				},
-				Timeseries: []writev2.TimeSeries{
-					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
-						Samples:    []writev2.Sample{{Value: 5, Timestamp: 50}},
-					},
-				},
-			},
-			expectedMetrics: func() pmetric.Metrics {
-				expected := pmetric.NewMetrics()
-				rm := expected.ResourceMetrics().AppendEmpty()
-				parseJobAndInstance(rm.Resource().Attributes(), "service-z/xyz", "inst-42")
-				sm := rm.ScopeMetrics().AppendEmpty()
-				// Expect fallback to default BuildInfo.
-				sm.Scope().SetName(defaultBuildName)
-				sm.Scope().SetVersion(defaultBuildVersion)
+
 				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
 				dp := m.DataPoints().AppendEmpty()
-				dp.Attributes().PutStr("d", "e")
-				dp.Attributes().PutStr("foo", "bar")
-				return expected
-			}(),
-			expectedStats: remote.WriteResponseStats{},
-		},
-		{
-			name: "custom BuildInfo used when no scope provided",
-			// Even if BuildInfo is overridden, if no otel_scope is provided, the overridden defaults are used.
-			buildNameOverride:    "customBuildName",
-			buildVersionOverride: "customBuildVersion",
-			request: &writev2.Request{
-				Symbols: []string{
-					"", "__name__", "metric_custom",
-					"job", "service-custom/svc",
-					"instance", "inst-custom",
-					"a", "b",
-				},
-				Timeseries: []writev2.TimeSeries{
-					{
-						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8},
-						Samples:    []writev2.Sample{{Value: 42, Timestamp: 100}},
-					},
-				},
-			},
-			expectedMetrics: func() pmetric.Metrics {
-				expected := pmetric.NewMetrics()
-				rm := expected.ResourceMetrics().AppendEmpty()
-				parseJobAndInstance(rm.Resource().Attributes(), "service-custom/svc", "inst-custom")
-				sm := rm.ScopeMetrics().AppendEmpty()
-				// Expect the overridden BuildInfo values.
-				sm.Scope().SetName("customBuildName")
-				sm.Scope().SetVersion("customBuildVersion")
-				m := sm.Metrics().AppendEmpty().SetEmptyGauge()
-				dp := m.DataPoints().AppendEmpty()
-				dp.Attributes().PutStr("a", "b")
+				dp.SetTimestamp(pcommon.Timestamp(100 * int64(time.Millisecond)))
+				dp.SetDoubleValue(10.0)
+
 				return expected
 			}(),
 			expectedStats: remote.WriteResponseStats{},
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.buildNameOverride != "" || tc.buildVersionOverride != "" {
-				prwReceiver.settings.BuildInfo.Description = tc.buildNameOverride
-				prwReceiver.settings.BuildInfo.Version = tc.buildVersionOverride
-			}
 			metrics, stats, err := prwReceiver.translateV2(ctx, tc.request)
 			if tc.expectError != "" {
 				assert.ErrorContains(t, err, tc.expectError)


### PR DESCRIPTION
This PR ensures that when Prometheus samples lack the otel_scope_name or otel_scope_version labels, the receiver fills in default values. If otel_scope_name is missing, it defaults to `opentelemetry-collector`. If otel_scope_version is missing, it uses the collector’s build version. This change makes sure every metric has a complete instrumentation scope as required.

more here: [Metrics which do not have an otel_scope_name or otel_scope_version label MUST be assigned an instrumentation scope identifying the entity performing the translation from Prometheus to OpenTelemetry](https://opentelemetry.io/docs/specs/otel/compatibility/prometheus_and_openmetrics/#instrumentation-scope)