### PR TITLE
 [connector/servicegraph] Set MetricsExpirationLoop default to 60s

### DIFF
--- a/.chloggen/fix_servicegraph-excesive-writes.yaml
+++ b/.chloggen/fix_servicegraph-excesive-writes.yaml
@@ -1,0 +1,28 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: servicegraphconnector
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: |
+  Fixes excessive writes to the servicegraph connector by setting a default expiration loop time of 60s.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [34843]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: []

--- a/.chloggen/fix_servicegraph-excesive-writes.yaml
+++ b/.chloggen/fix_servicegraph-excesive-writes.yaml
@@ -8,7 +8,7 @@ component: servicegraphconnector
 
 # A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
 note: |
-  Fixes excessive writes to the servicegraph connector by setting a default expiration loop time of 60s.
+  Change the default value of `metrics_flush_interval` to 60s to avoid excessive metric data point generation with default settings.
 
 # Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
 issues: [34843]

--- a/connector/servicegraphconnector/README.md
+++ b/connector/servicegraphconnector/README.md
@@ -139,7 +139,7 @@ The following settings can be optionally configured:
 - `virtual_node_extra_label`: adds an extra label `virtual_node` with an optional value of `client` or `server`, indicating which node is the uninstrumented one.
   - Default: `false`
 - `metrics_flush_interval`: the interval at which metrics are flushed to the exporter.
-  - Default: Metrics are flushed on every received batch of traces.
+  - Default: `60s`
 - `database_name_attribute`: the attribute name used to identify the database name from span attributes.
   - Default: `db.name`
 

--- a/connector/servicegraphconnector/config.go
+++ b/connector/servicegraphconnector/config.go
@@ -44,7 +44,7 @@ type Config struct {
 
 	// MetricsFlushInterval is the interval at which metrics are flushed to the exporter.
 	// If set to 0, metrics are flushed on every received batch of traces.
-	MetricsFlushInterval time.Duration `mapstructure:"metrics_flush_interval"`
+	MetricsFlushInterval *time.Duration `mapstructure:"metrics_flush_interval"`
 
 	// DatabaseNameAttribute is the attribute name used to identify the database name from span attributes.
 	// The default value is db.name.

--- a/connector/servicegraphconnector/config.go
+++ b/connector/servicegraphconnector/config.go
@@ -44,6 +44,7 @@ type Config struct {
 
 	// MetricsFlushInterval is the interval at which metrics are flushed to the exporter.
 	// If set to 0, metrics are flushed on every received batch of traces.
+	// Default is 60s if unset.
 	MetricsFlushInterval *time.Duration `mapstructure:"metrics_flush_interval"`
 
 	// DatabaseNameAttribute is the attribute name used to identify the database name from span attributes.

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -607,6 +607,7 @@ func TestExtraDimensionsLabels(t *testing.T) {
 		Dimensions:              extraDimensions,
 		LatencyHistogramBuckets: []time.Duration{time.Duration(0.1 * float64(time.Second)), time.Duration(1 * float64(time.Second)), time.Duration(10 * float64(time.Second))},
 		Store:                   StoreConfig{MaxItems: 10},
+		MetricsFlushInterval:    &[]time.Duration{0}[0],
 	}
 
 	set := componenttest.NewNopTelemetrySettings()
@@ -644,8 +645,7 @@ func TestVirtualNodeServerLabels(t *testing.T) {
 		Store:                     StoreConfig{MaxItems: 10},
 		VirtualNodePeerAttributes: virtualNodeDimensions,
 		VirtualNodeExtraLabel:     true,
-		// Reduce flush interval for faster test execution
-		MetricsFlushInterval: 10 * time.Millisecond,
+		MetricsFlushInterval:      &[]time.Duration{time.Millisecond}[0],
 	}
 
 	set := componenttest.NewNopTelemetrySettings()
@@ -691,8 +691,7 @@ func TestVirtualNodeClientLabels(t *testing.T) {
 		Store:                     StoreConfig{MaxItems: 10},
 		VirtualNodePeerAttributes: virtualNodeDimensions,
 		VirtualNodeExtraLabel:     true,
-		// Reduce flush interval for faster test execution
-		MetricsFlushInterval: 1 * time.Millisecond,
+		MetricsFlushInterval:      &[]time.Duration{time.Millisecond}[0],
 	}
 
 	set := componenttest.NewNopTelemetrySettings()

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -607,7 +607,7 @@ func TestExtraDimensionsLabels(t *testing.T) {
 		Dimensions:              extraDimensions,
 		LatencyHistogramBuckets: []time.Duration{time.Duration(0.1 * float64(time.Second)), time.Duration(1 * float64(time.Second)), time.Duration(10 * float64(time.Second))},
 		Store:                   StoreConfig{MaxItems: 10},
-		MetricsFlushInterval:    &[]time.Duration{0}[0],
+		MetricsFlushInterval:    ptr(time.Millisecond),
 	}
 
 	set := componenttest.NewNopTelemetrySettings()
@@ -645,7 +645,7 @@ func TestVirtualNodeServerLabels(t *testing.T) {
 		Store:                     StoreConfig{MaxItems: 10},
 		VirtualNodePeerAttributes: virtualNodeDimensions,
 		VirtualNodeExtraLabel:     true,
-		MetricsFlushInterval:      &[]time.Duration{time.Millisecond}[0],
+		MetricsFlushInterval:      ptr(time.Millisecond),
 	}
 
 	set := componenttest.NewNopTelemetrySettings()
@@ -691,7 +691,7 @@ func TestVirtualNodeClientLabels(t *testing.T) {
 		Store:                     StoreConfig{MaxItems: 10},
 		VirtualNodePeerAttributes: virtualNodeDimensions,
 		VirtualNodeExtraLabel:     true,
-		MetricsFlushInterval:      &[]time.Duration{time.Millisecond}[0],
+		MetricsFlushInterval:      ptr(time.Millisecond),
 	}
 
 	set := componenttest.NewNopTelemetrySettings()
@@ -727,4 +727,9 @@ func TestVirtualNodeClientLabels(t *testing.T) {
 		pmetrictest.IgnoreTimestamp(),
 	)
 	require.NoError(t, err)
+}
+
+// ptr returns a pointer to the given value.
+func ptr[T any](value T) *T {
+	return &value
 }

--- a/connector/servicegraphconnector/connector_test.go
+++ b/connector/servicegraphconnector/connector_test.go
@@ -607,7 +607,7 @@ func TestExtraDimensionsLabels(t *testing.T) {
 		Dimensions:              extraDimensions,
 		LatencyHistogramBuckets: []time.Duration{time.Duration(0.1 * float64(time.Second)), time.Duration(1 * float64(time.Second)), time.Duration(10 * float64(time.Second))},
 		Store:                   StoreConfig{MaxItems: 10},
-		MetricsFlushInterval:    ptr(time.Millisecond),
+		MetricsFlushInterval:    ptr(0 * time.Millisecond),
 	}
 
 	set := componenttest.NewNopTelemetrySettings()


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Fixes excessive writes to the servicegraph connector by setting a default expiration loop time of 60s.

<!-- Issue number (e.g. #1234) or full URL to issue, if applicable. -->
#### Link to tracking issue
Fixes 34843

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Updated testing to work with the new code.

<!--Describe the documentation added.-->
#### Documentation

Updated config docs.

<!--Please delete paragraphs that you did not use before submitting.-->
