### PR TITLE
[processor/k8sattributes] fix filter labels empty values bug

### DIFF
--- a/.chloggen/k8sattributes-fix-filter-labels-bug.yaml
+++ b/.chloggen/k8sattributes-fix-filter-labels-bug.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: k8sattributes
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where `Filters.Labels` failed with when the `exists` or `not-exists` operations were used.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37913]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/processor/k8sattributesprocessor/internal/kube/client.go
+++ b/processor/k8sattributesprocessor/internal/kube/client.go
@@ -949,7 +949,11 @@ func (c *WatchClient) shouldIgnorePod(pod *api_v1.Pod) bool {
 func selectorsFromFilters(filters Filters) (labels.Selector, fields.Selector, error) {
 	labelSelector := labels.Everything()
 	for _, f := range filters.Labels {
-		r, err := labels.NewRequirement(f.Key, f.Op, []string{f.Value})
+		var value []string
+		if f.Value != "" {
+			value = []string{f.Value}
+		}
+		r, err := labels.NewRequirement(f.Key, f.Op, value)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/processor/k8sattributesprocessor/internal/kube/informer_test.go
+++ b/processor/k8sattributesprocessor/internal/kube/informer_test.go
@@ -55,6 +55,10 @@ func Test_informerListFuncWithSelectors(t *testing.T) {
 				Value: "lv1",
 				Op:    selection.NotEquals,
 			},
+			{
+				Key: "lk2",
+				Op:  selection.Exists,
+			},
 		},
 	})
 	assert.NoError(t, err)


### PR DESCRIPTION
#### Description

Fix a bug where the k8sattributesprocessor's `Filter.Labels` configuration option errored when `op: exists` or `op:nont-exists` were used.

#### Link to tracking issue
Fixes https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/37892

<!--Describe what testing was performed and which tests were added.-->
#### Testing
Local testing and unit tests