### PR TITLE
[webhookeventreceiver] add option to include headers as attributes

### DIFF
--- a/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
+++ b/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
@@ -1,0 +1,30 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/webhookeventreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add option to include headers as log attributes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Adds new `convert_headers_to_attributes` option. If set, all headers, with the exception of the
+  required header (if also enabled) will be added as log attributes. Header names are normalized
+  to snake_case and then prefixed with the namespace `header`.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
+++ b/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
@@ -10,7 +10,7 @@ component: receiver/webhookeventreceiver
 note: Add option to include headers as log attributes
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
-issues: []
+issues: [37815]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
+++ b/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
@@ -17,7 +17,7 @@ issues: [37815]
 # Use pipe (|) for multiline entries.
 subtext: |
   Adds new `header_attribute_regex` option. If set, add headers matching supplied regex as log attributes.
-  Header attributes will be prefixed with `header.` and header keys will be normalized to snake_case
+  Header attributes will be prefixed with `header.`
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
+++ b/.chloggen/webhookeventreceiver-add-option-to-include-headers-as-attributes.yaml
@@ -16,9 +16,8 @@ issues: [37815]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: |
-  Adds new `convert_headers_to_attributes` option. If set, all headers, with the exception of the
-  required header (if also enabled) will be added as log attributes. Header names are normalized
-  to snake_case and then prefixed with the namespace `header`.
+  Adds new `header_attribute_regex` option. If set, add headers matching supplied regex as log attributes.
+  Header attributes will be prefixed with `header.` and header keys will be normalized to snake_case
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -32,6 +32,7 @@ The following settings are optional:
     * `key` (required if `required_header` config option is set): Represents the key portion of the required header.
     * `value` (required if `required_header` config option is set): Represents the value portion of the required header.
 * `split_logs_at_newline` (default: false): If true, the receiver will create a separate log record for each line in the request body.
+* `convert_headers_to_attributes` (optional): add all request headers (excluding `required_header` if also set) log attributes
 
 ### Split logs at newline example
 

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -33,6 +33,7 @@ The following settings are optional:
     * `value` (required if `required_header` config option is set): Represents the value portion of the required header.
 * `split_logs_at_newline` (default: false): If true, the receiver will create a separate log record for each line in the request body.
 * `convert_headers_to_attributes` (optional): add all request headers (excluding `required_header` if also set) log attributes
+* `header_attribute_regex` (optional): add headers matching supplied regex as log attributes. Header attributes will be prefixed with `header.` and header keys will be normalized to snake_case
 
 ### Split logs at newline example
 

--- a/receiver/webhookeventreceiver/README.md
+++ b/receiver/webhookeventreceiver/README.md
@@ -33,7 +33,7 @@ The following settings are optional:
     * `value` (required if `required_header` config option is set): Represents the value portion of the required header.
 * `split_logs_at_newline` (default: false): If true, the receiver will create a separate log record for each line in the request body.
 * `convert_headers_to_attributes` (optional): add all request headers (excluding `required_header` if also set) log attributes
-* `header_attribute_regex` (optional): add headers matching supplied regex as log attributes. Header attributes will be prefixed with `header.` and header keys will be normalized to snake_case
+* `header_attribute_regex` (optional): add headers matching supplied regex as log attributes. Header attributes will be prefixed with `header.`
 
 ### Split logs at newline example
 

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -5,6 +5,7 @@ package webhookeventreceiver // import "github.com/open-telemetry/opentelemetry-
 
 import (
 	"errors"
+	"regexp"
 	"time"
 
 	"go.opentelemetry.io/collector/config/confighttp"
@@ -16,6 +17,7 @@ var (
 	errReadTimeoutExceedsMaxValue  = errors.New("the duration specified for read_timeout exceeds the maximum allowed value of 10s")
 	errWriteTimeoutExceedsMaxValue = errors.New("the duration specified for write_timeout exceeds the maximum allowed value of 10s")
 	errRequiredHeader              = errors.New("both key and value are required to assign a required_header")
+	errHeaderAttributeRegexCompile = errors.New("regex for header_attribute_regex failed to compile")
 )
 
 // Config defines configuration for the Generic Webhook receiver.
@@ -28,6 +30,7 @@ type Config struct {
 	RequiredHeader             RequiredHeader           `mapstructure:"required_header"`               // optional setting to set a required header for all requests to have
 	SplitLogsAtNewLine         bool                     `mapstructure:"split_logs_at_newline"`         // optional setting to split logs into multiple log records
 	ConvertHeadersToAttributes bool                     `mapstructure:"convert_headers_to_attributes"` // optional to convert all headers to attributes
+	HeaderAttributeRegex       string                   `mapstructure:"header_attribute_regex"`        // optional to convert headers matching a regex to log attributes
 }
 
 type RequiredHeader struct {
@@ -70,6 +73,14 @@ func (cfg *Config) Validate() error {
 
 	if (cfg.RequiredHeader.Key != "" && cfg.RequiredHeader.Value == "") || (cfg.RequiredHeader.Value != "" && cfg.RequiredHeader.Key == "") {
 		errs = multierr.Append(errs, errRequiredHeader)
+	}
+
+	if cfg.HeaderAttributeRegex != "" {
+		_, err := regexp.Compile(cfg.HeaderAttributeRegex)
+		if err != nil {
+			errs = multierr.Append(errs, errHeaderAttributeRegexCompile)
+			errs = multierr.Append(errs, err)
+		}
 	}
 
 	return errs

--- a/receiver/webhookeventreceiver/config.go
+++ b/receiver/webhookeventreceiver/config.go
@@ -20,13 +20,14 @@ var (
 
 // Config defines configuration for the Generic Webhook receiver.
 type Config struct {
-	confighttp.ServerConfig `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
-	ReadTimeout             string                   `mapstructure:"read_timeout"`          // wait time for reading request headers in ms. Default is 500ms.
-	WriteTimeout            string                   `mapstructure:"write_timeout"`         // wait time for writing request response in ms. Default is 500ms.
-	Path                    string                   `mapstructure:"path"`                  // path for data collection. Default is /events
-	HealthPath              string                   `mapstructure:"health_path"`           // path for health check api. Default is /health_check
-	RequiredHeader          RequiredHeader           `mapstructure:"required_header"`       // optional setting to set a required header for all requests to have
-	SplitLogsAtNewLine      bool                     `mapstructure:"split_logs_at_newline"` // optional setting to split logs into multiple log records
+	confighttp.ServerConfig    `mapstructure:",squash"` // squash ensures fields are correctly decoded in embedded struct
+	ReadTimeout                string                   `mapstructure:"read_timeout"`                  // wait time for reading request headers in ms. Default is 500ms.
+	WriteTimeout               string                   `mapstructure:"write_timeout"`                 // wait time for writing request response in ms. Default is 500ms.
+	Path                       string                   `mapstructure:"path"`                          // path for data collection. Default is /events
+	HealthPath                 string                   `mapstructure:"health_path"`                   // path for health check api. Default is /health_check
+	RequiredHeader             RequiredHeader           `mapstructure:"required_header"`               // optional setting to set a required header for all requests to have
+	SplitLogsAtNewLine         bool                     `mapstructure:"split_logs_at_newline"`         // optional setting to split logs into multiple log records
+	ConvertHeadersToAttributes bool                     `mapstructure:"convert_headers_to_attributes"` // optional to convert all headers to attributes
 }
 
 type RequiredHeader struct {

--- a/receiver/webhookeventreceiver/factory.go
+++ b/receiver/webhookeventreceiver/factory.go
@@ -38,11 +38,12 @@ func NewFactory() receiver.Factory {
 // Default configuration for the generic webhook receiver
 func createDefaultConfig() component.Config {
 	return &Config{
-		Path:               defaultPath,
-		HealthPath:         defaultHealthPath,
-		ReadTimeout:        defaultReadTimeout,
-		WriteTimeout:       defaultWriteTimeout,
-		SplitLogsAtNewLine: false,
+		Path:                       defaultPath,
+		HealthPath:                 defaultHealthPath,
+		ReadTimeout:                defaultReadTimeout,
+		WriteTimeout:               defaultWriteTimeout,
+		ConvertHeadersToAttributes: false, // optional, off by default
+		SplitLogsAtNewLine:         false,
 	}
 }
 

--- a/receiver/webhookeventreceiver/receiver.go
+++ b/receiver/webhookeventreceiver/receiver.go
@@ -191,7 +191,7 @@ func (er *eventReceiver) handleReq(w http.ResponseWriter, r *http.Request, _ htt
 
 	// send body into a scanner and then convert the request body into a log
 	sc := bufio.NewScanner(bodyReader)
-	ld, numLogs := reqToLog(sc, r.URL.Query(), er.cfg, er.settings)
+	ld, numLogs := reqToLog(sc, r.Header, r.URL.Query(), er.cfg, er.settings)
 	consumerErr := er.logConsumer.ConsumeLogs(ctx, ld)
 
 	_ = bodyReader.Close()

--- a/receiver/webhookeventreceiver/receiver.go
+++ b/receiver/webhookeventreceiver/receiver.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"regexp"
 	"sync"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 
 var (
 	errNilLogsConsumer       = errors.New("missing a logs consumer")
-	errMissingEndpoint       = errors.New("missing a receiver endpoint")
 	errInvalidRequestMethod  = errors.New("invalid method. Valid method is POST")
 	errInvalidEncodingType   = errors.New("invalid encoding type")
 	errEmptyResponseBody     = errors.New("request body content length is zero")
@@ -37,13 +37,14 @@ var (
 const healthyResponse = `{"text": "Webhookevent receiver is healthy"}`
 
 type eventReceiver struct {
-	settings    receiver.Settings
-	cfg         *Config
-	logConsumer consumer.Logs
-	server      *http.Server
-	shutdownWG  sync.WaitGroup
-	obsrecv     *receiverhelper.ObsReport
-	gzipPool    *sync.Pool
+	settings            receiver.Settings
+	cfg                 *Config
+	logConsumer         consumer.Logs
+	server              *http.Server
+	shutdownWG          sync.WaitGroup
+	obsrecv             *receiverhelper.ObsReport
+	gzipPool            *sync.Pool
+	includeHeadersRegex *regexp.Regexp
 }
 
 func newLogsReceiver(params receiver.Settings, cfg Config, consumer consumer.Logs) (receiver.Logs, error) {
@@ -51,8 +52,13 @@ func newLogsReceiver(params receiver.Settings, cfg Config, consumer consumer.Log
 		return nil, errNilLogsConsumer
 	}
 
-	if cfg.Endpoint == "" {
-		return nil, errMissingEndpoint
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	var includeHeaderRegex *regexp.Regexp
+	if cfg.HeaderAttributeRegex != "" {
+		// Valdiate() call above has already ensured this will compile
+		includeHeaderRegex, _ = regexp.Compile(cfg.HeaderAttributeRegex)
 	}
 
 	transport := "http"
@@ -71,11 +77,12 @@ func newLogsReceiver(params receiver.Settings, cfg Config, consumer consumer.Log
 
 	// create eventReceiver instance
 	er := &eventReceiver{
-		settings:    params,
-		cfg:         &cfg,
-		logConsumer: consumer,
-		obsrecv:     obsrecv,
-		gzipPool:    &sync.Pool{New: func() any { return new(gzip.Reader) }},
+		settings:            params,
+		cfg:                 &cfg,
+		logConsumer:         consumer,
+		obsrecv:             obsrecv,
+		gzipPool:            &sync.Pool{New: func() any { return new(gzip.Reader) }},
+		includeHeadersRegex: includeHeaderRegex,
 	}
 
 	return er, nil
@@ -191,7 +198,7 @@ func (er *eventReceiver) handleReq(w http.ResponseWriter, r *http.Request, _ htt
 
 	// send body into a scanner and then convert the request body into a log
 	sc := bufio.NewScanner(bodyReader)
-	ld, numLogs := reqToLog(sc, r.Header, r.URL.Query(), er.cfg, er.settings)
+	ld, numLogs := er.reqToLog(sc, r.Header, r.URL.Query())
 	consumerErr := er.logConsumer.ConsumeLogs(ctx, ld)
 
 	_ = bodyReader.Close()

--- a/receiver/webhookeventreceiver/receiver_test.go
+++ b/receiver/webhookeventreceiver/receiver_test.go
@@ -38,7 +38,7 @@ func TestCreateNewLogReceiver(t *testing.T) {
 			desc:     "Default config fails (no endpoint)",
 			cfg:      *defaultConfig,
 			consumer: consumertest.NewNop(),
-			err:      errMissingEndpoint,
+			err:      errMissingEndpointFromConfig,
 		},
 		{
 			desc: "User defined config success",
@@ -46,8 +46,8 @@ func TestCreateNewLogReceiver(t *testing.T) {
 				ServerConfig: confighttp.ServerConfig{
 					Endpoint: "localhost:8080",
 				},
-				ReadTimeout:  "543",
-				WriteTimeout: "210",
+				ReadTimeout:  "5s",
+				WriteTimeout: "5s",
 				Path:         "/event",
 				HealthPath:   "/health",
 				RequiredHeader: RequiredHeader{
@@ -56,6 +56,79 @@ func TestCreateNewLogReceiver(t *testing.T) {
 				},
 			},
 			consumer: consumertest.NewNop(),
+		},
+		{
+			desc: "User defined config success with header_attribute_regex supplied",
+			cfg: Config{
+				ServerConfig: confighttp.ServerConfig{
+					Endpoint: "localhost:8080",
+				},
+				ReadTimeout:  "5s",
+				WriteTimeout: "5s",
+				Path:         "/event",
+				HealthPath:   "/health",
+				RequiredHeader: RequiredHeader{
+					Key:   "key-present",
+					Value: "value-present",
+				},
+				HeaderAttributeRegex: ".+",
+			},
+			consumer: consumertest.NewNop(),
+		},
+		{
+			desc: "User defined read timeout exceeds max value",
+			cfg: Config{
+				ServerConfig: confighttp.ServerConfig{
+					Endpoint: "localhost:8080",
+				},
+				ReadTimeout:  "11s",
+				WriteTimeout: "5s",
+				Path:         "/event",
+				HealthPath:   "/health",
+				RequiredHeader: RequiredHeader{
+					Key:   "key-present",
+					Value: "value-present",
+				},
+			},
+			consumer: consumertest.NewNop(),
+			err:      errReadTimeoutExceedsMaxValue,
+		},
+		{
+			desc: "User defined write timeout exceeds max value",
+			cfg: Config{
+				ServerConfig: confighttp.ServerConfig{
+					Endpoint: "localhost:8080",
+				},
+				ReadTimeout:  "5s",
+				WriteTimeout: "11s",
+				Path:         "/event",
+				HealthPath:   "/health",
+				RequiredHeader: RequiredHeader{
+					Key:   "key-present",
+					Value: "value-present",
+				},
+			},
+			consumer: consumertest.NewNop(),
+			err:      errWriteTimeoutExceedsMaxValue,
+		},
+		{
+			desc: "User defined regex fails to compile",
+			cfg: Config{
+				ServerConfig: confighttp.ServerConfig{
+					Endpoint: "localhost:8080",
+				},
+				ReadTimeout:  "5s",
+				WriteTimeout: "5s",
+				Path:         "/event",
+				HealthPath:   "/health",
+				RequiredHeader: RequiredHeader{
+					Key:   "key-present",
+					Value: "value-present",
+				},
+				HeaderAttributeRegex: "\\q", // some bogus regex value that will not compile
+			},
+			consumer: consumertest.NewNop(),
+			err:      errHeaderAttributeRegexCompile,
 		},
 	}
 

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -79,9 +79,13 @@ func appendHeaders(config *Config, scopeLog plog.ScopeLogs, headers http.Header)
 		if k == textproto.CanonicalMIMEHeaderKey(config.RequiredHeader.Key) {
 			continue
 		}
-		// store headers with "header" namespace and normalize key to snake_case
-		normalizedHeader := strings.ReplaceAll(k, "-", "_")
-		normalizedHeader = strings.ToLower(normalizedHeader)
-		scopeLog.Scope().Attributes().PutStr("header."+normalizedHeader, strings.Join(headers.Values(k), ";"))
+		scopeLog.Scope().Attributes().PutStr(headerAttributeKey(k), strings.Join(headers.Values(k), ";"))
 	}
+}
+
+// convert given header to snake_case and add "header" as a namespace prefix
+func headerAttributeKey(header string) string {
+	snakeCaseHeader := strings.ReplaceAll(header, "-", "_")
+	snakeCaseHeader = strings.ToLower(snakeCaseHeader)
+	return "header." + snakeCaseHeader
 }

--- a/receiver/webhookeventreceiver/req_to_log.go
+++ b/receiver/webhookeventreceiver/req_to_log.go
@@ -86,11 +86,7 @@ func appendHeaders(h http.Header, l plog.LogRecord, r *regexp.Regexp) {
 	}
 }
 
-// https://opentelemetry.io/docs/specs/semconv/general/naming/
-// header attribute key contains the header namespace and the header name
-// is normalized to snake_case
+// prepend the header key with the "header." namespace
 func headerAttributeKey(header string) string {
-	snakeCaseHeader := strings.ReplaceAll(header, "-", "_")
-	snakeCaseHeader = strings.ToLower(snakeCaseHeader)
-	return strings.Join([]string{headerNamespace, snakeCaseHeader}, ".")
+	return strings.Join([]string{headerNamespace, header}, ".")
 }

--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"io"
 	"log"
+	"net/http"
+	"net/textproto"
 	"net/url"
 	"testing"
 
@@ -23,10 +25,12 @@ func TestReqToLog(t *testing.T) {
 	defaultConfig := createDefaultConfig().(*Config)
 
 	tests := []struct {
-		desc  string
-		sc    *bufio.Scanner
-		query url.Values
-		tt    func(t *testing.T, reqLog plog.Logs, reqLen int, settings receiver.Settings)
+		desc    string
+		sc      *bufio.Scanner
+		headers http.Header
+		query   url.Values
+		config  *Config
+		tt      func(t *testing.T, reqLog plog.Logs, reqLen int, settings receiver.Settings)
 	}{
 		{
 			desc: "Valid query valid event",
@@ -112,11 +116,103 @@ func TestReqToLog(t *testing.T) {
 				require.Equal(t, 2, scopeLogsScope.Attributes().Len())
 			},
 		},
+		{
+			desc: "Headers not added by default",
+			headers: http.Header{
+				textproto.CanonicalMIMEHeaderKey("X-Foo"): []string{"1"},
+				textproto.CanonicalMIMEHeaderKey("X-Bar"): []string{"2"},
+			},
+			sc: func() *bufio.Scanner {
+				reader := io.NopCloser(bytes.NewReader([]byte("this is a: log")))
+				return bufio.NewScanner(reader)
+			}(),
+			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, _ receiver.Settings) {
+				require.Equal(t, 1, reqLen)
+
+				attributes := reqLog.ResourceLogs().At(0).Resource().Attributes()
+				require.Equal(t, 0, attributes.Len())
+
+				scopeLogsScope := reqLog.ResourceLogs().At(0).ScopeLogs().At(0).Scope()
+				require.Equal(t, 2, scopeLogsScope.Attributes().Len()) // expect no additional attributes even though headers are set
+			},
+		},
+		{
+			desc: "Headers added if ConvertHeadersToAttributes enabled",
+			headers: http.Header{
+				textproto.CanonicalMIMEHeaderKey("X-Foo"): []string{"1"},
+				textproto.CanonicalMIMEHeaderKey("X-Bar"): []string{"2"},
+			},
+			config: &Config{
+				Path:                       defaultPath,
+				HealthPath:                 defaultHealthPath,
+				ReadTimeout:                defaultReadTimeout,
+				WriteTimeout:               defaultWriteTimeout,
+				ConvertHeadersToAttributes: true,
+			},
+			sc: func() *bufio.Scanner {
+				reader := io.NopCloser(bytes.NewReader([]byte("this is a: log")))
+				return bufio.NewScanner(reader)
+			}(),
+			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, _ receiver.Settings) {
+				require.Equal(t, 1, reqLen)
+
+				attributes := reqLog.ResourceLogs().At(0).Resource().Attributes()
+				require.Equal(t, 0, attributes.Len())
+
+				scopeLogsScope := reqLog.ResourceLogs().At(0).ScopeLogs().At(0).Scope()
+				require.Equal(t, 4, scopeLogsScope.Attributes().Len()) // expect no additional attributes even though headers are set
+				v, exists := scopeLogsScope.Attributes().Get("header.x_foo")
+				require.True(t, exists)
+				require.Equal(t, "1", v.AsString())
+				v, exists = scopeLogsScope.Attributes().Get("header.x_bar")
+				require.True(t, exists)
+				require.Equal(t, "2", v.AsString())
+			},
+		},
+		{
+			desc: "Required header skipped",
+			headers: http.Header{
+				textproto.CanonicalMIMEHeaderKey("X-Foo"):             []string{"1"},
+				textproto.CanonicalMIMEHeaderKey("X-Bar"):             []string{"2"},
+				textproto.CanonicalMIMEHeaderKey("X-Required-Header"): []string{"password"},
+			},
+			config: &Config{
+				Path:                       defaultPath,
+				HealthPath:                 defaultHealthPath,
+				ReadTimeout:                defaultReadTimeout,
+				WriteTimeout:               defaultWriteTimeout,
+				RequiredHeader:             RequiredHeader{Key: "X-Required-Header", Value: "password"},
+				ConvertHeadersToAttributes: true,
+			},
+			sc: func() *bufio.Scanner {
+				reader := io.NopCloser(bytes.NewReader([]byte("this is a: log")))
+				return bufio.NewScanner(reader)
+			}(),
+			tt: func(t *testing.T, reqLog plog.Logs, reqLen int, _ receiver.Settings) {
+				require.Equal(t, 1, reqLen)
+
+				attributes := reqLog.ResourceLogs().At(0).Resource().Attributes()
+				require.Equal(t, 0, attributes.Len())
+
+				scopeLogsScope := reqLog.ResourceLogs().At(0).ScopeLogs().At(0).Scope()
+				require.Equal(t, 4, scopeLogsScope.Attributes().Len()) // expect no additional attributes even though headers are set
+				_, exists := scopeLogsScope.Attributes().Get("header.x_foo")
+				require.True(t, exists)
+				_, exists = scopeLogsScope.Attributes().Get("header.x_bar")
+				require.True(t, exists)
+				_, exists = scopeLogsScope.Attributes().Get("header.x_required_header")
+				require.False(t, exists)
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			reqLog, reqLen := reqToLog(test.sc, test.query, defaultConfig, receivertest.NewNopSettings(metadata.Type))
+			testConfig := defaultConfig
+			if test.config != nil {
+				testConfig = test.config
+			}
+			reqLog, reqLen := reqToLog(test.sc, test.headers, test.query, testConfig, receivertest.NewNopSettings(metadata.Type))
 			test.tt(t, reqLog, reqLen, receivertest.NewNopSettings(metadata.Type))
 		})
 	}

--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -14,12 +14,13 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver/internal/metadata"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/plog"
 	"go.opentelemetry.io/collector/receiver"
 	"go.opentelemetry.io/collector/receiver/receivertest"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/webhookeventreceiver/internal/metadata"
 )
 
 func TestReqToLog(t *testing.T) {
@@ -264,9 +265,12 @@ func TestReqToLog(t *testing.T) {
 			// receiver will fail to create if endpoint is empty
 			testConfig.ServerConfig.Endpoint = "localhost:8080"
 			receiver, err := newLogsReceiver(receivertest.NewNopSettings(metadata.Type), *testConfig, consumertest.NewNop())
-			require.Nil(t, err)
+			require.NoError(t, err)
 			eventReceiver := receiver.(*eventReceiver)
-			defer eventReceiver.Shutdown(context.Background())
+			defer func() {
+				err := eventReceiver.Shutdown(context.Background())
+				require.NoError(t, err)
+			}()
 
 			reqLog, reqLen := eventReceiver.reqToLog(test.sc, test.headers, test.query)
 			test.tt(t, reqLog, reqLen, receivertest.NewNopSettings(metadata.Type))

--- a/receiver/webhookeventreceiver/req_to_log_test.go
+++ b/receiver/webhookeventreceiver/req_to_log_test.go
@@ -201,10 +201,10 @@ func TestReqToLog(t *testing.T) {
 				processLogRecords(reqLog, func(lr plog.LogRecord) {
 					// expect no additional attributes even though headers are set
 					require.Equal(t, 2, lr.Attributes().Len())
-					v, exists := lr.Attributes().Get("header.x_foo")
+					v, exists := lr.Attributes().Get("header.X-Foo")
 					require.True(t, exists)
 					require.Equal(t, "1", v.Slice().At(0).AsString())
-					v, exists = lr.Attributes().Get("header.x_bar")
+					v, exists = lr.Attributes().Get("header.X-Bar")
 					require.True(t, exists)
 					require.Equal(t, "2", v.Slice().At(0).AsString())
 					require.Equal(t, "3", v.Slice().At(1).AsString())
@@ -242,10 +242,10 @@ func TestReqToLog(t *testing.T) {
 				processLogRecords(reqLog, func(lr plog.LogRecord) {
 					// X-Fizz and X-Buzz are missing because the regex is specific
 					require.Equal(t, 2, lr.Attributes().Len())
-					v, exists := lr.Attributes().Get("header.x_foo")
+					v, exists := lr.Attributes().Get("header.X-Foo")
 					require.True(t, exists)
 					require.Equal(t, "1", v.Slice().At(0).AsString())
-					v, exists = lr.Attributes().Get("header.x_bar")
+					v, exists = lr.Attributes().Get("header.X-Bar")
 					require.True(t, exists)
 					require.Equal(t, "2", v.Slice().At(0).AsString())
 					require.Equal(t, "3", v.Slice().At(1).AsString())
@@ -278,8 +278,8 @@ func TestHeaderAttributeKey(t *testing.T) {
 	// Test mix of header values to ensure consistent output
 	require.Equal(t, "header.foo", headerAttributeKey("foo"))
 	require.Equal(t, "header.1", headerAttributeKey("1"))
-	require.Equal(t, "header.content_type", headerAttributeKey("Content-type"))
-	require.Equal(t, "header.unexpected_camel_case_header", headerAttributeKey("UnExPectEd-CaMeL-CaSe-HeAdEr"))
+	require.Equal(t, "header.Content-type", headerAttributeKey("Content-type"))
+	require.Equal(t, "header.UnExPectEd-CaMeL-CaSe-HeAdEr", headerAttributeKey("UnExPectEd-CaMeL-CaSe-HeAdEr"))
 }
 
 // helper to run a func against each log record


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Hi! I'm looking to add a feature to the webhookeventreceiver to allow HTTP request headers to be passed through as log attributes. Our initial use case for this is for receiving [webhook events from Github/Github Enterprise](https://docs.github.com/en/enterprise-server@3.14/webhooks/webhook-events-and-payloads) - which stores important metadata in the webhook request headers that is absent from the payload.

This PR adds a new option, `convert_headers_to_attributes`, which will include any headers except the one specified in `required_header` in the payload as an attribute. 

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes

N/A - started with this PR

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Added unit tests and I'm running this successfully in our environment using a local build.

<!--Describe the documentation added.-->
#### Documentation

README

<!--Please delete paragraphs that you did not use before submitting.-->
