### PR TITLE
[processor/transform] Introduce optional metric name suffix setup for convert summary and extract histogram functions

### DIFF
--- a/.chloggen/transform-name-suffix.yaml
+++ b/.chloggen/transform-name-suffix.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: processor/transform
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Introduce optional metric name suffix setup for convert summary and extract histogram functions"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [33850]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "Adaptations of the metric name suffix were made to match the latest OTel convention which uses '.' instead of '_' in suffix"
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/transformprocessor/README.md
+++ b/processor/transformprocessor/README.md
@@ -340,6 +340,8 @@ In addition to OTTL functions, the processor defines its own functions to help w
 **Metrics only functions**
 - [convert_sum_to_gauge](#convert_sum_to_gauge)
 - [convert_gauge_to_sum](#convert_gauge_to_sum)
+- [extract_count_metric](#extract_count_metric)
+- [extract_sum_metric](#extract_sum_metric)
 - [convert_summary_count_val_to_sum](#convert_summary_count_val_to_sum)
 - [convert_summary_sum_val_to_sum](#convert_summary_sum_val_to_sum)
 - [copy_metric](#copy_metric)
@@ -382,13 +384,14 @@ Examples:
 > [!NOTE]  
 > This function supports Histograms, ExponentialHistograms and Summaries.
 
-`extract_count_metric(is_monotonic)`
+`extract_count_metric(is_monotonic, Optional[suffix])`
 
 The `extract_count_metric` function creates a new Sum metric from a Histogram, ExponentialHistogram or Summary's count value. A metric will only be created if there is at least one data point.
 
 `is_monotonic` is a boolean representing the monotonicity of the new metric.
+`suffix` is an optional string representing the suffix of the metric name. The default value is `.count`.
 
-The name for the new metric will be `<original metric name>_count`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, `description`, and `aggregation_temporality`. As metrics of type Summary don't have an `aggregation_temporality` field, this field will be set to `AGGREGATION_TEMPORALITY_CUMULATIVE` for those metrics.
+The name for the new metric will be `<original metric name>.count`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, `description`, and `aggregation_temporality`. As metrics of type Summary don't have an `aggregation_temporality` field, this field will be set to `AGGREGATION_TEMPORALITY_CUMULATIVE` for those metrics.
 
 The new metric that is created will be passed to all subsequent statements in the metrics statements list.
 
@@ -401,18 +404,21 @@ Examples:
 
 - `extract_count_metric(false)`
 
+- `extract_count_metric(false, "custom_suffix")`
+
 ### extract_sum_metric
 
 > [!NOTE]  
 > This function supports Histograms, ExponentialHistograms and Summaries.
 
-`extract_sum_metric(is_monotonic)`
+`extract_sum_metric(is_monotonic, Optional[suffix])`
 
 The `extract_sum_metric` function creates a new Sum metric from a Histogram, ExponentialHistogram or Summary's sum value. If the sum value of a Histogram or ExponentialHistogram data point is missing, no data point is added to the output metric. A metric will only be created if there is at least one data point.
 
 `is_monotonic` is a boolean representing the monotonicity of the new metric.
+`suffix` is an optional string representing the suffix of the metric name. The default value is `.sum`.
 
-The name for the new metric will be `<original metric name>_sum`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, `description`, and `aggregation_temporality`. As metrics of type Summary don't have an `aggregation_temporality` field, this field will be set to `AGGREGATION_TEMPORALITY_CUMULATIVE` for those metrics.
+The name for the new metric will be `<original metric name>.sum`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, `description`, and `aggregation_temporality`. As metrics of type Summary don't have an `aggregation_temporality` field, this field will be set to `AGGREGATION_TEMPORALITY_CUMULATIVE` for those metrics.
 
 The new metric that is created will be passed to all subsequent statements in the metrics statements list.
 
@@ -425,15 +431,18 @@ Examples:
 
 - `extract_sum_metric(false)`
 
+- `extract_sum_metric(false, "custom_suffix")`
+
 ### convert_summary_count_val_to_sum
 
-`convert_summary_count_val_to_sum(aggregation_temporality, is_monotonic)`
+`convert_summary_count_val_to_sum(aggregation_temporality, is_monotonic, Optional[suffix])`
 
 The `convert_summary_count_val_to_sum` function creates a new Sum metric from a Summary's count value.
 
 `aggregation_temporality` is a string (`"cumulative"` or `"delta"`) representing the desired aggregation temporality of the new metric. `is_monotonic` is a boolean representing the monotonicity of the new metric.
+`suffix` is an optional string representing the suffix of the metric name. The default value is `.count`.
 
-The name for the new metric will be `<summary metric name>_count`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, and `description`. The new metric that is created will be passed to all functions in the metrics statements list.  Function conditions will apply.
+The name for the new metric will be `<summary metric name>.count`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, and `description`. The new metric that is created will be passed to all functions in the metrics statements list.  Function conditions will apply.
 
 **NOTE:** This function may cause a metric to break semantics for [Sum metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#sums). Use at your own risk.
 
@@ -441,18 +450,20 @@ Examples:
 
 - `convert_summary_count_val_to_sum("delta", true)`
 
-
 - `convert_summary_count_val_to_sum("cumulative", false)`
+
+- `convert_summary_count_val_to_sum("cumulative", false, "custom_suffix")`
 
 ### convert_summary_sum_val_to_sum
 
-`convert_summary_sum_val_to_sum(aggregation_temporality, is_monotonic)`
+`convert_summary_sum_val_to_sum(aggregation_temporality, is_monotonic, Optional[suffix])`
 
 The `convert_summary_sum_val_to_sum` function creates a new Sum metric from a Summary's sum value.
 
 `aggregation_temporality` is a string (`"cumulative"` or `"delta"`) representing the desired aggregation temporality of the new metric. `is_monotonic` is a boolean representing the monotonicity of the new metric.
+`suffix` is an optional string representing the suffix of the metric name.  The default value is `.sum`.
 
-The name for the new metric will be `<summary metric name>_sum`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, and `description`. The new metric that is created will be passed to all functions in the metrics statements list.  Function conditions will apply.
+The name for the new metric will be `<summary metric name>.sum`. The fields that are copied are: `timestamp`, `starttimestamp`, `attributes`, and `description`. The new metric that is created will be passed to all functions in the metrics statements list.  Function conditions will apply.
 
 **NOTE:** This function may cause a metric to break semantics for [Sum metrics](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/metrics/data-model.md#sums). Use at your own risk.
 
@@ -460,8 +471,9 @@ Examples:
 
 - `convert_summary_sum_val_to_sum("delta", true)`
 
-
 - `convert_summary_sum_val_to_sum("cumulative", false)`
+
+- `convert_summary_sum_val_to_sum("cumulative", false, "custom_suffix")`
 
 ### copy_metric
 

--- a/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
+++ b/processor/transformprocessor/internal/metrics/func_convert_summary_sum_val_to_sum_test.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottldatapoint"
 )
 
@@ -18,6 +19,7 @@ type summaryTestCase struct {
 	input        pmetric.Metric
 	temporality  string
 	monotonicity bool
+	suffix       ottl.Optional[string]
 	want         func(pmetric.MetricSlice)
 }
 
@@ -36,7 +38,7 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(false)
 
-				sumMetric.SetName("summary_metric_sum")
+				sumMetric.SetName("summary_metric.sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(12.34)
 
@@ -57,7 +59,7 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 
-				sumMetric.SetName("summary_metric_sum")
+				sumMetric.SetName("summary_metric.sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(12.34)
 
@@ -78,7 +80,29 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 				sumMetric.Sum().SetIsMonotonic(false)
 
-				sumMetric.SetName("summary_metric_sum")
+				sumMetric.SetName("summary_metric.sum")
+				dp := sumMetric.Sum().DataPoints().AppendEmpty()
+				dp.SetDoubleValue(12.34)
+
+				attrs := getTestAttributes()
+				attrs.CopyTo(dp.Attributes())
+			},
+		},
+		{
+			name:         "convert_summary_sum_val_to_sum custom suffix",
+			input:        getTestSummaryMetric(),
+			temporality:  "delta",
+			monotonicity: false,
+			suffix:       ottl.NewTestingOptional("_custom_suf"),
+			want: func(metrics pmetric.MetricSlice) {
+				summaryMetric := getTestSummaryMetric()
+				summaryMetric.CopyTo(metrics.AppendEmpty())
+				sumMetric := metrics.AppendEmpty()
+				sumMetric.SetEmptySum()
+				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+				sumMetric.Sum().SetIsMonotonic(false)
+
+				sumMetric.SetName("summary_metric_custom_suf")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(12.34)
 
@@ -102,7 +126,7 @@ func Test_ConvertSummarySumValToSum(t *testing.T) {
 			actualMetrics := pmetric.NewMetricSlice()
 			tt.input.CopyTo(actualMetrics.AppendEmpty())
 
-			evaluate, err := convertSummarySumValToSum(tt.temporality, tt.monotonicity)
+			evaluate, err := convertSummarySumValToSum(tt.temporality, tt.monotonicity, tt.suffix)
 			assert.NoError(t, err)
 
 			_, err = evaluate(nil, ottldatapoint.NewTransformContext(pmetric.NewNumberDataPoint(), tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))
@@ -127,7 +151,7 @@ func Test_ConvertSummarySumValToSum_validation(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := convertSummarySumValToSum(tt.stringAggTemp, true)
+			_, err := convertSummarySumValToSum(tt.stringAggTemp, true, ottl.Optional[string]{})
 			assert.Error(t, err, "unknown aggregation temporality: not a real aggregation temporality")
 		})
 	}

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric.go
@@ -17,6 +17,7 @@ const sumCountName = "extract_count_metric"
 
 type extractCountMetricArguments struct {
 	Monotonic bool
+	Suffix    ottl.Optional[string]
 }
 
 func newExtractCountMetricFactory() ottl.Factory[ottlmetric.TransformContext] {
@@ -30,10 +31,14 @@ func createExtractCountMetricFunction(_ ottl.FunctionContext, oArgs ottl.Argumen
 		return nil, fmt.Errorf("extractCountMetricFactory args must be of type *extractCountMetricArguments")
 	}
 
-	return extractCountMetric(args.Monotonic)
+	return extractCountMetric(args.Monotonic, args.Suffix)
 }
 
-func extractCountMetric(monotonic bool) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+func extractCountMetric(monotonic bool, suffix ottl.Optional[string]) (ottl.ExprFunc[ottlmetric.TransformContext], error) {
+	metricNameSuffix := ".count"
+	if !suffix.IsEmpty() {
+		metricNameSuffix = suffix.Get()
+	}
 	return func(_ context.Context, tCtx ottlmetric.TransformContext) (any, error) {
 		metric := tCtx.GetMetric()
 
@@ -44,7 +49,7 @@ func extractCountMetric(monotonic bool) (ottl.ExprFunc[ottlmetric.TransformConte
 
 		countMetric := pmetric.NewMetric()
 		countMetric.SetDescription(metric.Description())
-		countMetric.SetName(metric.Name() + "_count")
+		countMetric.SetName(metric.Name() + metricNameSuffix)
 		// Use the default unit as the original metric unit does not apply to the 'count' field
 		countMetric.SetUnit("1")
 		countMetric.SetEmptySum().SetAggregationTemporality(aggTemp)

--- a/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_count_metric_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 )
 
@@ -29,7 +30,7 @@ func Test_extractCountMetric(t *testing.T) {
 				countMetric.Sum().SetAggregationTemporality(histogramMetric.Histogram().AggregationTemporality())
 				countMetric.Sum().SetIsMonotonic(false)
 
-				countMetric.SetName(histogramMetric.Name() + "_count")
+				countMetric.SetName(histogramMetric.Name() + ".count")
 				dp := countMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetIntValue(int64(histogramMetric.Histogram().DataPoints().At(0).Count()))
 
@@ -50,7 +51,7 @@ func Test_extractCountMetric(t *testing.T) {
 				countMetric.Sum().SetAggregationTemporality(histogramMetric.Histogram().AggregationTemporality())
 				countMetric.Sum().SetIsMonotonic(true)
 
-				countMetric.SetName(histogramMetric.Name() + "_count")
+				countMetric.SetName(histogramMetric.Name() + ".count")
 				dp := countMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetIntValue(int64(histogramMetric.Histogram().DataPoints().At(0).Count()))
 
@@ -71,7 +72,7 @@ func Test_extractCountMetric(t *testing.T) {
 				countMetric.Sum().SetAggregationTemporality(expHistogramMetric.ExponentialHistogram().AggregationTemporality())
 				countMetric.Sum().SetIsMonotonic(false)
 
-				countMetric.SetName(expHistogramMetric.Name() + "_count")
+				countMetric.SetName(expHistogramMetric.Name() + ".count")
 				dp := countMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetIntValue(int64(expHistogramMetric.ExponentialHistogram().DataPoints().At(0).Count()))
 
@@ -92,7 +93,7 @@ func Test_extractCountMetric(t *testing.T) {
 				countMetric.Sum().SetAggregationTemporality(expHistogramMetric.ExponentialHistogram().AggregationTemporality())
 				countMetric.Sum().SetIsMonotonic(true)
 
-				countMetric.SetName(expHistogramMetric.Name() + "_count")
+				countMetric.SetName(expHistogramMetric.Name() + ".count")
 				dp := countMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetIntValue(int64(expHistogramMetric.ExponentialHistogram().DataPoints().At(0).Count()))
 
@@ -113,7 +114,7 @@ func Test_extractCountMetric(t *testing.T) {
 				countMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 				countMetric.Sum().SetIsMonotonic(false)
 
-				countMetric.SetName("summary_metric_count")
+				countMetric.SetName("summary_metric.count")
 				dp := countMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetIntValue(int64(summaryMetric.Summary().DataPoints().At(0).Count()))
 
@@ -134,7 +135,29 @@ func Test_extractCountMetric(t *testing.T) {
 				countMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 				countMetric.Sum().SetIsMonotonic(true)
 
-				countMetric.SetName("summary_metric_count")
+				countMetric.SetName("summary_metric.count")
+				dp := countMetric.Sum().DataPoints().AppendEmpty()
+				dp.SetIntValue(int64(summaryMetric.Summary().DataPoints().At(0).Count()))
+
+				attrs := getTestAttributes()
+				attrs.CopyTo(dp.Attributes())
+			},
+		},
+		{
+			name:         "summary custom suffix",
+			input:        getTestSummaryMetric(),
+			monotonicity: true,
+			suffix:       ottl.NewTestingOptional("_custom_suf"),
+			want: func(metrics pmetric.MetricSlice) {
+				summaryMetric := getTestSummaryMetric()
+				summaryMetric.CopyTo(metrics.AppendEmpty())
+				countMetric := metrics.AppendEmpty()
+				countMetric.SetEmptySum()
+				countMetric.SetUnit("1")
+				countMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+				countMetric.Sum().SetIsMonotonic(true)
+
+				countMetric.SetName("summary_metric_custom_suf")
 				dp := countMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetIntValue(int64(summaryMetric.Summary().DataPoints().At(0).Count()))
 
@@ -154,7 +177,7 @@ func Test_extractCountMetric(t *testing.T) {
 			actualMetrics := pmetric.NewMetricSlice()
 			tt.input.CopyTo(actualMetrics.AppendEmpty())
 
-			evaluate, err := extractCountMetric(tt.monotonicity)
+			evaluate, err := extractCountMetric(tt.monotonicity, tt.suffix)
 			assert.NoError(t, err)
 
 			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))

--- a/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
+++ b/processor/transformprocessor/internal/metrics/func_extract_sum_metric_test.go
@@ -11,6 +11,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 
+	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl/contexts/ottlmetric"
 )
 
@@ -95,6 +96,7 @@ type histogramTestCase struct {
 	name         string
 	input        pmetric.Metric
 	monotonicity bool
+	suffix       ottl.Optional[string]
 	want         func(pmetric.MetricSlice)
 	wantErr      error
 }
@@ -113,7 +115,7 @@ func Test_extractSumMetric(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(histogramMetric.Histogram().AggregationTemporality())
 				sumMetric.Sum().SetIsMonotonic(false)
 
-				sumMetric.SetName(histogramMetric.Name() + "_sum")
+				sumMetric.SetName(histogramMetric.Name() + ".sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(histogramMetric.Histogram().DataPoints().At(0).Sum())
 
@@ -133,7 +135,7 @@ func Test_extractSumMetric(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(histogramMetric.Histogram().AggregationTemporality())
 				sumMetric.Sum().SetIsMonotonic(true)
 
-				sumMetric.SetName(histogramMetric.Name() + "_sum")
+				sumMetric.SetName(histogramMetric.Name() + ".sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(histogramMetric.Histogram().DataPoints().At(0).Sum())
 
@@ -167,7 +169,7 @@ func Test_extractSumMetric(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(expHistogramMetric.ExponentialHistogram().AggregationTemporality())
 				sumMetric.Sum().SetIsMonotonic(false)
 
-				sumMetric.SetName(expHistogramMetric.Name() + "_sum")
+				sumMetric.SetName(expHistogramMetric.Name() + ".sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(expHistogramMetric.ExponentialHistogram().DataPoints().At(0).Sum())
 
@@ -187,7 +189,7 @@ func Test_extractSumMetric(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(expHistogramMetric.ExponentialHistogram().AggregationTemporality())
 				sumMetric.Sum().SetIsMonotonic(true)
 
-				sumMetric.SetName(expHistogramMetric.Name() + "_sum")
+				sumMetric.SetName(expHistogramMetric.Name() + ".sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(expHistogramMetric.ExponentialHistogram().DataPoints().At(0).Sum())
 
@@ -207,7 +209,7 @@ func Test_extractSumMetric(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(expHistogramMetric.ExponentialHistogram().AggregationTemporality())
 				sumMetric.Sum().SetIsMonotonic(false)
 
-				sumMetric.SetName(expHistogramMetric.Name() + "_sum")
+				sumMetric.SetName(expHistogramMetric.Name() + ".sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(expHistogramMetric.ExponentialHistogram().DataPoints().At(0).Sum())
 
@@ -241,7 +243,7 @@ func Test_extractSumMetric(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 				sumMetric.Sum().SetIsMonotonic(false)
 
-				sumMetric.SetName("summary_metric_sum")
+				sumMetric.SetName("summary_metric.sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(12.34)
 
@@ -261,9 +263,30 @@ func Test_extractSumMetric(t *testing.T) {
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
 				sumMetric.Sum().SetIsMonotonic(true)
 
-				sumMetric.SetName("summary_metric_sum")
+				sumMetric.SetName("summary_metric.sum")
 				dp := sumMetric.Sum().DataPoints().AppendEmpty()
 				dp.SetDoubleValue(12.34)
+
+				attrs := getTestAttributes()
+				attrs.CopyTo(dp.Attributes())
+			},
+		},
+		{
+			name:         "histogram custom suffix",
+			input:        getTestHistogramMetric(),
+			monotonicity: false,
+			suffix:       ottl.NewTestingOptional("_custom_suf"),
+			want: func(metrics pmetric.MetricSlice) {
+				histogramMetric := getTestHistogramMetric()
+				histogramMetric.CopyTo(metrics.AppendEmpty())
+				sumMetric := metrics.AppendEmpty()
+				sumMetric.SetEmptySum()
+				sumMetric.Sum().SetAggregationTemporality(histogramMetric.Histogram().AggregationTemporality())
+				sumMetric.Sum().SetIsMonotonic(false)
+
+				sumMetric.SetName(histogramMetric.Name() + "_custom_suf")
+				dp := sumMetric.Sum().DataPoints().AppendEmpty()
+				dp.SetDoubleValue(histogramMetric.Histogram().DataPoints().At(0).Sum())
 
 				attrs := getTestAttributes()
 				attrs.CopyTo(dp.Attributes())
@@ -281,7 +304,7 @@ func Test_extractSumMetric(t *testing.T) {
 			actualMetrics := pmetric.NewMetricSlice()
 			tt.input.CopyTo(actualMetrics.AppendEmpty())
 
-			evaluate, err := extractSumMetric(tt.monotonicity)
+			evaluate, err := extractSumMetric(tt.monotonicity, tt.suffix)
 			assert.NoError(t, err)
 
 			_, err = evaluate(nil, ottlmetric.NewTransformContext(tt.input, actualMetrics, pcommon.NewInstrumentationScope(), pcommon.NewResource(), pmetric.NewScopeMetrics(), pmetric.NewResourceMetrics()))

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -206,7 +206,7 @@ func Test_ProcessMetrics_MetricContext(t *testing.T) {
 				histogramDp := histogramMetric.Histogram().DataPoints().At(0)
 
 				sumMetric.SetDescription(histogramMetric.Description())
-				sumMetric.SetName(histogramMetric.Name() + "_sum")
+				sumMetric.SetName(histogramMetric.Name() + ".sum")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit(histogramMetric.Unit())
@@ -222,7 +222,7 @@ func Test_ProcessMetrics_MetricContext(t *testing.T) {
 		{ // this checks if subsequent statements apply to the newly created metric
 			statements: []string{
 				`extract_sum_metric(true) where name == "operationB"`,
-				`set(name, "new_name") where name == "operationB_sum"`,
+				`set(name, "new_name") where name == "operationB.sum"`,
 			},
 			want: func(td pmetric.Metrics) {
 				sumMetric := td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty()
@@ -256,7 +256,7 @@ func Test_ProcessMetrics_MetricContext(t *testing.T) {
 				fillMetricTwo(histogramMetric)
 
 				countMetric.SetDescription(histogramMetric.Description())
-				countMetric.SetName(histogramMetric.Name() + "_count")
+				countMetric.SetName(histogramMetric.Name() + ".count")
 				countMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				countMetric.Sum().SetIsMonotonic(true)
 				countMetric.SetUnit("1")
@@ -753,7 +753,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 				summaryDp := summaryMetric.Summary().DataPoints().At(0)
 
 				sumMetric.SetDescription(summaryMetric.Description())
-				sumMetric.SetName(summaryMetric.Name() + "_count")
+				sumMetric.SetName(summaryMetric.Name() + ".count")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit(summaryMetric.Unit())
@@ -775,7 +775,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 				summaryDp := summaryMetric.Summary().DataPoints().At(0)
 
 				sumMetric.SetDescription(summaryMetric.Description())
-				sumMetric.SetName(summaryMetric.Name() + "_sum")
+				sumMetric.SetName(summaryMetric.Name() + ".sum")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit(summaryMetric.Unit())
@@ -800,7 +800,7 @@ func Test_ProcessMetrics_DataPointContext(t *testing.T) {
 				summaryDp := summaryMetric.Summary().DataPoints().At(0)
 
 				sumMetric.SetDescription(summaryMetric.Description())
-				sumMetric.SetName(summaryMetric.Name() + "_sum")
+				sumMetric.SetName(summaryMetric.Name() + ".sum")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit("new unit")

--- a/processor/transformprocessor/internal/metrics/processor_test.go
+++ b/processor/transformprocessor/internal/metrics/processor_test.go
@@ -381,7 +381,7 @@ func Test_ProcessMetrics_InferredMetricContext(t *testing.T) {
 				histogramDp := histogramMetric.Histogram().DataPoints().At(0)
 
 				sumMetric.SetDescription(histogramMetric.Description())
-				sumMetric.SetName(histogramMetric.Name() + "_sum")
+				sumMetric.SetName(histogramMetric.Name() + ".sum")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit(histogramMetric.Unit())
@@ -397,7 +397,7 @@ func Test_ProcessMetrics_InferredMetricContext(t *testing.T) {
 		{ // this checks if subsequent statements apply to the newly created metric
 			statements: []string{
 				`extract_sum_metric(true) where metric.name == "operationB"`,
-				`set(metric.name, "new_name") where metric.name == "operationB_sum"`,
+				`set(metric.name, "new_name") where metric.name == "operationB.sum"`,
 			},
 			want: func(td pmetric.Metrics) {
 				sumMetric := td.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().AppendEmpty()
@@ -431,7 +431,7 @@ func Test_ProcessMetrics_InferredMetricContext(t *testing.T) {
 				fillMetricTwo(histogramMetric)
 
 				countMetric.SetDescription(histogramMetric.Description())
-				countMetric.SetName(histogramMetric.Name() + "_count")
+				countMetric.SetName(histogramMetric.Name() + ".count")
 				countMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				countMetric.Sum().SetIsMonotonic(true)
 				countMetric.SetUnit("1")
@@ -1196,7 +1196,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 				summaryDp := summaryMetric.Summary().DataPoints().At(0)
 
 				sumMetric.SetDescription(summaryMetric.Description())
-				sumMetric.SetName(summaryMetric.Name() + "_count")
+				sumMetric.SetName(summaryMetric.Name() + ".count")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit(summaryMetric.Unit())
@@ -1218,7 +1218,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 				summaryDp := summaryMetric.Summary().DataPoints().At(0)
 
 				sumMetric.SetDescription(summaryMetric.Description())
-				sumMetric.SetName(summaryMetric.Name() + "_sum")
+				sumMetric.SetName(summaryMetric.Name() + ".sum")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit(summaryMetric.Unit())
@@ -1243,7 +1243,7 @@ func Test_ProcessMetrics_InferredDataPointContext(t *testing.T) {
 				summaryDp := summaryMetric.Summary().DataPoints().At(0)
 
 				sumMetric.SetDescription(summaryMetric.Description())
-				sumMetric.SetName(summaryMetric.Name() + "_sum")
+				sumMetric.SetName(summaryMetric.Name() + ".sum")
 				sumMetric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 				sumMetric.Sum().SetIsMonotonic(true)
 				sumMetric.SetUnit("new unit")


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Introduce optional metric name suffix setup for the following functions:
- `extract_count_metric`
- `extract_sum_metric`
- `convert_summary_sum_val_to_sum`
- `convert_summary_count_val_to_sum`

This PR also introduces a breaking change by adapting the metric suffix according to the latest OTel convention which uses `.` instead of `_`

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #33850

#### Note

Addition of `convert_summary_quantile_val_to_gauge(Optional[suffix])` function as described in the linked issue will be added in a [separate PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/37245)