### PR TITLE
fix(interval): Don't send empty metrics downstream

### DIFF
--- a/processor/intervalprocessor/processor.go
+++ b/processor/intervalprocessor/processor.go
@@ -171,6 +171,11 @@ func (p *Processor) ConsumeMetrics(ctx context.Context, md pmetric.Metrics) erro
 		return rm.ScopeMetrics().Len() == 0
 	})
 
+	// Don't send empty metrics downstream
+	if md.ResourceMetrics().Len() == 0 {
+		return errs
+	}
+
 	if err := p.nextConsumer.ConsumeMetrics(ctx, md); err != nil {
 		errs = errors.Join(errs, err)
 	}
@@ -222,6 +227,11 @@ func (p *Processor) exportMetrics() {
 
 		return out
 	}()
+
+	// Don't send empty metrics downstream
+	if md.ResourceMetrics().Len() == 0 {
+		return
+	}
 
 	if err := p.nextConsumer.ConsumeMetrics(p.ctx, md); err != nil {
 		p.logger.Error("Metrics export failed", zap.Error(err))


### PR DESCRIPTION
#### Description

Currently, interval processor will *always* send a metrics instance downstream, at every interval tick. Even if the instance is empty. This PR fixes this, to reduce spam, and so downstream exporters don't need to do extra filtering

#### Link to tracking issue
Fixes #37905

#### Testing
Locally built and ran the processor to see that no empty metrics are exported