### PR TITLE
[chore] Use public Linux ARM64 runners

### DIFF
--- a/.github/workflows/build-and-test-arm.yml
+++ b/.github/workflows/build-and-test-arm.yml
@@ -45,7 +45,7 @@ jobs:
           - cmd-1
           - other
     timeout-minutes: 30
-    runs-on: otel-linux-arm64
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -60,7 +60,7 @@ jobs:
           path: |
             ~/go/bin
             ~/go/pkg/mod
-          key: go-build-cache-otel-linux-arm64-go-${{ hashFiles('**/go.sum') }}
+          key: go-build-cache-ubuntu-22.04-arm-go-${{ hashFiles('**/go.sum') }}
       - name: Install dependencies
         if: steps.go-cache.outputs.cache-hit != 'true'
         run: make -j2 gomoddownload


### PR DESCRIPTION
#### Description

Switches Linux ARM64 runners to the public version.

#### Link to tracking issue
Handles https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/


<!--Describe what testing was performed and which tests were added.-->
#### Testing

CI

## Notes

Already done in .NET, .NET Auto and rust. It will allow to remove private runners from otel org and execute whole pipeline on public forks.
PR for collector: https://github.com/open-telemetry/opentelemetry-collector/pull/12389