### PR TITLE
Find unkeyed

### DIFF
--- a/cmd/checkapi/config.yaml
+++ b/cmd/checkapi/config.yaml
@@ -6,20 +6,33 @@ ignored_paths:
   - receiver/pulsarreceiver # 38930
   - exporter/pulsarexporter # 38929
   - exporter/elasticsearchexporter/integrationtest
+unkeyed_literal_initialization:
+  enabled: true
+  limit: 6
 allowed_functions:
-  - name: NewFactory
+  - classes:
+      - connector
+    name: NewFactory
     parameters:
     return_types: [connector.Factory]
-  - name: NewFactory
+  - classes:
+      - exporter
+    name: NewFactory
     parameters:
     return_types: [exporter.Factory]
-  - name: NewFactory
+  - classes:
+      - extension
+    name: NewFactory
     parameters:
     return_types: [extension.Factory]
-  - name: NewFactory
+  - classes:
+      - processor
+    name: NewFactory
     parameters:
     return_types: [processor.Factory]
-  - name: NewFactory
+  - classes:
+      - receiver
+    name: NewFactory
     parameters:
     return_types: [receiver.Factory]
 

--- a/cmd/checkapi/go.mod
+++ b/cmd/checkapi/go.mod
@@ -2,10 +2,7 @@ module github.com/open-telemetry/opentelemetry-collector-contrib/cmd/checkapi
 
 go 1.23.0
 
-require (
-	github.com/stretchr/testify v1.10.0
-	gopkg.in/yaml.v3 v3.0.1
-)
+require github.com/stretchr/testify v1.10.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
@@ -13,4 +10,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rogpeppe/go-internal v1.13.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/cmd/checkapi/internal/altpkg/config.yaml
+++ b/cmd/checkapi/internal/altpkg/config.yaml
@@ -2,9 +2,13 @@ ignored_paths:
   - receiver/badreceiver
 allowed_functions:
   - name: MyFoo
+    classes:
+      - receiver
     parameters: [string]
     return_types: [bool]
   - name: MyBar
+    classes:
+      - receiver
     parameters: [ bool ]
     return_types: [ string ]
 

--- a/cmd/checkapi/internal/altpkg/receiver/altreceiver/metadata.yaml
+++ b/cmd/checkapi/internal/altpkg/receiver/altreceiver/metadata.yaml
@@ -1,0 +1,4 @@
+type: alt
+
+status:
+  class: receiver

--- a/cmd/checkapi/internal/altpkg/receiver/badreceiver/metadata.yaml
+++ b/cmd/checkapi/internal/altpkg/receiver/badreceiver/metadata.yaml
@@ -1,0 +1,4 @@
+type: bad
+
+status:
+  class: receiver

--- a/cmd/checkapi/internal/ast.go
+++ b/cmd/checkapi/internal/ast.go
@@ -31,12 +31,16 @@ func ExprToString(expr ast.Expr) string {
 		return fmt.Sprintf("chan(%s)", ExprToString(e.Value))
 	case *ast.FuncType:
 		var results []string
-		for _, r := range e.Results.List {
-			results = append(results, ExprToString(r.Type))
+		if e.Results != nil {
+			for _, r := range e.Results.List {
+				results = append(results, ExprToString(r.Type))
+			}
 		}
 		var params []string
-		for _, r := range e.Params.List {
-			params = append(params, ExprToString(r.Type))
+		if e.Params != nil {
+			for _, r := range e.Params.List {
+				params = append(params, ExprToString(r.Type))
+			}
 		}
 		return fmt.Sprintf("func(%s) %s", strings.Join(params, ","), strings.Join(results, ","))
 	case *ast.SelectorExpr:
@@ -53,6 +57,12 @@ func ExprToString(expr ast.Expr) string {
 		return fmt.Sprintf("%s[%s]", ExprToString(e.X), ExprToString(e.Index))
 	case *ast.BasicLit:
 		return e.Value
+	case *ast.IndexListExpr:
+		var exprs []string
+		for _, e := range e.Indices {
+			exprs = append(exprs, ExprToString(e))
+		}
+		return strings.Join(exprs, ",")
 	default:
 		panic(fmt.Sprintf("Unsupported expr type: %#v", expr))
 	}

--- a/cmd/checkapi/internal/ast.go
+++ b/cmd/checkapi/internal/ast.go
@@ -6,6 +6,9 @@ package internal
 import (
 	"fmt"
 	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
 	"strings"
 )
 
@@ -66,4 +69,101 @@ func ExprToString(expr ast.Expr) string {
 	default:
 		panic(fmt.Sprintf("Unsupported expr type: %#v", expr))
 	}
+}
+
+func Read(folder string, ignoredFunctions []string) (*Api, error) {
+	result := &Api{}
+	set := token.NewFileSet()
+	packs, err := parser.ParseDir(set, folder, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pack := range packs {
+		for _, f := range pack.Files {
+			readFile(ignoredFunctions, f, result)
+		}
+	}
+
+	return result, nil
+}
+
+func readFile(ignoredFunctions []string, f *ast.File, result *Api) {
+	for _, d := range f.Decls {
+		if str, isStr := d.(*ast.GenDecl); isStr {
+			for _, s := range str.Specs {
+				if values, ok := s.(*ast.ValueSpec); ok {
+					for _, v := range values.Names {
+						if v.IsExported() {
+							result.Values = append(result.Values, v.Name)
+						}
+					}
+				}
+				if t, ok := s.(*ast.TypeSpec); ok {
+					var fieldNames []string
+					if t.TypeParams != nil {
+						fieldNames = make([]string, len(t.TypeParams.List))
+						for i, f := range t.TypeParams.List {
+							fieldNames[i] = f.Names[0].Name
+						}
+					}
+					result.Structs = append(result.Structs, &Apistruct{
+						Name:   t.Name.String(),
+						Fields: fieldNames,
+					})
+				}
+			}
+		}
+		if fn, isFn := d.(*ast.FuncDecl); isFn {
+			if !fn.Name.IsExported() {
+				continue
+			}
+			exported := false
+			receiver := ""
+			if fn.Recv.NumFields() == 0 && !isFunctionIgnored(ignoredFunctions, fn.Name.String()) {
+				exported = true
+			}
+			if fn.Recv.NumFields() > 0 {
+				for _, t := range fn.Recv.List {
+					for _, n := range t.Names {
+						exported = exported || n.IsExported()
+						if n.IsExported() {
+							receiver = n.Name
+						}
+					}
+				}
+			}
+			if exported {
+				var returnTypes []string
+				if fn.Type.Results.NumFields() > 0 {
+					for _, r := range fn.Type.Results.List {
+						returnTypes = append(returnTypes, ExprToString(r.Type))
+					}
+				}
+				var params []string
+				if fn.Type.Params.NumFields() > 0 {
+					for _, r := range fn.Type.Params.List {
+						params = append(params, ExprToString(r.Type))
+					}
+				}
+				f := &Function{
+					Name:        fn.Name.Name,
+					Receiver:    receiver,
+					ParamTypes:  params,
+					ReturnTypes: returnTypes,
+				}
+				result.Functions = append(result.Functions, f)
+			}
+		}
+	}
+}
+
+func isFunctionIgnored(ignoredFunctions []string, fnName string) bool {
+	for _, v := range ignoredFunctions {
+		reg := regexp.MustCompile(v)
+		if reg.MatchString(fnName) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/checkapi/internal/badpkg/receiver/badreceiver/metadata.yaml
+++ b/cmd/checkapi/internal/badpkg/receiver/badreceiver/metadata.yaml
@@ -1,0 +1,4 @@
+type: bad
+
+status:
+  class: receiver

--- a/cmd/checkapi/internal/config.go
+++ b/cmd/checkapi/internal/config.go
@@ -1,0 +1,38 @@
+package internal
+
+type Function struct {
+	Name        string   `json:"name"`
+	Receiver    string   `json:"receiver"`
+	ReturnTypes []string `json:"return_types,omitempty"`
+	ParamTypes  []string `json:"param_types,omitempty"`
+}
+
+type Apistruct struct {
+	Name   string   `json:"name"`
+	Fields []string `json:"fields"`
+}
+
+type Api struct {
+	Values    []string     `json:"values,omitempty"`
+	Structs   []*Apistruct `json:"structs,omitempty"`
+	Functions []*Function  `json:"functions,omitempty"`
+}
+
+type FunctionDescription struct {
+	Classes     []string `yaml:"classes"`
+	Name        string   `yaml:"name"`
+	Parameters  []string `yaml:"parameters"`
+	ReturnTypes []string `yaml:"return_types"`
+}
+
+type Config struct {
+	IgnoredPaths     []string              `yaml:"ignored_paths"`
+	AllowedFunctions []FunctionDescription `yaml:"allowed_functions"`
+	IgnoredFunctions []string              `yaml:"ignored_functions"`
+	UnkeyedLiteral   UnkeyedLiteral        `yaml:"unkeyed_literal_initialization"`
+}
+
+type UnkeyedLiteral struct {
+	Enabled bool `yaml:"enabled"`
+	Limit   int  `yaml:"limit"`
+}

--- a/cmd/checkapi/internal/metadata.go
+++ b/cmd/checkapi/internal/metadata.go
@@ -1,0 +1,35 @@
+package internal
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+type status struct {
+	Class string `yaml:"class"`
+}
+
+type metadata struct {
+	Status status `yaml:"status"`
+}
+
+func ReadComponentType(folder string) (string, error) {
+	var componentType string
+	if _, err := os.Stat(filepath.Join(folder, "metadata.yaml")); errors.Is(err, os.ErrNotExist) {
+		componentType = "pkg"
+	} else {
+		m, err := os.ReadFile(filepath.Join(folder, "metadata.yaml"))
+		if err != nil {
+			return "", err
+		}
+		var componentInfo metadata
+		if err = yaml.Unmarshal(m, &componentInfo); err != nil {
+			return "", err
+		}
+		componentType = componentInfo.Status.Class
+	}
+	return componentType, nil
+}

--- a/cmd/checkapi/internal/testpkg/receiver/validreceiver/metadata.yaml
+++ b/cmd/checkapi/internal/testpkg/receiver/validreceiver/metadata.yaml
@@ -1,0 +1,4 @@
+type: valid
+
+status:
+  class: receiver

--- a/cmd/checkapi/main.go
+++ b/cmd/checkapi/main.go
@@ -23,6 +23,10 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/cmd/checkapi/internal"
 )
 
+const (
+	unkeyedFieldsLimit = 6
+)
+
 func main() {
 	folder := flag.String("folder", ".", "folder investigated for modules")
 	configPath := flag.String("config", "cmd/checkapi/config.yaml", "configuration file")
@@ -291,6 +295,9 @@ func checkComponentFactoryFunction(newFactoryFn *function, folder string, compon
 
 func checkStructDisallowUnkeyedLiteral(s *apistruct, folder string) error {
 	if !unicode.IsUpper(rune(s.Name[0])) {
+		return nil
+	}
+	if len(s.Fields) > unkeyedFieldsLimit {
 		return nil
 	}
 	for _, f := range s.Fields {

--- a/testbed/mockdatasenders/mockdatadogagentexporter/metadata.yaml
+++ b/testbed/mockdatasenders/mockdatadogagentexporter/metadata.yaml
@@ -1,3 +1,4 @@
 status:
+  class: pkg
   codeowners:
     active: [boostchicken]


### PR DESCRIPTION
This implements the check for https://github.com/open-telemetry/opentelemetry-collector/issues/12363

Running this with the opentelemetry-collector repository returns this list:
```
connector/countconnector struct "MetricInfo" does not prevent unkeyed literal initialization
connector/datadogconnector struct "TracesConfig" does not prevent unkeyed literal initialization
connector/exceptionsconnector struct "Exemplars" does not prevent unkeyed literal initialization
connector/failoverconnector struct "Config" does not prevent unkeyed literal initialization
connector/grafanacloudconnector struct "Config" does not prevent unkeyed literal initialization
connector/otlpjsonconnector struct "Config" does not prevent unkeyed literal initialization
connector/roundrobinconnector struct "Config" does not prevent unkeyed literal initialization
connector/routingconnector struct "RoutingTableItem" does not prevent unkeyed literal initialization
connector/servicegraphconnector struct "StoreConfig" does not prevent unkeyed literal initialization
connector/spanmetricsconnector struct "HistogramConfig" does not prevent unkeyed literal initialization
connector/sumconnector struct "MetricInfo" does not prevent unkeyed literal initialization
exporter/alertmanagerexporter struct "Config" does not prevent unkeyed literal initialization
exporter/alibabacloudlogserviceexporter struct "KeyValues" does not prevent unkeyed literal initialization
exporter/awscloudwatchlogsexporter struct "Config" does not prevent unkeyed literal initialization
exporter/awsemfexporter struct "MetricDescriptor" does not prevent unkeyed literal initialization
exporter/awskinesisexporter struct "Exporter" does not prevent unkeyed literal initialization
exporter/awss3exporter struct "TestWriter" does not prevent unkeyed literal initialization
exporter/awsxrayexporter struct "Config" does not prevent unkeyed literal initialization
exporter/azureblobexporter struct "TelemetryConfig" does not prevent unkeyed literal initialization
exporter/azuredataexplorerexporter struct "Status" does not prevent unkeyed literal initialization
exporter/azuremonitorexporter struct "TraceVisitor" does not prevent unkeyed literal initialization
exporter/bmchelixexporter struct "Config" does not prevent unkeyed literal initialization
exporter/carbonexporter struct "Config" does not prevent unkeyed literal initialization
exporter/cassandraexporter struct "Replication" does not prevent unkeyed literal initialization
exporter/clickhouseexporter struct "TableEngine" does not prevent unkeyed literal initialization
exporter/coralogixexporter struct "Config" does not prevent unkeyed literal initialization
exporter/datadogexporter struct "TracesConfig" does not prevent unkeyed literal initialization
exporter/datasetexporter struct "TracesSettings" does not prevent unkeyed literal initialization
exporter/dorisexporter struct "Table" does not prevent unkeyed literal initialization
exporter/elasticsearchexporter struct "TelemetrySettings" does not prevent unkeyed literal initialization
exporter/fileexporter struct "Rotation" does not prevent unkeyed literal initialization
exporter/googlecloudexporter struct "Config" does not prevent unkeyed literal initialization
exporter/googlecloudpubsubexporter struct "WatermarkConfig" does not prevent unkeyed literal initialization
exporter/googlemanagedprometheusexporter struct "MetricConfig" does not prevent unkeyed literal initialization
exporter/honeycombmarkerexporter struct "Rules" does not prevent unkeyed literal initialization
exporter/influxdbexporter struct "V1Compatibility" does not prevent unkeyed literal initialization
exporter/kafkaexporter struct "TracesMarshaler" does not prevent unkeyed literal initialization
exporter/kineticaexporter struct "ValueTypePair" does not prevent unkeyed literal initialization
exporter/loadbalancingexporter struct "StaticResolver" does not prevent unkeyed literal initialization
exporter/logicmonitorexporter struct "MappingOperation" does not prevent unkeyed literal initialization
exporter/logzioexporter struct "Config" does not prevent unkeyed literal initialization
exporter/lokiexporter struct "Config" does not prevent unkeyed literal initialization
exporter/mezmoexporter struct "Config" does not prevent unkeyed literal initialization
exporter/opencensusexporter struct "Config" does not prevent unkeyed literal initialization
exporter/opensearchexporter struct "MappingsSettings" does not prevent unkeyed literal initialization
exporter/otelarrowexporter struct "Config" does not prevent unkeyed literal initialization
exporter/prometheusexporter struct "Config" does not prevent unkeyed literal initialization
exporter/prometheusremotewriteexporter struct "WALConfig" does not prevent unkeyed literal initialization
exporter/pulsarexporter struct "TracesMarshaler" does not prevent unkeyed literal initialization
exporter/rabbitmqexporter struct "RoutingConfig" does not prevent unkeyed literal initialization
exporter/sapmexporter struct "Config" does not prevent unkeyed literal initialization
exporter/sematextexporter struct "MetricsConfig" does not prevent unkeyed literal initialization
exporter/sentryexporter struct "TransactionFromSpanMarshalEventTestCase" does not prevent unkeyed literal initialization
exporter/signalfxexporter struct "DimensionClientConfig" does not prevent unkeyed literal initialization
exporter/splunkhecexporter struct "SplunkContainerConfig" does not prevent unkeyed literal initialization
exporter/stefexporter struct "Config" does not prevent unkeyed literal initialization
exporter/sumologicexporter struct "TraceFormatType" does not prevent unkeyed literal initialization
exporter/syslogexporter struct "Config" does not prevent unkeyed literal initialization
exporter/tencentcloudlogserviceexporter struct "Config" does not prevent unkeyed literal initialization
exporter/zipkinexporter struct "Config" does not prevent unkeyed literal initialization
extension/ackextension struct "Config" does not prevent unkeyed literal initialization
extension/asapauthextension struct "Config" does not prevent unkeyed literal initialization
extension/awsproxy struct "Config" does not prevent unkeyed literal initialization
extension/basicauthextension struct "HtpasswdSettings" does not prevent unkeyed literal initialization
extension/bearertokenauthextension struct "PerRPCAuth" does not prevent unkeyed literal initialization
extension/cgroupruntimeextension struct "GoMemLimitConfig" does not prevent unkeyed literal initialization
extension/encoding/avrologencodingextension struct "Config" does not prevent unkeyed literal initialization
extension/encoding/awscloudwatchmetricstreamsencodingextension struct "Config" does not prevent unkeyed literal initialization
extension/encoding struct "TracesUnmarshalerExtension" does not prevent unkeyed literal initialization
extension/encoding/googlecloudlogentryencodingextension struct "HandleAs" does not prevent unkeyed literal initialization
extension/encoding/jaegerencodingextension struct "JaegerProtocol" does not prevent unkeyed literal initialization
extension/encoding/jsonlogencodingextension struct "JSONEncodingMode" does not prevent unkeyed literal initialization
extension/encoding/otlpencodingextension struct "Config" does not prevent unkeyed literal initialization
extension/encoding/textencodingextension struct "Config" does not prevent unkeyed literal initialization
extension/encoding/zipkinencodingextension struct "Config" does not prevent unkeyed literal initialization
extension/googleclientauthextension struct "Config" does not prevent unkeyed literal initialization
extension/headerssetterextension struct "HeaderConfig" does not prevent unkeyed literal initialization
extension/healthcheckextension struct "ResponseBodySettings" does not prevent unkeyed literal initialization
extension/healthcheckv2extension struct "Config" does not prevent unkeyed literal initialization
extension/httpforwarderextension struct "Config" does not prevent unkeyed literal initialization
extension/jaegerremotesampling struct "Source" does not prevent unkeyed literal initialization
extension/k8sleaderelector struct "StopCallback" does not prevent unkeyed literal initialization
extension/oauth2clientauthextension struct "Config" does not prevent unkeyed literal initialization
extension/observer/cfgardenobserver struct "GardenConfig" does not prevent unkeyed literal initialization
extension/observer/dockerobserver struct "Config" does not prevent unkeyed literal initialization
extension/observer/ecsobserver struct "TaskDefinitionConfig" does not prevent unkeyed literal initialization
extension/observer/ecstaskobserver struct "Config" does not prevent unkeyed literal initialization
extension/observer/hostobserver struct "Config" does not prevent unkeyed literal initialization
extension/observer/k8sobserver struct "RunningContainer" does not prevent unkeyed literal initialization
extension/observer/kafkatopicsobserver struct "MockClusterAdmin" does not prevent unkeyed literal initialization
extension/oidcauthextension struct "Config" does not prevent unkeyed literal initialization
extension/opampextension struct "OpAMPServer" does not prevent unkeyed literal initialization
extension/pprofextension struct "Config" does not prevent unkeyed literal initialization
extension/remotetapextension struct "Config" does not prevent unkeyed literal initialization
extension/sigv4authextension struct "Config" does not prevent unkeyed literal initialization
extension/solarwindsapmsettingsextension struct "Config" does not prevent unkeyed literal initialization
extension/storage/dbstorage struct "Config" does not prevent unkeyed literal initialization
extension/storage/filestorage struct "Config" does not prevent unkeyed literal initialization
extension/storage/redisstorageextension struct "Config" does not prevent unkeyed literal initialization
extension/sumologicextension struct "SumologicExtension" does not prevent unkeyed literal initialization
pkg/datadog struct "Zaplogger" does not prevent unkeyed literal initialization
pkg/experimentalmetricmetadata struct "ResourceID" does not prevent unkeyed literal initialization
pkg/golden struct "WriteMetricsOption" does not prevent unkeyed literal initialization
pkg/ottl struct "ValueExpression" does not prevent unkeyed literal initialization
pkg/pdatautil struct "HashOption" does not prevent unkeyed literal initialization
pkg/resourcetotelemetry struct "Settings" does not prevent unkeyed literal initialization
pkg/sampling struct "W3CTraceState" does not prevent unkeyed literal initialization
pkg/status struct "Verbosity" does not prevent unkeyed literal initialization
pkg/translator/azure struct "TracesUnmarshaler" does not prevent unkeyed literal initialization
pkg/translator/azurelogs struct "TypeConversion" does not prevent unkeyed literal initialization
pkg/translator/loki struct "PushRequest" does not prevent unkeyed literal initialization
pkg/translator/prometheusremotewrite struct "Settings" does not prevent unkeyed literal initialization
pkg/translator/signalfx struct "ToTranslator" does not prevent unkeyed literal initialization
pkg/winperfcounters struct "PerfCounterWatcher" does not prevent unkeyed literal initialization
pkg/xk8stest struct "TelemetrygenObjInfo" does not prevent unkeyed literal initialization
processor/attributesprocessor struct "Config" does not prevent unkeyed literal initialization
processor/coralogixprocessor struct "Config" does not prevent unkeyed literal initialization
processor/cumulativetodeltaprocessor struct "MatchMetrics" does not prevent unkeyed literal initialization
processor/deltatocumulativeprocessor struct "State" does not prevent unkeyed literal initialization
processor/deltatorateprocessor struct "Config" does not prevent unkeyed literal initialization
processor/filterprocessor struct "TraceFilters" does not prevent unkeyed literal initialization
processor/geoipprocessor struct "ContextID" does not prevent unkeyed literal initialization
processor/groupbyattrsprocessor struct "Config" does not prevent unkeyed literal initialization
processor/groupbytraceprocessor struct "Config" does not prevent unkeyed literal initialization
processor/intervalprocessor struct "Processor" does not prevent unkeyed literal initialization
processor/k8sattributesprocessor struct "PodAssociationSourceConfig" does not prevent unkeyed literal initialization
processor/logdedupprocessor struct "Config" does not prevent unkeyed literal initialization
processor/logstransformprocessor struct "Config" does not prevent unkeyed literal initialization
processor/metricsgenerationprocessor struct "Rule" does not prevent unkeyed literal initialization
processor/metricstarttimeprocessor struct "Config" does not prevent unkeyed literal initialization
processor/metricstransformprocessor struct "ValueAction" does not prevent unkeyed literal initialization
processor/probabilisticsamplerprocessor struct "SamplerMode" does not prevent unkeyed literal initialization
processor/redactionprocessor struct "TestConfig" does not prevent unkeyed literal initialization
processor/remotetapprocessor struct "Config" does not prevent unkeyed literal initialization
processor/resourcedetectionprocessor struct "MockDetector" does not prevent unkeyed literal initialization
processor/resourceprocessor struct "Config" does not prevent unkeyed literal initialization
processor/routingprocessor struct "RoutingTableItem" does not prevent unkeyed literal initialization
processor/schemaprocessor struct "Config" does not prevent unkeyed literal initialization
processor/spanprocessor struct "ToAttributes" does not prevent unkeyed literal initialization
processor/sumologicprocessor struct "NestingProcessorConfig" does not prevent unkeyed literal initialization
processor/transformprocessor struct "Config" does not prevent unkeyed literal initialization
receiver/activedirectorydsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/aerospikereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/apachereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/apachesparkreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/awscloudwatchmetricsreceiver struct "NamedConfig" does not prevent unkeyed literal initialization
receiver/awscloudwatchreceiver struct "StreamConfig" does not prevent unkeyed literal initialization
receiver/awscontainerinsightreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/awsecscontainermetricsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/awsfirehosereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/awss3receiver struct "S3DownloaderConfig" does not prevent unkeyed literal initialization
receiver/awsxrayreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/azureblobreceiver struct "TracesConfig" does not prevent unkeyed literal initialization
receiver/azureeventhubreceiver struct "TimeFormat" does not prevent unkeyed literal initialization
receiver/azuremonitorreceiver struct "DimensionsConfig" does not prevent unkeyed literal initialization
receiver/bigipreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/carbonreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/chronyreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/cloudflarereceiver struct "LogsConfig" does not prevent unkeyed literal initialization
receiver/cloudfoundryreceiver struct "UAATokenProvider" does not prevent unkeyed literal initialization
receiver/collectdreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/couchdbreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/datadogreceiver struct "Endpoint" does not prevent unkeyed literal initialization
receiver/dockerstatsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/elasticsearchreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/envoyalsreceiver struct "Log" does not prevent unkeyed literal initialization
receiver/expvarreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/faroreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/filelogreceiver struct "ReceiverType" does not prevent unkeyed literal initialization
receiver/filestatsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/flinkmetricsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/fluentforwardreceiver struct "Peeker" does not prevent unkeyed literal initialization
receiver/githubreceiver struct "WebHook" does not prevent unkeyed literal initialization
receiver/gitlabreceiver struct "WebHook" does not prevent unkeyed literal initialization
receiver/googlecloudmonitoringreceiver struct "MetricConfig" does not prevent unkeyed literal initialization
receiver/googlecloudpubsubreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/googlecloudspannerreceiver struct "Project" does not prevent unkeyed literal initialization
receiver/haproxyreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/hostmetricsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/httpcheckreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/huaweicloudcesreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/iisreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/influxdbreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/jaegerreceiver struct "ServerConfigUDP" does not prevent unkeyed literal initialization
receiver/jmxreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/journaldreceiver struct "ReceiverType" does not prevent unkeyed literal initialization
receiver/k8sclusterreceiver struct "MockExporter" does not prevent unkeyed literal initialization
receiver/k8seventsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/k8sobjectsreceiver struct "MockDiscovery" does not prevent unkeyed literal initialization
receiver/kafkametricsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/kafkareceiver struct "TracesUnmarshaler" does not prevent unkeyed literal initialization
receiver/kubeletstatsreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/libhoneyreceiver struct "TeamInfo" does not prevent unkeyed literal initialization
receiver/lokireceiver struct "Protocols" does not prevent unkeyed literal initialization
receiver/memcachedreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/mongodbatlasreceiver struct "ProjectConfig" does not prevent unkeyed literal initialization
receiver/mongodbreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/mysqlreceiver struct "TableStats" does not prevent unkeyed literal initialization
receiver/namedpipereceiver struct "ReceiverType" does not prevent unkeyed literal initialization
receiver/netflowreceiver struct "PanicProducer" does not prevent unkeyed literal initialization
receiver/nginxreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/nsxtreceiver struct "MockClient" does not prevent unkeyed literal initialization
receiver/ntpreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/opencensusreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/oracledbreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/osqueryreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/otelarrowreceiver struct "Protocols" does not prevent unkeyed literal initialization
receiver/otlpjsonfilereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/podmanreceiver struct "PodmanClient" does not prevent unkeyed literal initialization
receiver/postgresqlreceiver struct "ConnectionPool" does not prevent unkeyed literal initialization
receiver/pprofreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/prometheusreceiver struct "PromConfig" does not prevent unkeyed literal initialization
receiver/prometheusremotewritereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/pulsarreceiver struct "TracesUnmarshaler" does not prevent unkeyed literal initialization
receiver/purefareceiver struct "Settings" does not prevent unkeyed literal initialization
receiver/purefbreceiver struct "Settings" does not prevent unkeyed literal initialization
receiver/rabbitmqreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/receivercreator struct "DiscoveryConfig" does not prevent unkeyed literal initialization
receiver/redisreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/riakreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/saphanareceiver struct "Config" does not prevent unkeyed literal initialization
receiver/sapmreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/signalfxreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/simpleprometheusreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/skywalkingreceiver struct "Protocols" does not prevent unkeyed literal initialization
receiver/snmpreceiver struct "SumMetric" does not prevent unkeyed literal initialization
receiver/snowflakereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/solacereceiver struct "SaslXAuth2Config" does not prevent unkeyed literal initialization
receiver/splunkenterprisereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/splunkhecreceiver struct "SplittingStrategy" does not prevent unkeyed literal initialization
receiver/sqlqueryreceiver struct "DbEngineUnderTest" does not prevent unkeyed literal initialization
receiver/sqlserverreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/sshcheckreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/statsdreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/syslogreceiver struct "SysLogConfig" does not prevent unkeyed literal initialization
receiver/systemdreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/tcpcheckreceiver struct "TCPConnectionState" does not prevent unkeyed literal initialization
receiver/tcplogreceiver struct "TCPLogConfig" does not prevent unkeyed literal initialization
receiver/tlscheckreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/udplogreceiver struct "UDPLogConfig" does not prevent unkeyed literal initialization
receiver/vcenterreceiver struct "DatacenterStats" does not prevent unkeyed literal initialization
receiver/wavefrontreceiver struct "WavefrontParser" does not prevent unkeyed literal initialization
receiver/webhookeventreceiver struct "RequiredHeader" does not prevent unkeyed literal initialization
receiver/windowseventlogreceiver struct "WindowsLogConfig" does not prevent unkeyed literal initialization
receiver/windowsperfcountersreceiver struct "SumMetric" does not prevent unkeyed literal initialization
receiver/windowsservicereceiver struct "Config" does not prevent unkeyed literal initialization
receiver/zipkinreceiver struct "Config" does not prevent unkeyed literal initialization
receiver/zookeeperreceiver struct "Config" does not prevent unkeyed literal initialization
scraper/zookeeperscraper struct "Config" does not prevent unkeyed literal initialization
testbed/mockdatasenders/mockdatadogagentexporter struct "Config" does not prevent unkeyed literal initialization
```