### PR TITLE
[tailsamplingprocessor] [chore] Fix merge of #37797 and #37035

### DIFF
--- a/processor/tailsamplingprocessor/factory.go
+++ b/processor/tailsamplingprocessor/factory.go
@@ -39,10 +39,9 @@ func createTracesProcessor(
 	nextConsumer consumer.Traces,
 ) (processor.Traces, error) {
 	tCfg := cfg.(*Config)
-	opts := []Option{}
 
 	if telemetry.IsRecordPolicyEnabled() {
-		opts = append(opts, withRecordPolicy())
+		tCfg.Options = append(tCfg.Options, withRecordPolicy())
 	}
-	return newTracesProcessor(ctx, params, nextConsumer, *tCfg, opts...)
+	return newTracesProcessor(ctx, params, nextConsumer, *tCfg)
 }

--- a/processor/tailsamplingprocessor/processor_decisions_test.go
+++ b/processor/tailsamplingprocessor/processor_decisions_test.go
@@ -168,10 +168,6 @@ func TestSamplingMultiplePolicies(t *testing.T) {
 }
 
 func TestSamplingMultiplePolicies_WithRecordPolicy(t *testing.T) {
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-	}
 	nextConsumer := new(consumertest.TracesSink)
 	s := setupTestTelemetry()
 	ct := s.newSettings()
@@ -185,7 +181,13 @@ func TestSamplingMultiplePolicies_WithRecordPolicy(t *testing.T) {
 		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
 	}
 
-	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg, withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy())
+	cfg := Config{
+		DecisionWait: defaultTestDecisionWait,
+		NumTraces:    defaultNumTraces,
+		Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
+	}
+
+	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg)
 	require.NoError(t, err)
 
 	require.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
@@ -267,10 +269,6 @@ func TestSamplingPolicyDecisionNotSampled(t *testing.T) {
 }
 
 func TestSamplingPolicyDecisionNotSampled_WithRecordPolicy(t *testing.T) {
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-	}
 	nextConsumer := new(consumertest.TracesSink)
 	s := setupTestTelemetry()
 	ct := s.newSettings()
@@ -282,7 +280,13 @@ func TestSamplingPolicyDecisionNotSampled_WithRecordPolicy(t *testing.T) {
 		{name: "mock-policy-1", evaluator: mpe1, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-1"))},
 	}
 
-	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg, withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy())
+	cfg := Config{
+		DecisionWait: defaultTestDecisionWait,
+		NumTraces:    defaultNumTraces,
+		Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
+	}
+
+	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg)
 	require.NoError(t, err)
 
 	require.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))
@@ -361,10 +365,6 @@ func TestSamplingPolicyDecisionInvertNotSampled(t *testing.T) {
 }
 
 func TestSamplingPolicyDecisionInvertNotSampled_WithRecordPolicy(t *testing.T) {
-	cfg := Config{
-		DecisionWait: defaultTestDecisionWait,
-		NumTraces:    defaultNumTraces,
-	}
 	nextConsumer := new(consumertest.TracesSink)
 	s := setupTestTelemetry()
 	ct := s.newSettings()
@@ -378,7 +378,13 @@ func TestSamplingPolicyDecisionInvertNotSampled_WithRecordPolicy(t *testing.T) {
 		{name: "mock-policy-2", evaluator: mpe2, attribute: metric.WithAttributes(attribute.String("policy", "mock-policy-2"))},
 	}
 
-	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg, withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy())
+	cfg := Config{
+		DecisionWait: defaultTestDecisionWait,
+		NumTraces:    defaultNumTraces,
+		Options:      []Option{withDecisionBatcher(idb), withPolicies(policies), withRecordPolicy()},
+	}
+
+	p, err := newTracesProcessor(context.Background(), ct, nextConsumer, cfg)
 	require.NoError(t, err)
 
 	require.NoError(t, p.Start(context.Background(), componenttest.NewNopHost()))


### PR DESCRIPTION
#### Description

Two PRs were merged recently on the tailsamplingprocessor, #37797 and #37035. #37035 changed the signature of an internal function in a way that broke #37797. The result is that the component [fails to build](https://github.com/open-telemetry/opentelemetry-collector/actions/runs/13329091378/job/37228871811?pr=12384). This PR fixes that.

This wasn't noticed before merging because 1. there were no merge conflicts, 2. the latest rebase of #37797 was before #37035 was merged, and 3. there is no merge queue to perform final checks.