### PR TITLE
[pkg/ottl] Add context inferrer debug logs

### DIFF
--- a/pkg/ottl/context_inferrer_test.go
+++ b/pkg/ottl/context_inferrer_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/component/componenttest"
 )
 
 var defaultDummyPriorityContextInferrerCandidate = &priorityContextInferrerCandidate{
@@ -141,6 +142,7 @@ func Test_NewPriorityContextInferrer_Infer(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			inferrer := newPriorityContextInferrer(
+				componenttest.NewNopTelemetrySettings(),
 				tt.candidates,
 				withContextInferrerPriorities(tt.priority),
 			)
@@ -152,7 +154,7 @@ func Test_NewPriorityContextInferrer_Infer(t *testing.T) {
 }
 
 func Test_NewPriorityContextInferrer_InvalidStatement(t *testing.T) {
-	inferrer := newPriorityContextInferrer(map[string]*priorityContextInferrerCandidate{})
+	inferrer := newPriorityContextInferrer(componenttest.NewNopTelemetrySettings(), map[string]*priorityContextInferrerCandidate{})
 	statements := []string{"set(foo.field,"}
 	_, err := inferrer.infer(statements)
 	require.ErrorContains(t, err, "unexpected token")
@@ -170,7 +172,7 @@ func Test_DefaultPriorityContextInferrer(t *testing.T) {
 		"instrumentation_scope",
 	}
 
-	inferrer := newPriorityContextInferrer(map[string]*priorityContextInferrerCandidate{}).(*priorityContextInferrer)
+	inferrer := newPriorityContextInferrer(componenttest.NewNopTelemetrySettings(), map[string]*priorityContextInferrerCandidate{}).(*priorityContextInferrer)
 	require.NotNil(t, inferrer)
 
 	for pri, ctx := range expectedPriority {

--- a/pkg/ottl/parser_collection.go
+++ b/pkg/ottl/parser_collection.go
@@ -156,7 +156,7 @@ func NewParserCollection[R any](
 	pc := &ParserCollection[R]{
 		Settings:                  settings,
 		contextParsers:            map[string]*parserCollectionParser{},
-		contextInferrer:           newPriorityContextInferrer(contextInferrerCandidates),
+		contextInferrer:           newPriorityContextInferrer(settings, contextInferrerCandidates),
 		contextInferrerCandidates: contextInferrerCandidates,
 		candidatesLowerContexts:   map[string][]string{},
 	}
@@ -282,7 +282,7 @@ func (pc *ParserCollection[R]) ParseStatements(statements StatementsGetter) (R, 
 	}
 
 	if inferredContext == "" {
-		return *new(R), fmt.Errorf("unable to infer context from statements %+q, path's first segment must be a valid context name: %+q", statementsValues, pc.supportedContextNames())
+		return *new(R), fmt.Errorf("unable to infer context from statements, path's first segment must be a valid context name: %+q, and at least one context must be capable of parsing all statements: %+q", pc.supportedContextNames(), statementsValues)
 	}
 
 	_, ok := pc.contextParsers[inferredContext]


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Added debug logs for the [context inferrer utility](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/35721), it will be useful for troubleshooting possibly issues after officially releasing the new `transformprocessor` configuration syntaxes.


Example successfully inferred:

```
2025-02-10T11:58:42.735+0100	DEBUG	Inferring context from statements	{"candidates": ["resource", "scope", "metric", "datapoint"], "priority": {"datapoint":1,"instrumentation_scope":7,"log":0,"metric":2,"resource":5,"scope":6,"span":4,"spanevent":3}, "statements": ["replace_pattern(metric.name, \"my.(.+)\", \"metrics.$1\")"]}
2025-02-10T11:58:42.736+0100	DEBUG	Validating selected context candidate: "metric"
2025-02-10T11:58:42.736+0100	DEBUG	Inferred context: "metric"
```

Example unable to infer:

```
2025-02-10T12:05:00.863+0100	DEBUG	Inferring context from statements	{"candidates": ["metric", "datapoint", "resource", "scope"], "priority": {"datapoint":1,"instrumentation_scope":7,"log":0,"metric":2,"resource":5,"scope":6,"span":4,"spanevent":3}, "statements": ["convert_sum_to_gauge() where metric.name == \"system.processes.count\"", "limit(datapoint.attributes, 100, [\"host.name\"])"]}
2025-02-10T12:05:00.867+0100	DEBUG	Validating selected context candidate: "datapoint"
2025-02-10T12:05:00.867+0100	DEBUG	Context "datapoint" does not meet the function requirement: "convert_sum_to_gauge"
2025-02-10T12:05:00.867+0100	DEBUG	Trying to infer context using "datapoint" lower contexts
2025-02-10T12:05:00.867+0100	DEBUG	Unable to infer context from statements
```

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29017

<!--Please delete paragraphs that you did not use before submitting.-->
