### PR TITLE
[chore][exporter/datadog] Add integration tests on metrics mapping

### DIFF
--- a/exporter/datadogexporter/integrationtest/go.mod
+++ b/exporter/datadogexporter/integrationtest/go.mod
@@ -8,7 +8,9 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/common v0.119.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor v0.119.0
+	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver v0.119.0
 	github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver v0.119.0
 	github.com/stretchr/testify v1.10.0
 	github.com/tinylib/msgp v1.2.5
@@ -262,7 +264,7 @@ require (
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/filter v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/k8sconfig v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/internal/metadataproviders v0.119.0 // indirect
-	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog v0.119.0 // indirect
+	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/experimentalmetricmetadata v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/pdatautil v0.119.0 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.119.0 // indirect
@@ -283,6 +285,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
+	github.com/prometheus-community/windows_exporter v0.27.2 // indirect
 	github.com/prometheus/client_golang v1.20.5 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
@@ -302,6 +305,7 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stormcat24/protodep v0.1.8 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect
+	github.com/tilinna/clock v1.1.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.14 // indirect
 	github.com/tklauser/numcpus v0.9.0 // indirect
 	github.com/ua-parser/uap-go v0.0.0-20240611065828-3a4781585db6 // indirect
@@ -342,6 +346,7 @@ require (
 	go.opentelemetry.io/collector/extension/extensioncapabilities v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/extension/extensiontest v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/extension/xextension v0.119.1-0.20250210123122-44b3eeda354c // indirect
+	go.opentelemetry.io/collector/filter v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/internal/fanoutconsumer v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/internal/sharedcomponent v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/pdata v1.25.1-0.20250210123122-44b3eeda354c // indirect
@@ -353,6 +358,8 @@ require (
 	go.opentelemetry.io/collector/processor/xprocessor v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/receiver/receivertest v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/receiver/xreceiver v0.119.1-0.20250210123122-44b3eeda354c // indirect
+	go.opentelemetry.io/collector/scraper v0.119.1-0.20250210123122-44b3eeda354c // indirect
+	go.opentelemetry.io/collector/scraper/scraperhelper v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/semconv v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/collector/service v0.119.1-0.20250210123122-44b3eeda354c // indirect
 	go.opentelemetry.io/contrib/bridges/otelzap v0.9.0 // indirect

--- a/exporter/datadogexporter/integrationtest/go.sum
+++ b/exporter/datadogexporter/integrationtest/go.sum
@@ -36,6 +36,8 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RXyy7KQOVs=
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0 h1:nyQWyZvwGTvunIMxi1Y9uXkcyr+I7TeNrr/foo4Kpk8=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.14.0/go.mod h1:l38EPgmsp71HHLq9j7De57JcKOWPyhrsW1Awm1JS6K0=
@@ -343,6 +345,8 @@ github.com/containerd/cgroups/v3 v3.0.5 h1:44na7Ud+VwyE7LIoJ8JTNQOa549a8543BmzaJ
 github.com/containerd/cgroups/v3 v3.0.5/go.mod h1:SA5DLYnXO8pTGYiAHXz94qvLQTKfVM5GEVisn4jpins=
 github.com/containerd/log v0.1.0 h1:TCJt7ioM2cr/tfR8GPbGf9/VRAX8D2B4PjzCpfX540I=
 github.com/containerd/log v0.1.0/go.mod h1:VRRf09a7mHDIRezVKTRCrOq78v577GXq3bSa3EhrzVo=
+github.com/containerd/platforms v0.2.1 h1:zvwtM3rz2YHPQsF2CHYM8+KtB5dvhISiXh5ZpSBQv6A=
+github.com/containerd/platforms v0.2.1/go.mod h1:XHCb+2/hzowdiut9rkudds9bE5yJ7npe7dG/wG+uFPw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.3/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -353,6 +357,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/dockercfg v0.3.2 h1:DlJTyZGBDlXqUZ2Dk2Q3xHs/FtnooJJVaad2S9GKorA=
+github.com/cpuguy83/dockercfg v0.3.2/go.mod h1:sugsbF4//dDlL/i+S+rtpIWp+5h0BHJHfjj5/jFyUJc=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -773,7 +779,13 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
+github.com/moby/patternmatcher v0.6.0 h1:GmP9lR19aU5GqSSFko+5pRqHi+Ohk1O69aFiKkVGiPk=
+github.com/moby/patternmatcher v0.6.0/go.mod h1:hDPoyOpDY7OrrMDLaYoY3hf52gNCR/YOUYxkhApJIxc=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
+github.com/moby/sys/sequential v0.5.0 h1:OPvI35Lzn9K04PBbCLW0g4LcFAJgHsvXsRyewg5lXtc=
+github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
+github.com/moby/sys/user v0.1.0 h1:WmZ93f5Ux6het5iituh9x2zAG7NFY9Aqi49jjE1PaQg=
+github.com/moby/sys/user v0.1.0/go.mod h1:fKJhFOnsCN6xZ5gSfbM6zaHGgDJMrqt9/reuj4T7MmU=
 github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.0 h1:xt8Q1nalod/v7BqbG21f8mQPqH+xAaC9C3N3wfWbVP0=
@@ -971,6 +983,8 @@ github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
+github.com/testcontainers/testcontainers-go v0.35.0 h1:uADsZpTKFAtp8SLK+hMwSaa+X+JiERHtd4sQAFmXeMo=
+github.com/testcontainers/testcontainers-go v0.35.0/go.mod h1:oEVBj5zrfJTrgjwONs1SsRbnBtH9OKl+IGl3UMcr2B4=
 github.com/tidwall/gjson v1.10.2 h1:APbLGOM0rrEkd8WBw9C24nllro4ajFuJu0Sc9hRz8Bo=
 github.com/tidwall/gjson v1.10.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
 github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
@@ -1163,6 +1177,8 @@ go.opentelemetry.io/collector/scraper v0.119.1-0.20250210123122-44b3eeda354c h1:
 go.opentelemetry.io/collector/scraper v0.119.1-0.20250210123122-44b3eeda354c/go.mod h1:VhtDISOJAfQTrx3L9OYS6MLrI2qFDheC6Hw+DLnM2QU=
 go.opentelemetry.io/collector/scraper/scraperhelper v0.119.1-0.20250210123122-44b3eeda354c h1:M7MIgzjHeyVESxgwwYEnftii6oA0tmdJaoV5nGpd2R8=
 go.opentelemetry.io/collector/scraper/scraperhelper v0.119.1-0.20250210123122-44b3eeda354c/go.mod h1:nnbuqNnmtYhjKT+wlj7PB1qvbotE1bN89f1+/YfCBmc=
+go.opentelemetry.io/collector/scraper/scrapertest v0.119.1-0.20250210123122-44b3eeda354c h1:qlFUGkEBIV9vPO/R/4SmTWv8ntlJv6VGCktHY8aCGgE=
+go.opentelemetry.io/collector/scraper/scrapertest v0.119.1-0.20250210123122-44b3eeda354c/go.mod h1:5huKmgG8seOXOjPvo8n3KAJ2IH2xdsRoCrPjJdhYcxY=
 go.opentelemetry.io/collector/semconv v0.119.1-0.20250210123122-44b3eeda354c h1:yz+u41i4EjY03xkAw9lHeNEBP+ryN38JoOwqJd5i+y0=
 go.opentelemetry.io/collector/semconv v0.119.1-0.20250210123122-44b3eeda354c/go.mod h1:N6XE8Q0JKgBN2fAhkUQtqK9LT7rEGR6+Wu/Rtbal1iI=
 go.opentelemetry.io/collector/service v0.119.1-0.20250210123122-44b3eeda354c h1:/cDZY34GBuAUp+O535zyUnYk2Q8+FGpo4wdXpTpzA30=

--- a/exporter/datadogexporter/integrationtest/integration_test.go
+++ b/exporter/datadogexporter/integrationtest/integration_test.go
@@ -48,7 +48,9 @@ import (
 	"github.com/open-telemetry/opentelemetry-collector-contrib/connector/datadogconnector"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter"
 	commonTestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	pkgdatadog "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/processor/tailsamplingprocessor"
+	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver"
 )
 
@@ -164,6 +166,7 @@ func getIntegrationTestComponents(t *testing.T) otelcol.Factories {
 		[]receiver.Factory{
 			otlpreceiver.NewFactory(),
 			prometheusreceiver.NewFactory(),
+			hostmetricsreceiver.NewFactory(),
 		}...,
 	)
 	require.NoError(t, err)
@@ -538,4 +541,80 @@ func sendLogs(t *testing.T, numLogs int, endpoint string) {
 	assert.NoError(t, err)
 	lr := make([]log.Record, numLogs)
 	assert.NoError(t, logExporter.Export(ctx, lr))
+}
+
+func TestIntegrationHostMetrics_WithRemapping(t *testing.T) {
+	prevVal := pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), false))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), prevVal))
+	}()
+
+	expectedMetrics := map[string]struct{}{
+		// DD conventions
+		"system.load.15":    {},
+		"system.load.5":     {},
+		"system.mem.total":  {},
+		"system.mem.usable": {},
+
+		// OTel conventions with otel. prefix
+		"otel.system.cpu.load_average.15m": {},
+		"otel.system.cpu.load_average.5m":  {},
+		"otel.system.memory.usage":         {},
+	}
+	testIntegrationHostMetrics(t, expectedMetrics)
+}
+
+func TestIntegrationHostMetrics_WithoutRemapping(t *testing.T) {
+	prevVal := pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), true))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), prevVal))
+	}()
+
+	expectedMetrics := map[string]struct{}{
+		// OTel conventions
+		"system.cpu.load_average.15m": {},
+		"system.cpu.load_average.5m":  {},
+		"system.memory.usage":         {},
+	}
+	testIntegrationHostMetrics(t, expectedMetrics)
+}
+
+func testIntegrationHostMetrics(t *testing.T, expectedMetrics map[string]struct{}) {
+	// 1. Set up mock Datadog server
+	seriesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.MetricV2Endpoint, ReqChan: make(chan []byte, 100)}
+	server := testutil.DatadogServerMock(seriesRec.HandlerFunc)
+	defer server.Close()
+	t.Setenv("SERVER_URL", server.URL)
+
+	// 2. Start in-process collector
+	factories := getIntegrationTestComponents(t)
+	app := getIntegrationTestCollector(t, "integration_test_host_metrics_config.yaml", factories)
+	go func() {
+		assert.NoError(t, app.Run(context.Background()))
+	}()
+	defer app.Shutdown()
+
+	waitForReadiness(app)
+
+	// 3. Validate host metrics in DD and/or OTel conventions are sent to the mock server
+	// See https://docs.datadoghq.com/opentelemetry/integrations/host_metrics/?tab=host
+	metricMap := make(map[string]series)
+	for len(metricMap) < len(expectedMetrics) {
+		select {
+		case metricsBytes := <-seriesRec.ReqChan:
+			var metrics seriesSlice
+			gz := getGzipReader(t, metricsBytes)
+			dec := json.NewDecoder(gz)
+			assert.NoError(t, dec.Decode(&metrics))
+			for _, s := range metrics.Series {
+				if _, ok := expectedMetrics[s.Metric]; ok {
+					metricMap[s.Metric] = s
+				}
+			}
+		case <-time.After(60 * time.Second):
+			t.Fail()
+		}
+	}
 }

--- a/exporter/datadogexporter/integrationtest/integration_test_host_metrics_config.yaml
+++ b/exporter/datadogexporter/integrationtest/integration_test_host_metrics_config.yaml
@@ -1,0 +1,29 @@
+
+receivers:
+  hostmetrics:
+    collection_interval: 2s
+    scrapers:
+      load:
+      memory:
+
+exporters:
+  datadog:
+    api:
+      key: "aaa"
+    tls:
+      insecure_skip_verify: true
+    host_metadata:
+      enabled: false
+    metrics:
+      endpoint: ${env:SERVER_URL}
+      sums:
+        cumulative_monotonic_mode: raw_value
+
+service:
+  telemetry:
+    metrics:
+      level: none
+  pipelines:
+    metrics:
+      receivers: [hostmetrics]
+      exporters: [datadog]

--- a/exporter/datadogexporter/integrationtest/no_race_integration_test.go
+++ b/exporter/datadogexporter/integrationtest/no_race_integration_test.go
@@ -14,41 +14,22 @@ import (
 
 	"github.com/DataDog/datadog-agent/comp/otelcol/otlp/testutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/featuregate"
 
 	commonTestutil "github.com/open-telemetry/opentelemetry-collector-contrib/internal/common/testutil"
+	pkgdatadog "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/datadog"
 )
 
-func TestIntegrationInternalMetrics(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("flaky test on windows https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34836")
-	}
-	// 1. Set up mock Datadog server
-	seriesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.MetricV2Endpoint, ReqChan: make(chan []byte, 100)}
-	tracesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.TraceEndpoint, ReqChan: make(chan []byte, 100)}
-	server := testutil.DatadogServerMock(seriesRec.HandlerFunc, tracesRec.HandlerFunc)
-	defer server.Close()
-	t.Setenv("SERVER_URL", server.URL)
-	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
-	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
-	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
-	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
-
-	// 2. Start in-process collector
-	factories := getIntegrationTestComponents(t)
-	app := getIntegrationTestCollector(t, "integration_test_internal_metrics_config.yaml", factories)
-	go func() {
-		assert.NoError(t, app.Run(context.Background()))
+func TestIntegrationInternalMetrics_WithRemapping(t *testing.T) {
+	prevVal := pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), false))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), prevVal))
 	}()
-	defer app.Shutdown()
 
-	waitForReadiness(app)
-
-	// 3. Generate and send traces
-	sendTraces(t, otlpGRPCEndpoint)
-
-	// 4. Validate Datadog trace agent & OTel internal metrics are sent to the mock server
 	expectedMetrics := map[string]struct{}{
-		// Datadog internal metrics on trace and stats writers
+		// Datadog internal metrics on trace and stats writers, with the otelcol_ prefix
 		"otelcol_datadog_otlp_translator_resources_missing_source": {},
 		"otelcol_datadog_trace_agent_stats_writer_bytes":           {},
 		"otelcol_datadog_trace_agent_stats_writer_retries":         {},
@@ -80,7 +61,81 @@ func TestIntegrationInternalMetrics(t *testing.T) {
 		"otelcol_exporter_sent_spans":                    {},
 		"otelcol_exporter_sent_metric_points":            {},
 	}
+	testIntegrationInternalMetrics(t, expectedMetrics)
+}
 
+func TestIntegrationInternalMetrics_WithoutRemapping(t *testing.T) {
+	prevVal := pkgdatadog.MetricRemappingDisabledFeatureGate.IsEnabled()
+	require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), true))
+	defer func() {
+		require.NoError(t, featuregate.GlobalRegistry().Set(pkgdatadog.MetricRemappingDisabledFeatureGate.ID(), prevVal))
+	}()
+
+	expectedMetrics := map[string]struct{}{
+		// Datadog internal metrics on trace and stats writers
+		"datadog_otlp_translator_resources_missing_source": {},
+		"datadog_trace_agent_stats_writer_bytes":           {},
+		"datadog_trace_agent_stats_writer_retries":         {},
+		"datadog_trace_agent_stats_writer_stats_buckets":   {},
+		"datadog_trace_agent_stats_writer_stats_entries":   {},
+		"datadog_trace_agent_stats_writer_payloads":        {},
+		"datadog_trace_agent_stats_writer_client_payloads": {},
+		"datadog_trace_agent_stats_writer_errors":          {},
+		"datadog_trace_agent_stats_writer_splits":          {},
+		"datadog_trace_agent_trace_writer_bytes":           {},
+		"datadog_trace_agent_trace_writer_retries":         {},
+		"datadog_trace_agent_trace_writer_spans":           {},
+		"datadog_trace_agent_trace_writer_traces":          {},
+		"datadog_trace_agent_trace_writer_payloads":        {},
+		"datadog_trace_agent_trace_writer_errors":          {},
+		"datadog_trace_agent_trace_writer_events":          {},
+
+		// OTel collector internal metrics
+		"otelcol_process_memory_rss":                     {},
+		"otelcol_process_runtime_total_sys_memory_bytes": {},
+		"otelcol_process_uptime":                         {},
+		"otelcol_process_cpu_seconds":                    {},
+		"otelcol_process_runtime_heap_alloc_bytes":       {},
+		"otelcol_process_runtime_total_alloc_bytes":      {},
+		"otelcol_receiver_accepted_metric_points":        {},
+		"otelcol_receiver_accepted_spans":                {},
+		"otelcol_exporter_queue_capacity":                {},
+		"otelcol_exporter_queue_size":                    {},
+		"otelcol_exporter_sent_spans":                    {},
+		"otelcol_exporter_sent_metric_points":            {},
+	}
+	testIntegrationInternalMetrics(t, expectedMetrics)
+}
+
+func testIntegrationInternalMetrics(t *testing.T, expectedMetrics map[string]struct{}) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flaky test on windows https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/34836")
+	}
+	// 1. Set up mock Datadog server
+	seriesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.MetricV2Endpoint, ReqChan: make(chan []byte, 100)}
+	tracesRec := &testutil.HTTPRequestRecorderWithChan{Pattern: testutil.TraceEndpoint, ReqChan: make(chan []byte, 100)}
+	server := testutil.DatadogServerMock(seriesRec.HandlerFunc, tracesRec.HandlerFunc)
+	defer server.Close()
+	t.Setenv("SERVER_URL", server.URL)
+	t.Setenv("PROM_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	t.Setenv("OTLP_HTTP_SERVER", commonTestutil.GetAvailableLocalAddress(t))
+	otlpGRPCEndpoint := commonTestutil.GetAvailableLocalAddress(t)
+	t.Setenv("OTLP_GRPC_SERVER", otlpGRPCEndpoint)
+
+	// 2. Start in-process collector
+	factories := getIntegrationTestComponents(t)
+	app := getIntegrationTestCollector(t, "integration_test_internal_metrics_config.yaml", factories)
+	go func() {
+		assert.NoError(t, app.Run(context.Background()))
+	}()
+	defer app.Shutdown()
+
+	waitForReadiness(app)
+
+	// 3. Generate and send traces
+	sendTraces(t, otlpGRPCEndpoint)
+
+	// 4. Validate Datadog trace agent & OTel internal metrics are sent to the mock server
 	metricMap := make(map[string]series)
 	for len(metricMap) < len(expectedMetrics) {
 		select {


### PR DESCRIPTION
#### Description
Add integration tests on metrics mapping:
- When `exporter.datadogexporter.metricremappingdisabled` is off (currently default): Host metrics are sent with both Datadog conventions and OTel conventions with `otel.` prefix. Agent internal metrics also have the `otelcol_` prefix
- When `exporter.datadogexporter.metricremappingdisabled` is on: Host metrics are sent with only OTel conventions without prefix. Agent internal metrics do not have the `otelcol_` prefix