### PR TITLE
[chore] Schedule automatic update-otel PRs

### DIFF
--- a/.github/workflows/update-otel.yaml
+++ b/.github/workflows/update-otel.yaml
@@ -1,9 +1,8 @@
 name: 'Update contrib to the latest core source'
 on:
   workflow_dispatch:
-  # TODO: Enable schedule once it's verified that the action works as expected.
-  #  schedule:
-  #    - cron: "27 21 * * *" # Run at an arbitrary time on weekdays.
+  schedule:
+    - cron: "27 8 * * 1" # Run at 08:27 UTC on Mondays.
 
 jobs:
   update-otel:


### PR DESCRIPTION
#### Description
This PR schedules the `update-otel` CI action to run every Monday at 08:27 UTC (00:27 PST / 01:27 MST / 03:27 EST / 09:27 CET / adjust for DST). The day and time was chosen to let release managers work on that PR on release days. (The :27 is arbitrary, though we want to avoid the start of the hour [for load reasons](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule).)

#### Link to tracking issue
Resolves #37679

#### Testing
Only time will tell.

#### Documentation
Maybe this should be documented in the release document over on the core repo?