### PR TITLE
receiver/prometheusremotewrite: Add two fields timestamp and value.

### DIFF
--- a/.chloggen/prw-timestamp-handling.yaml
+++ b/.chloggen/prw-timestamp-handling.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: receiver/prometheusremotewrite
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add value and timestamp handling in the Prometheus Remote Write receiver by using SetDoubleValue and SetTimestamp"
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37277]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/receiver/prometheusremotewritereceiver/receiver_test.go
+++ b/receiver/prometheusremotewritereceiver/receiver_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/golang/snappy"
@@ -18,6 +19,7 @@ import (
 	"github.com/prometheus/prometheus/storage/remote"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/consumer/consumertest"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/receiver/receivertest"
 
@@ -150,17 +152,17 @@ func TestTranslateV2(t *testing.T) {
 				Timeseries: []writev2.TimeSeries{
 					{
 						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16}, // Same scope: scope_name: scope1. scope_version v1
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
 						Samples:    []writev2.Sample{{Value: 1, Timestamp: 1}},
 					},
 					{
 						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16}, // Same scope: scope_name: scope1. scope_version v1
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 16},
 						Samples:    []writev2.Sample{{Value: 2, Timestamp: 2}},
 					},
 					{
 						Metadata:   writev2.Metadata{Type: writev2.Metadata_METRIC_TYPE_GAUGE},
-						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 17, 18}, // Different scope: scope_name: scope2. scope_version v2
+						LabelsRefs: []uint32{1, 2, 3, 4, 5, 6, 11, 12, 13, 14, 17, 18},
 						Samples:    []writev2.Sample{{Value: 3, Timestamp: 3}},
 					},
 				},
@@ -172,19 +174,30 @@ func TestTranslateV2(t *testing.T) {
 				rmAttributes1.PutStr("service.namespace", "service-x")
 				rmAttributes1.PutStr("service.name", "test")
 				rmAttributes1.PutStr("service.instance.id", "107cn001")
+
 				sm1 := rm1.ScopeMetrics().AppendEmpty()
 				sm1.Scope().SetName("scope1")
 				sm1.Scope().SetVersion("v1")
-				sm1Attributes := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty().Attributes()
-				sm1Attributes.PutStr("d", "e")
-				sm2Attributes := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty().Attributes()
-				sm2Attributes.PutStr("d", "e")
+
+				dp1 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp1.SetDoubleValue(1.0)
+				dp1.Attributes().PutStr("d", "e")
+
+				dp2 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp2.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
+				dp2.SetDoubleValue(2.0)
+				dp2.Attributes().PutStr("d", "e")
 
 				sm2 := rm1.ScopeMetrics().AppendEmpty()
 				sm2.Scope().SetName("scope2")
 				sm2.Scope().SetVersion("v2")
-				sm3Attributes := sm2.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty().Attributes()
-				sm3Attributes.PutStr("foo", "bar")
+
+				dp3 := sm2.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp3.SetTimestamp(pcommon.Timestamp(3 * int64(time.Millisecond)))
+				dp3.SetDoubleValue(3.0)
+				dp3.Attributes().PutStr("foo", "bar")
+
 				return expected
 			}(),
 			expectedStats: remote.WriteResponseStats{},
@@ -225,23 +238,30 @@ func TestTranslateV2(t *testing.T) {
 				rmAttributes1.PutStr("service.namespace", "service-x")
 				rmAttributes1.PutStr("service.name", "test")
 				rmAttributes1.PutStr("service.instance.id", "107cn001")
+
 				sm1 := rm1.ScopeMetrics().AppendEmpty()
-				sm1Attributes := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty().Attributes()
-				sm1Attributes.PutStr("d", "e")
-				sm1Attributes.PutStr("foo", "bar")
-				// Since we don't check "scope_name" and "scope_version", we end up with duplicated scope metrics for repeated series.
-				// TODO: Properly handle scope metrics.
-				sm2Attributes := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty().Attributes()
-				sm2Attributes.PutStr("d", "e")
-				sm2Attributes.PutStr("foo", "bar")
+				dp1 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp1.SetTimestamp(pcommon.Timestamp(1 * int64(time.Millisecond)))
+				dp1.SetDoubleValue(1.0)
+				dp1.Attributes().PutStr("d", "e")
+				dp1.Attributes().PutStr("foo", "bar")
+
+				dp2 := sm1.Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp2.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
+				dp2.SetDoubleValue(2.0)
+				dp2.Attributes().PutStr("d", "e")
+				dp2.Attributes().PutStr("foo", "bar")
 
 				rm2 := expected.ResourceMetrics().AppendEmpty()
 				rmAttributes2 := rm2.Resource().Attributes()
 				rmAttributes2.PutStr("service.name", "foo")
 				rmAttributes2.PutStr("service.instance.id", "bar")
-				mAttributes2 := rm2.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty().Attributes()
-				mAttributes2.PutStr("d", "e")
-				mAttributes2.PutStr("foo", "bar")
+
+				dp3 := rm2.ScopeMetrics().AppendEmpty().Metrics().AppendEmpty().SetEmptyGauge().DataPoints().AppendEmpty()
+				dp3.SetTimestamp(pcommon.Timestamp(2 * int64(time.Millisecond)))
+				dp3.SetDoubleValue(2.0)
+				dp3.Attributes().PutStr("d", "e")
+				dp3.Attributes().PutStr("foo", "bar")
 
 				return expected
 			}(),


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description
Convert sample timestamps from milliseconds to nanoseconds. Set datapoint values using SetDoubleValue based on incoming sample values. Update tests in translateV2 to verify that samples are correctly ingested and their timestamps properly converted.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes part of #37277.

<!--Please delete paragraphs that you did not use before submitting.-->
