### PR TITLE
[chore] fix codeowners allowlist

### DIFF
--- a/cmd/githubgen/allowlist.txt
+++ b/cmd/githubgen/allowlist.txt
@@ -12,7 +12,6 @@ jcreixell
 jriguera
 KiranmayiB
 m1rp
-rlankfo
 shazlehu
 swar8080
 thmshmm


### PR DESCRIPTION
@rlankfo is now a member of the OpenTelemetry organization and doesn't need to be in the allowlist anymore. Congrats!