### PR TITLE
[processor/resourcedetection] add instructions for recommended use of the dynatrace detector

### DIFF
--- a/processor/resourcedetectionprocessor/README.md
+++ b/processor/resourcedetectionprocessor/README.md
@@ -598,8 +598,16 @@ Example:
 ```yaml
 processors:
   resourcedetection/dynatrace:
+    override: false
     detectors: [dynatrace]
 ```
+
+It is strongly recommended to use the `override: false` configuration option, to prevent the detector from overwriting
+existing resource attributes.
+If the Dynatrace host entity identifier attribute `dt.entity.host` or `host.name` are already present on incoming data as it is sent from
+other sources to the collector, then these describe the monitored entity in the best way.
+Overriding these with the collector's own identifier would instead make the telemetry appear as if it was coming from the collector
+or the collector's host instead, which might be inaccurate.
 
 ## Configuration
 


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

This PR adds a note about the recommended use of the `override: false` option to the Dynatrace detector

