### PR TITLE
[reciever/azureeventhub] Fix reload offset bug

### DIFF
--- a/.chloggen/azure-eventhub-checkpoint.yaml
+++ b/.chloggen/azure-eventhub-checkpoint.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: azureeventhubreceiver
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix bug where persisted offset would be ignored after restart
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37157]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/receiver/azureeventhubreceiver/README.md
+++ b/receiver/azureeventhubreceiver/README.md
@@ -34,6 +34,7 @@ Default: ""
 
 ### offset (Optional)
 The offset at which to start watching the event hub. If empty, it starts with the latest offset.
+Only applicable when `partition` is set.
 
 Default: ""
 

--- a/receiver/azureeventhubreceiver/config.go
+++ b/receiver/azureeventhubreceiver/config.go
@@ -61,5 +61,8 @@ func (config *Config) Validate() error {
 	if !isValidFormat(config.Format) {
 		return fmt.Errorf("invalid format; must be one of %#v", validFormats)
 	}
+	if config.Partition == "" && config.Offset != "" {
+		return errors.New("cannot use 'offset' without 'partition'")
+	}
 	return nil
 }

--- a/receiver/azureeventhubreceiver/config_test.go
+++ b/receiver/azureeventhubreceiver/config_test.go
@@ -74,3 +74,10 @@ func TestInvalidFormat(t *testing.T) {
 	err := xconfmap.Validate(cfg)
 	assert.ErrorContains(t, err, "invalid format; must be one of")
 }
+
+func TestOffsetWithoutPartition(t *testing.T) {
+	cfg := NewFactory().CreateDefaultConfig().(*Config)
+	cfg.Connection = "Endpoint=sb://namespace.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=superSecret1234=;EntityPath=hubName"
+	cfg.Offset = "foo"
+	assert.ErrorContains(t, cfg.Validate(), "cannot use 'offset' without 'partition'")
+}

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -71,60 +71,33 @@ func (h *eventhubHandler) run(ctx context.Context, host component.Host) error {
 			h.settings.Logger.Debug("Error connecting to Event Hub", zap.Error(newHubErr))
 			return newHubErr
 		}
-		h.hub = &hubWrapperImpl{
-			hub: hub,
-		}
+		h.hub = &hubWrapperImpl{hub: hub}
 	}
 
-	if h.config.Partition == "" {
-		// listen to each partition of the Event Hub
-		runtimeInfo, err := h.hub.GetRuntimeInformation(ctx)
-		if err != nil {
-			h.settings.Logger.Debug("Error getting Runtime Information", zap.Error(err))
-			return err
-		}
-
-		for _, partitionID := range runtimeInfo.PartitionIDs {
-			err = h.setUpOnePartition(ctx, partitionID, false)
-			if err != nil {
-				h.settings.Logger.Debug("Error setting up partition", zap.Error(err))
-				return err
-			}
-		}
-	} else {
+	if h.config.Partition != "" {
 		err := h.setUpOnePartition(ctx, h.config.Partition, true)
 		if err != nil {
 			h.settings.Logger.Debug("Error setting up partition", zap.Error(err))
-			return err
 		}
-	}
-
-	if h.hub != nil {
-		return nil
-	}
-
-	hub, err := eventhub.NewHubFromConnectionString(h.config.Connection)
-	if err != nil {
 		return err
 	}
 
-	h.hub = &hubWrapperImpl{
-		hub: hub,
-	}
-
-	runtimeInfo, err := hub.GetRuntimeInformation(ctx)
+	// listen to each partition of the Event Hub
+	runtimeInfo, err := h.hub.GetRuntimeInformation(ctx)
 	if err != nil {
+		h.settings.Logger.Debug("Error getting Runtime Information", zap.Error(err))
 		return err
 	}
 
+	var errs []error
 	for _, partitionID := range runtimeInfo.PartitionIDs {
-		_, err := hub.Receive(ctx, partitionID, h.newMessageHandler, eventhub.ReceiveWithLatestOffset())
+		err = h.setUpOnePartition(ctx, partitionID, false)
 		if err != nil {
-			return err
+			h.settings.Logger.Debug("Error setting up partition", zap.Error(err), zap.String("partition", partitionID))
+			errs = append(errs, err)
 		}
 	}
-
-	return nil
+	return errors.Join(errs...)
 }
 
 func (h *eventhubHandler) setUpOnePartition(ctx context.Context, partitionID string, applyOffset bool) error {

--- a/receiver/azureeventhubreceiver/eventhubhandler.go
+++ b/receiver/azureeventhubreceiver/eventhubhandler.go
@@ -104,8 +104,6 @@ func (h *eventhubHandler) setUpOnePartition(ctx context.Context, partitionID str
 	receiverOptions := []eventhub.ReceiveOption{}
 	if applyOffset && h.config.Offset != "" {
 		receiverOptions = append(receiverOptions, eventhub.ReceiveWithStartingOffset(h.config.Offset))
-	} else {
-		receiverOptions = append(receiverOptions, eventhub.ReceiveWithLatestOffset())
 	}
 
 	if h.config.ConsumerGroup != "" {


### PR DESCRIPTION
Resolves #37157.

Also removes a significant dead code path, and slightly refactors what's left. Clarifies that `offset` is only applicable when `partition` is set (because otherwise the same offset would apply to all partitions, which doesn't make sense).