### PR TITLE
Add support for looping over lists in OTTL

### DIFF
--- a/.chloggen/ottl-list-comprehension.yaml
+++ b/.chloggen/ottl-list-comprehension.yaml
@@ -1,0 +1,27 @@
+# Use this changelog template to create an entry for release notes.
+
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component, or a single word describing the area of concern, (e.g. filelogreceiver)
+component: pkg/ottl
+
+# A brief description of the change.  Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add list comprehensions to OTTL.
+
+# Mandatory: One or more tracking issues related to the change. You can use the PR number here if no issue exists.
+issues: [29289]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+
+# If your change doesn't affect end users or the exported elements of any package,
+# you should instead start your pull request title with [chore] or use the "Skip Changelog" label.
+# Optional: The change log or logs in which this entry should be included.
+# e.g. '[user]' or '[user, api]'
+# Include 'user' if the change is relevant to end users.
+# Include 'api' if there is a change to a library API.
+# Default: '[user]'
+change_logs: [user]

--- a/pkg/ottl/comprehension.go
+++ b/pkg/ottl/comprehension.go
@@ -122,7 +122,7 @@ type wrappedGetter[K any] struct {
 
 // Get implements Getter.
 func (w *wrappedGetter[K]) Get(ctx context.Context, tCtx K) (any, error) {
-	// HACK - we know this cannot be called from the comprehensions context, so it HAS
+	// Note - we know this cannot be called from the comprehensions context, so it HAS
 	// to be an underlying one.  We cannot force-cast because go reflection/generic will kill us.
 	// We can only construct a broken context that we know won't be abused because
 	// the getter had to be wrapped by the nested parser.
@@ -135,14 +135,14 @@ type wrappedKey[K any] struct {
 
 // ExpressionGetter implements Key.
 func (w *wrappedKey[K]) ExpressionGetter(ctx context.Context, kCtx K) (Getter[K], error) {
-	// HACK - we know this cannot be called from the comprehensions context, so it HAS
+	// Note - we know this cannot be called from the comprehensions context, so it HAS
 	// to be an underlying one.  We cannot force-cast because go reflection/generic will kill us.
 	// We can only construct a broken context that we know won't be abused because
 	// the getter had to be wrapped by the nested parser.
-	hackCtx := comprehensionContext[any]{
+	wrapCtx := comprehensionContext[any]{
 		underlying: kCtx,
 	}
-	underlying, err := w.k.ExpressionGetter(ctx, hackCtx)
+	underlying, err := w.k.ExpressionGetter(ctx, wrapCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -151,26 +151,26 @@ func (w *wrappedKey[K]) ExpressionGetter(ctx context.Context, kCtx K) (Getter[K]
 
 // Int implements Key.
 func (w *wrappedKey[K]) Int(ctx context.Context, kCtx K) (*int64, error) {
-	// HACK - we know this cannot be called from the comprehensions context, so it HAS
+	// Note - we know this cannot be called from the comprehensions context, so it HAS
 	// to be an underlying one.  We cannot force-cast because go reflection/generic will kill us.
 	// We can only construct a broken context that we know won't be abused because
 	// the getter had to be wrapped by the nested parser.
-	hackCtx := comprehensionContext[any]{
+	wrapCtx := comprehensionContext[any]{
 		underlying: kCtx,
 	}
-	return w.k.Int(ctx, hackCtx)
+	return w.k.Int(ctx, wrapCtx)
 }
 
 // String implements Key.
 func (w *wrappedKey[K]) String(ctx context.Context, kCtx K) (*string, error) {
-	// HACK - we know this cannot be called from the comprehensions context, so it HAS
+	// Note - we know this cannot be called from the comprehensions context, so it HAS
 	// to be an underlying one.  We cannot force-cast because go reflection/generic will kill us.
 	// We can only construct a broken context that we know won't be abused because
 	// the getter had to be wrapped by the nested parser.
-	hackCtx := comprehensionContext[any]{
+	wrapCtx := comprehensionContext[any]{
 		underlying: kCtx,
 	}
-	return w.k.String(ctx, hackCtx)
+	return w.k.String(ctx, wrapCtx)
 }
 
 type wrapedPath[K any] struct {
@@ -207,7 +207,7 @@ func (w *wrapedPath[K]) String() string {
 	return w.p.String()
 }
 
-// Hackily construct a new parser that uses our loop-comprehension context instead of the original.
+// Create a new parser that uses our loop-comprehension context instead of the original.
 func newComprehensionParser[K any](p *Parser[K], ident string) (Parser[comprehensionContext[any]], error) {
 	forceFunc := map[string]Factory[comprehensionContext[any]]{}
 	for n, f := range p.functions {

--- a/pkg/ottl/comprehension.go
+++ b/pkg/ottl/comprehension.go
@@ -1,0 +1,66 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottl // import "github.com/open-telemetry/opentelemetry-collector-contrib/pkg/ottl"
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+type comprehensionContext[K any] struct {
+	underlying   K
+	currentValue any
+	index        int
+}
+
+// An expression like `[{yield} for {list} where {cond}]`.
+type comprehensionExpr[K any] struct {
+	// The list we're iterating over.
+	listExpr Expr[K]
+	// When is the iterator over. This is against the comprhension
+	condExpr BoolExpr[comprehensionContext[K]]
+	// The expression to evaluate at each item.
+	yieldExpr Expr[comprehensionContext[K]]
+}
+
+func (c comprehensionExpr[K]) Get(ctx context.Context, tCtx K) (any, error) {
+	listResult, err := c.listExpr.Eval(ctx, tCtx)
+	if err != nil {
+		return nil, err
+	}
+	var list []any
+	switch l := listResult.(type) {
+	case pcommon.Slice:
+		list = l.AsRaw()
+	case []any:
+		list = l
+	default:
+		return nil, fmt.Errorf("unsupported list type: %s", reflect.TypeOf(listResult).Name())
+	}
+	result := []any{}
+	for i, v := range list {
+		subCtx := comprehensionContext[K]{tCtx, v, i}
+
+		cond, err := c.condExpr.Eval(ctx, subCtx)
+		if err != nil {
+			return nil, err
+		}
+		if cond {
+			// Evaluate next value for result.
+			item, err := c.yieldExpr.Eval(ctx, subCtx)
+			if err != nil {
+				return nil, err
+			}
+			// TODO - cast the item?
+			result = append(result, item)
+		}
+	}
+	// We always return results in a pslice.
+	sr := pcommon.NewSlice()
+	sr.FromRaw(result)
+	return sr, nil
+}

--- a/pkg/ottl/comprehension.go
+++ b/pkg/ottl/comprehension.go
@@ -20,7 +20,7 @@ type comprehensionContext[K any] struct {
 	index          int
 }
 
-// An expression like `[{yield} for {list} where {cond}]`.
+// An expression like `[{yield} for {id} in {list} if {cond}]`.
 type comprehensionExpr[K any] struct {
 	currentValueID string
 	// The list we're iterating over.
@@ -173,17 +173,17 @@ func (w *wrappedKey[K]) String(ctx context.Context, kCtx K) (*string, error) {
 	return w.k.String(ctx, hackCtx)
 }
 
-type wrapedPath[K any] struct {
+type wrappedPath[K any] struct {
 	p Path[comprehensionContext[any]]
 }
 
 // Context implements Path.
-func (w *wrapedPath[K]) Context() string {
+func (w *wrappedPath[K]) Context() string {
 	return w.p.Context()
 }
 
 // Keys implements Path.
-func (w *wrapedPath[K]) Keys() []Key[K] {
+func (w *wrappedPath[K]) Keys() []Key[K] {
 	keys := w.p.Keys()
 	result := make([]Key[K], len(keys))
 	for i, key := range keys {
@@ -193,17 +193,17 @@ func (w *wrapedPath[K]) Keys() []Key[K] {
 }
 
 // Name implements Path.
-func (w *wrapedPath[K]) Name() string {
+func (w *wrappedPath[K]) Name() string {
 	return w.p.Name()
 }
 
 // Next implements Path.
-func (w *wrapedPath[K]) Next() Path[K] {
-	return &wrapedPath[K]{w.p.Next()}
+func (w *wrappedPath[K]) Next() Path[K] {
+	return &wrappedPath[K]{w.p.Next()}
 }
 
 // String implements Path.
-func (w *wrapedPath[K]) String() string {
+func (w *wrappedPath[K]) String() string {
 	return w.p.String()
 }
 
@@ -241,7 +241,7 @@ func newComprehensionParser[K any](p *Parser[K], ident string) (Parser[comprehen
 				},
 			}, nil
 		}
-		var forcedPath Path[K] = &wrapedPath[K]{path}
+		var forcedPath Path[K] = &wrappedPath[K]{path}
 		res, err := p.pathParser(forcedPath)
 		if err != nil {
 			return nil, err

--- a/pkg/ottl/comprehension.go
+++ b/pkg/ottl/comprehension.go
@@ -11,24 +11,28 @@ import (
 	"go.opentelemetry.io/collector/pdata/pcommon"
 )
 
+// A context we use for parsing sub-expressions of a list comprehension.
 type comprehensionContext[K any] struct {
-	underlying   K
-	currentValue any
-	index        int
+	// Must of type K
+	underlying     any
+	currentValueId string
+	currentValue   any
+	index          int
 }
 
 // An expression like `[{yield} for {list} where {cond}]`.
 type comprehensionExpr[K any] struct {
+	currentValueId string
 	// The list we're iterating over.
-	listExpr Expr[K]
+	listExpr Getter[K]
 	// When is the iterator over. This is against the comprhension
-	condExpr BoolExpr[comprehensionContext[K]]
+	condExpr BoolExpr[comprehensionContext[any]]
 	// The expression to evaluate at each item.
-	yieldExpr Expr[comprehensionContext[K]]
+	yieldExpr Getter[comprehensionContext[any]]
 }
 
 func (c comprehensionExpr[K]) Get(ctx context.Context, tCtx K) (any, error) {
-	listResult, err := c.listExpr.Eval(ctx, tCtx)
+	listResult, err := c.listExpr.Get(ctx, tCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -43,7 +47,7 @@ func (c comprehensionExpr[K]) Get(ctx context.Context, tCtx K) (any, error) {
 	}
 	result := []any{}
 	for i, v := range list {
-		subCtx := comprehensionContext[K]{tCtx, v, i}
+		subCtx := comprehensionContext[any]{tCtx, c.currentValueId, v, i}
 
 		cond, err := c.condExpr.Eval(ctx, subCtx)
 		if err != nil {
@@ -51,7 +55,7 @@ func (c comprehensionExpr[K]) Get(ctx context.Context, tCtx K) (any, error) {
 		}
 		if cond {
 			// Evaluate next value for result.
-			item, err := c.yieldExpr.Eval(ctx, subCtx)
+			item, err := c.yieldExpr.Get(ctx, subCtx)
 			if err != nil {
 				return nil, err
 			}
@@ -63,4 +67,100 @@ func (c comprehensionExpr[K]) Get(ctx context.Context, tCtx K) (any, error) {
 	sr := pcommon.NewSlice()
 	sr.FromRaw(result)
 	return sr, nil
+}
+
+// Constructs a new list comprehension getter, where we will construct a new parser for list
+// sub expressions that can delegate to list context.
+func newListComprehensionGetter[K any](p *Parser[K], c *listComprehension) (Getter[K], error) {
+	list, err := p.newGetter(c.List)
+	if err != nil {
+		return nil, err
+	}
+	// Now we create a new parser that uses this list.
+	newParser, err := newComprehensionParser(p, c.Ident)
+	if err != nil {
+		return nil, err
+	}
+
+	yield, err := newParser.newGetter(c.Yield)
+	if err != nil {
+		return nil, err
+	}
+	cond := BoolExpr[comprehensionContext[any]]{alwaysTrue[comprehensionContext[any]]}
+	if c.Cond != nil {
+		cond, err = newParser.newBoolExpr(c.Cond)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &comprehensionExpr[K]{
+		currentValueId: c.Ident,
+		listExpr:       list,
+		yieldExpr:      yield,
+		condExpr:       cond,
+	}, nil
+}
+
+// Builds a new list-comprehension as an argument to a function.
+// c: the list comprehension.
+// argType: The type expected.
+func (p *Parser[K]) buildComprehensionSliceArg(c *listComprehension, argType reflect.Type) (any, error) {
+	getter, err := newListComprehensionGetter(p, c)
+	// TODO - deal with argType reflection.
+	return getter, err
+}
+
+// Hackily construct a new parser that uses our loop-comprehension context instead of the original.
+func newComprehensionParser[K any](p *Parser[K], ident string) (Parser[comprehensionContext[any]], error) {
+	forceFunc := map[string]Factory[comprehensionContext[any]]{}
+	for n, f := range p.functions {
+		forceFunc[n] = NewFactory[comprehensionContext[any]](
+			f.Name(),
+			f.CreateDefaultArguments(),
+			func(fCtx FunctionContext, args Arguments) (ExprFunc[comprehensionContext[any]], error) {
+				underlying, err := f.CreateFunction(fCtx, args)
+				if err != nil {
+					return nil, err
+				}
+				return func(ctx context.Context, tCtx comprehensionContext[any]) (any, error) {
+					return underlying(ctx, tCtx.underlying.(K))
+				}, nil
+			},
+		)
+	}
+	pathParser := func(path Path[comprehensionContext[any]]) (GetSetter[comprehensionContext[any]], error) {
+		if path.Name() == ident {
+			return &StandardGetSetter[comprehensionContext[any]]{
+				Getter: func(ctx context.Context, tCtx comprehensionContext[any]) (any, error) {
+					// TODO - Remove this limitation in the future.
+					// Likely forces rewrite of Getter/Setter pattern.
+					if tCtx.currentValueId != ident {
+						return nil, fmt.Errorf("list comprehensions cannot be nested!")
+					}
+					return tCtx.currentValue, nil
+				},
+				Setter: func(ctx context.Context, tCtx comprehensionContext[any], val any) error {
+					return fmt.Errorf("cannot set loop index value: %s", ident)
+				},
+			}, nil
+		}
+		var forcedPath any = path
+		res, err := p.pathParser(forcedPath.(Path[K]))
+		if err != nil {
+			return nil, err
+		}
+		return &StandardGetSetter[comprehensionContext[any]]{
+			Getter: func(ctx context.Context, tCtx comprehensionContext[any]) (any, error) {
+				return res.Get(ctx, tCtx.underlying.(K))
+			},
+			Setter: func(ctx context.Context, tCtx comprehensionContext[any], val any) error {
+				return res.Set(ctx, tCtx.underlying.(K), val)
+			},
+		}, nil
+	}
+	return NewParser[comprehensionContext[any]](
+		forceFunc,
+		pathParser,
+		p.telemetrySettings,
+	)
 }

--- a/pkg/ottl/comprehension_test.go
+++ b/pkg/ottl/comprehension_test.go
@@ -1,0 +1,110 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package ottl
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func Test_comprehensions(t *testing.T) {
+
+	tests := []struct {
+		name       string
+		collection any
+		want       any
+		expr       comprehensionExpr[any]
+	}{
+		{
+			name:       "return same collection",
+			collection: []any{"one", "two"},
+			want: func() any {
+				r := pcommon.NewSlice()
+				r.FromRaw([]any{"one", "two"})
+				return r
+			}(),
+			expr: comprehensionExpr[any]{
+				listExpr: Expr[any]{
+					func(ctx context.Context, tCtx any) (any, error) {
+						return tCtx, nil
+					},
+				},
+				condExpr: BoolExpr[comprehensionContext[any]]{
+					func(ctx context.Context, tCtx comprehensionContext[any]) (bool, error) {
+						return true, nil
+					},
+				},
+				// TODO - this should interact with nested context soemhow.
+				yieldExpr: Expr[comprehensionContext[any]]{
+					func(ctx context.Context, tCtx comprehensionContext[any]) (any, error) {
+						return tCtx.currentValue, nil
+					},
+				},
+			},
+		},
+		{
+			name:       "return first item of collection",
+			collection: []any{"one", "two"},
+			want: func() any {
+				r := pcommon.NewSlice()
+				r.FromRaw([]any{"one"})
+				return r
+			}(),
+			expr: comprehensionExpr[any]{
+				listExpr: Expr[any]{
+					func(ctx context.Context, tCtx any) (any, error) {
+						return tCtx, nil
+					},
+				},
+				condExpr: BoolExpr[comprehensionContext[any]]{
+					func(ctx context.Context, tCtx comprehensionContext[any]) (bool, error) {
+						return tCtx.index == 0, nil
+					},
+				},
+				yieldExpr: Expr[comprehensionContext[any]]{
+					func(ctx context.Context, tCtx comprehensionContext[any]) (any, error) {
+						return tCtx.currentValue, nil
+					},
+				},
+			},
+		},
+		{
+			name:       "return appended strings of collection",
+			collection: []any{"one", "two"},
+			want: func() any {
+				r := pcommon.NewSlice()
+				r.FromRaw([]any{"one-extra", "two-extra"})
+				return r
+			}(),
+			expr: comprehensionExpr[any]{
+				listExpr: Expr[any]{
+					func(ctx context.Context, tCtx any) (any, error) {
+						return tCtx, nil
+					},
+				},
+				condExpr: BoolExpr[comprehensionContext[any]]{
+					func(ctx context.Context, tCtx comprehensionContext[any]) (bool, error) {
+						return true, nil
+					},
+				},
+				yieldExpr: Expr[comprehensionContext[any]]{
+					func(ctx context.Context, tCtx comprehensionContext[any]) (any, error) {
+						return fmt.Sprintf("%s-extra", tCtx.currentValue), nil
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := tt.expr.Get(context.Background(), tt.collection)
+			assert.Nil(t, err)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/pkg/ottl/comprehension_test.go
+++ b/pkg/ottl/comprehension_test.go
@@ -14,7 +14,7 @@ import (
 
 type testListGetter[K any] struct{}
 
-func (t testListGetter[K]) Get(ctx context.Context, tCtx K) (any, error) {
+func (t testListGetter[K]) Get(_ context.Context, tCtx K) (any, error) {
 	return tCtx, nil
 }
 
@@ -22,12 +22,11 @@ type testYieldExpr struct {
 	Yield func(tCtx comprehensionContext[any]) (any, error)
 }
 
-func (t testYieldExpr) Get(ctx context.Context, tCtx comprehensionContext[any]) (any, error) {
+func (t testYieldExpr) Get(_ context.Context, tCtx comprehensionContext[any]) (any, error) {
 	return t.Yield(tCtx)
 }
 
 func Test_comprehensions(t *testing.T) {
-
 	tests := []struct {
 		name       string
 		collection any
@@ -39,14 +38,14 @@ func Test_comprehensions(t *testing.T) {
 			collection: []any{"one", "two"},
 			want: func() any {
 				r := pcommon.NewSlice()
-				r.FromRaw([]any{"one", "two"})
+				_ = r.FromRaw([]any{"one", "two"})
 				return r
 			}(),
 			expr: comprehensionExpr[any]{
-				currentValueId: "x",
+				currentValueID: "x",
 				listExpr:       testListGetter[any]{},
 				condExpr: BoolExpr[comprehensionContext[any]]{
-					func(ctx context.Context, tCtx comprehensionContext[any]) (bool, error) {
+					func(context.Context, comprehensionContext[any]) (bool, error) {
 						return true, nil
 					},
 				},
@@ -62,14 +61,14 @@ func Test_comprehensions(t *testing.T) {
 			collection: []any{"one", "two"},
 			want: func() any {
 				r := pcommon.NewSlice()
-				r.FromRaw([]any{"one"})
+				_ = r.FromRaw([]any{"one"})
 				return r
 			}(),
 			expr: comprehensionExpr[any]{
-				currentValueId: "x",
+				currentValueID: "x",
 				listExpr:       testListGetter[any]{},
 				condExpr: BoolExpr[comprehensionContext[any]]{
-					func(ctx context.Context, tCtx comprehensionContext[any]) (bool, error) {
+					func(_ context.Context, tCtx comprehensionContext[any]) (bool, error) {
 						return tCtx.index == 0, nil
 					},
 				},
@@ -85,14 +84,14 @@ func Test_comprehensions(t *testing.T) {
 			collection: []any{"one", "two"},
 			want: func() any {
 				r := pcommon.NewSlice()
-				r.FromRaw([]any{"one-extra", "two-extra"})
+				_ = r.FromRaw([]any{"one-extra", "two-extra"})
 				return r
 			}(),
 			expr: comprehensionExpr[any]{
-				currentValueId: "x",
+				currentValueID: "x",
 				listExpr:       testListGetter[any]{},
 				condExpr: BoolExpr[comprehensionContext[any]]{
-					func(ctx context.Context, tCtx comprehensionContext[any]) (bool, error) {
+					func(context.Context, comprehensionContext[any]) (bool, error) {
 						return true, nil
 					},
 				},
@@ -107,7 +106,7 @@ func Test_comprehensions(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := tt.expr.Get(context.Background(), tt.collection)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tt.want, result)
 		})
 	}

--- a/pkg/ottl/e2e/e2e_test.go
+++ b/pkg/ottl/e2e/e2e_test.go
@@ -406,6 +406,13 @@ func Test_e2e_converters(t *testing.T) {
 			},
 		},
 		{
+			statement: `set(attributes["new_slice"], [x for x in attributes["foo"]["slice"]])`,
+			want: func(tCtx ottllog.TransformContext) {
+				s := tCtx.GetLogRecord().Attributes().PutEmptySlice("new_slice")
+				s.AppendEmpty().SetStr("val")
+			},
+		},
+		{
 			statement: `set(attributes["test"], Base64Decode("cGFzcw=="))`,
 			want: func(tCtx ottllog.TransformContext) {
 				tCtx.GetLogRecord().Attributes().PutStr("test", "pass")

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -785,7 +785,10 @@ func (p *Parser[K]) newGetter(val value) (Getter[K], error) {
 			return p.newGetterFromConverter(*eL.Converter)
 		}
 	}
-	// TODO - handle list comprehensions
+	if val.List != nil && val.List.Comprehension != nil {
+		// We need to construct a new parser for the list.
+		return newListComprehensionGetter(p, val.List.Comprehension)
+	}
 	if val.List != nil && val.List.List != nil {
 		lg := listGetter[K]{slice: make([]Getter[K], len(val.List.List.Values))}
 		for i, v := range val.List.List.Values {

--- a/pkg/ottl/expression.go
+++ b/pkg/ottl/expression.go
@@ -785,10 +785,10 @@ func (p *Parser[K]) newGetter(val value) (Getter[K], error) {
 			return p.newGetterFromConverter(*eL.Converter)
 		}
 	}
-
-	if val.List != nil {
-		lg := listGetter[K]{slice: make([]Getter[K], len(val.List.Values))}
-		for i, v := range val.List.Values {
+	// TODO - handle list comprehensions
+	if val.List != nil && val.List.List != nil {
+		lg := listGetter[K]{slice: make([]Getter[K], len(val.List.List.Values))}
+		for i, v := range val.List.List.Values {
 			getter, err := p.newGetter(v)
 			if err != nil {
 				return nil, err

--- a/pkg/ottl/expression_test.go
+++ b/pkg/ottl/expression_test.go
@@ -392,8 +392,10 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "empty list",
 			val: value{
-				List: &list{
-					Values: []value{},
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{},
+					},
 				},
 			},
 			want: []any{},
@@ -401,13 +403,15 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "string list",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							String: ottltest.Strp("test0"),
-						},
-						{
-							String: ottltest.Strp("test1"),
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								String: ottltest.Strp("test0"),
+							},
+							{
+								String: ottltest.Strp("test1"),
+							},
 						},
 					},
 				},
@@ -417,16 +421,18 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "int list",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							Literal: &mathExprLiteral{
-								Int: ottltest.Intp(1),
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								Literal: &mathExprLiteral{
+									Int: ottltest.Intp(1),
+								},
 							},
-						},
-						{
-							Literal: &mathExprLiteral{
-								Int: ottltest.Intp(2),
+							{
+								Literal: &mathExprLiteral{
+									Int: ottltest.Intp(2),
+								},
 							},
 						},
 					},
@@ -437,16 +443,18 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "float list",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							Literal: &mathExprLiteral{
-								Float: ottltest.Floatp(1.2),
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								Literal: &mathExprLiteral{
+									Float: ottltest.Floatp(1.2),
+								},
 							},
-						},
-						{
-							Literal: &mathExprLiteral{
-								Float: ottltest.Floatp(2.4),
+							{
+								Literal: &mathExprLiteral{
+									Float: ottltest.Floatp(2.4),
+								},
 							},
 						},
 					},
@@ -457,13 +465,15 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "bool list",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							Bool: (*boolean)(ottltest.Boolp(true)),
-						},
-						{
-							Bool: (*boolean)(ottltest.Boolp(false)),
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								Bool: (*boolean)(ottltest.Boolp(true)),
+							},
+							{
+								Bool: (*boolean)(ottltest.Boolp(false)),
+							},
 						},
 					},
 				},
@@ -473,13 +483,15 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "byte slice list",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
-						},
-						{
-							Bytes: (*byteSlice)(&[]byte{9, 8, 7, 6, 5, 4, 3, 2}),
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+							},
+							{
+								Bytes: (*byteSlice)(&[]byte{9, 8, 7, 6, 5, 4, 3, 2}),
+							},
 						},
 					},
 				},
@@ -489,14 +501,16 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "path expression",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							Literal: &mathExprLiteral{
-								Path: &path{
-									Fields: []field{
-										{
-											Name: "name",
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								Literal: &mathExprLiteral{
+									Path: &path{
+										Fields: []field{
+											{
+												Name: "name",
+											},
 										},
 									},
 								},
@@ -511,12 +525,14 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "function call",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							Literal: &mathExprLiteral{
-								Converter: &converter{
-									Function: "Hello",
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								Literal: &mathExprLiteral{
+									Converter: &converter{
+										Function: "Hello",
+									},
 								},
 							},
 						},
@@ -528,13 +544,15 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "nil slice",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							IsNil: (*isNil)(ottltest.Boolp(true)),
-						},
-						{
-							IsNil: (*isNil)(ottltest.Boolp(true)),
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								IsNil: (*isNil)(ottltest.Boolp(true)),
+							},
+							{
+								IsNil: (*isNil)(ottltest.Boolp(true)),
+							},
 						},
 					},
 				},
@@ -544,14 +562,16 @@ func Test_newGetter(t *testing.T) {
 		{
 			name: "heterogeneous slice",
 			val: value{
-				List: &list{
-					Values: []value{
-						{
-							String: ottltest.Strp("test0"),
-						},
-						{
-							Literal: &mathExprLiteral{
-								Int: ottltest.Intp(1),
+				List: &listOrComprehension{
+					List: &list{
+						Values: []value{
+							{
+								String: ottltest.Strp("test0"),
+							},
+							{
+								Literal: &mathExprLiteral{
+									Int: ottltest.Intp(1),
+								},
 							},
 						},
 					},
@@ -631,14 +651,16 @@ func Test_newGetter(t *testing.T) {
 										{
 											Key: ottltest.Strp("listAttr"),
 											Value: &value{
-												List: &list{
-													Values: []value{
-														{
-															String: ottltest.Strp("test0"),
-														},
-														{
-															Literal: &mathExprLiteral{
-																Int: ottltest.Intp(1),
+												List: &listOrComprehension{
+													List: &list{
+														Values: []value{
+															{
+																String: ottltest.Strp("test0"),
+															},
+															{
+																Literal: &mathExprLiteral{
+																	Int: ottltest.Intp(1),
+																},
 															},
 														},
 													},

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -428,6 +428,9 @@ func (p *Parser[K]) buildArgs(ed editor, argsVal reflect.Value) error {
 }
 
 func (p *Parser[K]) buildSliceArg(argVal value, argType reflect.Type) (any, error) {
+	if argVal.List != nil && argVal.List.Comprehension != nil {
+		return p.buildComprehensionSliceArg(argVal.List.Comprehension, argType)
+	}
 	name := argType.Elem().Name()
 	switch {
 	case name == reflect.Uint8.String():
@@ -657,7 +660,7 @@ func buildSlice[T any](argVal value, argType reflect.Type, buildArg buildArgFunc
 		return nil, fmt.Errorf("must be a list of type %v", name)
 	}
 
-	// TODO - handle list comprehension.
+	// We don't allow list comprehensions to get here.
 	vals := []T{}
 	if argVal.List.List != nil {
 		values := argVal.List.List.Values

--- a/pkg/ottl/functions.go
+++ b/pkg/ottl/functions.go
@@ -657,21 +657,24 @@ func buildSlice[T any](argVal value, argType reflect.Type, buildArg buildArgFunc
 		return nil, fmt.Errorf("must be a list of type %v", name)
 	}
 
+	// TODO - handle list comprehension.
 	vals := []T{}
-	values := argVal.List.Values
-	for j := 0; j < len(values); j++ {
-		untypedVal, err := buildArg(values[j], argType.Elem())
-		if err != nil {
-			return nil, fmt.Errorf("error while parsing list argument at index %v: %w", j, err)
+	if argVal.List.List != nil {
+		values := argVal.List.List.Values
+		for j := 0; j < len(values); j++ {
+			untypedVal, err := buildArg(values[j], argType.Elem())
+			if err != nil {
+				return nil, fmt.Errorf("error while parsing list argument at index %v: %w", j, err)
+			}
+
+			val, ok := untypedVal.(T)
+
+			if !ok {
+				return nil, fmt.Errorf("invalid element type at list index %v, must be of type %v", j, name)
+			}
+
+			vals = append(vals, val)
 		}
-
-		val, ok := untypedVal.(T)
-
-		if !ok {
-			return nil, fmt.Errorf("invalid element type at list index %v, must be of type %v", j, name)
-		}
-
-		vals = append(vals, val)
 	}
 
 	return vals, nil

--- a/pkg/ottl/functions_test.go
+++ b/pkg/ottl/functions_test.go
@@ -244,14 +244,16 @@ func Test_NewFunctionCall_invalid(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("test"),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(10),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("test"),
+										},
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(10),
+											},
 										},
 									},
 								},
@@ -483,8 +485,10 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{},
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{},
+								},
 							},
 						},
 					},
@@ -499,16 +503,18 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("test"),
-									},
-									{
-										String: ottltest.Strp("test"),
-									},
-									{
-										String: ottltest.Strp("test"),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("test"),
+										},
+										{
+											String: ottltest.Strp("test"),
+										},
+										{
+											String: ottltest.Strp("test"),
+										},
 									},
 								},
 							},
@@ -525,21 +531,23 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1.1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1.1),
+											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1.2),
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1.2),
+											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1.3),
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1.3),
+											},
 										},
 									},
 								},
@@ -557,21 +565,23 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1),
+											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1),
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1),
+											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1),
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1),
+											},
 										},
 									},
 								},
@@ -589,70 +599,80 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										Literal: &mathExprLiteral{
-											Path: &path{
-												Fields: []field{
-													{
-														Name: "name",
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											Literal: &mathExprLiteral{
+												Path: &path{
+													Fields: []field{
+														{
+															Name: "name",
+														},
 													},
 												},
 											},
 										},
-									},
-									{
-										String: ottltest.Strp("test"),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1),
+										{
+											String: ottltest.Strp("test"),
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1.1),
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1),
+											},
 										},
-									},
-									{
-										Bool: (*boolean)(ottltest.Boolp(true)),
-									},
-									{
-										Enum: (*enumSymbol)(ottltest.Strp("TEST_ENUM")),
-									},
-									{
-										List: &list{
-											Values: []value{
-												{
-													String: ottltest.Strp("test"),
-												},
-												{
-													String: ottltest.Strp("test"),
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1.1),
+											},
+										},
+										{
+											Bool: (*boolean)(ottltest.Boolp(true)),
+										},
+										{
+											Enum: (*enumSymbol)(ottltest.Strp("TEST_ENUM")),
+										},
+										{
+											List: &listOrComprehension{
+												List: &list{
+													Values: []value{
+														{
+															String: ottltest.Strp("test"),
+														},
+														{
+															String: ottltest.Strp("test"),
+														},
+													},
 												},
 											},
 										},
-									},
-									{
-										List: &list{
-											Values: []value{
-												{
-													String: ottltest.Strp("test"),
-												},
-												{
-													List: &list{
-														Values: []value{
-															{
-																String: ottltest.Strp("test"),
-															},
-															{
+										{
+											List: &listOrComprehension{
+												List: &list{
+													Values: []value{
+														{
+															String: ottltest.Strp("test"),
+														},
+														{
+															List: &listOrComprehension{
 																List: &list{
 																	Values: []value{
 																		{
 																			String: ottltest.Strp("test"),
 																		},
 																		{
-																			String: ottltest.Strp("test"),
+																			List: &listOrComprehension{
+																				List: &list{
+																					Values: []value{
+																						{
+																							String: ottltest.Strp("test"),
+																						},
+																						{
+																							String: ottltest.Strp("test"),
+																						},
+																					},
+																				},
+																			},
 																		},
 																	},
 																},
@@ -662,19 +682,19 @@ func Test_NewFunctionCall(t *testing.T) {
 												},
 											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Converter: &converter{
-												Function: "testing_getter",
-												Arguments: []argument{
-													{
-														Value: value{
-															Literal: &mathExprLiteral{
-																Path: &path{
-																	Fields: []field{
-																		{
-																			Name: "name",
+										{
+											Literal: &mathExprLiteral{
+												Converter: &converter{
+													Function: "testing_getter",
+													Arguments: []argument{
+														{
+															Value: value{
+																Literal: &mathExprLiteral{
+																	Path: &path{
+																		Fields: []field{
+																			{
+																				Name: "name",
+																			},
 																		},
 																	},
 																},
@@ -700,13 +720,15 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("test"),
-									},
-									{
-										String: ottltest.Strp("also test"),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("test"),
+										},
+										{
+											String: ottltest.Strp("also test"),
+										},
 									},
 								},
 							},
@@ -723,10 +745,12 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("test"),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("test"),
+										},
 									},
 								},
 							},
@@ -742,10 +766,12 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("test"),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("test"),
+										},
 									},
 								},
 							},
@@ -761,14 +787,16 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("1.1"),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("1.1"),
+										},
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1),
+											},
 										},
 									},
 								},
@@ -786,16 +814,18 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1),
+											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(2),
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(2),
+											},
 										},
 									},
 								},
@@ -813,25 +843,27 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										Literal: &mathExprLiteral{
-											Path: &path{
-												Fields: []field{
-													{
-														Name: "name",
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											Literal: &mathExprLiteral{
+												Path: &path{
+													Fields: []field{
+														{
+															Name: "name",
+														},
 													},
 												},
 											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Path: &path{
-												Fields: []field{
-													{
-														Name: "name",
+										{
+											Literal: &mathExprLiteral{
+												Path: &path{
+													Fields: []field{
+														{
+															Name: "name",
+														},
 													},
 												},
 											},
@@ -852,14 +884,16 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("test"),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("test"),
+										},
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1),
+											},
 										},
 									},
 								},
@@ -877,14 +911,16 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("1.1"),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1.1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("1.1"),
+										},
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1.1),
+											},
 										},
 									},
 								},
@@ -902,14 +938,16 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("1"),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1.1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("1"),
+										},
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1.1),
+											},
 										},
 									},
 								},
@@ -1007,50 +1045,52 @@ func Test_NewFunctionCall(t *testing.T) {
 				Arguments: []argument{
 					{
 						Value: value{
-							List: &list{
-								Values: []value{
-									{
-										String: ottltest.Strp("test"),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Int: ottltest.Intp(1),
+							List: &listOrComprehension{
+								List: &list{
+									Values: []value{
+										{
+											String: ottltest.Strp("test"),
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Float: ottltest.Floatp(1.1),
+										{
+											Literal: &mathExprLiteral{
+												Int: ottltest.Intp(1),
+											},
 										},
-									},
-									{
-										Bool: (*boolean)(ottltest.Boolp(true)),
-									},
-									{
-										Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
-									},
-									{
-										Literal: &mathExprLiteral{
-											Path: &path{
-												Fields: []field{
-													{
-														Name: "name",
+										{
+											Literal: &mathExprLiteral{
+												Float: ottltest.Floatp(1.1),
+											},
+										},
+										{
+											Bool: (*boolean)(ottltest.Boolp(true)),
+										},
+										{
+											Bytes: (*byteSlice)(&[]byte{1, 2, 3, 4, 5, 6, 7, 8}),
+										},
+										{
+											Literal: &mathExprLiteral{
+												Path: &path{
+													Fields: []field{
+														{
+															Name: "name",
+														},
 													},
 												},
 											},
 										},
-									},
-									{
-										Literal: &mathExprLiteral{
-											Converter: &converter{
-												Function: "testing_getter",
-												Arguments: []argument{
-													{
-														Value: value{
-															Literal: &mathExprLiteral{
-																Path: &path{
-																	Fields: []field{
-																		{
-																			Name: "name",
+										{
+											Literal: &mathExprLiteral{
+												Converter: &converter{
+													Function: "testing_getter",
+													Arguments: []argument{
+														{
+															Value: value{
+																Literal: &mathExprLiteral{
+																	Path: &path{
+																		Fields: []field{
+																			{
+																				Name: "name",
+																			},
 																		},
 																	},
 																},

--- a/pkg/ottl/grammar.go
+++ b/pkg/ottl/grammar.go
@@ -264,11 +264,7 @@ func (v *value) accept(vis grammarVisitor) {
 	}
 	if v.List != nil {
 		if v.List.Comprehension != nil {
-			v.List.Comprehension.List.accept(vis)
-			if v.List.Comprehension.Cond != nil {
-				v.List.Comprehension.Cond.accept(vis)
-			}
-			v.List.Comprehension.Yield.accept(vis)
+			vis.visitListComprehension(v.List.Comprehension)
 		}
 		if v.List.List != nil {
 			for _, i := range v.List.List.Values {
@@ -576,6 +572,7 @@ type grammarVisitor interface {
 	visitConverter(v *converter)
 	visitValue(v *value)
 	visitMathExprLiteral(v *mathExprLiteral)
+	visitListComprehension(v *listComprehension)
 }
 
 // grammarCustomErrorsVisitor is used to execute custom validations on the grammar AST.
@@ -604,6 +601,14 @@ func (g *grammarCustomErrorsVisitor) visitEditor(v *editor) {
 	if v.Keys != nil {
 		g.add(fmt.Errorf("only paths and converters may be indexed, not editors, but got %s%s", v.Function, buildOriginalKeysText(v.Keys)))
 	}
+}
+
+func (g *grammarCustomErrorsVisitor) visitListComprehension(v *listComprehension) {
+	if v.Cond != nil {
+		v.Cond.accept(g)
+	}
+	v.List.accept(g)
+	v.Yield.accept(g)
 }
 
 func (g *grammarCustomErrorsVisitor) visitMathExprLiteral(v *mathExprLiteral) {

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -115,7 +115,6 @@ func Test_listComprehension(t *testing.T) {
 			},
 		},
 	}, comp.List)
-
 }
 
 func Test_parse(t *testing.T) {
@@ -141,61 +140,6 @@ func Test_parse(t *testing.T) {
 				WhereClause: nil,
 			},
 		},
-		// {
-		// 	name:      "list comprehension",
-		// 	statement: `set([x for x in mylist])`,
-		// 	expected: &parsedStatement{
-		// 		Editor: editor{
-		// 			Function: "set",
-		// 			Arguments: []argument{
-		// 				{
-		// 					Value: value{
-		// 						List: &listOrComprehension{
-		// 							Comprehension: &listComprehension{
-		// 								Ident: "x",
-		// 								Yield: value{
-		// 									Literal: &mathExprLiteral{
-		// 										Path: &path{
-		// 											Pos: lexer.Position{
-		// 												Offset: 1,
-		// 												Line:   1,
-		// 												Column: 2,
-		// 											},
-		// 											Context: "",
-		// 											Fields: []field{
-		// 												{
-		// 													Name: "x",
-		// 												},
-		// 											},
-		// 										},
-		// 									},
-		// 								},
-		// 								List: value{
-		// 									Literal: &mathExprLiteral{
-		// 										Path: &path{
-		// 											Pos: lexer.Position{
-		// 												Offset: 12,
-		// 												Line:   1,
-		// 												Column: 13,
-		// 											},
-		// 											Context: "",
-		// 											Fields: []field{
-		// 												{
-		// 													Name: "mylist",
-		// 												},
-		// 											},
-		// 										},
-		// 									},
-		// 								},
-		// 							},
-		// 						},
-		// 					},
-		// 				},
-		// 			},
-		// 		},
-		// 		WhereClause: nil,
-		// 	},
-		// },
 		{
 			name:      "editor with float",
 			statement: `met(1.2)`,
@@ -2389,7 +2333,7 @@ func Test_parseValueExpression_full(t *testing.T) {
 			valueExpression: `[x*2 for x in [1, 2, 3, 4] if x > 2]`,
 			expected: func() any {
 				result := pcommon.NewSlice()
-				result.FromRaw([]any{6, 8})
+				_ = result.FromRaw([]any{6, 8})
 				return result
 			},
 		},

--- a/pkg/ottl/parser_test.go
+++ b/pkg/ottl/parser_test.go
@@ -2384,6 +2384,15 @@ func Test_parseValueExpression_full(t *testing.T) {
 				return []any{"list", "of", "strings"}
 			},
 		},
+		{
+			name:            "list comprehension",
+			valueExpression: `[x*2 for x in [1, 2, 3, 4] if x > 2]`,
+			expected: func() any {
+				result := pcommon.NewSlice()
+				result.FromRaw([]any{6, 8})
+				return result
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/ottl/paths.go
+++ b/pkg/ottl/paths.go
@@ -29,6 +29,7 @@ func (v *grammarPathVisitor) visitListComprehension(c *listComprehension) {
 		}
 	}
 }
+
 func (v *grammarPathVisitor) visitPath(value *path) {
 	v.paths = append(v.paths, *value)
 }

--- a/pkg/ottl/paths.go
+++ b/pkg/ottl/paths.go
@@ -12,7 +12,23 @@ func (v *grammarPathVisitor) visitEditor(_ *editor)                   {}
 func (v *grammarPathVisitor) visitConverter(_ *converter)             {}
 func (v *grammarPathVisitor) visitValue(_ *value)                     {}
 func (v *grammarPathVisitor) visitMathExprLiteral(_ *mathExprLiteral) {}
+func (v *grammarPathVisitor) visitListComprehension(c *listComprehension) {
+	// THIS IS A HACK: Ignore loop variables here.
+	c.List.accept(v)
 
+	// path to ignore ->
+	visitor := &grammarPathVisitor{[]path{}}
+	c.Yield.accept(visitor)
+	if c.Cond != nil {
+		c.Cond.accept(visitor)
+	}
+	for _, p := range visitor.paths {
+		// Skip loop variable
+		if !(p.Context == "" && len(p.Fields) == 1 && p.Fields[0].Name == c.Ident) {
+			v.paths = append(v.paths, p)
+		}
+	}
+}
 func (v *grammarPathVisitor) visitPath(value *path) {
 	v.paths = append(v.paths, *value)
 }


### PR DESCRIPTION
#### Description

Adds list-comprehension support to OTTL.  As of this PR you can successfully write expressions like: `[x*2 for x in mylist if x > 0]`

#### Link to tracking issue

Fixes #29289

#### Testing

- [x] Basic testing (see [this for end to end](https://github.com/jsuereth/opentelemetry-collector-contrib/blob/wip-for-comprehension-29289/pkg/ottl/parser_test.go#L2388))
- [ ] Test with existing list-based functions, like append.
- [x] Create advanced testing scenarios

#### Documentation

- [ ] Document baseline syntax and usage


#### Next Steps

- Decide if no-further-nesting limitation is something we can work around or need to refactor.
- Evaluate [Alternative Architecture Proposal](https://github.com/jsuereth/opentelemetry-collector-contrib/tree/wip-redo-ottl/pkg/ottl2)
