### PR TITLE
[connector/routing] Avoid unnecessary copy of the data

### DIFF
--- a/.chloggen/rm-copies-routing.yaml
+++ b/.chloggen/rm-copies-routing.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: routingconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Avoid unnecessary copy of the data in routing connector
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [37946]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/connector/routingconnector/internal/plogutil/logs_test.go
+++ b/connector/routingconnector/internal/plogutil/logs_test.go
@@ -233,3 +233,16 @@ func TestMoveRecordsWithContextIf(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkMoveResourcesIfLogs(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		from := plogutiltest.NewLogs("AB", "CD", "EF")
+		to := plog.NewLogs()
+		plogutil.MoveResourcesIf(from, to, func(plog.ResourceLogs) bool {
+			return true
+		})
+		assert.Equal(b, 0, from.LogRecordCount())
+		assert.Equal(b, 8, to.LogRecordCount())
+	}
+}

--- a/connector/routingconnector/internal/pmetricutil/metrics_test.go
+++ b/connector/routingconnector/internal/pmetricutil/metrics_test.go
@@ -1506,3 +1506,16 @@ func TestMoveDataPointsWithContextIf(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkMoveResourcesIfMetrics(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		from := pmetricutiltest.NewGauges("AB", "CD", "EF", "GH")
+		to := pmetric.NewMetrics()
+		pmetricutil.MoveResourcesIf(from, to, func(pmetric.ResourceMetrics) bool {
+			return true
+		})
+		assert.Equal(b, 0, from.DataPointCount())
+		assert.Equal(b, 16, to.DataPointCount())
+	}
+}

--- a/connector/routingconnector/internal/ptraceutil/traces_test.go
+++ b/connector/routingconnector/internal/ptraceutil/traces_test.go
@@ -264,3 +264,16 @@ func TestMoveSpansWithContextIf(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkMoveResourcesIfTraces(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		from := ptraceutiltest.NewTraces("AB", "CD", "EF", "GH")
+		to := ptrace.NewTraces()
+		ptraceutil.MoveResourcesIf(from, to, func(ptrace.ResourceSpans) bool {
+			return true
+		})
+		assert.Equal(b, 0, from.SpanCount())
+		assert.Equal(b, 8, to.SpanCount())
+	}
+}


### PR DESCRIPTION
**Before:**

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector/internal/plogutil
cpu: Apple M2 Max
BenchmarkMoveResourcesIfLogs-12    	  474394	      2522 ns/op	    3992 B/op	      74 allocs/op
BenchmarkMoveResourcesIfMetrics-12    	  201031	      6035 ns/op	    8408 B/op	     210 allocs/op
BenchmarkMoveResourcesIfTraces-12    	  221934	      5243 ns/op	    9112 B/op	     178 allocs/op
```

**After:**

```
goos: darwin
goarch: arm64
pkg: github.com/open-telemetry/opentelemetry-collector-contrib/connector/routingconnector/internal/plogutil
cpu: Apple M2 Max
BenchmarkMoveResourcesIfLogs-12    	  577471	      1840 ns/op	    2392 B/op	      60 allocs/op
BenchmarkMoveResourcesIfMetrics-12    	  303607	      3911 ns/op	    4824 B/op	     148 allocs/op
BenchmarkMoveResourcesIfTraces-12    	  317731	      3872 ns/op	    5208 B/op	     132 allocs/op
```