### PR TITLE
elasticsearchexporter: refactor encoding; drop metrics support from raw/none/bodymap mapping modes

### DIFF
--- a/.chloggen/elasticsearchexporter-refactor-encoder.yaml
+++ b/.chloggen/elasticsearchexporter-refactor-encoder.yaml
@@ -1,0 +1,31 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: elasticsearchexporter
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: drop support for metrics for none, raw, and bodymap mapping modes
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37928]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  Metrics support is in development, and was added for "ecs" and "otel" mapping modes.
+  Support was unintentionally added for the other mapping modes, defaulting to the same
+  behaviour as "ecs" mode. While metrics support is still in development, drop support
+  from these mapping modes and require users to use the intended mapping modes.
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/exporter/elasticsearchexporter/README.md
+++ b/exporter/elasticsearchexporter/README.md
@@ -173,14 +173,77 @@ behaviours, which may be configured through the following settings:
             body is serialized to JSON as-is and becomes a separate document for ingestion.
             If the log record body is not a map, the exporter will log a warning and drop the log record.
 
+#### OTel mapping mode
+
+In `otel` mapping mode, the Elasticsearch Exporter stores documents in an OTel-native schema.
+
+| Signal    | Supported          |
+| --------- | ------------------ |
+| Logs      | :white_check_mark: |
+| Traces    | :white_check_mark: |
+| Metrics   | :white_check_mark: |
+| Profiles  | :white_check_mark: |
+
 #### ECS mapping mode
 
 > [!WARNING]
 > The ECS mode mapping mode is currently undergoing changes, and its behaviour is unstable.
 
-In ECS mapping mode, the Elasticsearch Exporter attempts to map fields from
-[OpenTelemetry Semantic Conventions][SemConv] (version 1.22.0) to [Elastic Common Schema][ECS].
+In `ecs` mapping mode, the Elasticsearch Exporter maps fields from
+[OpenTelemetry Semantic Conventions][SemConv] (version 1.22.0) to [Elastic Common Schema][ECS] where possible.
 This mode may be used for compatibility with existing dashboards that work with ECS.
+
+| Signal    | `ecs`              |
+| --------- | ------------------ |
+| Logs      | :white_check_mark: |
+| Traces    | :white_check_mark: |
+| Metrics   | :white_check_mark: |
+| Profiles  | :no_entry_sign:    |
+
+#### Bodymap mapping mode
+
+> [!WARNING]
+> The Bodymap mode mapping mode is currently undergoing changes, and its behaviour is unstable.
+
+In `bodymap` mapping mode, the Elasticsearch Exporter supports only logs and will take the "body"
+of a log record as the exact content of the Elasticsearch document without any transformation.
+This mapping mode is intended for use cases where the client wishes to have complete control over
+the Elasticsearch document structure.
+
+| Signal    | `bodymap`          |
+| --------- | ------------------ |
+| Logs      | :white_check_mark: |
+| Traces    | :no_entry_sign:    |
+| Metrics   | :no_entry_sign:    |
+| Profiles  | :no_entry_sign:    |
+
+#### Default (none) mapping mode
+
+In the `none` mapping mode the Elasticsearhc Exporter produces documents with the original
+field names of from the OTLP data structures.
+
+| Signal    | `none`             |
+| --------- | ------------------ |
+| Logs      | :white_check_mark: |
+| Traces    | :white_check_mark: |
+| Metrics   | :no_entry_sign:    |
+| Profiles  | :no_entry_sign:    |
+
+#### Raw mapping mode
+
+The `raw` mapping mode is identical to `none`, except for two differences:
+
+ - In `none` mode attributes are mapped with an `Attributes.` prefix,
+   while in `raw` mode they are not.
+ - In `none` mode span events are mapped with an `Events.` prefix,
+   while in `raw` mode they are not.
+
+| Signal    | `raw `             |
+| --------- | ------------------ |
+| Logs      | :white_check_mark: |
+| Traces    | :white_check_mark: |
+| Metrics   | :no_entry_sign:    |
+| Profiles  | :no_entry_sign:    |
 
 ### Elasticsearch ingest pipeline
 

--- a/exporter/elasticsearchexporter/integrationtest/datareceiver.go
+++ b/exporter/elasticsearchexporter/integrationtest/datareceiver.go
@@ -148,6 +148,8 @@ func (es *esDataReceiver) GenConfigYAMLStr() string {
       enabled: false
     sending_queue:
       enabled: true
+    mapping:
+      mode: otel
     retry:
       enabled: true
       initial_interval: 100ms

--- a/exporter/elasticsearchexporter/metadata.yaml
+++ b/exporter/elasticsearchexporter/metadata.yaml
@@ -12,3 +12,7 @@ status:
 tests:
   config:
     endpoints: [http://localhost:9200]
+    mapping:
+      # Set mapping mode to otel, since the default ("none") does
+      # not support all signals.
+      mode: otel

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -72,21 +72,85 @@ var resourceAttrsToPreserve = map[string]bool{
 
 var ErrInvalidTypeForBodyMapMode = errors.New("invalid log record body type for 'bodymap' mapping mode")
 
-type mappingModel interface {
-	encodeLog(pcommon.Resource, string, plog.LogRecord, pcommon.InstrumentationScope, string, elasticsearch.Index, *bytes.Buffer) error
-	encodeSpan(pcommon.Resource, string, ptrace.Span, pcommon.InstrumentationScope, string, elasticsearch.Index, *bytes.Buffer) error
-	encodeSpanEvent(resource pcommon.Resource, resourceSchemaURL string, span ptrace.Span, spanEvent ptrace.SpanEvent, scope pcommon.InstrumentationScope, scopeSchemaURL string, idx elasticsearch.Index, buf *bytes.Buffer)
-	encodeMetrics(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, dataPoints []datapoints.DataPoint, validationErrors *[]error, idx elasticsearch.Index, buf *bytes.Buffer) (map[string]string, error)
-	encodeProfile(pcommon.Resource, pcommon.InstrumentationScope, pprofile.Profile, func(*bytes.Buffer, string, string) error) error
+// documentEncoder is an interface for encoding signals to Elasticsearch documents.
+type documentEncoder interface {
+	encodeLog(encodingContext, plog.LogRecord, elasticsearch.Index, *bytes.Buffer) error
+	encodeSpan(encodingContext, ptrace.Span, elasticsearch.Index, *bytes.Buffer) error
+	encodeSpanEvent(encodingContext, ptrace.Span, ptrace.SpanEvent, elasticsearch.Index, *bytes.Buffer) error
+	encodeMetrics(_ encodingContext, _ []datapoints.DataPoint, validationErrors *[]error, _ elasticsearch.Index, _ *bytes.Buffer) (map[string]string, error)
+	encodeProfile(_ encodingContext, _ pprofile.Profile, _ func(*bytes.Buffer, string, string) error) error
 }
 
-// encodeModel tries to keep the event as close to the original open telemetry semantics as is.
-// No fields will be mapped by default.
-//
-// See: https://github.com/open-telemetry/oteps/blob/master/text/logs/0097-log-data-model.md
-type encodeModel struct {
-	mode MappingMode
+type encodingContext struct {
+	resource          pcommon.Resource
+	resourceSchemaURL string
+	scope             pcommon.InstrumentationScope
+	scopeSchemaURL    string
 }
+
+func newEncoder(mode MappingMode) (documentEncoder, error) {
+	switch mode {
+	case MappingNone:
+		return legacyModeEncoder{
+			metricsUnsupportedEncoder:  metricsUnsupportedEncoder{mode: mode},
+			profilesUnsupportedEncoder: profilesUnsupportedEncoder{mode: mode},
+			nonOTelSpanEncoder: nonOTelSpanEncoder{
+				attributesPrefix: "Attributes",
+				eventsPrefix:     "Events",
+			},
+			attributesPrefix: "Attributes",
+		}, nil
+	case MappingRaw:
+		return legacyModeEncoder{
+			metricsUnsupportedEncoder:  metricsUnsupportedEncoder{mode: mode},
+			profilesUnsupportedEncoder: profilesUnsupportedEncoder{mode: mode},
+			nonOTelSpanEncoder: nonOTelSpanEncoder{
+				attributesPrefix: "",
+				eventsPrefix:     "",
+			},
+			attributesPrefix: "",
+		}, nil
+	case MappingECS:
+		return ecsModeEncoder{
+			profilesUnsupportedEncoder: profilesUnsupportedEncoder{mode: mode},
+			nonOTelSpanEncoder: nonOTelSpanEncoder{
+				attributesPrefix: "Attributes",
+				eventsPrefix:     "Events",
+				dedot:            true,
+			},
+		}, nil
+	case MappingBodyMap:
+		return bodymapModeEncoder{
+			metricsUnsupportedEncoder:  metricsUnsupportedEncoder{mode: mode},
+			profilesUnsupportedEncoder: profilesUnsupportedEncoder{mode: mode},
+		}, nil
+	case MappingOTel:
+		return otelModeEncoder{}, nil
+	}
+	return nil, fmt.Errorf("unknown mapping mode %q (%d)", mode, int(mode))
+}
+
+type legacyModeEncoder struct {
+	nonOTelSpanEncoder
+	nopSpanEventEncoder
+	metricsUnsupportedEncoder
+	profilesUnsupportedEncoder
+	attributesPrefix string
+}
+
+type ecsModeEncoder struct {
+	ecsDataPointsEncoder
+	nonOTelSpanEncoder
+	nopSpanEventEncoder
+	profilesUnsupportedEncoder
+}
+
+type bodymapModeEncoder struct {
+	metricsUnsupportedEncoder
+	profilesUnsupportedEncoder
+}
+
+type otelModeEncoder struct{}
 
 const (
 	traceIDField   = "traceID"
@@ -94,63 +158,44 @@ const (
 	attributeField = "attribute"
 )
 
-func (m *encodeModel) encodeLog(resource pcommon.Resource, resourceSchemaURL string, record plog.LogRecord, scope pcommon.InstrumentationScope, scopeSchemaURL string, idx elasticsearch.Index, buf *bytes.Buffer) error {
-	var document objmodel.Document
-	switch m.mode {
-	case MappingECS:
-		document = m.encodeLogECSMode(resource, record, scope, idx)
-	case MappingOTel:
-		return otelserializer.SerializeLog(resource, resourceSchemaURL, scope, scopeSchemaURL, record, idx, buf)
-	case MappingBodyMap:
-		return m.encodeLogBodyMapMode(record, buf)
-	default:
-		document = m.encodeLogDefaultMode(resource, record, scope, idx)
-	}
-	return document.Serialize(buf, m.mode == MappingECS)
-}
-
-func (m *encodeModel) encodeLogDefaultMode(resource pcommon.Resource, record plog.LogRecord, scope pcommon.InstrumentationScope, idx elasticsearch.Index) objmodel.Document {
+func (e legacyModeEncoder) encodeLog(ec encodingContext, record plog.LogRecord, idx elasticsearch.Index, buf *bytes.Buffer) error {
 	var document objmodel.Document
 
 	docTimeStamp := record.Timestamp()
 	if docTimeStamp.AsTime().UnixNano() == 0 {
 		docTimeStamp = record.ObservedTimestamp()
 	}
-	document.AddTimestamp("@timestamp", docTimeStamp) // We use @timestamp in order to ensure that we can index if the default data stream logs template is used.
+	// We use @timestamp in order to ensure that we can index if the default data stream logs template is used.
+	document.AddTimestamp("@timestamp", docTimeStamp)
 	document.AddTraceID("TraceId", record.TraceID())
 	document.AddSpanID("SpanId", record.SpanID())
 	document.AddInt("TraceFlags", int64(record.Flags()))
 	document.AddString("SeverityText", record.SeverityText())
 	document.AddInt("SeverityNumber", int64(record.SeverityNumber()))
 	document.AddAttribute("Body", record.Body())
-	m.encodeAttributes(&document, record.Attributes(), idx)
-	document.AddAttributes("Resource", resource.Attributes())
-	document.AddAttributes("Scope", scopeToAttributes(scope))
+	document.AddAttributes("Resource", ec.resource.Attributes())
+	document.AddAttributes("Scope", scopeToAttributes(ec.scope))
+	encodeAttributes(e.attributesPrefix, &document, record.Attributes(), idx)
 
-	return document
+	return document.Serialize(buf, false)
 }
 
-func (m *encodeModel) encodeLogBodyMapMode(record plog.LogRecord, buf *bytes.Buffer) error {
-	body := record.Body()
-	if body.Type() != pcommon.ValueTypeMap {
-		return fmt.Errorf("%w: %q", ErrInvalidTypeForBodyMapMode, body.Type())
-	}
-
-	serializer.Map(body.Map(), buf)
-	return nil
-}
-
-func (m *encodeModel) encodeLogECSMode(resource pcommon.Resource, record plog.LogRecord, scope pcommon.InstrumentationScope, idx elasticsearch.Index) objmodel.Document {
+func (e ecsModeEncoder) encodeLog(
+	ec encodingContext,
+	record plog.LogRecord,
+	idx elasticsearch.Index,
+	buf *bytes.Buffer,
+) error {
 	var document objmodel.Document
 
 	// First, try to map resource-level attributes to ECS fields.
-	encodeAttributesECSMode(&document, resource.Attributes(), resourceAttrsConversionMap, resourceAttrsToPreserve)
+	encodeAttributesECSMode(&document, ec.resource.Attributes(), resourceAttrsConversionMap, resourceAttrsToPreserve)
 
 	// Then, try to map scope-level attributes to ECS fields.
 	scopeAttrsConversionMap := map[string]string{
 		// None at the moment
 	}
-	encodeAttributesECSMode(&document, scope.Attributes(), scopeAttrsConversionMap, resourceAttrsToPreserve)
+	encodeAttributesECSMode(&document, ec.scope.Attributes(), scopeAttrsConversionMap, resourceAttrsToPreserve)
 
 	// Finally, try to map record-level attributes to ECS fields.
 	recordAttrsConversionMap := map[string]string{
@@ -164,9 +209,9 @@ func (m *encodeModel) encodeLogECSMode(resource pcommon.Resource, record plog.Lo
 	addDataStreamAttributes(&document, "", idx)
 
 	// Handle special cases.
-	encodeLogAgentNameECSMode(&document, resource)
-	encodeLogAgentVersionECSMode(&document, resource)
-	encodeLogHostOsTypeECSMode(&document, resource)
+	encodeLogAgentNameECSMode(&document, ec.resource)
+	encodeLogAgentVersionECSMode(&document, ec.resource)
+	encodeLogHostOsTypeECSMode(&document, ec.resource)
 	encodeLogTimestampECSMode(&document, record)
 	document.AddTraceID("trace.id", record.TraceID())
 	document.AddSpanID("span.id", record.SpanID())
@@ -180,13 +225,162 @@ func (m *encodeModel) encodeLogECSMode(resource pcommon.Resource, record plog.Lo
 		document.AddAttribute("message", record.Body())
 	}
 
-	return document
+	return document.Serialize(buf, true)
 }
 
-func (m *encodeModel) encodeDataPointsECSMode(resource pcommon.Resource, dataPoints []datapoints.DataPoint, validationErrors *[]error, idx elasticsearch.Index, buf *bytes.Buffer) (map[string]string, error) {
+func (e otelModeEncoder) encodeLog(
+	ec encodingContext,
+	record plog.LogRecord,
+	idx elasticsearch.Index,
+	buf *bytes.Buffer,
+) error {
+	return otelserializer.SerializeLog(
+		ec.resource, ec.resourceSchemaURL,
+		ec.scope, ec.scopeSchemaURL,
+		record, idx, buf,
+	)
+}
+
+func (otelModeEncoder) encodeSpan(
+	ec encodingContext,
+	span ptrace.Span,
+	idx elasticsearch.Index,
+	buf *bytes.Buffer,
+) error {
+	return otelserializer.SerializeSpan(
+		ec.resource, ec.resourceSchemaURL,
+		ec.scope, ec.scopeSchemaURL,
+		span, idx, buf,
+	)
+}
+
+func (otelModeEncoder) encodeSpanEvent(
+	ec encodingContext,
+	span ptrace.Span,
+	spanEvent ptrace.SpanEvent,
+	idx elasticsearch.Index,
+	buf *bytes.Buffer,
+) error {
+	otelserializer.SerializeSpanEvent(
+		ec.resource, ec.resourceSchemaURL,
+		ec.scope, ec.scopeSchemaURL,
+		span, spanEvent, idx, buf,
+	)
+	return nil
+}
+
+func (otelModeEncoder) encodeMetrics(
+	ec encodingContext,
+	dataPoints []datapoints.DataPoint,
+	validationErrors *[]error,
+	idx elasticsearch.Index,
+	buf *bytes.Buffer,
+) (map[string]string, error) {
+	return otelserializer.SerializeMetrics(
+		ec.resource, ec.resourceSchemaURL,
+		ec.scope, ec.scopeSchemaURL,
+		dataPoints, validationErrors, idx, buf,
+	)
+}
+
+func (otelModeEncoder) encodeProfile(
+	ec encodingContext,
+	profile pprofile.Profile,
+	pushData func(*bytes.Buffer, string, string) error,
+) error {
+	return otelserializer.SerializeProfile(ec.resource, ec.scope, profile, pushData)
+}
+
+func (e bodymapModeEncoder) encodeLog(
+	_ encodingContext,
+	record plog.LogRecord,
+	_ elasticsearch.Index,
+	buf *bytes.Buffer,
+) error {
+	body := record.Body()
+	if body.Type() != pcommon.ValueTypeMap {
+		return fmt.Errorf("%w: %q", ErrInvalidTypeForBodyMapMode, body.Type())
+	}
+	serializer.Map(body.Map(), buf)
+	return nil
+}
+
+func (bodymapModeEncoder) encodeSpan(encodingContext, ptrace.Span, elasticsearch.Index, *bytes.Buffer) error {
+	return fmt.Errorf("bodymap mode does not support encoding spans")
+}
+
+func (bodymapModeEncoder) encodeSpanEvent(encodingContext, ptrace.Span, ptrace.SpanEvent, elasticsearch.Index, *bytes.Buffer) error {
+	return fmt.Errorf("bodymap mode does not support encoding span events")
+}
+
+type metricsUnsupportedEncoder struct {
+	mode MappingMode
+}
+
+//nolint:unparam // result 0 is expected to always be nil
+func (e metricsUnsupportedEncoder) encodeMetrics(
+	_ encodingContext,
+	_ []datapoints.DataPoint,
+	_ *[]error,
+	_ elasticsearch.Index,
+	_ *bytes.Buffer,
+) (map[string]string, error) {
+	return nil, fmt.Errorf("mapping mode %q (%d) does not support metrics", e.mode, int(e.mode))
+}
+
+type profilesUnsupportedEncoder struct {
+	mode MappingMode
+}
+
+func (e profilesUnsupportedEncoder) encodeProfile(
+	_ encodingContext, _ pprofile.Profile, _ func(*bytes.Buffer, string, string) error,
+) error {
+	return fmt.Errorf("mapping mode %q (%d) does not support profiles", e.mode, int(e.mode))
+}
+
+type nonOTelSpanEncoder struct {
+	attributesPrefix string
+	eventsPrefix     string
+	dedot            bool
+}
+
+func (e nonOTelSpanEncoder) encodeSpan(
+	ec encodingContext,
+	span ptrace.Span,
+	idx elasticsearch.Index,
+	buf *bytes.Buffer,
+) error {
+	var document objmodel.Document
+	document.AddTimestamp("@timestamp", span.StartTimestamp()) // We use @timestamp in order to ensure that we can index if the default data stream logs template is used.
+	document.AddTimestamp("EndTimestamp", span.EndTimestamp())
+	document.AddTraceID("TraceId", span.TraceID())
+	document.AddSpanID("SpanId", span.SpanID())
+	document.AddSpanID("ParentSpanId", span.ParentSpanID())
+	document.AddString("Name", span.Name())
+	document.AddString("Kind", traceutil.SpanKindStr(span.Kind()))
+	document.AddInt("TraceStatus", int64(span.Status().Code()))
+	document.AddString("TraceStatusDescription", span.Status().Message())
+	document.AddString("Link", spanLinksToString(span.Links()))
+	document.AddAttributes("Resource", ec.resource.Attributes())
+	document.AddInt("Duration", durationAsMicroseconds(span.StartTimestamp().AsTime(), span.EndTimestamp().AsTime())) // unit is microseconds
+	document.AddAttributes("Scope", scopeToAttributes(ec.scope))
+	encodeAttributes(e.attributesPrefix, &document, span.Attributes(), idx)
+	document.AddEvents(e.eventsPrefix, span.Events())
+	return document.Serialize(buf, e.dedot)
+}
+
+type ecsDataPointsEncoder struct{}
+
+func (ecsDataPointsEncoder) encodeMetrics(
+	ec encodingContext,
+	dataPoints []datapoints.DataPoint,
+	validationErrors *[]error,
+	idx elasticsearch.Index,
+	buf *bytes.Buffer,
+) (map[string]string, error) {
 	dp0 := dataPoints[0]
 	var document objmodel.Document
-	encodeAttributesECSMode(&document, resource.Attributes(), resourceAttrsConversionMap, resourceAttrsToPreserve)
+	encodeAttributesECSMode(&document, ec.resource.Attributes(), resourceAttrsConversionMap, resourceAttrsToPreserve)
 	document.AddTimestamp("@timestamp", dp0.Timestamp())
 	document.AddAttributes("", dp0.Attributes())
 	addDataStreamAttributes(&document, "", idx)
@@ -212,55 +406,7 @@ func addDataStreamAttributes(document *objmodel.Document, key string, idx elasti
 	}
 }
 
-func (m *encodeModel) encodeMetrics(resource pcommon.Resource, resourceSchemaURL string, scope pcommon.InstrumentationScope, scopeSchemaURL string, dataPoints []datapoints.DataPoint, validationErrors *[]error, idx elasticsearch.Index, buf *bytes.Buffer) (map[string]string, error) {
-	switch m.mode {
-	case MappingOTel:
-		return otelserializer.SerializeMetrics(resource, resourceSchemaURL, scope, scopeSchemaURL, dataPoints, validationErrors, idx, buf)
-	default:
-		return m.encodeDataPointsECSMode(resource, dataPoints, validationErrors, idx, buf)
-	}
-}
-
-func (m *encodeModel) encodeSpan(resource pcommon.Resource, resourceSchemaURL string, span ptrace.Span, scope pcommon.InstrumentationScope, scopeSchemaURL string, idx elasticsearch.Index, buf *bytes.Buffer) error {
-	var document objmodel.Document
-	switch m.mode {
-	case MappingOTel:
-		return otelserializer.SerializeSpan(resource, resourceSchemaURL, scope, scopeSchemaURL, span, idx, buf)
-	default:
-		document = m.encodeSpanDefaultMode(resource, span, scope, idx)
-	}
-	return document.Serialize(buf, m.mode == MappingECS)
-}
-
-func (m *encodeModel) encodeSpanDefaultMode(resource pcommon.Resource, span ptrace.Span, scope pcommon.InstrumentationScope, idx elasticsearch.Index) objmodel.Document {
-	var document objmodel.Document
-	document.AddTimestamp("@timestamp", span.StartTimestamp()) // We use @timestamp in order to ensure that we can index if the default data stream logs template is used.
-	document.AddTimestamp("EndTimestamp", span.EndTimestamp())
-	document.AddTraceID("TraceId", span.TraceID())
-	document.AddSpanID("SpanId", span.SpanID())
-	document.AddSpanID("ParentSpanId", span.ParentSpanID())
-	document.AddString("Name", span.Name())
-	document.AddString("Kind", traceutil.SpanKindStr(span.Kind()))
-	document.AddInt("TraceStatus", int64(span.Status().Code()))
-	document.AddString("TraceStatusDescription", span.Status().Message())
-	document.AddString("Link", spanLinksToString(span.Links()))
-	m.encodeAttributes(&document, span.Attributes(), idx)
-	document.AddAttributes("Resource", resource.Attributes())
-	m.encodeEvents(&document, span.Events())
-	document.AddInt("Duration", durationAsMicroseconds(span.StartTimestamp().AsTime(), span.EndTimestamp().AsTime())) // unit is microseconds
-	document.AddAttributes("Scope", scopeToAttributes(scope))
-	return document
-}
-
-func (m *encodeModel) encodeSpanEvent(resource pcommon.Resource, resourceSchemaURL string, span ptrace.Span, spanEvent ptrace.SpanEvent, scope pcommon.InstrumentationScope, scopeSchemaURL string, idx elasticsearch.Index, buf *bytes.Buffer) {
-	if m.mode != MappingOTel {
-		// Currently span events are stored separately only in OTel mapping mode.
-		// In other modes, they are stored within the span document.
-		return
-	}
-	otelserializer.SerializeSpanEvent(resource, resourceSchemaURL, scope, scopeSchemaURL, span, spanEvent, idx, buf)
-}
-
+/*
 func (m *encodeModel) encodeProfile(resource pcommon.Resource, scope pcommon.InstrumentationScope, record pprofile.Profile, pushData func(*bytes.Buffer, string, string) error) error {
 	switch m.mode {
 	case MappingOTel:
@@ -269,22 +415,21 @@ func (m *encodeModel) encodeProfile(resource pcommon.Resource, scope pcommon.Ins
 		return errors.New("profiles can only be encoded in OTel mode")
 	}
 }
+*/
 
-func (m *encodeModel) encodeAttributes(document *objmodel.Document, attributes pcommon.Map, idx elasticsearch.Index) {
-	key := "Attributes"
-	if m.mode == MappingRaw {
-		key = ""
-	}
-	document.AddAttributes(key, attributes)
-	addDataStreamAttributes(document, key, idx)
+// nopSpanEventEncoder is embedded in all non-OTel encoders,
+// since only OTel mapping mode currently encodes span events
+// as separate documents. In all others they are stored within
+// the span document.
+type nopSpanEventEncoder struct{}
+
+func (nopSpanEventEncoder) encodeSpanEvent(encodingContext, ptrace.Span, ptrace.SpanEvent, elasticsearch.Index, *bytes.Buffer) error {
+	return nil
 }
 
-func (m *encodeModel) encodeEvents(document *objmodel.Document, events ptrace.SpanEventSlice) {
-	key := "Events"
-	if m.mode == MappingRaw {
-		key = ""
-	}
-	document.AddEvents(key, events)
+func encodeAttributes(prefix string, document *objmodel.Document, attributes pcommon.Map, idx elasticsearch.Index) {
+	document.AddAttributes(prefix, attributes)
+	addDataStreamAttributes(document, prefix, idx)
 }
 
 func spanLinksToString(spanLinkSlice ptrace.SpanLinkSlice) string {

--- a/exporter/elasticsearchexporter/model.go
+++ b/exporter/elasticsearchexporter/model.go
@@ -406,17 +406,6 @@ func addDataStreamAttributes(document *objmodel.Document, key string, idx elasti
 	}
 }
 
-/*
-func (m *encodeModel) encodeProfile(resource pcommon.Resource, scope pcommon.InstrumentationScope, record pprofile.Profile, pushData func(*bytes.Buffer, string, string) error) error {
-	switch m.mode {
-	case MappingOTel:
-		return otelserializer.SerializeProfile(resource, scope, record, pushData)
-	default:
-		return errors.New("profiles can only be encoded in OTel mode")
-	}
-}
-*/
-
 // nopSpanEventEncoder is embedded in all non-OTel encoders,
 // since only OTel mapping mode currently encodes span events
 // as separate documents. In all others they are stored within


### PR DESCRIPTION
#### Description

Remove `mappingModel`, replace with `encoder` interface with mapping mode-specific implementations. Drop support for encoding metrics from "none", "raw", and "bodymap" mapping modes - I don't think their support was intentional.

#### Link to tracking issue

More refactoring related to https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/36092

#### Testing

Unit tests added. Non-functional change, except that none/raw/bodymap can no longer handle metrics.

#### Documentation

N/A