### PR TITLE
[exporter/elasticsearch] Fix data loss due to metric grouping regression

### DIFF
--- a/.chloggen/elasticsearchexporter_metrics-grouping-data-loss.yaml
+++ b/.chloggen/elasticsearchexporter_metrics-grouping-data-loss.yaml
@@ -15,7 +15,7 @@ issues: [37898]
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Fix data loss due to metric grouping regression in ECS and OTel mode. Data points / metrics were incorrectly grouped together, leading to data loss with warning logs.
+subtext: Fix data loss when the same metric exists across different resources or scopes. Data points / metrics were incorrectly grouped together, leading to data loss with warning logs e.g. "metric with name '***' has already been serialized".
 
 # If your change doesn't affect end users or the exported elements of any package,
 # you should instead start your pull request title with [chore] or use the "Skip Changelog" label.

--- a/.chloggen/elasticsearchexporter_metrics-grouping-data-loss.yaml
+++ b/.chloggen/elasticsearchexporter_metrics-grouping-data-loss.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix data loss caused by incorrect metric grouping in ECS and OTel mode
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37898]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Fix data loss due to metric grouping regression in ECS and OTel mode. Data points / metrics were incorrectly grouped together, leading to data loss with warning logs.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/exporter.go
+++ b/exporter/elasticsearchexporter/exporter.go
@@ -285,7 +285,7 @@ func (e *elasticsearchExporter) pushMetricsData(
 						groupedDataPoints = make(map[uint32]*dataPointsGroup)
 						groupedDataPointsByIndex[index] = groupedDataPoints
 					}
-					dpHash := hasher.hashDataPoint(dp)
+					dpHash := hasher.hashDataPoint(resource, scope, dp)
 					dpGroup, ok := groupedDataPoints[dpHash]
 					if !ok {
 						groupedDataPoints[dpHash] = &dataPointsGroup{

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -1035,7 +1035,7 @@ func TestExporterMetrics(t *testing.T) {
 			mustSendMetrics(t, exporter, metrics)
 
 			assertDocsInIndices(t, map[string]int{
-				"metrics-generic-bar":                1,
+				"metrics-generic-bar":                2, // AA, BA
 				"metrics-generic-resource.namespace": 3,
 				"metrics-scope.b-bar":                1,
 				"metrics-scope.b-resource.namespace": 3,

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -979,7 +979,7 @@ func TestExporterMetrics(t *testing.T) {
 
 		scopeAB := resourceA.ScopeMetrics().AppendEmpty()
 		fillAttributeMap(scopeAB.Scope().Attributes(), map[string]any{
-			elasticsearch.DataStreamDataset: "scope.b", // routes to a different index and should not be grouped together
+			elasticsearch.DataStreamDataset: "scope.ab", // routes to a different index and should not be grouped together
 		})
 		addToMetricSlice(scopeAB.Metrics())
 
@@ -987,7 +987,7 @@ func TestExporterMetrics(t *testing.T) {
 		fillAttributeMap(scopeAC.Scope().Attributes(), map[string]any{
 			// ecs: scope attributes are ignored, and duplicates are dropped silently.
 			// otel: scope attributes are dimensions and should result in a separate group.
-			"some.scope.attribute": "scope.c",
+			"some.scope.attribute": "scope.ac",
 		})
 		addToMetricSlice(scopeAC.Metrics())
 
@@ -1039,11 +1039,11 @@ func TestExporterMetrics(t *testing.T) {
 			mustSendMetrics(t, exporter, metrics)
 
 			assertDocsInIndices(t, map[string]int{
-				"metrics-generic-bar":                2, // AA, BA
-				"metrics-generic-resource.namespace": 3,
-				"metrics-scope.b-bar":                1,
-				"metrics-scope.b-resource.namespace": 3,
-				"metrics-generic-default":            3,
+				"metrics-generic-bar":                 2, // AA, BA
+				"metrics-generic-resource.namespace":  3,
+				"metrics-scope.ab-bar":                1,
+				"metrics-scope.ab-resource.namespace": 3,
+				"metrics-generic-default":             3,
 			}, rec)
 		})
 
@@ -1061,11 +1061,11 @@ func TestExporterMetrics(t *testing.T) {
 			mustSendMetrics(t, exporter, metrics)
 
 			assertDocsInIndices(t, map[string]int{
-				"metrics-generic.otel-bar":                4, // AA->bar, AC->bar, BA->bar, BB->bar
-				"metrics-generic.otel-resource.namespace": 6, // AA, AC
-				"metrics-scope.b.otel-bar":                1, // AB->bar
-				"metrics-scope.b.otel-resource.namespace": 3, // AB
-				"metrics-generic.otel-default":            6, // BA, BB
+				"metrics-generic.otel-bar":                 4, // AA->bar, AC->bar, BA->bar, BB->bar
+				"metrics-generic.otel-resource.namespace":  6, // AA, AC
+				"metrics-scope.ab.otel-bar":                1, // AB->bar
+				"metrics-scope.ab.otel-resource.namespace": 3, // AB
+				"metrics-generic.otel-default":             6, // BA, BB
 			}, rec)
 		})
 	})

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -997,6 +997,13 @@ func TestExporterMetrics(t *testing.T) {
 		scopeBA := resourceB.ScopeMetrics().AppendEmpty()
 		addToMetricSlice(scopeBA.Metrics())
 
+		// identical resource
+		resourceAnotherB := metrics.ResourceMetrics().AppendEmpty()
+		fillAttributeMap(resourceAnotherB.Resource().Attributes(), map[string]any{
+			"my.resource": "resource.b",
+		})
+		addToMetricSlice(resourceAnotherB.ScopeMetrics().AppendEmpty().Metrics())
+
 		t.Run("ecs", func(t *testing.T) {
 			rec := newBulkRecorder()
 			server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -1402,40 +1402,6 @@ func TestExporterMetrics(t *testing.T) {
 		assertRecordedItems(t, expected, rec, false)
 	})
 
-	t.Run("otel mode grouping of equal resources", func(t *testing.T) {
-		rec := newBulkRecorder()
-		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
-			rec.Record(docs)
-			return itemsAllOK(docs)
-		})
-
-		exporter := newTestMetricsExporter(t, server.URL, func(cfg *Config) {
-			cfg.Mapping.Mode = "otel"
-		})
-
-		metrics := pmetric.NewMetrics()
-		for _, n := range []string{"m1", "m2"} {
-			resourceMetric := metrics.ResourceMetrics().AppendEmpty()
-			scopeMetric := resourceMetric.ScopeMetrics().AppendEmpty()
-
-			sumMetric := scopeMetric.Metrics().AppendEmpty()
-			sumMetric.SetName(n)
-			sumDP := sumMetric.SetEmptySum().DataPoints().AppendEmpty()
-			sumDP.SetIntValue(0)
-		}
-
-		mustSendMetrics(t, exporter, metrics)
-
-		expected := []itemRequest{
-			{
-				Action:   []byte(`{"create":{"_index":"metrics-generic.otel-default","dynamic_templates":{"metrics.m1":"gauge_long","metrics.m2":"gauge_long"}}}`),
-				Document: []byte(`{"@timestamp":"0.0","data_stream":{"dataset":"generic.otel","namespace":"default","type":"metrics"},"metrics":{"m1":0,"m2":0},"resource":{},"scope":{}}`),
-			},
-		}
-
-		assertRecordedItems(t, expected, rec, false)
-	})
-
 	t.Run("otel mode aggregate_metric_double hint", func(t *testing.T) {
 		rec := newBulkRecorder()
 		server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -998,6 +998,10 @@ func TestExporterMetrics(t *testing.T) {
 		scopeBA := resourceB.ScopeMetrics().AppendEmpty()
 		addToMetricSlice(scopeBA.Metrics())
 
+		scopeBB := resourceB.ScopeMetrics().AppendEmpty()
+		scopeBB.Scope().SetName("scope.bb")
+		addToMetricSlice(scopeBB.Metrics())
+
 		// identical resource
 		resourceAnotherB := metrics.ResourceMetrics().AppendEmpty()
 		fillAttributeMap(resourceAnotherB.Resource().Attributes(), map[string]any{
@@ -1057,11 +1061,11 @@ func TestExporterMetrics(t *testing.T) {
 			mustSendMetrics(t, exporter, metrics)
 
 			assertDocsInIndices(t, map[string]int{
-				"metrics-generic.otel-bar":                3, // AA->bar, AC->bar, BA->bar
+				"metrics-generic.otel-bar":                4, // AA->bar, AC->bar, BA->bar, BB->bar
 				"metrics-generic.otel-resource.namespace": 6, // AA, AC
 				"metrics-scope.b.otel-bar":                1, // AB->bar
 				"metrics-scope.b.otel-resource.namespace": 3, // AB
-				"metrics-generic.otel-default":            3, // BA
+				"metrics-generic.otel-default":            6, // BA, BB
 			}, rec)
 		})
 	})

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -1019,7 +1019,7 @@ func TestExporterMetrics(t *testing.T) {
 			actualDocsPerIndex := make(map[string]int)
 			for _, item := range rec.Items() {
 				idx := gjson.GetBytes(item.Action, "create._index")
-				actualDocsPerIndex[idx.String()] += 1
+				actualDocsPerIndex[idx.String()]++
 			}
 			assert.Equal(t, wantDocsPerIndex, actualDocsPerIndex)
 		}

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"math"
 	"net/http"
 	"runtime"
@@ -1011,7 +1010,7 @@ func TestExporterMetrics(t *testing.T) {
 
 		assertDocsInIndices := func(t *testing.T, wantDocsPerIndex map[string]int, rec *bulkRecorder) {
 			var sum int
-			for v := range maps.Values(wantDocsPerIndex) {
+			for _, v := range wantDocsPerIndex {
 				sum += v
 			}
 			rec.WaitItems(sum)

--- a/exporter/elasticsearchexporter/exporter_test.go
+++ b/exporter/elasticsearchexporter/exporter_test.go
@@ -990,6 +990,13 @@ func TestExporterMetrics(t *testing.T) {
 		})
 		addToMetricSlice(scopeAC.Metrics())
 
+		resourceB := metrics.ResourceMetrics().AppendEmpty()
+		fillAttributeMap(resourceB.Resource().Attributes(), map[string]any{
+			"my.resource": "resource.b",
+		})
+		scopeBA := resourceB.ScopeMetrics().AppendEmpty()
+		addToMetricSlice(scopeBA.Metrics())
+
 		t.Run("ecs", func(t *testing.T) {
 			rec := newBulkRecorder()
 			server := newESTestServer(t, func(docs []itemRequest) ([]itemResponse, error) {
@@ -1036,6 +1043,18 @@ func TestExporterMetrics(t *testing.T) {
 				{
 					Action:   []byte(`{"create":{"_index":"metrics-scope.b-resource.namespace"}}`),
 					Document: []byte(`{"@timestamp":"1970-01-01T01:00:00.000000000Z","data_stream":{"dataset":"scope.b","namespace":"resource.namespace","type":"metrics"},"metric":{"baz":1.0}}`),
+				},
+				{
+					Action:   []byte(`{"create":{"_index":"metrics-generic-default"}}`),
+					Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"dp":{"attribute":"dp.attribute.value"},"metric":{"bar":1.0,"foo":1.0},"my":{"resource":"resource.b"}}`),
+				},
+				{
+					Action:   []byte(`{"create":{"_index":"metrics-generic-default"}}`),
+					Document: []byte(`{"@timestamp":"1970-01-01T00:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"bar":1.0,"foo":1},"my":{"resource":"resource.b"}}`),
+				},
+				{
+					Action:   []byte(`{"create":{"_index":"metrics-generic-default"}}`),
+					Document: []byte(`{"@timestamp":"1970-01-01T01:00:00.000000000Z","data_stream":{"dataset":"generic","namespace":"default","type":"metrics"},"metric":{"baz":1.0},"my":{"resource":"resource.b"}}`),
 				},
 			}
 

--- a/exporter/elasticsearchexporter/model_test.go
+++ b/exporter/elasticsearchexporter/model_test.go
@@ -101,7 +101,7 @@ func TestEncodeMetric(t *testing.T) {
 	dps := m.Sum().DataPoints()
 	for i := 0; i < dps.Len(); i++ {
 		dp := datapoints.NewNumber(m, dps.At(i))
-		dpHash := hasher.hashDataPoint(dp)
+		dpHash := hasher.hashDataPoint(rm.Resource(), sm.Scope(), dp)
 		dataPoints, ok := groupedDataPoints[dpHash]
 		if !ok {
 			groupedDataPoints[dpHash] = []datapoints.DataPoint{dp}


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fix data loss when the same metric exists across different resources or scopes. Data points / metrics were incorrectly grouped together due to missing hash on resource / scope, leading to data loss with warning logs e.g. "metric with name '***' has already been serialized".

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes #37898

<!--Describe what testing was performed and which tests were added.-->
#### Testing

<!--Describe the documentation added.-->
#### Documentation

<!--Please delete paragraphs that you did not use before submitting.-->
