### PR TITLE
prometheusreceiver: deprecate start time adjustment

### DIFF
--- a/.chloggen/prometheus-deprecate-adjuster.yaml
+++ b/.chloggen/prometheus-deprecate-adjuster.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: prometheusreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate metric start time adjustment in the prometheus receiver. It is being replaced by the metricstarttime processor.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37186]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Start time adjustment is still enabled by default. To disable it, enable the |
+receiver.prometheusreceiver.RemoveStartTimeAdjuster feature gate.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/prometheus-deprecate-adjuster.yaml
+++ b/.chloggen/prometheus-deprecate-adjuster.yaml
@@ -16,7 +16,7 @@ issues: [37186]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: Start time adjustment is still enabled by default. To disable it, enable the |
-receiver.prometheusreceiver.RemoveStartTimeAdjuster feature gate.
+  receiver.prometheusreceiver.RemoveStartTimeAdjuster feature gate.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/prometheus-deprecate-adjuster.yaml
+++ b/.chloggen/prometheus-deprecate-adjuster.yaml
@@ -16,7 +16,7 @@ issues: [37186]
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
 subtext: Start time adjustment is still enabled by default. To disable it, enable the |
-  receiver.prometheusreceiver.RemoveStartTimeAdjuster feature gate.
+  receiver.prometheusreceiver.RemoveStartTimeAdjustment feature gate.
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -90,6 +90,12 @@ prometheus --config.file=prom.yaml
 "--feature-gates=receiver.prometheusreceiver.RemoveLegacyResourceAttributes"
 ```
 
+- `receiver.prometheusreceiver.RemoveStartTimeAdjuster`: If enabled, the prometheus receiver no longer sets the start timestamp of metrics if it is not known. Use the `metricstarttime` processor instead if you need this functionality.
+
+```shell
+"--feature-gates=receiver.prometheusreceiver.RemoveStartTimeAdjuster"
+```
+
 - `report_extra_scrape_metrics`: Extra Prometheus scrape metrics can be reported by setting this parameter to `true`
 
 You can copy and paste that same configuration under:

--- a/receiver/prometheusreceiver/README.md
+++ b/receiver/prometheusreceiver/README.md
@@ -90,10 +90,10 @@ prometheus --config.file=prom.yaml
 "--feature-gates=receiver.prometheusreceiver.RemoveLegacyResourceAttributes"
 ```
 
-- `receiver.prometheusreceiver.RemoveStartTimeAdjuster`: If enabled, the prometheus receiver no longer sets the start timestamp of metrics if it is not known. Use the `metricstarttime` processor instead if you need this functionality.
+- `receiver.prometheusreceiver.RemoveStartTimeAdjustment`: If enabled, the prometheus receiver no longer sets the start timestamp of metrics if it is not known. Use the `metricstarttime` processor instead if you need this functionality.
 
 ```shell
-"--feature-gates=receiver.prometheusreceiver.RemoveStartTimeAdjuster"
+"--feature-gates=receiver.prometheusreceiver.RemoveStartTimeAdjustment"
 ```
 
 - `report_extra_scrape_metrics`: Extra Prometheus scrape metrics can be reported by setting this parameter to `true`

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -145,7 +145,7 @@ func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice)
 	tsNanos := timestampFromMs(mg.ts)
 	if mg.created != 0 {
 		point.SetStartTimestamp(timestampFromFloat64(mg.created))
-	} else {
+	} else if !removeStartTimeAdjuster.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
 	}
@@ -223,7 +223,7 @@ func (mg *metricGroup) toExponentialHistogramDataPoints(dest pmetric.Exponential
 	tsNanos := timestampFromMs(mg.ts)
 	if mg.created != 0 {
 		point.SetStartTimestamp(timestampFromFloat64(mg.created))
-	} else {
+	} else if !removeStartTimeAdjuster.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
 	}
@@ -317,7 +317,7 @@ func (mg *metricGroup) toSummaryPoint(dest pmetric.SummaryDataPointSlice) {
 	point.SetTimestamp(tsNanos)
 	if mg.created != 0 {
 		point.SetStartTimestamp(timestampFromFloat64(mg.created))
-	} else {
+	} else if !removeStartTimeAdjuster.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
 	}
@@ -331,7 +331,7 @@ func (mg *metricGroup) toNumberDataPoint(dest pmetric.NumberDataPointSlice) {
 	if mg.mtype == pmetric.MetricTypeSum {
 		if mg.created != 0 {
 			point.SetStartTimestamp(timestampFromFloat64(mg.created))
-		} else {
+		} else if !removeStartTimeAdjuster.IsEnabled() {
 			// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 			point.SetStartTimestamp(tsNanos)
 		}

--- a/receiver/prometheusreceiver/internal/metricfamily.go
+++ b/receiver/prometheusreceiver/internal/metricfamily.go
@@ -145,7 +145,7 @@ func (mg *metricGroup) toDistributionPoint(dest pmetric.HistogramDataPointSlice)
 	tsNanos := timestampFromMs(mg.ts)
 	if mg.created != 0 {
 		point.SetStartTimestamp(timestampFromFloat64(mg.created))
-	} else if !removeStartTimeAdjuster.IsEnabled() {
+	} else if !removeStartTimeAdjustment.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
 	}
@@ -223,7 +223,7 @@ func (mg *metricGroup) toExponentialHistogramDataPoints(dest pmetric.Exponential
 	tsNanos := timestampFromMs(mg.ts)
 	if mg.created != 0 {
 		point.SetStartTimestamp(timestampFromFloat64(mg.created))
-	} else if !removeStartTimeAdjuster.IsEnabled() {
+	} else if !removeStartTimeAdjustment.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
 	}
@@ -317,7 +317,7 @@ func (mg *metricGroup) toSummaryPoint(dest pmetric.SummaryDataPointSlice) {
 	point.SetTimestamp(tsNanos)
 	if mg.created != 0 {
 		point.SetStartTimestamp(timestampFromFloat64(mg.created))
-	} else if !removeStartTimeAdjuster.IsEnabled() {
+	} else if !removeStartTimeAdjustment.IsEnabled() {
 		// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 		point.SetStartTimestamp(tsNanos)
 	}
@@ -331,7 +331,7 @@ func (mg *metricGroup) toNumberDataPoint(dest pmetric.NumberDataPointSlice) {
 	if mg.mtype == pmetric.MetricTypeSum {
 		if mg.created != 0 {
 			point.SetStartTimestamp(timestampFromFloat64(mg.created))
-		} else if !removeStartTimeAdjuster.IsEnabled() {
+		} else if !removeStartTimeAdjustment.IsEnabled() {
 			// metrics_adjuster adjusts the startTimestamp to the initial scrape timestamp
 			point.SetStartTimestamp(tsNanos)
 		}

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -260,6 +260,9 @@ func NewInitialPointAdjuster(logger *zap.Logger, gcInterval time.Duration, useCr
 // AdjustMetrics takes a sequence of metrics and adjust their start times based on the initial and
 // previous points in the timeseriesMap.
 func (a *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
+	if removeStartTimeAdjuster.IsEnabled() {
+		return nil
+	}
 	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {
 		rm := metrics.ResourceMetrics().At(i)
 		_, found := rm.Resource().Attributes().Get(semconv.AttributeServiceName)

--- a/receiver/prometheusreceiver/internal/metrics_adjuster.go
+++ b/receiver/prometheusreceiver/internal/metrics_adjuster.go
@@ -260,7 +260,7 @@ func NewInitialPointAdjuster(logger *zap.Logger, gcInterval time.Duration, useCr
 // AdjustMetrics takes a sequence of metrics and adjust their start times based on the initial and
 // previous points in the timeseriesMap.
 func (a *initialPointAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
-	if removeStartTimeAdjuster.IsEnabled() {
+	if removeStartTimeAdjustment.IsEnabled() {
 		return nil
 	}
 	for i := 0; i < metrics.ResourceMetrics().Len(); i++ {

--- a/receiver/prometheusreceiver/internal/starttimemetricadjuster.go
+++ b/receiver/prometheusreceiver/internal/starttimemetricadjuster.go
@@ -60,6 +60,9 @@ func NewStartTimeMetricAdjuster(logger *zap.Logger, startTimeMetricRegex *regexp
 }
 
 func (stma *startTimeMetricAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
+	if removeStartTimeAdjuster.IsEnabled() {
+		return nil
+	}
 	startTime, err := stma.getStartTime(metrics)
 	if err != nil {
 		if !useCollectorStartTimeFallbackGate.IsEnabled() {

--- a/receiver/prometheusreceiver/internal/starttimemetricadjuster.go
+++ b/receiver/prometheusreceiver/internal/starttimemetricadjuster.go
@@ -60,7 +60,7 @@ func NewStartTimeMetricAdjuster(logger *zap.Logger, startTimeMetricRegex *regexp
 }
 
 func (stma *startTimeMetricAdjuster) AdjustMetrics(metrics pmetric.Metrics) error {
-	if removeStartTimeAdjuster.IsEnabled() {
+	if removeStartTimeAdjustment.IsEnabled() {
 		return nil
 	}
 	startTime, err := stma.getStartTime(metrics)

--- a/receiver/prometheusreceiver/internal/transaction.go
+++ b/receiver/prometheusreceiver/internal/transaction.go
@@ -30,8 +30,8 @@ import (
 	mdata "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver/internal/metadata"
 )
 
-var removeStartTimeAdjuster = featuregate.GlobalRegistry().MustRegister(
-	"receiver.prometheusreceiver.RemoveStartTimeAdjuster",
+var removeStartTimeAdjustment = featuregate.GlobalRegistry().MustRegister(
+	"receiver.prometheusreceiver.RemoveStartTimeAdjustment",
 	featuregate.StageAlpha,
 	featuregate.WithRegisterDescription("When enabled, the Prometheus receiver will"+
 		" leave the start time unset. Use the new metricstarttime processor instead."),
@@ -473,7 +473,7 @@ func (t *transaction) Commit() error {
 		return nil
 	}
 
-	if !removeStartTimeAdjuster.IsEnabled() {
+	if !removeStartTimeAdjustment.IsEnabled() {
 		if err = t.metricAdjuster.AdjustMetrics(md); err != nil {
 			t.obsrecv.EndMetricsOp(ctx, dataformat, numPoints, err)
 			return err

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -10,10 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
-
-	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
 	"github.com/prometheus/prometheus/model/histogram"
@@ -30,6 +26,10 @@ import (
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 )
 
 const (

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
 	"github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/model/exemplar"
@@ -27,8 +30,6 @@ import (
 	"go.opentelemetry.io/collector/receiver/receiverhelper"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 	conventions "go.opentelemetry.io/collector/semconv/v1.27.0"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zaptest/observer"
 )
 
 const (

--- a/receiver/prometheusreceiver/internal/transaction_test.go
+++ b/receiver/prometheusreceiver/internal/transaction_test.go
@@ -845,7 +845,7 @@ func TestMetricBuilderCounters(t *testing.T) {
 		for _, tt := range tests {
 			for _, enableNativeHistograms := range []bool{true, false} {
 				t.Run(fmt.Sprintf("%s/enableNativeHistograms=%v/disableMetricAdjustment=%v", tt.name, enableNativeHistograms, disableMetricAdjustment), func(t *testing.T) {
-					defer testutil.SetFeatureGateForTest(t, removeStartTimeAdjuster, disableMetricAdjustment)()
+					defer testutil.SetFeatureGateForTest(t, removeStartTimeAdjustment, disableMetricAdjustment)()
 					tt.run(t, enableNativeHistograms)
 				})
 			}


### PR DESCRIPTION
#### Description

Start time metric adjustment is still enabled by default, but can now be disabled using a feature gate.

It is being replaced by the metricstarttime processor: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37186

#### Link to tracking issue

Part of https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37186

#### Testing

I updated the unit test for counters

#### Documentation

Updated the README